### PR TITLE
Jwilaby/bot context as revocable

### DIFF
--- a/libraries/botbuilder/src/bot.ts
+++ b/libraries/botbuilder/src/bot.ts
@@ -26,6 +26,7 @@ import { BotContext } from './botContext';
 export class Bot extends MiddlewareSet {
     private receivers: ((context: BotContext) => Promiseable<void>)[] = [];
     private _adapter: ActivityAdapter;
+    private pluginReflectMetadata = new Map<{ [property: string]: any, constructor?: Function }, { [propName: string]: PropertyDescriptor | undefined }>();
 
     /**
      * Creates a new instance of a bot
@@ -62,6 +63,68 @@ export class Bot extends MiddlewareSet {
     }
 
     /**
+     * Adds a plugin whose functions (including getters/setters) become available
+     * on the context object passed to the middleware api. In order to resolve name
+     * collisions, calling a plugin function on the context returns an iterator
+     * containing the functions matched by name.
+     *
+     * ```js
+     * class MiddlewarePlugin extends BotContext {
+     *   doStuff() {
+     *     if (this.request.entities) {
+     *       this.processEntities(this.request.entities);
+     *   }
+     *
+     *   processEntities() {
+     *     // Process entities
+     *   }
+     *
+     *   flushResponses() {
+     *      // Intercept flush responses then...
+     *      super.flushResponses(); // call super
+     *   }
+     * }
+     *
+     * class MyMiddleware {
+     *   receiveActivity(context, next) {
+     *     // calls to "doStuff" returns an iterator since
+     *     // multiple plugins may contain same-named functions.
+     *     for (let doStuff in context.doStuff()) {
+     *         doStuff(); // doStuff() is bound to context's scope
+     *     }
+     *   }
+     * }
+     * const bot = new Bot();
+     * bot.plugin(new MiddlewarePlugin())
+     *    .use(new MyMiddleware());
+     *
+     * ```
+     *
+     * @param plugin Either a constructed class, a class prototype or an object containing properties
+     * whose values are functions.
+     */
+    public plugin(plugin: { [property: string]: any, constructor?: Function }): Bot {
+        const {pluginReflectMetadata} = this;
+        const reflect = (prototype: { [property: string]: any, constructor?: Function }): { [key: string]: PropertyDescriptor | undefined } => {
+            const meta = {} as { [key: string]: PropertyDescriptor | undefined };
+            // Tail call avoidance
+            while (prototype && prototype !== Object.prototype && prototype !== BotContext.prototype) {
+                // Retain descriptors for use later
+                Reflect.ownKeys(prototype).forEach(key => {
+                    meta[key] = Reflect.getOwnPropertyDescriptor(prototype, key);
+                });
+                prototype = Reflect.getPrototypeOf(prototype);
+            }
+            return meta;
+        };
+        if (typeof plugin === 'object' && !('prototype' in plugin)) {
+            plugin = Reflect.getPrototypeOf(plugin);
+        }
+        pluginReflectMetadata.set(plugin, reflect(plugin));
+        return this;
+    }
+
+    /**
      * Creates a new context object given an activity or conversation reference. The context object
      * will be disposed of automatically once the callback completes or the promise it returns
      * completes.
@@ -82,24 +145,24 @@ export class Bot extends MiddlewareSet {
      */
     public createContext(activityOrReference: Activity | ConversationReference, onReady: (context: BotContext) => Promiseable<void>): Promise<void> {
         // Initialize context object
-        let context: BotContext;
+        const handler = new MiddlewareProxyHandler(this.pluginReflectMetadata);
+        let revocable: {proxy: BotContext, revoke: Function};
         if ((activityOrReference as Activity).type) {
-            context = new BotContext(this, activityOrReference);
+            revocable = Proxy.revocable(new BotContext(this, activityOrReference), handler);
         } else {
-            context = new BotContext(this);
-            context.conversationReference = activityOrReference;
+            revocable = Proxy.revocable(new BotContext(this), handler);
+            revocable.proxy.conversationReference = activityOrReference;
         }
-
         // Run context created pipeline
-        return this.contextCreated(context, function contextReady() {
+        return this.contextCreated(revocable.proxy, function contextReady() {
             // Run proactive or reactive logic
-            return Promise.resolve(onReady(context));
+            return Promise.resolve(onReady(revocable.proxy));
         }).then(() => {
             // Next flush any queued up responses
-            return context.flushResponses();
+            return revocable.proxy.flushResponses();
         }).then(() => {
             // Dispose of the context object
-            context.dispose();
+            revocable.revoke();
         });
     }
 
@@ -177,5 +240,30 @@ export class Bot extends MiddlewareSet {
         return this.createContext(activity,
             (context) => this.receiveActivity(context,
                 () => Promise.resolve()));
+    }
+}
+
+class MiddlewareProxyHandler implements ProxyHandler<BotContext> {
+    constructor(private pluginReflectMetadata: Map<{ [property: string]: any, constructor?: Function }, { [propName: string]: PropertyDescriptor | undefined }>) {
+
+    }
+
+    public get(target: BotContext, prop: PropertyKey, receiver: ProxyConstructor): Function[] | Function | any {
+        if (prop in target) {
+            return (target as any)[prop];
+        }
+        const matches = this.getDescriptorIteratorByName(prop, target);
+        return matches.length ? matches : matches[0];
+    }
+
+    private getDescriptorIteratorByName(propertyName: PropertyKey, target: BotContext): Function[] | Function | any {
+        const matches: PropertyDescriptor[] = [];
+        this.pluginReflectMetadata.forEach(meta => {
+            const descriptor = meta[propertyName];
+            if (descriptor) {
+                matches.push((descriptor.get ? descriptor.get.call(target) : descriptor.value.bind(target)));
+            }
+        });
+        return matches;
     }
 }

--- a/libraries/botbuilder/src/bot.ts
+++ b/libraries/botbuilder/src/bot.ts
@@ -69,7 +69,7 @@ export class Bot extends MiddlewareSet {
      * on the context returns an array containing the functions matched by name.
      *
      * ```js
-     * class MiddlewarePlugin implements BotContext {
+     * class ContextPlugin implements BotContext {
      *   doStuff() {
      *     if (this.request.entities) {
      *       this.processEntities(this.request.entities);
@@ -77,11 +77,6 @@ export class Bot extends MiddlewareSet {
      *
      *   processEntities() {
      *     // Process entities
-     *   }
-     *
-     *   flushResponses() {
-     *      // Intercept flush responses then...
-     *      super.flushResponses(); // call super
      *   }
      * }
      *
@@ -91,7 +86,7 @@ export class Bot extends MiddlewareSet {
      *   }
      * }
      * const bot = new Bot();
-     * bot.plugin(new MiddlewarePlugin())
+     * bot.plugin(new ContextPlugin())
      *    .use(new MyMiddleware());
      *
      * ```

--- a/libraries/botbuilder/src/botContext.ts
+++ b/libraries/botbuilder/src/botContext.ts
@@ -38,7 +38,6 @@ export class BotContext {
 
     /** The Bot object for this context. */
     get bot(): Bot {
-        this.throwIfDisposed('bot');
         return this._bot;
     }
 
@@ -49,13 +48,11 @@ export class BotContext {
 
     /** Returns the conversation reference for the current turn. */
     get conversationReference(): ConversationReference {
-        this.throwIfDisposed('conversationReference');
         return this._reference;
     }
 
     /** Assigns the conversation reference for the current turn. */
     set conversationReference(reference: ConversationReference) {
-        this.throwIfDisposed('conversationReference');
         this._reference = reference;
     }
 
@@ -64,38 +61,23 @@ export class BotContext {
      * undefined.
      */
     get request(): Activity | undefined {
-        this.throwIfDisposed('request');
         return this._request;
     }
 
     /** Queue of responses to send to the user. */
     get responses(): Partial<Activity>[] {
-        this.throwIfDisposed('responses');
         return this._responses;
     }
 
     /** If true at least one response has been sent for the current turn of conversation. */
     get responded(): boolean {
-        this.throwIfDisposed('responded');
         return this._responded;
-    }
-
-    /**
-     * INTERNAL disposes of the context object, making it unusable. Calling any properties or
-     * methods off a disposed of context will result in an exception being thrown.
-     */
-    public dispose(): void {
-        ['_bot', '_request', '_reference', '_responses', '_properties'].forEach((prop) => {
-            (this as any)[prop] = undefined;
-        });
     }
 
     /**
      * Forces the delivery of any queued up responses to the user.
      */
     public flushResponses<T>(): Promise<T> {
-        this.throwIfDisposed('flushResponses()');
-
         const args: any[] = this._responses.slice(0);
         const cnt = args.length;
         args.unshift(this);
@@ -115,8 +97,6 @@ export class BotContext {
      * @param name Name of the property to return.
      */
     public get<T = any>(name: string): T {
-        this.throwIfDisposed(`get("${name}")`);
-
         if (!this._properties.hasOwnProperty(name)) {
             throw new Error(`BotContext.get("${name}"): property not found.`);
         }
@@ -129,8 +109,6 @@ export class BotContext {
      * @param name Name of the property to look up.
      */
     public has(name: string): boolean {
-        this.throwIfDisposed(`has("${name}")`);
-
         return !this._properties.hasOwnProperty(name);
     }
 
@@ -140,19 +118,6 @@ export class BotContext {
      * @param value Value to store for the property.
      */
     public set(name: string, value: any): void {
-        this.throwIfDisposed(`set("${name}")`);
-
         this._properties[name] = value;
-    }
-
-    /**
-     * Helper function used by context object extensions to ensure the context object hasn't
-     * been disposed of prior to use.
-     * @param member Name of the extension property or method being called.
-     */
-    public throwIfDisposed(member: string) {
-        if (this.disposed) {
-            throw new Error(`BotContext.${member}: error calling property/method after context has been disposed.`);
-        }
     }
 }

--- a/libraries/botbuilder/tests/botContext.js
+++ b/libraries/botbuilder/tests/botContext.js
@@ -1,0 +1,118 @@
+const assert = require('assert');
+const builder = require('../');
+const BotFrameworkAdapter = require('../../botbuilder-services').BotFrameworkAdapter;
+
+describe('The BotContext', () => {
+    describe('should accept a plugin', () => {
+        let bot;
+        beforeEach(() => {
+            const botFrameworkAdapter = new BotFrameworkAdapter({
+                appId: process.env.MICROSOFT_APP_ID,
+                appPassword: process.env.MICROSOFT_APP_PASSWORD
+            });
+            bot = new builder.Bot(botFrameworkAdapter);
+        });
+
+        it('of a classy type and properly reflect it\'s prototype', () => {
+            class A extends builder.BotContext {
+                pluginClassAFunction1() {
+                }
+
+                pluginClassAFunction2() {
+                }
+            }
+
+            const a = new A();
+            assert.doesNotThrow(() => bot.plugin(a));
+            assert(bot.pluginReflectMetadata.has(A.prototype));
+            ['pluginClassAFunction1', 'pluginClassAFunction2'].forEach(key => assert(key in bot.pluginReflectMetadata.get(A.prototype)));
+        });
+
+        it('as an object literal and properly reflect it\'s properties', () => {
+            const obj = {
+                objectLiteralFunction1: function () {
+                },
+                objectLiteralFunction2: function () {
+                }
+            };
+
+            assert.doesNotThrow(() => bot.plugin(obj));
+            assert(bot.pluginReflectMetadata.has(obj));
+            ['objectLiteralFunction1', 'objectLiteralFunction2'].forEach(key => assert(key in bot.pluginReflectMetadata.get(obj)));
+        });
+
+        it('of a class prototype and properly reflect it\'s properties', () => {
+            class A extends builder.BotContext {
+                pluginClassPrototypeAFunction1() {
+                }
+
+                pluginClassPrototypeAFunction2() {
+                }
+            }
+
+            assert.doesNotThrow(() => bot.plugin(A.prototype));
+            assert(bot.pluginReflectMetadata.has(A.prototype));
+            ['pluginClassPrototypeAFunction1', 'pluginClassPrototypeAFunction2'].forEach(key => assert(key in bot.pluginReflectMetadata.get(A.prototype)));
+        });
+    });
+
+    describe('should proxy the plugin', () => {
+        let bot;
+        beforeEach(() => {
+            const botFrameworkAdapter = new BotFrameworkAdapter({
+                appId: process.env.MICROSOFT_APP_ID,
+                appPassword: process.env.MICROSOFT_APP_PASSWORD
+            });
+            bot = new builder.Bot(botFrameworkAdapter);
+            bot.plugin(new class {
+                pluginFunction1() {
+                    return this;
+                }
+            });
+        });
+
+        it('and call the proxied function in the context of the BotContext object', () => {
+            class MiddleWare {
+                receiveActivity(context) {
+                    const value = context.pluginFunction1();
+                    assert(value instanceof builder.BotContext);
+                }
+            }
+
+            bot.use(new MiddleWare());
+            bot.receive('hello')
+        });
+
+        it('and return an array of functions when a naming collision occurs', () => {
+            class MiddleWare {
+                receiveActivity(context) {
+                    assert(context.pluginFunction1() instanceof Array);
+                    context.pluginFunction1().forEach(func => assert.equal(typeof func, 'function'));
+                }
+            }
+
+            bot.plugin(new class {
+                pluginFunction1() {
+                    return this;
+                }
+            });
+
+            bot.use(new MiddleWare());
+            bot.receive('hello')
+        });
+
+        it('and revoke the context then throw if a function is called after revocation', done => {
+            class MiddleWare {
+                receiveActivity(context) {
+                    setTimeout(() => {
+                        assert.throws(() => context.pluginFunction1());
+                        done();
+                    })
+                }
+            }
+
+            bot.use(new MiddleWare());
+            bot.receive('hello')
+        });
+    });
+});


### PR DESCRIPTION
This PR provides a revocable, extensible BotContext solution without the need to add properties to the `prototype` or explicitly throw when the context is disposed.

## example:
```js
// Create the plugin like any other class - it must implement BotContext
class ContextPlugin implements BotContext {
  public doStuff(): void {
    if (this.request.entities) {
     this.processEntities(this.request.entities);
    }
  }
  private processEntities(): void{
    // Process entities
  }
}
// Create a middleware that knows about the ContextPlugin type
class ContextSpecificMiddleware implements Middleware { 
  receiveActivity(context: ContextPlugin , next: () => Promise<void>): Promise<void>{
    context.doStuff(); // TypeScript should know about this without needing ambient declarations
  }
}

const bot = new Bot();
// Add as many plugins as needed to carry out the mission
bot.plugin(new ContextPlugin()
      .use(new ContextSpecificMiddleware());
```