### PR TITLE
Add /luis to default cognitive services url

### DIFF
--- a/libraries/botbuilder-ai/src/luisRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizer.ts
@@ -46,7 +46,7 @@ export class LuisRecognizer extends IntentRecognizer {
         }
 
         // Create client and override callbacks
-        const baseUri = (this.options.serviceEndpoint || 'https://westus.api.cognitive.microsoft.com');
+        const baseUri = (this.options.serviceEndpoint || 'https://westus.api.cognitive.microsoft.com/luis');
         this.luisClient = new LuisClient(baseUri + '/luis/');
         this.onRecognize((context) => {
             const intents: Intent[] = [];


### PR DESCRIPTION
The base url was pointing to cognitive services but didn't specify the service LUIS so the requests would fail with 404 Not Found

Closes: #86