### PR TITLE
Tests for Console Adapter bug that throws unhandled exceptions when used with a bot

### DIFF
--- a/libraries/botbuilder/tests/coreIntegrationTests.js
+++ b/libraries/botbuilder/tests/coreIntegrationTests.js
@@ -1,0 +1,42 @@
+const assert = require('assert');
+const builder = require('../');
+const { ConsoleAdapter } = require('../../botbuilder-node');
+
+describe('Core integration tests', () => {
+    describe('console adapter', () => {
+        let adapter;
+        
+        beforeEach(() => adapter = new ConsoleAdapter().listen())
+
+        it.only('can pipe incoming messages to the bot and see outgoing responses', () => {
+            const bot = new builder.Bot(adapter);
+
+            const outgoingMessageSuccessProimse = new Promise((res, rej) => {
+                bot.use(new builder.MemoryStorage())
+                    .use(new builder.BotStateManager())
+                    .use({
+                        postActivity: (context, activities, next) => {
+                            if(activities.length === 0) {
+                                rej('no outgoing activity received');
+                                return next();
+                            }
+
+                            const text = activities[1].text;
+
+                            assert.equal(text, 'HELLO!');
+
+                            return next();
+                        }
+                    });
+                });
+            
+            bot.onReceive((context) => {
+                context.reply('HELLO!');
+            });
+
+            adapter.receive('hey');
+
+            return outgoingMessageSuccessProimse;
+        })
+    });
+})

--- a/libraries/botbuilder/tests/coreIntegrationTests.js
+++ b/libraries/botbuilder/tests/coreIntegrationTests.js
@@ -8,7 +8,7 @@ describe('Core integration tests', () => {
         
         beforeEach(() => adapter = new ConsoleAdapter().listen())
 
-        it.only('can pipe incoming messages to the bot and see outgoing responses', () => {
+        it('can pipe incoming messages to the bot and see outgoing responses', () => {
             const bot = new builder.Bot(adapter);
 
             const outgoingMessageSuccessProimse = new Promise((res, rej) => {


### PR DESCRIPTION
# Issue reference #97 


Because ```ConsoleAdapter``` is part of the botbuilder-node package, a new test file for testing the integration between core and other libraries (in this case botbuilder-node) seemed to be fitting. While this currently only has the test for the ```ConsoleAdapter``` I would expect it to be an appropriate file to add additional integration tests.

## Notes
 * this PR does not provide a solution, it merely gives a test to verify the bad state and the fix.
 * use of the console Adapter within a test scope is harmless, though the particular test will run slightly slower due to IO constraints.
