### PR TITLE
M2 Developer Workflow Tools Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,21 @@
 {
+	"private": true,
+	"name": "botbuilder-packages",
+	"scripts": {
+		"postinstall": "lerna bootstrap --hoist",
+		"build": "lerna run build",
+		"clean": "lerna run clean",
+		"test": "lerna run test --stream",
+		"build-docs": "lerna run build-docs"
+	},
 	"dependencies": {
 		"replace-in-file": "^3.1.1",
 		"typedoc": "^0.9.0",
 		"typedoc-plugin-external-module-name": "^1.0.10",
 		"typedoc-plugin-markdown": "^1.0.12"
+	},
+	"devDependencies": {
+		"@types/jsonwebtoken": "7.2.5",
+		"lerna": "^2.9.0"
 	}
 }


### PR DESCRIPTION
Added npm postinstall scripts to automate lerna bootstrapping and make lerna transparent to the developer.
Added various npm run scripts to enable a single command to link botbuilder to the global node_modules folder to make it easier for developers to add their local cloned repo to a project.

The new developer workflow would look like this:
```bash
git clone git@github.com:Microsoft/botbuilder-js.git
cd botbuilder-js
git checkout m2
npm install 
npm run dev #ignore error messages
```

Any project that you would like to use your local clone botbuilder sdk, just go into that project and run `npm link botbuilder` to have it use the globally symlinked botbuilder module pointing to your local clone.

