### PR TITLE
created a separate local test target in npm (distinct from travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - lerna bootstrap --hoist
 
 script:
-  - npm run test
+  - npm run test:travis
 
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 		"postinstall": "lerna bootstrap --hoist",
 		"build": "lerna run build",
 		"clean": "lerna run clean",
-		"test": "lerna run build && nyc mocha \"libraries/bot*/tests/*.test.suite.js\" && nyc report --reporter=text-lcov | coveralls",
+		"test:travis": "lerna run build && nyc mocha \"libraries/bot*/tests/*.test.suite.js\" && nyc report --reporter=text-lcov | coveralls",
+		"test": "lerna run build && nyc mocha \"libraries/bot*/tests/*.test.suite.js\"",
 		"build-docs": "lerna run build-docs"
 	},
 	"dependencies": {


### PR DESCRIPTION
you can now type:

  npm test

And it will work (travis has a new target called test:travis).
The issue was that the coverall report doesn't work locally.