### PR TITLE
Added comment with guidance for edge case scenario 'InvalidBlobkList'

### DIFF
--- a/libraries/botbuilder-azure/src/blobStorage.ts
+++ b/libraries/botbuilder-azure/src/blobStorage.ts
@@ -157,6 +157,9 @@ export class BlobStorage implements Storage {
                 };
             });
 
+            // A block blob can be uploaded using a single PUT operation or divided into multiple PUT block operations
+            // depending on the payload's size. The default maximum size for a single blob upload is 128MB.
+            // An 'InvalidBlockList' error is commonly caused due to concurrently uploading an object larger than 128MB in size.
             let promise = (blob) => this.client.createBlockBlobFromTextAsync(container.name, blob.id, blob.data, blob.options);
 
             // if the blob service client is using the storage emulator, all write operations must be performed in a sequential mode


### PR DESCRIPTION
After some discussion, we decided not to try to replicate and handle the concurrent large object upload since it is really an edge case scenario. Instead, we simply included a clarifying comment in the code with the same guidance we added to the C# version.