### PR TITLE
Adding samples and fixing bugs with OAuthCard support

### DIFF
--- a/libraries/botbuilder-dialogs/lib/prompts/oauthPrompt.d.ts
+++ b/libraries/botbuilder-dialogs/lib/prompts/oauthPrompt.d.ts
@@ -91,7 +91,7 @@ export declare class OAuthPrompt<C extends TurnContext> extends Dialog<C> {
      * @param validator (Optional) validator that will be called each time the user responds to the prompt. If the validator replies with a message no additional retry prompt will be sent.
      */
     constructor(settings: OAuthPromptSettingsWithTimeout, validator?: prompts.PromptValidator<any, any>);
-    dialogBegin(dc: DialogContext<C>, options: PromptOptions): Promise<any>;
+    dialogBegin(dc: DialogContext<C>, options?: PromptOptions): Promise<any>;
     dialogContinue(dc: DialogContext<C>): Promise<any>;
     /**
      * Signs the user out of the service.

--- a/libraries/botbuilder-dialogs/lib/prompts/oauthPrompt.js
+++ b/libraries/botbuilder-dialogs/lib/prompts/oauthPrompt.js
@@ -95,14 +95,14 @@ class OAuthPrompt extends dialog_1.Dialog {
                 // Return token
                 return dc.end(output);
             }
-            else if (typeof options.prompt === 'string') {
+            else if (options && typeof options.prompt === 'string') {
                 // Send supplied prompt then OAuthCard
                 return dc.context.sendActivity(options.prompt, options.speak)
                     .then(() => this.prompt.prompt(dc.context));
             }
             else {
                 // Send OAuthCard
-                return this.prompt.prompt(dc.context, options.prompt);
+                return this.prompt.prompt(dc.context, options ? options.prompt : undefined);
             }
         });
     }

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -97,7 +97,7 @@ export class OAuthPrompt<C extends TurnContext> extends Dialog<C> {
         this.prompt = prompts.createOAuthPrompt(settings, validator);
     }
 
-    public dialogBegin(dc: DialogContext<C>, options: PromptOptions): Promise<any> {
+    public dialogBegin(dc: DialogContext<C>, options?: PromptOptions): Promise<any> {
         // Persist options and state
         const timeout = typeof this.settings.timeout === 'number' ? this.settings.timeout : 54000000; 
         const instance = dc.activeDialog;
@@ -110,13 +110,13 @@ export class OAuthPrompt<C extends TurnContext> extends Dialog<C> {
             if (output !== undefined) {
                 // Return token
                 return dc.end(output);
-            } else if (typeof options.prompt === 'string') {
+            } else if (options && typeof options.prompt === 'string') {
                 // Send supplied prompt then OAuthCard
                 return dc.context.sendActivity(options.prompt, options.speak)
                     .then(() => this.prompt.prompt(dc.context));
             } else {
                 // Send OAuthCard
-                return this.prompt.prompt(dc.context, options.prompt);
+                return this.prompt.prompt(dc.context, options ? <Partial<Activity>>options.prompt : undefined);
             }
         });
     }

--- a/libraries/botbuilder/lib/botFrameworkAdapter.d.ts
+++ b/libraries/botbuilder/lib/botFrameworkAdapter.d.ts
@@ -67,6 +67,7 @@ export declare class BotFrameworkAdapter extends BotAdapter {
     protected readonly credentials: MicrosoftAppCredentials;
     protected readonly credentialsProvider: SimpleCredentialProvider;
     protected readonly settings: BotFrameworkAdapterSettings;
+    private isEmulatingOAuthCards;
     /**
      * Creates a new BotFrameworkAdapter instance.
      * @param settings (optional) configuration settings for the adapter.
@@ -281,6 +282,16 @@ export declare class BotFrameworkAdapter extends BotAdapter {
      * @param serviceUrl Clients service url.
      */
     protected createOAuthApiClient(serviceUrl: string): OAuthApiClient;
+    /**
+     * Allows for mocking of the OAuth Api URL in unit tests.
+     * @param contextOrServiceUrl The URL of the channel server to query or a TurnContext.  This can be retrieved from `context.activity.serviceUrl`.
+     */
+    protected oauthApiUrl(contextOrServiceUrl: TurnContext | string): string;
+    /**
+     * Allows for mocking of toggling the emulating OAuthCards in unit tests.
+     * @param context The TurnContext
+     */
+    protected checkEmulatingOAuthCards(context: TurnContext): void;
     /**
      * Allows for the overriding of the context object in unit tests and derived adapters.
      * @param request Received request.

--- a/libraries/botframework-connector/lib/auth/microsoftAppCredentials.js
+++ b/libraries/botframework-connector/lib/auth/microsoftAppCredentials.js
@@ -144,7 +144,8 @@ class MicrosoftAppCredentials {
     }
 }
 MicrosoftAppCredentials.trustedHostNames = new Map([
-    ['state.botframework.com', new Date(8640000000000000)] // Date.MAX_VALUE
+    ['state.botframework.com', new Date(8640000000000000)],
+    ['api.botframework.com', new Date(8640000000000000)] // Date.MAX_VALUE,
 ]);
 MicrosoftAppCredentials.cache = new Map();
 exports.MicrosoftAppCredentials = MicrosoftAppCredentials;

--- a/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
@@ -16,7 +16,8 @@ import { Constants } from './constants';
 export class MicrosoftAppCredentials implements msrest.ServiceClientCredentials {
 
     private static readonly trustedHostNames: Map<string, Date> = new Map<string, Date>([
-        ['state.botframework.com', new Date(8640000000000000)]              // Date.MAX_VALUE
+        ['state.botframework.com', new Date(8640000000000000)],              // Date.MAX_VALUE,
+        ['api.botframework.com', new Date(8640000000000000)]                 // Date.MAX_VALUE,
     ]);
 
     private static readonly cache: Map<string, OAuthResponse> = new Map<string, OAuthResponse>();

--- a/samples/dialogs/echobot-ts/lib/app.js
+++ b/samples/dialogs/echobot-ts/lib/app.js
@@ -18,9 +18,10 @@ server.listen(process.env.port || process.env.PORT || 3978, function () {
 });
 // Create adapter
 const adapter = new botbuilder_1.BotFrameworkAdapter({
-    appId: process.env.MICROSOFT_APP_ID,
-    appPassword: process.env.MICROSOFT_APP_PASSWORD
+    appId: '558e9c44-900b-42e2-a20a-1c5ebdcd97e6',
+    appPassword: 'zlkq$7$dP%20!u{a' // process.env.MICROSOFT_APP_PASSWORD 
 });
+const connectionName = 'MyBuildConnection'; // process.env.CONNECTION_NAME;
 const conversationState = new botbuilder_1.ConversationState(new botbuilder_1.MemoryStorage());
 adapter.use(conversationState);
 // Create empty dialog set

--- a/samples/dialogs/echobot-ts/src/app.ts
+++ b/samples/dialogs/echobot-ts/src/app.ts
@@ -10,9 +10,11 @@ server.listen(process.env.port || process.env.PORT || 3978, function () {
 
 // Create adapter
 const adapter = new BotFrameworkAdapter( { 
-    appId: process.env.MICROSOFT_APP_ID, 
-    appPassword: process.env.MICROSOFT_APP_PASSWORD 
+    appId: '558e9c44-900b-42e2-a20a-1c5ebdcd97e6', // process.env.MICROSOFT_APP_ID, 
+    appPassword: 'zlkq$7$dP%20!u{a' // process.env.MICROSOFT_APP_PASSWORD 
 });
+
+const connectionName = 'MyBuildConnection'; // process.env.CONNECTION_NAME;
 
 // Add conversation state middleware
 interface EchoState {

--- a/samples/dialogs/oauthbot-ts/README.md
+++ b/samples/dialogs/oauthbot-ts/README.md
@@ -1,0 +1,4 @@
+This sample uses OAuthPrompts as part of dialogs to log a user into a remote resource and display the user's token.
+
+## Running
+To run this sample folow the common instructions for running all of the samples found [here](../README.md#running).  This sample can be built using `npm run build-sample` and started using `npm run start`.

--- a/samples/dialogs/oauthbot-ts/lib/app.js
+++ b/samples/dialogs/oauthbot-ts/lib/app.js
@@ -1,0 +1,87 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const botbuilder_1 = require("botbuilder");
+const botbuilder_dialogs_1 = require("botbuilder-dialogs");
+const restify = require("restify");
+// Create server
+let server = restify.createServer();
+server.listen(process.env.port || process.env.PORT || 3978, function () {
+    console.log(`${server.name} listening to ${server.url}`);
+});
+// Create adapter
+const adapter = new botbuilder_1.BotFrameworkAdapter({
+    appId: process.env.MICROSOFT_APP_ID,
+    appPassword: process.env.MICROSOFT_APP_PASSWORD
+});
+const connectionName = process.env.CONNECTION_NAME;
+// Add conversation state middleware
+const conversationState = new botbuilder_1.ConversationState(new botbuilder_1.MemoryStorage());
+adapter.use(conversationState);
+// Create empty dialog set
+const dialogs = new botbuilder_dialogs_1.DialogSet();
+// Listen for incoming requests 
+server.post('/api/messages', (req, res) => {
+    // Route received request to adapter for processing
+    adapter.processActivity(req, res, (context) => __awaiter(this, void 0, void 0, function* () {
+        // Use this command to have the emulator send mocked tokens to the bot rather than authenticating
+        // adapter.emulateOAuthCards(context, true);
+        if (context.activity.type === 'message') {
+            if (context.activity.text === 'signout') {
+                yield adapter.signOutUser(context, connectionName);
+                yield context.sendActivity("You are now signed out.");
+            }
+            else {
+                // Create dialog context and continue executing the "current" dialog, if any.
+                const state = conversationState.get(context);
+                const dc = dialogs.createContext(context, state);
+                yield dc.continue();
+                // Check to see if anyone replied. If not then start dialog
+                if (!context.responded) {
+                    yield dc.begin('displayToken');
+                }
+            }
+        }
+        else if (context.activity.type === 'event' || context.activity.type === 'invoke') {
+            // Create dialog context and continue executing the "current" dialog, if any.
+            // This is important for OAuthCards because tokens can be received via TokenResponse events
+            const state = conversationState.get(context);
+            const dc = dialogs.createContext(context, state);
+            yield dc.continue();
+        }
+    }));
+});
+// Add a dialog to get a token for the connectrion
+dialogs.add('loginPrompt', new botbuilder_dialogs_1.OAuthPrompt({
+    connectionName: connectionName,
+    text: "Please Sign In",
+    title: "Sign In",
+    timeout: 300000 // User has 5 minutes to login
+}));
+// Add a dialog to display the token once the user has logged in
+dialogs.add('displayToken', [
+    function (dc) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield dc.begin('loginPrompt');
+        });
+    },
+    function (dc, token) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (token) {
+                // Continue with task needing access token
+                yield dc.context.sendActivity(`Your token is: ` + token.token);
+            }
+            else {
+                yield dc.context.sendActivity(`Sorry... We couldn't log you in. Try again later.`);
+                yield dc.end();
+            }
+        });
+    }
+]);

--- a/samples/dialogs/oauthbot-ts/package.json
+++ b/samples/dialogs/oauthbot-ts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "dialogs-oauthbot-ts",
+  "version": "1.0.0",
+  "description": "Bot Builder example showing a simple bot that uses dialogs to send an ouathcard.",
+  "main": "./lib/app.js",
+  "scripts": {
+    "build-sample": "tsc",
+    "start": "tsc && node ./lib/app.js"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@types/node": "^9.3.0",
+    "@types/restify": "^5.0.7",
+    "botbuilder": "^4.0.0-preview1.2",
+    "botbuilder-prompts": "^4.0.0-preview1.2",
+    "botbuilder-dialogs": "^4.0.0-preview1.2",
+    "restify": "^6.3.4"
+  }
+}

--- a/samples/dialogs/oauthbot-ts/src/app.ts
+++ b/samples/dialogs/oauthbot-ts/src/app.ts
@@ -1,0 +1,82 @@
+import { BotFrameworkAdapter, MemoryStorage, ConversationState, TurnContext } from 'botbuilder';
+import { DialogSet, OAuthPrompt } from 'botbuilder-dialogs';
+import * as restify from 'restify';
+import { connect } from 'net';
+
+// Create server
+let server = restify.createServer();
+server.listen(process.env.port || process.env.PORT || 3978, function () {
+    console.log(`${server.name} listening to ${server.url}`);
+});
+
+// Create adapter
+const adapter = new BotFrameworkAdapter( { 
+    appId: process.env.MICROSOFT_APP_ID, 
+    appPassword: process.env.MICROSOFT_APP_PASSWORD 
+});
+
+const connectionName = process.env.CONNECTION_NAME;
+
+// Add conversation state middleware
+const conversationState = new ConversationState(new MemoryStorage());
+adapter.use(conversationState);
+
+// Create empty dialog set
+const dialogs = new DialogSet();
+
+// Listen for incoming requests 
+server.post('/api/messages', (req, res) => {
+    // Route received request to adapter for processing
+    adapter.processActivity(req, res, async (context) => {
+        
+        // Use this command to have the emulator send mocked tokens to the bot rather than authenticating
+        // adapter.emulateOAuthCards(context, true);
+
+        if (context.activity.type === 'message') {
+            if(context.activity.text === 'signout') {
+                await adapter.signOutUser(context, connectionName);
+                await context.sendActivity("You are now signed out.");
+            } else {
+                // Create dialog context and continue executing the "current" dialog, if any.
+                const state = conversationState.get(context);
+                const dc = dialogs.createContext(context, state);
+                await dc.continue();
+
+                // Check to see if anyone replied. If not then start dialog
+                if (!context.responded) {
+                    await dc.begin('displayToken');
+                }
+            }
+        } else if (context.activity.type === 'event' || context.activity.type === 'invoke') {
+            // Create dialog context and continue executing the "current" dialog, if any.
+            // This is important for OAuthCards because tokens can be received via TokenResponse events
+            const state = conversationState.get(context);
+            const dc = dialogs.createContext(context, state);
+            await dc.continue();
+        }
+    });
+});
+
+// Add a dialog to get a token for the connectrion
+dialogs.add('loginPrompt', new OAuthPrompt({
+    connectionName: connectionName,
+    text: "Please Sign In",
+    title: "Sign In",
+    timeout: 300000        // User has 5 minutes to login
+}));
+ 
+// Add a dialog to display the token once the user has logged in
+ dialogs.add('displayToken', [
+      async function (dc) {
+          await dc.begin('loginPrompt');
+      },
+      async function (dc, token) {
+          if (token) {
+              // Continue with task needing access token
+              await dc.context.sendActivity(`Your token is: ` + token.token);
+          } else {
+              await dc.context.sendActivity(`Sorry... We couldn't log you in. Try again later.`);
+              await dc.end();
+          }
+      }
+ ]);

--- a/samples/dialogs/oauthbot-ts/tsconfig.json
+++ b/samples/dialogs/oauthbot-ts/tsconfig.json
@@ -1,0 +1,53 @@
+{
+  "compilerOptions": {
+    /* Basic Options */                       
+    "target": "ES2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd' or 'es2015'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation:  */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./lib",                        /* Redirect output structure to the directory. */
+    "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+                                              
+    /* Strict Type-Checking Options */        
+    // "strict": true,                            /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+                                              
+    /* Additional Checks */                   
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+                                              
+    /* Module Resolution Options */           
+    "moduleResolution": "node"            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+                                              
+    /* Source Map Options */                  
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+                                              
+    /* Experimental Options */                
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  }
+}

--- a/samples/oauth-prompt-bot-es6/app.js
+++ b/samples/oauth-prompt-bot-es6/app.js
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const { BotFrameworkAdapter, BotStateSet, ConversationState, MemoryStorage, UserState } = require('botbuilder');
+const { createOAuthPrompt } = require('botbuilder-prompts');
+const restify = require('restify');
+
+// Create server
+let server = restify.createServer();
+server.listen(process.env.port || process.env.PORT || 3978, function () {
+    console.log(`${server.name} listening to ${server.url}`);
+});
+
+// Create adapter
+const adapter = new BotFrameworkAdapter({ 
+    appId: process.env.MICROSOFT_APP_ID, 
+    appPassword: process.env.MICROSOFT_APP_PASSWORD  
+});
+
+// Set the OAuth Connection Setting name to use
+const connectionName = process.env.CONNECTION_NAME;
+
+// Add state middleware
+const storage = new MemoryStorage();
+const convoState = new ConversationState(storage);
+const userState = new UserState(storage);
+adapter.use(new BotStateSet(convoState, userState));
+
+// Create our oauthPrompt
+const oauthPrompt = createOAuthPrompt({
+    text: 'Please sign in',
+    title: 'Sign in',
+    connectionName: connectionName,
+});
+
+// Listen for incoming requests 
+server.post('/api/messages', (req, res) => {
+    adapter.processActivity(req, res, async (context) => {
+        const state = convoState.get(context);
+        
+        // Use this command to have the emulator send mocked tokens to the bot rather than authenticating
+        // adapter.emulateOAuthCards(context, true);
+
+        if (context.activity.type === 'conversationUpdate' && context.activity.membersAdded[0].name !== 'Bot') {
+            // Sign the user in using an OAuthCard
+            state.prompt = 'oauth';
+            await oauthPrompt.prompt(context);
+        } else if (context.activity.type === 'message') {
+            // If the user is in an OAuthPrompt, continue it
+            if (state.prompt === 'oauth') {
+                const value = await oauthPrompt.recognize(context);
+                await context.sendActivity("Your token is: " + value.token);
+                state.prompt = undefined;
+            } else {
+                if (context.activity.text === 'signout') {
+                    // Sign the user out
+                    await oauthPrompt.signOutUser(context);
+                    await context.sendActivity("You are now signed out.");
+                } else {
+                    // See if the user is already logged in
+                    const value = await oauthPrompt.getUserToken(context);
+                    if (value) {
+                        await context.sendActivity("You are already signed in with token: " + value.token);
+                    } else {
+                        // sign the user in
+                        state.prompt = 'oauth';
+                        await oauthPrompt.prompt(context);
+                    }
+                }
+            }
+        } else if (context.activity.type === 'event') {
+            // If the user is in an OAuthPrompt, continue it because this is likely the TokenResponse event
+            if (state.prompt === 'oauth') {
+                const value = await oauthPrompt.recognize(context);
+                await context.sendActivity("Your token is: " + value.token);
+                state.prompt = undefined;
+            }
+        }
+    });
+});

--- a/samples/oauth-prompt-bot-es6/package.json
+++ b/samples/oauth-prompt-bot-es6/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "oauth-prompt-bot-es6",
+  "version": "1.0.0",
+  "description": "Bot Builder v4 example showing a simple bot prompting a user with an OAuthCard",
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "author": "Microsoft",
+  "license": "MIT",
+  "dependencies": {
+    "botbuilder": "^4.0.0-preview1.2",
+    "botbuilder-prompts": "^4.0.0-preview1.2",
+    "restify": "^6.3.4"
+  }
+}


### PR DESCRIPTION
Fixing a few issues with OAuthCard support and added two samples:

- Fixed sending credentials on OAuthAPI calls
- Fixed parsing of result objects
- Added support for using 'emulateOAuthCards' with the emulator
- Added sample for using the basic OAuthPrompt
- Added sample for using OAuthPrompt's as part of dialogs