### PR TITLE
Create event types for continue/create #420

### DIFF
--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -131,7 +131,7 @@ export class BotFrameworkAdapter extends BotAdapter {
      * @param logic A function handler that will be called to perform the bots logic after the the adapters middleware has been run.
      */
     public continueConversation(reference: Partial<ConversationReference>, logic: (context: TurnContext) => Promiseable<void>): Promise<void> {
-        const request = TurnContext.applyConversationReference({}, reference, true);
+        const request = TurnContext.applyConversationReference({type: 'event'}, reference, true);
         const context = this.createContext(request);
         return this.runMiddleware(context, logic as any);
     }
@@ -168,7 +168,7 @@ export class BotFrameworkAdapter extends BotAdapter {
             const client = this.createConnectorClient(reference.serviceUrl);
             return client.conversations.createConversation(parameters).then((response) => {
                 // Initialize request and copy over new conversation ID and updated serviceUrl.
-                const request = TurnContext.applyConversationReference({}, reference, true);
+                const request = TurnContext.applyConversationReference({type:'event'}, reference, true);
                 request.conversation = { id: response.id } as ConversationAccount;
                 if (response.serviceUrl) { request.serviceUrl = response.serviceUrl }
 

--- a/libraries/botbuilder/tests/botFrameworkAdapter.test.js
+++ b/libraries/botbuilder/tests/botFrameworkAdapter.test.js
@@ -250,7 +250,7 @@ describe(`BotFrameworkAdapter`, function () {
         adapter.continueConversation(reference, (context) => {
             assert(context, `context not passed.`);
             assert(context.activity, `context has no request.`);
-            assert(context.activity.type === undefined, `request has invalid type.`);
+            assert(context.activity.type === 'event', `request has invalid type.`);
             assert(context.activity.from && context.activity.from.id === reference.user.id, `request has invalid from.id.`);
             assert(context.activity.recipient && context.activity.recipient.id === reference.bot.id, `request has invalid recipient.id.`);
             called = true;


### PR DESCRIPTION
Currently BotFrameworkAdapter.continueConversation() mocks up an activity of type message and BotFrameworkAdapter.createConversation() mocks up an activity of type conversationUpdate. I'd argue that both of these are somewhat dangerous as they can easily trigger unexpected behavior in the bot and it might be safer to mock up an 'event' activity of some sort instead.

The potential issue with message is that it could cause the bot to call a service like LUIS unnecessarily or even worse it could cause a logger to log that the user sent a message with empty text when it was actually the bot initiating the flow.

For conversationUpdate the issue is it could cause a GreetingMiddleware to send an extra greeting to the user which on the surface doesn't sound too bad but what if the bot developer doesn't want this extra greeting? The middleware has no way of telling if the conversationUpdate was generated because the user started a conversation with the bot versus the bot starting the conversation with the user so filtering to only sending a greeting when the user starts the conversation with the bot could be impossible. In fact the GreetingMiddleware could actually intercept the conversationUpdate activity such that the bots logic doesn't event run.

By switching to an event activity that has a name of either continueConversation or createConversation the bots middleware can clearly identify the context in which its being run and there's no accidental running of unexpected behavior. In the GreetingMiddleware case a bot developer can now configure the middleware to respond to just one or even both scenarios since they're still well know activity types.

https://github.com/Microsoft/botbuilder-dotnet/issues/420