### PR TITLE
Fix botbuilder-schema deploy

### DIFF
--- a/libraries/botframework-schema/.gitignore
+++ b/libraries/botframework-schema/.gitignore
@@ -1,6 +1,6 @@
 /**/node_modules
 /**/.vscode
-/**/lib/*
+/**/lib
 #coverage
 **/*/coverage
 **/*/.nyc_output

--- a/libraries/botframework-schema/.gitignore
+++ b/libraries/botframework-schema/.gitignore
@@ -1,6 +1,6 @@
 /**/node_modules
 /**/.vscode
-/**/lib
+/**/lib/*
 #coverage
 **/*/coverage
 **/*/.nyc_output

--- a/libraries/botframework-schema/.npmignore
+++ b/libraries/botframework-schema/.npmignore
@@ -1,0 +1,4 @@
+/**/node_modules
+/**/.vscode
+coverage
+.nyc_output


### PR DESCRIPTION
Publish was not uploading the lib folder for botbuilder-schema because of the .gitignore. Adding the .npmignore overrode and fixed it.