### PR TITLE
Adding OpenIdMetadataEndpoint and OAuthApiEndpoint parameters

### DIFF
--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -12,7 +12,8 @@ import {
     JwtTokenValidation,
     MicrosoftAppCredentials,
     OAuthApiClient,
-    SimpleCredentialProvider
+    SimpleCredentialProvider,
+    ChannelValidation
 } from 'botframework-connector';
 
 import {
@@ -62,6 +63,14 @@ export interface BotFrameworkAdapterSettings {
      * Password assigned to your bot in the [Bot Framework Portal](https://dev.botframework.com/).
      */
     appPassword: string;
+    /**
+     * The OAuth API Endpoint for your bot to use.
+     */
+    oAuthEndpoint?: string;
+    /**
+     * The Open ID Metadata Endpoint for your bot to use.
+     */
+    openIdMetadata?: string;
 }
 
 /**
@@ -123,6 +132,9 @@ export class BotFrameworkAdapter extends BotAdapter {
         this.credentials = new MicrosoftAppCredentials(this.settings.appId, this.settings.appPassword || '');
         this.credentialsProvider = new SimpleCredentialProvider(this.credentials.appId, this.credentials.appPassword);
         this.isEmulatingOAuthCards = false;
+        if (this.settings.openIdMetadata) {
+            ChannelValidation.OpenIdMetadataEndpoint = this.settings.openIdMetadata;
+        }
     }
 
     /**
@@ -634,7 +646,7 @@ export class BotFrameworkAdapter extends BotAdapter {
     protected oauthApiUrl(contextOrServiceUrl: TurnContext|string): string {
         return this.isEmulatingOAuthCards ?
             (typeof contextOrServiceUrl === 'object' ? contextOrServiceUrl.activity.serviceUrl : contextOrServiceUrl) :
-            OAUTH_ENDPOINT;
+            (this.settings.oAuthEndpoint ? this.settings.oAuthEndpoint : OAUTH_ENDPOINT);
     }
 
     /**

--- a/libraries/botbuilder/tests/botFrameworkAdapter.test.js
+++ b/libraries/botbuilder/tests/botFrameworkAdapter.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { TurnContext } = require('botbuilder-core');
+const { ChannelValidation } = require('botframework-connector');
 const { BotFrameworkAdapter } = require('../');
 const os = require('os');
 
@@ -519,6 +520,21 @@ describe(`BotFrameworkAdapter`, function () {
         const pjson = require('../package.json');
         const userAgent = 'Microsoft-BotFramework/3.1 BotBuilder/' + pjson.version + ' (Node.js,Version=' + process.version + '; ' + os.type() + ' ' + os.release() + '; ' + os.arch() + ')';
         assert(userAgentHeader.includes(userAgent), `ConnectorClient doesn't have user-agent header created by BotFrameworkAdapter or header is incorrect.`);
+        done();
+    });
+
+    it(`should set openIdMetadata property on ChannelValidation`, function (done) {
+        const testEndpoint = "http://rainbows.com";
+        const adapter = new BotFrameworkAdapter({openIdMetadata: testEndpoint});
+        assert(testEndpoint === ChannelValidation.OpenIdMetadataEndpoint, `ChannelValidation.OpenIdMetadataEndpoint was not set.`);
+        done();
+    });
+
+    it(`should set oAuthEndpoint property on connector client`, function (done) {
+        const testEndpoint = "http://rainbows.com";
+        const adapter = new BotFrameworkAdapter({oAuthEndpoint: testEndpoint});
+        const url = adapter.oauthApiUrl();
+        assert(testEndpoint === url, `adapter.oauthApiUrl is incorrect.`);
         done();
     });
 });

--- a/libraries/botbuilder/tests/botFrameworkAdapter.test.js
+++ b/libraries/botbuilder/tests/botFrameworkAdapter.test.js
@@ -525,8 +525,10 @@ describe(`BotFrameworkAdapter`, function () {
 
     it(`should set openIdMetadata property on ChannelValidation`, function (done) {
         const testEndpoint = "http://rainbows.com";
+        const original = ChannelValidation.OpenIdMetadataEndpoint;
         const adapter = new BotFrameworkAdapter({openIdMetadata: testEndpoint});
         assert(testEndpoint === ChannelValidation.OpenIdMetadataEndpoint, `ChannelValidation.OpenIdMetadataEndpoint was not set.`);
+        ChannelValidation.OpenIdMetadataEndpoint = original;
         done();
     });
 

--- a/libraries/botframework-connector/src/auth/channelValidation.ts
+++ b/libraries/botframework-connector/src/auth/channelValidation.ts
@@ -13,6 +13,8 @@ import { JwtTokenExtractor } from './jwtTokenExtractor';
 
 export module ChannelValidation {
 
+    export var OpenIdMetadataEndpoint : string = Constants.ToBotFromChannelOpenIdMetadataUrl;
+
     /**
      * TO BOT FROM CHANNEL: Token validation parameters when connecting to a bot
      */
@@ -64,7 +66,7 @@ export module ChannelValidation {
 
         const tokenExtractor: JwtTokenExtractor = new JwtTokenExtractor(
             ToBotFromChannelTokenValidationParameters,
-            Constants.ToBotFromChannelOpenIdMetadataUrl,
+            OpenIdMetadataEndpoint,
             Constants.AllowedSigningAlgorithms);
 
         const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(authHeader, channelId);


### PR DESCRIPTION
These were part of the v3 SDK and so adding them to V4.

The parameters are optional properties on the BotFrameworkAdapterSettings class. If they are not set, the default, constant values are used.

oAuthEndpoint - the endpoint to use for the OAuth API calls

openIdMetadata - the endpoint to use to get open id metadata

