### PR TITLE
Support for 'channelService' property

### DIFF
--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -71,6 +71,10 @@ export interface BotFrameworkAdapterSettings {
      * The Open ID Metadata Endpoint for your bot to use.
      */
     openIdMetadata?: string;
+    /**
+     * The optional channel service option for this bot to validate connections from Azure or other channel locations
+     */
+    channelService?: string;
 }
 
 /**
@@ -614,7 +618,8 @@ export class BotFrameworkAdapter extends BotAdapter {
     protected authenticateRequest(request: Partial<Activity>, authHeader: string): Promise<void> {
         return JwtTokenValidation.authenticateRequest(
             request as Activity, authHeader,
-            this.credentialsProvider
+            this.credentialsProvider,
+            this.settings.channelService
         ).then((claims: ClaimsIdentity) => {
             if (!claims.isAuthenticated) { throw new Error('Unauthorized Access. Request is not authorized'); }
         });

--- a/libraries/botframework-connector/src/auth/channelValidation.ts
+++ b/libraries/botframework-connector/src/auth/channelValidation.ts
@@ -97,7 +97,7 @@ export module ChannelValidation {
         // Look for the "aud" claim, but only if issued from the Bot Framework
         if (identity.getClaimValue(Constants.IssuerClaim) !== Constants.ToBotFromChannelTokenIssuer) {
             // The relevant Audiance Claim MUST be present. Not Authorized.
-            throw new Error('Unauthorized. Audiance Claim MUST be present.');
+            throw new Error('Unauthorized. Issuer Claim MUST be present.');
         }
 
         // The AppId from the claim in the token must match the AppId specified by the developer.

--- a/libraries/botframework-connector/src/auth/claimsIdentity.ts
+++ b/libraries/botframework-connector/src/auth/claimsIdentity.ts
@@ -22,7 +22,7 @@ export class ClaimsIdentity {
 
     constructor(claims: Claim[], isAuthenticated: boolean) {
         this.claims = claims;
-        this.isAuthenticated = true;
+        this.isAuthenticated = isAuthenticated;
     }
 
     /**

--- a/libraries/botframework-connector/src/auth/constants.ts
+++ b/libraries/botframework-connector/src/auth/constants.ts
@@ -27,6 +27,11 @@ export module Constants {
     export const ToBotFromChannelOpenIdMetadataUrl: string = 'https://login.botframework.com/v1/.well-known/openidconfiguration';
 
     /**
+     * TO BOT FROM ENTERPRISE CHANNEL: OpenID metadata document for tokens coming from MSA
+     */
+    export const ToBotFromEnterpriseChannelOpenIdMetadataUrlFormat = 'https://{channelService}.enterprisechannel.botframework.com/v1/.well-known/openidconfiguration';
+
+    /**
      * TO BOT FROM EMULATOR: OpenID metadata document for tokens coming from MSA
      */
     export const ToBotFromEmulatorOpenIdMetadataUrl: string =

--- a/libraries/botframework-connector/src/auth/enterpriseChannelValidation.ts
+++ b/libraries/botframework-connector/src/auth/enterpriseChannelValidation.ts
@@ -106,7 +106,7 @@ export module EnterpriseChannelValidation {
         // Look for the "aud" claim, but only if issued from the Bot Framework
         if (identity.getClaimValue(Constants.IssuerClaim) !== Constants.ToBotFromChannelTokenIssuer) {
             // The relevant Audiance Claim MUST be present. Not Authorized.
-            throw new Error('Unauthorized. Audiance Claim MUST be present.');
+            throw new Error('Unauthorized. Issuer Claim MUST be present.');
         }
 
         // The AppId from the claim in the token must match the AppId specified by the developer.

--- a/libraries/botframework-connector/src/auth/governmentChannelValidation.ts
+++ b/libraries/botframework-connector/src/auth/governmentChannelValidation.ts
@@ -8,18 +8,18 @@
 import { VerifyOptions } from 'jsonwebtoken';
 import { ClaimsIdentity } from './claimsIdentity';
 import { Constants } from './constants';
+import { GovernmentConstants } from './governmentConstants';
+import { ChannelValidation } from './channelValidation';
 import { ICredentialProvider } from './credentialProvider';
 import { JwtTokenExtractor } from './jwtTokenExtractor';
 
-export module ChannelValidation {
-
-    export var OpenIdMetadataEndpoint : string = undefined;
+export module GovernmentChannelValidation {
 
     /**
-     * TO BOT FROM CHANNEL: Token validation parameters when connecting to a bot
+     * TO BOT FROM GOVERNMENT CHANNEL: Token validation parameters when connecting to a bot
      */
-    export const ToBotFromChannelTokenValidationParameters: VerifyOptions = {
-        issuer: [Constants.ToBotFromChannelTokenIssuer],
+    export const ToBotFromGovernmentChannelTokenValidationParameters: VerifyOptions = {
+        issuer: [GovernmentConstants.ToBotFromChannelTokenIssuer],
         audience: undefined,                                 // Audience validation takes place manually in code.
         clockTolerance: 5 * 60,
         ignoreExpiration: false
@@ -65,16 +65,16 @@ export module ChannelValidation {
     ): Promise<ClaimsIdentity> {
 
         const tokenExtractor: JwtTokenExtractor = new JwtTokenExtractor(
-            ToBotFromChannelTokenValidationParameters,
-            OpenIdMetadataEndpoint ? OpenIdMetadataEndpoint : Constants.ToBotFromChannelOpenIdMetadataUrl,
+            ToBotFromGovernmentChannelTokenValidationParameters,
+            ChannelValidation.OpenIdMetadataEndpoint ? ChannelValidation.OpenIdMetadataEndpoint : GovernmentConstants.ToBotFromChannelOpenIdMetadataUrl,
             Constants.AllowedSigningAlgorithms);
 
         const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(authHeader, channelId);
-        
+
         return await validateIdentity(identity, credentials);
     }
 
-    /**
+     /**
      * Validate the ClaimsIdentity to ensure it came from the channel service.
      * @param  {ClaimsIdentity} identity The identity to validate
      * @param  {ICredentialProvider} credentials The user defined set of valid credentials, such as the AppId.
@@ -82,8 +82,13 @@ export module ChannelValidation {
      */
     export async function validateIdentity(
         identity: ClaimsIdentity,
-        credentials: ICredentialProvider
+        credentials: ICredentialProvider,
     ): Promise<ClaimsIdentity> {
+        if (!identity) {
+            // No valid identity. Not Authorized.
+            throw new Error('Unauthorized. No valid identity.');
+        }
+
         if (!identity.isAuthenticated) {
             // The token is in some way invalid. Not Authorized.
             throw new Error('Unauthorized. Is not authenticated');
@@ -95,7 +100,7 @@ export module ChannelValidation {
         // Async validation.
 
         // Look for the "aud" claim, but only if issued from the Bot Framework
-        if (identity.getClaimValue(Constants.IssuerClaim) !== Constants.ToBotFromChannelTokenIssuer) {
+        if (identity.getClaimValue(Constants.IssuerClaim) !== GovernmentConstants.ToBotFromChannelTokenIssuer) {
             // The relevant Audiance Claim MUST be present. Not Authorized.
             throw new Error('Unauthorized. Audiance Claim MUST be present.');
         }

--- a/libraries/botframework-connector/src/auth/governmentChannelValidation.ts
+++ b/libraries/botframework-connector/src/auth/governmentChannelValidation.ts
@@ -102,7 +102,7 @@ export module GovernmentChannelValidation {
         // Look for the "aud" claim, but only if issued from the Bot Framework
         if (identity.getClaimValue(Constants.IssuerClaim) !== GovernmentConstants.ToBotFromChannelTokenIssuer) {
             // The relevant Audiance Claim MUST be present. Not Authorized.
-            throw new Error('Unauthorized. Audiance Claim MUST be present.');
+            throw new Error('Unauthorized. Issuer Claim MUST be present.');
         }
 
         // The AppId from the claim in the token must match the AppId specified by the developer.

--- a/libraries/botframework-connector/src/auth/governmentConstants.ts
+++ b/libraries/botframework-connector/src/auth/governmentConstants.ts
@@ -1,0 +1,33 @@
+/**
+ * @module botbuilder
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+export module GovernmentConstants {
+    /**
+     * Government Channel Service property value
+     */
+    export const ChannelService: string = 'https://botframework.us';
+
+    /**
+     * TO CHANNEL FROM BOT: Login URL
+     */
+    export const ToChannelFromBotLoginUrl: string = 'https://login.microsoftonline.us/botframework.com/oauth2/v2.0/token';
+
+    /**
+     * TO CHANNEL FROM BOT: OAuth scope to request
+     */
+    export const ToChannelFromBotOAuthScope: string = 'https://api.botframework.us/.default';
+
+    /**
+     * TO BOT FROM CHANNEL: Token issuer
+     */
+    export const ToBotFromChannelTokenIssuer : string = 'https://api.botframework.us';
+
+    /**
+     * TO BOT FROM CHANNEL: OpenID metadata document for tokens coming from MSA
+     */
+    export const ToBotFromChannelOpenIdMetadataUrl: string = 'https://login.botframework.us/v1/.well-known/openidconfiguration';
+}

--- a/libraries/botframework-connector/src/auth/index.ts
+++ b/libraries/botframework-connector/src/auth/index.ts
@@ -9,6 +9,8 @@ export * from './credentialProvider';
 export * from './microsoftAppCredentials';
 export * from './jwtTokenValidation';
 export * from './channelValidation';
+export * from './governmentChannelValidation';
+export * from './enterpriseChannelValidation';
 export * from './emulatorValidation';
 export * from './endorsementsValidator';
 export * from './claimsIdentity';

--- a/libraries/botframework-connector/tests/auth.test.js
+++ b/libraries/botframework-connector/tests/auth.test.js
@@ -218,5 +218,230 @@ describe('Bot Framework Connector - Auth Tests', function () {
                 done();
             });
         });
+
+        describe('ChannelValidator', function () {
+            it('validateIdentity should fail if unauthenticated', function(done) {
+                Connector.ChannelValidation.validateIdentity(new Connector.ClaimsIdentity([], false), undefined)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+
+            it('validateIdentity should fail if no identity', function(done) {
+                Connector.ChannelValidation.validateIdentity(undefined, undefined)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+            
+            it('validateIdentity should fail if no issuer', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.ChannelValidation.validateIdentity(new Connector.ClaimsIdentity([{type: 'peanut', value: 'peanut'}], true), credentials)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+
+            it('validateIdentity should fail if wrong issuer', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.ChannelValidation.validateIdentity(new Connector.ClaimsIdentity([{type: 'iss', value: 'peanut'}], true), credentials)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+
+            it('validateIdentity should fail if no audience', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.ChannelValidation.validateIdentity(new Connector.ClaimsIdentity([{type: 'iss', value: 'https://api.botframework.com'}], true), credentials)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+            
+            it('validateIdentity should fail if wrong audience', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.ChannelValidation.validateIdentity(new Connector.ClaimsIdentity([
+                    {type: 'iss', value: 'https://api.botframework.com'},
+                    {type: 'aud', value: 'peanut'}
+                ], true), credentials)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+
+            it('validateIdentity should work', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.ChannelValidation.validateIdentity(new Connector.ClaimsIdentity([
+                    {type: 'iss', value: 'https://api.botframework.com'},
+                    {type: 'aud', value: credentials.appId}
+                ], true), credentials)
+                    .then(identity => done())
+                    .catch(err => {
+                        done(new Error('Should have validated successfully'));
+                    });
+            });
+        });
+
+        describe('GovernmentChannelValidator', function () {
+            it('validateIdentity should fail if unauthenticated', function(done) {
+                Connector.GovernmentChannelValidation.validateIdentity(new Connector.ClaimsIdentity([], false), undefined)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+
+            it('validateIdentity should fail if no identity', function(done) {
+                Connector.GovernmentChannelValidation.validateIdentity(undefined, undefined)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+            
+            it('validateIdentity should fail if no issuer', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.GovernmentChannelValidation.validateIdentity(new Connector.ClaimsIdentity([{type: 'peanut', value: 'peanut'}], true), credentials)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+
+            it('validateIdentity should fail if wrong issuer', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.GovernmentChannelValidation.validateIdentity(new Connector.ClaimsIdentity([{type: 'iss', value: 'peanut'}], true), credentials)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+
+            it('validateIdentity should fail if no audience', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.GovernmentChannelValidation.validateIdentity(new Connector.ClaimsIdentity([{type: 'iss', value: 'https://api.botframework.us'}], true), credentials)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+            
+            it('validateIdentity should fail if wrong audience', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.GovernmentChannelValidation.validateIdentity(new Connector.ClaimsIdentity([
+                    {type: 'iss', value: 'https://api.botframework.us'},
+                    {type: 'aud', value: 'peanut'}
+                ], true), credentials)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+
+            it('validateIdentity should work', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.GovernmentChannelValidation.validateIdentity(new Connector.ClaimsIdentity([
+                    {type: 'iss', value: 'https://api.botframework.us'},
+                    {type: 'aud', value: credentials.appId}
+                ], true), credentials)
+                    .then(identity => done())
+                    .catch(err => {
+                        done(new Error('Should have validated successfully'));
+                    });
+            });
+        });
+
+        describe('EnterpriseChannelValidator', function () {
+            it('validateIdentity should fail if unauthenticated', function(done) {
+                Connector.EnterpriseChannelValidation.validateIdentity(new Connector.ClaimsIdentity([], false), undefined)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+
+            it('validateIdentity should fail if no identity', function(done) {
+                Connector.EnterpriseChannelValidation.validateIdentity(undefined, undefined)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+            
+            it('validateIdentity should fail if no issuer', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.EnterpriseChannelValidation.validateIdentity(new Connector.ClaimsIdentity([{type: 'peanut', value: 'peanut'}], true), credentials)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+
+            it('validateIdentity should fail if wrong issuer', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.EnterpriseChannelValidation.validateIdentity(new Connector.ClaimsIdentity([{type: 'iss', value: 'peanut'}], true), credentials)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+
+            it('validateIdentity should fail if no audience', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.EnterpriseChannelValidation.validateIdentity(new Connector.ClaimsIdentity([{type: 'iss', value: 'https://api.botframework.com'}], true), credentials)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+            
+            it('validateIdentity should fail if wrong audience', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.EnterpriseChannelValidation.validateIdentity(new Connector.ClaimsIdentity([
+                    {type: 'iss', value: 'https://api.botframework.com'},
+                    {type: 'aud', value: 'peanut'}
+                ], true), credentials)
+                    .then(claims => done(new Error('Expected validation to fail.')))
+                    .catch(err => {
+                        assert(!!err);
+                        done();
+                    });
+            });
+
+            it('validateIdentity should work', function(done) {
+                var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '2.30Vs3VQLKt974F');
+                Connector.EnterpriseChannelValidation.validateIdentity(new Connector.ClaimsIdentity([
+                    {type: 'iss', value: 'https://api.botframework.com'},
+                    {type: 'aud', value: credentials.appId}
+                ], true), credentials)
+                    .then(identity => done())
+                    .catch(err => {
+                        done(new Error('Should have validated successfully'));
+                    });
+            });
+        });
     });
 });

--- a/libraries/botframework-connector/tests/auth.test.js
+++ b/libraries/botframework-connector/tests/auth.test.js
@@ -11,7 +11,7 @@ describe('Bot Framework Connector - Auth Tests', function () {
                 Connector.ChannelValidation.ToBotFromChannelTokenValidationParameters.ignoreExpiration = true;
                 var header = 'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IkdDeEFyWG9OOFNxbzdQd2VBNy16NjVkZW5KUSIsIng1dCI6IkdDeEFyWG9OOFNxbzdQd2VBNy16NjVkZW5KUSJ9.eyJzZXJ2aWNldXJsIjoiaHR0cHM6Ly93ZWJjaGF0LmJvdGZyYW1ld29yay5jb20vIiwiaXNzIjoiaHR0cHM6Ly9hcGkuYm90ZnJhbWV3b3JrLmNvbSIsImF1ZCI6IjM5NjE5YTU5LTVhMGMtNGY5Yi04N2M1LTgxNmM2NDhmZjM1NyIsImV4cCI6MTUxNjczNzUyMCwibmJmIjoxNTE2NzM2OTIwfQ.TBgpxbDS-gx1wm7ldvl7To-igfskccNhp-rU1mxUMtGaDjnsU--usH4OXZfzRsZqMlnXWXug_Hgd_qOr5RH8wVlnXnMWewoZTSGZrfp8GOd7jHF13Gz3F1GCl8akc3jeK0Ppc8R_uInpuUKa0SopY0lwpDclCmvDlz4PN6yahHkt_666k-9UGmRt0DDkxuYjbuYG8EDZxyyAhr7J6sFh3yE2UGRpJjRDB4wXWqv08Cp0Gn9PAW2NxOyN8irFzZH5_YZqE3DXDAYZ_IOLpygXQR0O-bFIhLDVxSz6uCeTBRjh8GU7XJ_yNiRDoaby7Rd2IfRrSnvMkBRsB8MsWN8oXg';
                 var credentials = new Connector.SimpleCredentialProvider('39619a59-5a0c-4f9b-87c5-816c648ff357', '');
-                Connector.JwtTokenValidation.validateAuthHeader(header, credentials, 'webchat', 'https://webchat.botframework.com/')
+                Connector.JwtTokenValidation.validateAuthHeader(header, credentials, undefined, 'webchat', 'https://webchat.botframework.com/')
                     .then(claims => {
                         assert(claims.isAuthenticated);
                         assert.notEqual(claims.claims.length, 0);
@@ -27,7 +27,7 @@ describe('Bot Framework Connector - Auth Tests', function () {
                 Connector.ChannelValidation.ToBotFromChannelTokenValidationParameters.ignoreExpiration = true;
                 var header = 'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IkdDeEFyWG9OOFNxbzdQd2VBNy16NjVkZW5KUSIsIng1dCI6IkdDeEFyWG9OOFNxbzdQd2VBNy16NjVkZW5KUSJ9.eyJzZXJ2aWNldXJsIjoiaHR0cHM6Ly93ZWJjaGF0LmJvdGZyYW1ld29yay5jb20vIiwiaXNzIjoiaHR0cHM6Ly9hcGkuYm90ZnJhbWV3b3JrLmNvbSIsImF1ZCI6IjM5NjE5YTU5LTVhMGMtNGY5Yi04N2M1LTgxNmM2NDhmZjM1NyIsImV4cCI6MTUxNjczNzUyMCwibmJmIjoxNTE2NzM2OTIwfQ.TBgpxbDS-gx1wm7ldvl7To-igfskccNhp-rU1mxUMtGaDjnsU--usH4OXZfzRsZqMlnXWXug_Hgd_qOr5RH8wVlnXnMWewoZTSGZrfp8GOd7jHF13Gz3F1GCl8akc3jeK0Ppc8R_uInpuUKa0SopY0lwpDclCmvDlz4PN6yahHkt_666k-9UGmRt0DDkxuYjbuYG8EDZxyyAhr7J6sFh3yE2UGRpJjRDB4wXWqv08Cp0Gn9PAW2NxOyN8irFzZH5_YZqE3DXDAYZ_IOLpygXQR0O-bFIhLDVxSz6uCeTBRjh8GU7XJ_yNiRDoaby7Rd2IfRrSnvMkBRsB8MsWN8oXg';
                 var credentials = new Connector.SimpleCredentialProvider('39619a59-5a0c-4f9b-87c5-816c648ff357', '');
-                Connector.JwtTokenValidation.validateAuthHeader(header, credentials, 'foo', 'https://webchat.botframework.com/')
+                Connector.JwtTokenValidation.validateAuthHeader(header, credentials, undefined, 'foo', 'https://webchat.botframework.com/')
                     .then(claims => done(new Error('Expected validation to fail.')))
                     .catch(err => done())
                     .then(() => {
@@ -40,7 +40,7 @@ describe('Bot Framework Connector - Auth Tests', function () {
                 tokenGenerator.getToken(true).then(token => {
                     var header = `Bearer ${token}`;
                     var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '');
-                    Connector.JwtTokenValidation.validateAuthHeader(header, credentials, '', 'https://webchat.botframework.com/')
+                    Connector.JwtTokenValidation.validateAuthHeader(header, credentials, undefined, '', 'https://webchat.botframework.com/')
                         .then(claims => {
                             assert(claims.isAuthenticated);
                             assert.notEqual(claims.claims.length, 0);
@@ -55,7 +55,7 @@ describe('Bot Framework Connector - Auth Tests', function () {
                 tokenGenerator.getToken(true).then(token => {
                     var header = `Bearer ${token}`;
                     var credentials = new Connector.SimpleCredentialProvider('00000000-0000-0000-0000-000000000000', '');
-                    Connector.JwtTokenValidation.validateAuthHeader(header, credentials, '', '')
+                    Connector.JwtTokenValidation.validateAuthHeader(header, credentials, undefined, '', '')
                         .then(claims => done(new Error('Expected validation to fail.')))
                         .catch(err => {
                             assert(!!err);
@@ -69,7 +69,7 @@ describe('Bot Framework Connector - Auth Tests', function () {
                 tokenGenerator.getToken(true).then(token => {
                     var header = `Bearer ${token}`;
                     var credentials = new Connector.SimpleCredentialProvider('', '');
-                    Connector.JwtTokenValidation.validateAuthHeader(header, credentials, '', '')
+                    Connector.JwtTokenValidation.validateAuthHeader(header, credentials, undefined, '', '')
                         .then(claims => done(new Error('Expected validation to fail.')))
                         .catch(err => {
                             assert(!!err);
@@ -83,7 +83,7 @@ describe('Bot Framework Connector - Auth Tests', function () {
 
             it('Bot with noCredentials should throw', function(done) {
                 var credentials = new Connector.SimpleCredentialProvider('', '');
-                Connector.JwtTokenValidation.validateAuthHeader('', credentials, '', '')
+                Connector.JwtTokenValidation.validateAuthHeader('', credentials, undefined, '', '')
                     .then(claims => done(new Error('Expected validation to fail.')))
                     .catch(err => {
                         assert(!!err);
@@ -99,7 +99,7 @@ describe('Bot Framework Connector - Auth Tests', function () {
                 tokenGenerator.getToken(true).then(token => {
                     var header = `Bearer ${token}`;
                     var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '');
-                    Connector.JwtTokenValidation.validateAuthHeader(header, credentials, '', '')
+                    Connector.JwtTokenValidation.validateAuthHeader(header, credentials, undefined, '', '')
                         .then(claims => {
                             assert(claims.isAuthenticated);
                             done();
@@ -113,7 +113,7 @@ describe('Bot Framework Connector - Auth Tests', function () {
                 tokenGenerator.getToken(true).then(token => {
                     var header = `Bearer ${token}`;
                     var credentials = new Connector.SimpleCredentialProvider('00000000-0000-0000-0000-000000000000', '');
-                    Connector.JwtTokenValidation.validateAuthHeader(header, credentials, '', '')
+                    Connector.JwtTokenValidation.validateAuthHeader(header, credentials, undefined, '', '')
                         .then(claims => done(new Error('Expected validation to fail.')))
                         .catch(err => {
                             assert(!!err);
@@ -130,7 +130,7 @@ describe('Bot Framework Connector - Auth Tests', function () {
                 tokenGenerator.getToken(true).then(token => {
                     var header = `Bearer ${token}`;
                     var credentials = new Connector.SimpleCredentialProvider('2cd87869-38a0-4182-9251-d056e8f0ac24', '');
-                    Connector.JwtTokenValidation.authenticateRequest({ serviceUrl: 'https://smba.trafficmanager.net/amer-client-ss.msg/' }, header, credentials)
+                    Connector.JwtTokenValidation.authenticateRequest({ serviceUrl: 'https://smba.trafficmanager.net/amer-client-ss.msg/' }, header, credentials, undefined)
                         .then(claims => {
                             assert(Connector.MicrosoftAppCredentials.isTrustedServiceUrl('https://smba.trafficmanager.net/amer-client-ss.msg/'))
                             done();
@@ -144,7 +144,7 @@ describe('Bot Framework Connector - Auth Tests', function () {
                 tokenGenerator.getToken(true).then(token => {
                     var header = `Bearer ${token}`;
                     var credentials = new Connector.SimpleCredentialProvider('7f74513e-6f96-4dbc-be9d-9a81fea22b88', '');
-                    Connector.JwtTokenValidation.authenticateRequest({ serviceUrl: 'https://webchat.botframework.com/' }, header, credentials)
+                    Connector.JwtTokenValidation.authenticateRequest({ serviceUrl: 'https://webchat.botframework.com/' }, header, credentials, undefined)
                         .then(claims => done(new Error('Expected validation to fail.')))
                         .catch(err => {
                             assert(!Connector.MicrosoftAppCredentials.isTrustedServiceUrl('https://webchat.botframework.com/'))
@@ -155,7 +155,7 @@ describe('Bot Framework Connector - Auth Tests', function () {
     
             it('with AuthenticationDisabled should be anonymous', function(done) {
                 var credentials = new Connector.SimpleCredentialProvider('', '');
-                Connector.JwtTokenValidation.authenticateRequest({ serviceUrl: 'https://webchat.botframework.com/' }, '', credentials)
+                Connector.JwtTokenValidation.authenticateRequest({ serviceUrl: 'https://webchat.botframework.com/' }, '', credentials, undefined)
                     .then(claims => {
                         assert(claims.isAuthenticated);
                         assert.equal(claims.claims.length, 0);
@@ -166,7 +166,7 @@ describe('Bot Framework Connector - Auth Tests', function () {
     
             it('with authentication disabled and serviceUrl should not be trusted', function(done) {
                 var credentials = new Connector.SimpleCredentialProvider('', '');
-                Connector.JwtTokenValidation.authenticateRequest({ serviceUrl: 'https://webchat.botframework.com/' }, '', credentials)
+                Connector.JwtTokenValidation.authenticateRequest({ serviceUrl: 'https://webchat.botframework.com/' }, '', credentials, undefined)
                     .then(claims => {
                         assert(claims.isAuthenticated);
                         assert(!Connector.MicrosoftAppCredentials.isTrustedServiceUrl('https://webchat.botframework.com/'));


### PR DESCRIPTION
This supports bots built for Gov and custom channels.

Changes include:
1. New channel validators for Azure Government data centers (.us) and custom channels (called enterprise channels).
2. New constants for gov