### PR TITLE
fix onTurnError and add unit test for onTurnError

### DIFF
--- a/libraries/botbuilder-core/src/botAdapter.ts
+++ b/libraries/botbuilder-core/src/botAdapter.ts
@@ -7,7 +7,7 @@
  */
 import { Activity, ConversationReference, ResourceResponse } from 'botframework-schema';
 import { makeRevocable } from './internal';
-import {  Middleware, MiddlewareHandler, MiddlewareSet } from './middlewareSet';
+import { Middleware, MiddlewareHandler, MiddlewareSet } from './middlewareSet';
 import { TurnContext } from './turnContext';
 
 /**
@@ -55,7 +55,7 @@ export abstract class BotAdapter {
     }
 
     public set onTurnError(value: (context: TurnContext, error: Error) => Promise<void>) {
-        this.onTurnError = value;
+        this.turnError = value;
     }
 
     /**

--- a/libraries/botbuilder-core/tests/botAdapter.test.js
+++ b/libraries/botbuilder-core/tests/botAdapter.test.js
@@ -8,7 +8,9 @@ class SimpleAdapter extends BotAdapter {
         const context = new TurnContext(this, activity);
         return this.runMiddleware(context, handler);
     }
+
 }
+
 
 describe(`BotAdapter`, function () {
     this.timeout(5000);
@@ -22,6 +24,10 @@ describe(`BotAdapter`, function () {
     }
 
     const adapter = new SimpleAdapter();
+    adapter.onTurnError = async (turnContext, error) => {
+        assert.equal(error.message, 'uhoh');
+    };
+    
     it(`should use() middleware individually.`, function (done) {
         adapter.use(middleware).use(middleware);
         done();
@@ -38,4 +44,12 @@ describe(`BotAdapter`, function () {
             assert(calls === 5, `only "${calls} of 5" middleware called.`);
         }).then(() => done());
     });
+
+    it(`onError should be called on exceptions when derived.`, function (done) {
+        adapter.processRequest(testMessage, (context) => {
+            throw new Error('uhoh');
+        })
+        .then(() => done());
+    });
+
 });


### PR DESCRIPTION
the property accessor function was called onTurnError, and the inner field was turnError.
The accessor was trying to replace itself instead of setting the inner field