### PR TITLE
Add .editorConfig. This file is taken from the VSCode repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: http://EditorConfig.org
+# File take from the VSCode repo at:
+# https://github.com/Microsoft/vscode/blob/master/.editorconfig
+
+# top-most EditorConfig file
+root = true
+
+# Tab indentation
+[*]
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+
+# The indent size used in the `package.json` file cannot be changed
+# https://github.com/npm/npm/pull/3180#issuecomment-16336516
+[{*.yml,*.yaml,package.json}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Added in a default .editorConfig file to standardize settings such as tabs. 

The file here is taken directly from the VSCode repo. 