### PR TITLE
make encrypt()/decrypt() do nothing with null or empty values

### DIFF
--- a/libraries/botframework-config/package-lock.json
+++ b/libraries/botframework-config/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-config",
-  "version": "4.0.0-preview1.3.4",
+  "version": "4.0.0-preview1.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/libraries/botframework-config/package.json
+++ b/libraries/botframework-config/package.json
@@ -2,7 +2,7 @@
   "name": "botframework-config",
   "author": "Microsoft Corp.",
   "description": "library for working with Bot Framework .bot configuration files",
-  "version": "4.0.0-preview1.3.4",
+  "version": "4.0.0-preview1.3.5",
   "license": "MIT",
   "keywords": [
     "bots",

--- a/libraries/botframework-config/src/encrypt.ts
+++ b/libraries/botframework-config/src/encrypt.ts
@@ -18,10 +18,10 @@ export function generateKey(): string {
  */
 export function encryptString(plainText: string, secret: string): string {
     if (!plainText || plainText.length === 0) {
-        throw new Error('you must pass a value');
+        return plainText;
     }
 
-    if (!secret || plainText.length === 0) {
+    if (!secret || secret.length === 0) {
         throw new Error('you must pass a secret');
     }
 
@@ -48,7 +48,7 @@ export function encryptString(plainText: string, secret: string): string {
  */
 export function decryptString(encryptedValue: string, secret: string): string {
     if (!encryptedValue || encryptedValue.length === 0) {
-        throw new Error('you must pass a encryptedValue');
+        return encryptedValue;
     }
 
     if (!secret || secret.length === 0) {

--- a/libraries/botframework-config/tests/encryption.test.js
+++ b/libraries/botframework-config/tests/encryption.test.js
@@ -12,6 +12,36 @@ describe("EncryptionTests", () => {
         assert.ok(value === decrypted, "decryption failed");
     });
 
+    it("EncryptDecryptEmptyDoesNothing", () => {
+        let secret = "lgCbJPXnfOlatjbBDKMbh0ie6bc8PD/cjqA/2tPgMS0=";
+        let value = "";
+        let encrypted = encrypt.encryptString(value, secret);
+        assert.ok(value == encrypted, "encryption failed");
+
+        let decrypted = encrypt.decryptString(encrypted, secret);
+        assert.ok(value === decrypted, "decryption failed");
+    });
+
+    it("EncryptDecryptNullDoesNothing", () => {
+        let secret = "lgCbJPXnfOlatjbBDKMbh0ie6bc8PD/cjqA/2tPgMS0=";
+        let value = null;
+        let encrypted = encrypt.encryptString(value, secret);
+        assert.ok(value == encrypted, "encryption failed");
+
+        let decrypted = encrypt.decryptString(encrypted, secret);
+        assert.ok(value === decrypted, "decryption failed");
+    });
+
+    it("EncryptDecryptUndefinedDoesNothing", () => {
+        let secret = "lgCbJPXnfOlatjbBDKMbh0ie6bc8PD/cjqA/2tPgMS0=";
+        let value = undefined;
+        let encrypted = encrypt.encryptString(value, secret);
+        assert.ok(value == encrypted, "encryption failed");
+
+        let decrypted = encrypt.decryptString(encrypted, secret);
+        assert.ok(value === decrypted, "decryption failed");
+    });
+
     it("GenerateKeyWorks", () => {
         let secret = encrypt.generateKey();
         let value = "1234567890";


### PR DESCRIPTION
recipes can end up with empty strings which our encrypt routines blow up on. 
fix for https://github.com/Microsoft/botbuilder-tools/issues/510
