### PR TITLE
Update recognizer dependencies to latest version

### DIFF
--- a/libraries/botbuilder-ai/package-lock.json
+++ b/libraries/botbuilder-ai/package-lock.json
@@ -5,91 +5,85 @@
 	"requires": true,
 	"dependencies": {
 		"@microsoft/recognizers-text": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text/-/recognizers-text-1.0.1.tgz",
-			"integrity": "sha512-BZbI6YiLrWRd/jAYgSpLQ+Otl3WYMctefh7Myw6jqMdHhADaj5WpwOdf+yfJHZHOJWQh7lK2v50R6Y0g3TJ18w=="
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text/-/@microsoft/recognizers-text-1.1.2.tgz",
+			"integrity": "sha1-lh0dT2PfnDTLlcWNWo/3JDdlF9A="
 		},
 		"@microsoft/recognizers-text-date-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-date-time/-/recognizers-text-date-time-1.0.1.tgz",
-			"integrity": "sha512-Tb8j+nDYSMe65pQhXh7hlm8uibfqliwbsUx6MY3g6ZlZnTzhq9cnzHYY1LILkJqlY5QtaGlUXr4BvW+a4SD8ew==",
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-date-time/-/@microsoft/recognizers-text-date-time-1.1.2.tgz",
+			"integrity": "sha1-pV+UhW5iHKfjkBWMkWym0z5YiPA=",
 			"requires": {
-				"@microsoft/recognizers-text": "1.0.1",
-				"@microsoft/recognizers-text-number": "1.0.1",
-				"@microsoft/recognizers-text-number-with-unit": "1.0.1",
-				"lodash.isequal": "4.5.0",
-				"lodash.tonumber": "4.0.3"
+				"@microsoft/recognizers-text": "~1.1.2",
+				"@microsoft/recognizers-text-number": "~1.1.2",
+				"@microsoft/recognizers-text-number-with-unit": "~1.1.2",
+				"lodash.isequal": "^4.5.0",
+				"lodash.tonumber": "^4.0.3"
 			}
 		},
 		"@microsoft/recognizers-text-number": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number/-/recognizers-text-number-1.0.1.tgz",
-			"integrity": "sha512-eMhzRfWmzGaGdeBi+1vTtJ6AtTqhHNetJ+Rdt6isiv+R3+i18bzR2YzIOzIdHRhnApf0mbJG3wMEbWdWQBhvyg==",
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-number/-/@microsoft/recognizers-text-number-1.1.2.tgz",
+			"integrity": "sha1-tydc9UC6AY4CJcXV4H7AsENSZ+w=",
 			"requires": {
-				"@microsoft/recognizers-text": "1.0.1",
-				"bignumber.js": "4.1.0",
-				"lodash.escaperegexp": "4.1.2",
-				"lodash.sortby": "4.7.0",
-				"lodash.trimend": "4.5.1",
-				"xregexp": "3.2.0"
+				"@microsoft/recognizers-text": "~1.1.2",
+				"bignumber.js": "^7.2.1",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.sortby": "^4.7.0",
+				"lodash.trimend": "^4.5.1"
 			}
 		},
 		"@microsoft/recognizers-text-number-with-unit": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number-with-unit/-/recognizers-text-number-with-unit-1.0.1.tgz",
-			"integrity": "sha512-g4Tum3sxkbeI52eYQX+h8t97Ww1TJi6M+bIpjB4/go7trmq/w005oFxnARmrJQNMQUukEHeQ0GGqR/uMe75SzA==",
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-number-with-unit/-/@microsoft/recognizers-text-number-with-unit-1.1.2.tgz",
+			"integrity": "sha1-P69wBKq4QuKWI2cVad7WZyg7s74=",
 			"requires": {
-				"@microsoft/recognizers-text": "1.0.1",
-				"@microsoft/recognizers-text-number": "1.0.1",
-				"lodash.escaperegexp": "4.1.2",
-				"lodash.last": "3.0.0",
-				"lodash.max": "4.0.1"
+				"@microsoft/recognizers-text": "~1.1.2",
+				"@microsoft/recognizers-text-number": "~1.1.2",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.last": "^3.0.0",
+				"lodash.max": "^4.0.1"
 			}
 		},
 		"bignumber.js": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-			"integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
+			"version": "7.2.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/bignumber.js/-/bignumber.js-7.2.1.tgz",
+			"integrity": "sha1-gMBIdZ2CaACAfEv9Uh5Q7bulel8="
 		},
 		"lodash.escaperegexp": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
 			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
 		"lodash.last": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.last/-/lodash.last-3.0.0.tgz",
 			"integrity": "sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw="
 		},
 		"lodash.max": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.max/-/lodash.max-4.0.1.tgz",
 			"integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
 		"lodash.tonumber": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
 			"integrity": "sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="
 		},
 		"lodash.trimend": {
 			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
 			"integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
-		},
-		"xregexp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.2.0.tgz",
-			"integrity": "sha1-yzYBmHv+JpW1hAAMGPHEqMMih44="
 		}
 	}
 }

--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -20,7 +20,7 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "dependencies": {
-    "@microsoft/recognizers-text-date-time": "1.0.1",
+    "@microsoft/recognizers-text-date-time": "^1.1.0",
     "@types/html-entities": "^1.2.16",
     "@types/node": "^9.3.0",
     "@types/request-promise-native": "^1.0.10",

--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -20,7 +20,7 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "dependencies": {
-    "@microsoft/recognizers-text-date-time": "^1.1.0",
+    "@microsoft/recognizers-text-date-time": "^1.1.2",
     "@types/html-entities": "^1.2.16",
     "@types/node": "^9.3.0",
     "@types/request-promise-native": "^1.0.10",

--- a/libraries/botbuilder-dialogs/package-lock.json
+++ b/libraries/botbuilder-dialogs/package-lock.json
@@ -5,76 +5,75 @@
 	"requires": true,
 	"dependencies": {
 		"@microsoft/recognizers-text": {
-			"version": "1.0.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/@microsoft/recognizers-text/-/@microsoft/recognizers-text-1.0.1.tgz",
-			"integrity": "sha1-RmCYcq7n3tZS3bnezonrZNKjsE0="
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text/-/@microsoft/recognizers-text-1.1.2.tgz",
+			"integrity": "sha1-lh0dT2PfnDTLlcWNWo/3JDdlF9A="
 		},
 		"@microsoft/recognizers-text-choice": {
-			"version": "1.0.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/@microsoft/recognizers-text-choice/-/@microsoft/recognizers-text-choice-1.0.1.tgz",
-			"integrity": "sha1-FbNwqko6lIpP2GWTI48B+HJvAWU=",
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-choice/-/@microsoft/recognizers-text-choice-1.1.2.tgz",
+			"integrity": "sha1-9HWbwSFM2sZ32HQCIIBpy8DGD4g=",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.0.1",
+				"@microsoft/recognizers-text": "~1.1.2",
 				"grapheme-splitter": "^1.0.2"
 			}
 		},
 		"@microsoft/recognizers-text-date-time": {
-			"version": "1.0.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/@microsoft/recognizers-text-date-time/-/@microsoft/recognizers-text-date-time-1.0.1.tgz",
-			"integrity": "sha1-OUF8iIlNF5Qc7EzwQ9EuUsko/ng=",
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-date-time/-/@microsoft/recognizers-text-date-time-1.1.2.tgz",
+			"integrity": "sha1-pV+UhW5iHKfjkBWMkWym0z5YiPA=",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.0.1",
-				"@microsoft/recognizers-text-number": "~1.0.1",
-				"@microsoft/recognizers-text-number-with-unit": "~1.0.1",
+				"@microsoft/recognizers-text": "~1.1.2",
+				"@microsoft/recognizers-text-number": "~1.1.2",
+				"@microsoft/recognizers-text-number-with-unit": "~1.1.2",
 				"lodash.isequal": "^4.5.0",
 				"lodash.tonumber": "^4.0.3"
 			}
 		},
 		"@microsoft/recognizers-text-number": {
-			"version": "1.0.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/@microsoft/recognizers-text-number/-/@microsoft/recognizers-text-number-1.0.1.tgz",
-			"integrity": "sha1-q8yWhZCBVOW7lcZAgzhufukVkvY=",
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-number/-/@microsoft/recognizers-text-number-1.1.2.tgz",
+			"integrity": "sha1-tydc9UC6AY4CJcXV4H7AsENSZ+w=",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.0.1",
-				"bignumber.js": "^4.1.0",
+				"@microsoft/recognizers-text": "~1.1.2",
+				"bignumber.js": "^7.2.1",
 				"lodash.escaperegexp": "^4.1.2",
 				"lodash.sortby": "^4.7.0",
-				"lodash.trimend": "^4.5.1",
-				"xregexp": "^3.2.0"
+				"lodash.trimend": "^4.5.1"
 			}
 		},
 		"@microsoft/recognizers-text-number-with-unit": {
-			"version": "1.0.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/@microsoft/recognizers-text-number-with-unit/-/@microsoft/recognizers-text-number-with-unit-1.0.1.tgz",
-			"integrity": "sha1-yLUCNE64dBsF2a5ijT5GBvu20eE=",
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-number-with-unit/-/@microsoft/recognizers-text-number-with-unit-1.1.2.tgz",
+			"integrity": "sha1-P69wBKq4QuKWI2cVad7WZyg7s74=",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.0.1",
-				"@microsoft/recognizers-text-number": "~1.0.1",
+				"@microsoft/recognizers-text": "~1.1.2",
+				"@microsoft/recognizers-text-number": "~1.1.2",
 				"lodash.escaperegexp": "^4.1.2",
 				"lodash.last": "^3.0.0",
 				"lodash.max": "^4.0.1"
 			}
 		},
 		"@microsoft/recognizers-text-sequence": {
-			"version": "1.0.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/@microsoft/recognizers-text-sequence/-/@microsoft/recognizers-text-sequence-1.0.1.tgz",
-			"integrity": "sha1-lJ1MypzTenD2XlAYfMbr2L0SBRY=",
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-sequence/-/@microsoft/recognizers-text-sequence-1.1.2.tgz",
+			"integrity": "sha1-qT8TaRs/aBzLn3bp0RC70OrXfbI=",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.0.1",
+				"@microsoft/recognizers-text": "~1.1.2",
 				"grapheme-splitter": "^1.0.2"
 			}
 		},
 		"@microsoft/recognizers-text-suite": {
-			"version": "1.0.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/@microsoft/recognizers-text-suite/-/@microsoft/recognizers-text-suite-1.0.1.tgz",
-			"integrity": "sha1-DaE/arTvE/sbvv76ms72AR273cE=",
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-suite/-/@microsoft/recognizers-text-suite-1.1.2.tgz",
+			"integrity": "sha1-2sRcXNgN3TEq05wUbQMktm1+Zk8=",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.0.1",
-				"@microsoft/recognizers-text-choice": "~1.0.1",
-				"@microsoft/recognizers-text-date-time": "~1.0.1",
-				"@microsoft/recognizers-text-number": "~1.0.1",
-				"@microsoft/recognizers-text-number-with-unit": "~1.0.1",
-				"@microsoft/recognizers-text-sequence": "~1.0.1"
+				"@microsoft/recognizers-text": "~1.1.2",
+				"@microsoft/recognizers-text-choice": "~1.1.2",
+				"@microsoft/recognizers-text-date-time": "~1.1.2",
+				"@microsoft/recognizers-text-number": "~1.1.2",
+				"@microsoft/recognizers-text-number-with-unit": "~1.1.2",
+				"@microsoft/recognizers-text-sequence": "~1.1.2"
 			}
 		},
 		"@types/mocha": {
@@ -131,14 +130,14 @@
 		},
 		"balanced-match": {
 			"version": "1.0.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/balanced-match/-/balanced-match-1.0.0.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
 		"bignumber.js": {
-			"version": "4.1.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/bignumber.js/-/bignumber.js-4.1.0.tgz",
-			"integrity": "sha1-228UBnwUC9RmJIFaeRbJLZtsJLE="
+			"version": "7.2.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/bignumber.js/-/bignumber.js-7.2.1.tgz",
+			"integrity": "sha1-gMBIdZ2CaACAfEv9Uh5Q7bulel8="
 		},
 		"botbuilder-core": {
 			"version": "4.0.0-preview1.2",
@@ -160,7 +159,7 @@
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
 			"dev": true,
 			"requires": {
@@ -228,7 +227,7 @@
 		},
 		"concat-map": {
 			"version": "0.0.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/concat-map/-/concat-map-0.0.1.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
@@ -260,7 +259,7 @@
 		},
 		"debug": {
 			"version": "3.1.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/debug/-/debug-3.1.0.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/debug/-/debug-3.1.0.tgz",
 			"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
 			"dev": true,
 			"requires": {
@@ -287,13 +286,13 @@
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
 		"glob": {
 			"version": "7.1.2",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/glob/-/glob-7.1.2.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
 			"dev": true,
 			"requires": {
@@ -307,7 +306,7 @@
 		},
 		"grapheme-splitter": {
 			"version": "1.0.4",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
 			"integrity": "sha1-nPOmZcYkdHmJaDSvNc8du0QAdn4="
 		},
 		"growl": {
@@ -324,7 +323,7 @@
 		},
 		"he": {
 			"version": "1.1.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/he/-/he-1.1.1.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/he/-/he-1.1.1.tgz",
 			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
 			"dev": true
 		},
@@ -339,7 +338,7 @@
 		},
 		"inflight": {
 			"version": "1.0.6",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/inflight/-/inflight-1.0.6.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
@@ -349,7 +348,7 @@
 		},
 		"inherits": {
 			"version": "2.0.3",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/inherits/-/inherits-2.0.3.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 			"dev": true
 		},
@@ -361,37 +360,37 @@
 		},
 		"lodash.escaperegexp": {
 			"version": "4.1.2",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
 			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
 		"lodash.last": {
 			"version": "3.0.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash.last/-/lodash.last-3.0.0.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.last/-/lodash.last-3.0.0.tgz",
 			"integrity": "sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw="
 		},
 		"lodash.max": {
 			"version": "4.0.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash.max/-/lodash.max-4.0.1.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.max/-/lodash.max-4.0.1.tgz",
 			"integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
 		"lodash.tonumber": {
 			"version": "4.0.3",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
 			"integrity": "sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="
 		},
 		"lodash.trimend": {
 			"version": "4.5.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
 			"integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
 		},
 		"make-error": {
@@ -402,7 +401,7 @@
 		},
 		"minimatch": {
 			"version": "3.0.4",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/minimatch/-/minimatch-3.0.4.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
 			"dev": true,
 			"requires": {
@@ -467,7 +466,7 @@
 		},
 		"ms": {
 			"version": "2.0.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms/-/ms-2.0.0.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
 		},
@@ -3103,7 +3102,7 @@
 		},
 		"once": {
 			"version": "1.4.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/once/-/once-1.4.0.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
@@ -3118,7 +3117,7 @@
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
@@ -3290,14 +3289,9 @@
 		},
 		"wrappy": {
 			"version": "1.0.2",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/wrappy/-/wrappy-1.0.2.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
-		},
-		"xregexp": {
-			"version": "3.2.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/xregexp/-/xregexp-3.2.0.tgz",
-			"integrity": "sha1-yzYBmHv+JpW1hAAMGPHEqMMih44="
 		},
 		"yn": {
 			"version": "2.0.0",

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -22,10 +22,10 @@
   "dependencies": {
     "@types/node": "^9.3.0",
     "botbuilder-core": "^4.0.0",
-    "@microsoft/recognizers-text-suite": "1.0.1",
-    "@microsoft/recognizers-text-choice": "1.0.1",
-    "@microsoft/recognizers-text-number": "1.0.1",
-    "@microsoft/recognizers-text-date-time": "1.0.1"
+    "@microsoft/recognizers-text-suite": "^1.1.0",
+    "@microsoft/recognizers-text-choice": "^1.1.0",
+    "@microsoft/recognizers-text-number": "^1.1.0",
+    "@microsoft/recognizers-text-date-time": "^1.1.0"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.47",

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -20,12 +20,12 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "dependencies": {
+    "@microsoft/recognizers-text-choice": "^1.1.2",
+    "@microsoft/recognizers-text-date-time": "^1.1.2",
+    "@microsoft/recognizers-text-number": "^1.1.2",
+    "@microsoft/recognizers-text-suite": "^1.1.2",
     "@types/node": "^9.3.0",
-    "botbuilder-core": "^4.0.0",
-    "@microsoft/recognizers-text-suite": "^1.1.0",
-    "@microsoft/recognizers-text-choice": "^1.1.0",
-    "@microsoft/recognizers-text-number": "^1.1.0",
-    "@microsoft/recognizers-text-date-time": "^1.1.0"
+    "botbuilder-core": "^4.0.0"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.47",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,78 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
+		"@microsoft/recognizers-text": {
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text/-/@microsoft/recognizers-text-1.1.2.tgz",
+			"integrity": "sha1-lh0dT2PfnDTLlcWNWo/3JDdlF9A="
+		},
+		"@microsoft/recognizers-text-choice": {
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-choice/-/@microsoft/recognizers-text-choice-1.1.2.tgz",
+			"integrity": "sha1-9HWbwSFM2sZ32HQCIIBpy8DGD4g=",
+			"requires": {
+				"@microsoft/recognizers-text": "~1.1.2",
+				"grapheme-splitter": "^1.0.2"
+			}
+		},
+		"@microsoft/recognizers-text-date-time": {
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-date-time/-/@microsoft/recognizers-text-date-time-1.1.2.tgz",
+			"integrity": "sha1-pV+UhW5iHKfjkBWMkWym0z5YiPA=",
+			"requires": {
+				"@microsoft/recognizers-text": "~1.1.2",
+				"@microsoft/recognizers-text-number": "~1.1.2",
+				"@microsoft/recognizers-text-number-with-unit": "~1.1.2",
+				"lodash.isequal": "^4.5.0",
+				"lodash.tonumber": "^4.0.3"
+			}
+		},
+		"@microsoft/recognizers-text-number": {
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-number/-/@microsoft/recognizers-text-number-1.1.2.tgz",
+			"integrity": "sha1-tydc9UC6AY4CJcXV4H7AsENSZ+w=",
+			"requires": {
+				"@microsoft/recognizers-text": "~1.1.2",
+				"bignumber.js": "^7.2.1",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.sortby": "^4.7.0",
+				"lodash.trimend": "^4.5.1"
+			}
+		},
+		"@microsoft/recognizers-text-number-with-unit": {
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-number-with-unit/-/@microsoft/recognizers-text-number-with-unit-1.1.2.tgz",
+			"integrity": "sha1-P69wBKq4QuKWI2cVad7WZyg7s74=",
+			"requires": {
+				"@microsoft/recognizers-text": "~1.1.2",
+				"@microsoft/recognizers-text-number": "~1.1.2",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.last": "^3.0.0",
+				"lodash.max": "^4.0.1"
+			}
+		},
+		"@microsoft/recognizers-text-sequence": {
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-sequence/-/@microsoft/recognizers-text-sequence-1.1.2.tgz",
+			"integrity": "sha1-qT8TaRs/aBzLn3bp0RC70OrXfbI=",
+			"requires": {
+				"@microsoft/recognizers-text": "~1.1.2",
+				"grapheme-splitter": "^1.0.2"
+			}
+		},
+		"@microsoft/recognizers-text-suite": {
+			"version": "1.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@microsoft/recognizers-text-suite/-/@microsoft/recognizers-text-suite-1.1.2.tgz",
+			"integrity": "sha1-2sRcXNgN3TEq05wUbQMktm1+Zk8=",
+			"requires": {
+				"@microsoft/recognizers-text": "~1.1.2",
+				"@microsoft/recognizers-text-choice": "~1.1.2",
+				"@microsoft/recognizers-text-date-time": "~1.1.2",
+				"@microsoft/recognizers-text-number": "~1.1.2",
+				"@microsoft/recognizers-text-number-with-unit": "~1.1.2",
+				"@microsoft/recognizers-text-sequence": "~1.1.2"
+			}
+		},
 		"@sinonjs/formatio": {
 			"version": "2.0.0",
 			"resolved": "http://bbnpm.azurewebsites.net/@sinonjs%2fformatio/-/formatio-2.0.0.tgz",
@@ -16,12 +88,44 @@
 			"resolved": "http://bbnpm.azurewebsites.net/@sinonjs%2fsamsam/-/samsam-2.0.0.tgz",
 			"integrity": "sha512-D7VxhADdZbDJ0HjUTMnSQ5xIGb4H2yWpg8k9Sf1T08zfFiQYlaxM8LZydpR4FQ2E6LZJX8IlabNZ5io4vdChwg=="
 		},
+		"@types/bunyan": {
+			"version": "1.8.4",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/bunyan/-/@types/bunyan-1.8.4.tgz",
+			"integrity": "sha1-acEa3HtQU41F+2jZrjnQYrlDLzg=",
+			"requires": {
+				"@types/events": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/caseless": {
+			"version": "0.12.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/caseless/-/@types/caseless-0.12.1.tgz",
+			"integrity": "sha1-l5TGnIOF0BkqzEcaVA0fjg0WIYo="
+		},
+		"@types/events": {
+			"version": "1.2.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/events/-/@types/events-1.2.0.tgz",
+			"integrity": "sha1-gaZzHOTfQ2GeXIyUU4Oz5iqJ6oY="
+		},
+		"@types/filenamify": {
+			"version": "2.0.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/filenamify/-/@types/filenamify-2.0.1.tgz",
+			"integrity": "sha1-KnWtJm9PuC4RPvf9xS4DVcJ8Kz0="
+		},
+		"@types/form-data": {
+			"version": "2.2.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/form-data/-/@types/form-data-2.2.1.tgz",
+			"integrity": "sha1-7is7jqoRwJOCiZU2BrdFtzjFSx4=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/fs-extra": {
 			"version": "4.0.0",
 			"resolved": "http://bbnpm.azurewebsites.net/@types%2ffs-extra/-/fs-extra-4.0.0.tgz",
 			"integrity": "sha1-HddCrVybzjCPelLQLrwBQhvJEC8=",
 			"requires": {
-				"@types/node": "9.4.7"
+				"@types/node": "*"
 			}
 		},
 		"@types/handlebars": {
@@ -34,13 +138,26 @@
 			"resolved": "http://bbnpm.azurewebsites.net/@types%2fhighlight.js/-/highlight.js-9.1.8.tgz",
 			"integrity": "sha1-0ifxi8uPPxh+FpZfJESFmgRol1g="
 		},
+		"@types/html-entities": {
+			"version": "1.2.16",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/html-entities/-/@types/html-entities-1.2.16.tgz",
+			"integrity": "sha1-TR/iCMTDNyesRlfm9dkr/lJCcCM="
+		},
+		"@types/is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/is-stream/-/@types/is-stream-1.1.0.tgz",
+			"integrity": "sha1-uE17sgeiEPKvm+1DHcD76cQUO+E=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/jsonwebtoken": {
 			"version": "7.2.5",
 			"resolved": "http://bbnpm.azurewebsites.net/@types%2fjsonwebtoken/-/jsonwebtoken-7.2.5.tgz",
 			"integrity": "sha512-8CIcK1Vzq4w5TJyJYkLVhqASmCo1FSO1XIPQM1qv+Xo2nnb9RoRHxx8pkIzSZ4Tm9r3V4ZyFbF/fBewNPdclwA==",
 			"dev": true,
 			"requires": {
-				"@types/node": "9.4.7"
+				"@types/node": "*"
 			}
 		},
 		"@types/lodash": {
@@ -59,17 +176,90 @@
 			"resolved": "http://bbnpm.azurewebsites.net/@types%2fminimatch/-/minimatch-2.0.29.tgz",
 			"integrity": "sha1-UALhT3Xi1x5WQoHfBDHIwbSio2o="
 		},
+		"@types/mocha": {
+			"version": "2.2.48",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/mocha/-/@types/mocha-2.2.48.tgz",
+			"integrity": "sha1-NSOxJqCwSUguHDwRh3Rg92Yi/6s="
+		},
 		"@types/node": {
 			"version": "9.4.7",
 			"resolved": "http://bbnpm.azurewebsites.net/@types%2fnode/-/node-9.4.7.tgz",
 			"integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw=="
+		},
+		"@types/node-fetch": {
+			"version": "1.6.9",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/node-fetch/-/@types/node-fetch-1.6.9.tgz",
+			"integrity": "sha1-p1D7D0zylgv3K0YuTIaQgCLdacU=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/request": {
+			"version": "2.47.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/request/-/@types/request-2.47.1.tgz",
+			"integrity": "sha1-JUENOvvawEyRqUrZ78mCQQBzWCQ=",
+			"requires": {
+				"@types/caseless": "*",
+				"@types/form-data": "*",
+				"@types/node": "*",
+				"@types/tough-cookie": "*"
+			}
+		},
+		"@types/request-promise-native": {
+			"version": "1.0.15",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/request-promise-native/-/@types/request-promise-native-1.0.15.tgz",
+			"integrity": "sha1-WzNp/Gqvnn/ve2toiu9MV1liPhY=",
+			"requires": {
+				"@types/request": "*"
+			}
+		},
+		"@types/restify": {
+			"version": "5.0.9",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/restify/-/@types/restify-5.0.9.tgz",
+			"integrity": "sha1-lb8wsP17kjKaaVu9YP6uAZ8+Mf0=",
+			"requires": {
+				"@types/bunyan": "*",
+				"@types/node": "*",
+				"@types/spdy": "*"
+			}
 		},
 		"@types/shelljs": {
 			"version": "0.7.0",
 			"resolved": "http://bbnpm.azurewebsites.net/@types%2fshelljs/-/shelljs-0.7.0.tgz",
 			"integrity": "sha1-IpwVfGvB5n1rmQ5sXhjb0v9Yz/A=",
 			"requires": {
-				"@types/node": "9.4.7"
+				"@types/node": "*"
+			}
+		},
+		"@types/spdy": {
+			"version": "3.4.4",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/spdy/-/@types/spdy-3.4.4.tgz",
+			"integrity": "sha1-MoL9StjEYDqkn3AX3VIKCKNFsrw=",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/strip-bom/-/@types/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I="
+		},
+		"@types/strip-json-comments": {
+			"version": "0.0.30",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/strip-json-comments/-/@types/strip-json-comments-0.0.30.tgz",
+			"integrity": "sha1-mqMMBNshKpoGSdaub9UKzMQHSKE="
+		},
+		"@types/tough-cookie": {
+			"version": "2.3.3",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/tough-cookie/-/@types/tough-cookie-2.3.3.tgz",
+			"integrity": "sha1-fyJtZ9ZU7JBw51X0ba6/AUYo6dk="
+		},
+		"@types/uuid": {
+			"version": "3.4.4",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/uuid/-/@types/uuid-3.4.4.tgz",
+			"integrity": "sha1-evaTYPpl7w3stB/RUL9MpcDO/fU=",
+			"requires": {
+				"@types/node": "*"
 			}
 		},
 		"abab": {
@@ -87,7 +277,30 @@
 			"resolved": "http://bbnpm.azurewebsites.net/acorn-globals/-/acorn-globals-3.1.0.tgz",
 			"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
 			"requires": {
-				"acorn": "4.0.13"
+				"acorn": "^4.0.4"
+			}
+		},
+		"adal-node": {
+			"version": "0.1.28",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/adal-node/-/adal-node-0.1.28.tgz",
+			"integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
+			"requires": {
+				"@types/node": "^8.0.47",
+				"async": ">=0.6.0",
+				"date-utils": "*",
+				"jws": "3.x.x",
+				"request": ">= 2.52.0",
+				"underscore": ">= 1.3.1",
+				"uuid": "^3.1.0",
+				"xmldom": ">= 0.1.x",
+				"xpath.js": "~1.1.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "8.10.29",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/@types/node/-/@types/node-8.10.29.tgz",
+					"integrity": "sha1-s6E7WN17BoK/G0ICK+9KWpcY9oc="
+				}
 			}
 		},
 		"ajv": {
@@ -95,10 +308,10 @@
 			"resolved": "http://bbnpm.azurewebsites.net/ajv/-/ajv-5.5.2.tgz",
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.1.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"align-text": {
@@ -106,9 +319,9 @@
 			"resolved": "http://bbnpm.azurewebsites.net/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"requires": {
-				"kind-of": "3.2.2",
-				"longest": "1.0.1",
-				"repeat-string": "1.6.1"
+				"kind-of": "^3.0.2",
+				"longest": "^1.0.1",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"amdefine": {
@@ -126,8 +339,13 @@
 			"resolved": "http://bbnpm.azurewebsites.net/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"requires": {
-				"color-convert": "1.9.1"
+				"color-convert": "^1.9.0"
 			}
+		},
+		"app-root-path": {
+			"version": "2.1.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/app-root-path/-/app-root-path-2.1.0.tgz",
+			"integrity": "sha1-mL9lmTJ+zqGZMJhm6BQDaP0uZGo="
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -135,7 +353,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"array-equal": {
@@ -143,20 +361,46 @@
 			"resolved": "http://bbnpm.azurewebsites.net/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
 		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
 		"asn1": {
 			"version": "0.2.3",
 			"resolved": "http://bbnpm.azurewebsites.net/asn1/-/asn1-0.2.3.tgz",
 			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+		},
+		"assert": {
+			"version": "1.4.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/assert/-/assert-1.4.1.tgz",
+			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+			"requires": {
+				"util": "0.10.3"
+			}
 		},
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "http://bbnpm.azurewebsites.net/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
+		"assertion-error": {
+			"version": "1.1.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs="
+		},
 		"async": {
 			"version": "1.5.2",
 			"resolved": "http://bbnpm.azurewebsites.net/async/-/async-1.5.2.tgz",
 			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+		},
+		"async-file": {
+			"version": "2.0.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/async-file/-/async-file-2.0.2.tgz",
+			"integrity": "sha1-Aq0HhWrDcX6DayCuxaTP4AxG3yM=",
+			"requires": {
+				"rimraf": "^2.5.2"
+			}
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -173,15 +417,133 @@
 			"resolved": "http://bbnpm.azurewebsites.net/aws4/-/aws4-1.6.0.tgz",
 			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
 		},
+		"azure-cognitiveservices-luis-runtime": {
+			"version": "1.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/azure-cognitiveservices-luis-runtime/-/azure-cognitiveservices-luis-runtime-1.0.0.tgz",
+			"integrity": "sha1-MyZRn9Xw8Sy/0xPSTH9YIWxNbgg=",
+			"requires": {
+				"ms-rest": "^2.3.3"
+			}
+		},
+		"azure-storage": {
+			"version": "2.10.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/azure-storage/-/azure-storage-2.10.1.tgz",
+			"integrity": "sha1-+MF4C9qXu4A+Wkv31qrXhiMBzYE=",
+			"requires": {
+				"browserify-mime": "~1.2.9",
+				"extend": "~1.2.1",
+				"json-edm-parser": "0.1.2",
+				"md5.js": "1.3.4",
+				"readable-stream": "~2.0.0",
+				"request": "^2.86.0",
+				"underscore": "~1.8.3",
+				"uuid": "^3.0.0",
+				"validator": "~9.4.1",
+				"xml2js": "0.2.8",
+				"xmlbuilder": "0.4.3"
+			},
+			"dependencies": {
+				"aws4": {
+					"version": "1.8.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/aws4/-/aws4-1.8.0.tgz",
+					"integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+				},
+				"extend": {
+					"version": "1.2.1",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/extend/-/extend-1.2.1.tgz",
+					"integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w="
+				},
+				"har-validator": {
+					"version": "5.1.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/har-validator/-/har-validator-5.1.0.tgz",
+					"integrity": "sha1-RGV/VoiiLP1LckhugbOj+xF0LCk=",
+					"requires": {
+						"ajv": "^5.3.0",
+						"har-schema": "^2.0.0"
+					}
+				},
+				"mime-db": {
+					"version": "1.36.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/mime-db/-/mime-db-1.36.0.tgz",
+					"integrity": "sha1-UCBHjbPH/pOq17vMTc+GnEM2M5c="
+				},
+				"mime-types": {
+					"version": "2.1.20",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/mime-types/-/mime-types-2.1.20.tgz",
+					"integrity": "sha1-kwy3GdVx6QNzhSD4RwkRVIyizBk=",
+					"requires": {
+						"mime-db": "~1.36.0"
+					}
+				},
+				"oauth-sign": {
+					"version": "0.9.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
+					"integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+				},
+				"qs": {
+					"version": "6.5.2",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/qs/-/qs-6.5.2.tgz",
+					"integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+				},
+				"request": {
+					"version": "2.88.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/request/-/request-2.88.0.tgz",
+					"integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+					"requires": {
+						"aws-sign2": "~0.7.0",
+						"aws4": "^1.8.0",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.6",
+						"extend": "~3.0.2",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.3.2",
+						"har-validator": "~5.1.0",
+						"http-signature": "~1.2.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.19",
+						"oauth-sign": "~0.9.0",
+						"performance-now": "^2.1.0",
+						"qs": "~6.5.2",
+						"safe-buffer": "^5.1.2",
+						"tough-cookie": "~2.4.3",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.3.2"
+					},
+					"dependencies": {
+						"extend": {
+							"version": "3.0.2",
+							"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/extend/-/extend-3.0.2.tgz",
+							"integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+						}
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				}
+			}
+		},
 		"babel-code-frame": {
 			"version": "6.26.0",
 			"resolved": "http://bbnpm.azurewebsites.net/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -202,11 +564,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "2.2.1",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "2.0.0",
-						"strip-ansi": "3.0.1",
-						"supports-color": "2.0.0"
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -215,7 +577,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -231,19 +593,43 @@
 			"resolved": "http://bbnpm.azurewebsites.net/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
+		"base64url": {
+			"version": "2.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/base64url/-/base64url-2.0.0.tgz",
+			"integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
+		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
 			"resolved": "http://bbnpm.azurewebsites.net/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
+		},
+		"big-integer": {
+			"version": "1.6.36",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/big-integer/-/big-integer-1.6.36.tgz",
+			"integrity": "sha1-eGMQdiZdSuNVXAT4Xn2dLzoHGjY="
 		},
 		"bignumber.js": {
 			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-			"integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/bignumber.js/-/bignumber.js-7.2.1.tgz",
+			"integrity": "sha1-gMBIdZ2CaACAfEv9Uh5Q7bulel8="
+		},
+		"binary": {
+			"version": "0.3.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/binary/-/binary-0.3.0.tgz",
+			"integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+			"requires": {
+				"buffers": "~0.1.1",
+				"chainsaw": "~0.1.0"
+			}
+		},
+		"binary-search-bounds": {
+			"version": "2.0.3",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz",
+			"integrity": "sha1-X/hhbW3SylOIvIWy1iZuK52lAtw="
 		},
 		"block-elements": {
 			"version": "1.2.0",
@@ -255,7 +641,15 @@
 			"resolved": "http://bbnpm.azurewebsites.net/boom/-/boom-4.3.1.tgz",
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
 			"requires": {
-				"hoek": "4.2.1"
+				"hoek": "4.x.x"
+			}
+		},
+		"botframework-schema": {
+			"version": "4.0.5",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/botframework-schema/-/botframework-schema-4.0.5.tgz",
+			"integrity": "sha1-080u8EfqM7PLHlfFMPP9E+JbGQ4=",
+			"requires": {
+				"@types/node": "^9.3.0"
 			}
 		},
 		"brace-expansion": {
@@ -263,7 +657,7 @@
 			"resolved": "http://bbnpm.azurewebsites.net/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -272,6 +666,26 @@
 			"resolved": "http://bbnpm.azurewebsites.net/browser-stdout/-/browser-stdout-1.3.1.tgz",
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
+		},
+		"browserify-mime": {
+			"version": "1.2.9",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/browserify-mime/-/browserify-mime-1.2.9.tgz",
+			"integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
+		},
+		"buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+		},
+		"buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
+		},
+		"buffers": {
+			"version": "0.1.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/buffers/-/buffers-0.1.1.tgz",
+			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
@@ -295,8 +709,29 @@
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
 			"optional": true,
 			"requires": {
-				"align-text": "0.1.4",
-				"lazy-cache": "1.0.4"
+				"align-text": "^0.1.3",
+				"lazy-cache": "^1.0.3"
+			}
+		},
+		"chai": {
+			"version": "4.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/chai/-/chai-4.1.2.tgz",
+			"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+			"requires": {
+				"assertion-error": "^1.0.1",
+				"check-error": "^1.0.1",
+				"deep-eql": "^3.0.0",
+				"get-func-name": "^2.0.0",
+				"pathval": "^1.0.0",
+				"type-detect": "^4.0.0"
+			}
+		},
+		"chainsaw": {
+			"version": "0.1.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/chainsaw/-/chainsaw-0.1.0.tgz",
+			"integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+			"requires": {
+				"traverse": ">=0.3.0 <0.4"
 			}
 		},
 		"chalk": {
@@ -304,9 +739,149 @@
 			"resolved": "http://bbnpm.azurewebsites.net/chalk/-/chalk-2.3.2.tgz",
 			"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.3.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"chatdown": {
+			"version": "1.0.10",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/chatdown/-/chatdown-1.0.10.tgz",
+			"integrity": "sha1-8IFyooc8LzdUmDGNkPsrMs7H2Jg=",
+			"requires": {
+				"botframework-schema": "^4.0.0-preview1.2",
+				"chalk": "^2.3.2",
+				"cli-table3": "^0.5.0",
+				"fs-extra": "^5.0.0",
+				"mime-types": "^2.1.18",
+				"minimist": "^1.2.0",
+				"please-upgrade-node": "^3.0.1",
+				"read-text-file": "^1.1.0",
+				"request": "^2.85.0",
+				"request-promise-native": "^1.0.5",
+				"semver": "^5.5.0",
+				"window-size": "^1.1.0"
+			},
+			"dependencies": {
+				"aws4": {
+					"version": "1.8.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/aws4/-/aws4-1.8.0.tgz",
+					"integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+				},
+				"fs-extra": {
+					"version": "5.0.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fs-extra/-/fs-extra-5.0.0.tgz",
+					"integrity": "sha1-QU0BEM3QZwVzTQVWUsVBEmDDGr0=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"har-validator": {
+					"version": "5.1.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/har-validator/-/har-validator-5.1.0.tgz",
+					"integrity": "sha1-RGV/VoiiLP1LckhugbOj+xF0LCk=",
+					"requires": {
+						"ajv": "^5.3.0",
+						"har-schema": "^2.0.0"
+					}
+				},
+				"mime-db": {
+					"version": "1.36.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/mime-db/-/mime-db-1.36.0.tgz",
+					"integrity": "sha1-UCBHjbPH/pOq17vMTc+GnEM2M5c="
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"oauth-sign": {
+					"version": "0.9.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
+					"integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+				},
+				"qs": {
+					"version": "6.5.2",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/qs/-/qs-6.5.2.tgz",
+					"integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+				},
+				"request": {
+					"version": "2.88.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/request/-/request-2.88.0.tgz",
+					"integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+					"requires": {
+						"aws-sign2": "~0.7.0",
+						"aws4": "^1.8.0",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.6",
+						"extend": "~3.0.2",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.3.2",
+						"har-validator": "~5.1.0",
+						"http-signature": "~1.2.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.19",
+						"oauth-sign": "~0.9.0",
+						"performance-now": "^2.1.0",
+						"qs": "~6.5.2",
+						"safe-buffer": "^5.1.2",
+						"tough-cookie": "~2.4.3",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.3.2"
+					},
+					"dependencies": {
+						"mime-types": {
+							"version": "2.1.20",
+							"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/mime-types/-/mime-types-2.1.20.tgz",
+							"integrity": "sha1-kwy3GdVx6QNzhSD4RwkRVIyizBk=",
+							"requires": {
+								"mime-db": "~1.36.0"
+							}
+						}
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				},
+				"window-size": {
+					"version": "1.1.1",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/window-size/-/window-size-1.1.1.tgz",
+					"integrity": "sha1-mFhYZYCtp4qybs1peKbgMRXBryA=",
+					"requires": {
+						"define-property": "^1.0.0",
+						"is-number": "^3.0.0"
+					}
+				}
+			}
+		},
+		"check-error": {
+			"version": "1.0.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/check-error/-/check-error-1.0.2.tgz",
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+		},
+		"cli-table3": {
+			"version": "0.5.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/cli-table3/-/cli-table3-0.5.1.tgz",
+			"integrity": "sha1-AlI3LZTfxA29jfBgBfSPMfZW8gI=",
+			"requires": {
+				"colors": "^1.1.2",
+				"object-assign": "^4.1.0",
+				"string-width": "^2.1.1"
 			}
 		},
 		"cliui": {
@@ -314,9 +889,9 @@
 			"resolved": "http://bbnpm.azurewebsites.net/cliui/-/cliui-4.0.0.tgz",
 			"integrity": "sha1-dD1GUOBfNtHtJXW1ljjYcyK/u8w=",
 			"requires": {
-				"string-width": "2.1.1",
-				"strip-ansi": "4.0.0",
-				"wrap-ansi": "2.1.0"
+				"string-width": "^2.1.1",
+				"strip-ansi": "^4.0.0",
+				"wrap-ansi": "^2.0.0"
 			}
 		},
 		"co": {
@@ -329,13 +904,38 @@
 			"resolved": "http://bbnpm.azurewebsites.net/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
+		"codelyzer": {
+			"version": "4.4.4",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/codelyzer/-/codelyzer-4.4.4.tgz",
+			"integrity": "sha1-KbfbtRup7MRccwDWEoCmVkdl1AI=",
+			"requires": {
+				"app-root-path": "^2.1.0",
+				"css-selector-tokenizer": "^0.7.0",
+				"cssauron": "^1.4.0",
+				"semver-dsl": "^1.0.1",
+				"source-map": "^0.5.7",
+				"sprintf-js": "^1.1.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				},
+				"sprintf-js": {
+					"version": "1.1.1",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/sprintf-js/-/sprintf-js-1.1.1.tgz",
+					"integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+				}
+			}
+		},
 		"collapse-whitespace": {
 			"version": "1.1.2",
 			"resolved": "http://bbnpm.azurewebsites.net/collapse-whitespace/-/collapse-whitespace-1.1.2.tgz",
 			"integrity": "sha1-ubMdedVZTuPCLBWBnFSCjlZbMIU=",
 			"requires": {
-				"block-elements": "1.2.0",
-				"void-elements": "2.0.1"
+				"block-elements": "^1.0.0",
+				"void-elements": "^2.0.1"
 			}
 		},
 		"color-convert": {
@@ -343,7 +943,7 @@
 			"resolved": "http://bbnpm.azurewebsites.net/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.1.1"
 			}
 		},
 		"color-name": {
@@ -351,12 +951,18 @@
 			"resolved": "http://bbnpm.azurewebsites.net/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
+		"colors": {
+			"version": "1.3.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/colors/-/colors-1.3.2.tgz",
+			"integrity": "sha1-Lfj/Vz378lWvVi+M5xgda5caNZs=",
+			"optional": true
+		},
 		"combined-stream": {
 			"version": "1.0.6",
 			"resolved": "http://bbnpm.azurewebsites.net/combined-stream/-/combined-stream-1.0.6.tgz",
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
@@ -386,11 +992,11 @@
 			"integrity": "sha1-Iu9zAzBTgIDSm4wVHckUav3oipk=",
 			"dev": true,
 			"requires": {
-				"js-yaml": "3.11.0",
-				"lcov-parse": "0.0.10",
-				"log-driver": "1.2.7",
-				"minimist": "1.2.0",
-				"request": "2.83.0"
+				"js-yaml": "^3.6.1",
+				"lcov-parse": "^0.0.10",
+				"log-driver": "^1.2.5",
+				"minimist": "^1.2.0",
+				"request": "^2.79.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -406,9 +1012,9 @@
 			"resolved": "http://bbnpm.azurewebsites.net/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"requires": {
-				"lru-cache": "4.1.2",
-				"shebang-command": "1.2.0",
-				"which": "1.3.0"
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"cryptiles": {
@@ -416,7 +1022,7 @@
 			"resolved": "http://bbnpm.azurewebsites.net/cryptiles/-/cryptiles-3.1.2.tgz",
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
 			"requires": {
-				"boom": "5.2.0"
+				"boom": "5.x.x"
 			},
 			"dependencies": {
 				"boom": {
@@ -424,10 +1030,33 @@
 					"resolved": "http://bbnpm.azurewebsites.net/boom/-/boom-5.2.0.tgz",
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
 					"requires": {
-						"hoek": "4.2.1"
+						"hoek": "4.x.x"
 					}
 				}
 			}
+		},
+		"css-selector-tokenizer": {
+			"version": "0.7.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+			"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+			"requires": {
+				"cssesc": "^0.1.0",
+				"fastparse": "^1.1.1",
+				"regexpu-core": "^1.0.0"
+			}
+		},
+		"cssauron": {
+			"version": "1.4.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/cssauron/-/cssauron-1.4.0.tgz",
+			"integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
+			"requires": {
+				"through": "X.X.X"
+			}
+		},
+		"cssesc": {
+			"version": "0.1.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/cssesc/-/cssesc-0.1.0.tgz",
+			"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
 		},
 		"cssom": {
 			"version": "0.3.2",
@@ -439,7 +1068,7 @@
 			"resolved": "http://bbnpm.azurewebsites.net/cssstyle/-/cssstyle-0.2.37.tgz",
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
 			"requires": {
-				"cssom": "0.3.2"
+				"cssom": "0.3.x"
 			}
 		},
 		"dashdash": {
@@ -447,14 +1076,18 @@
 			"resolved": "http://bbnpm.azurewebsites.net/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
+		},
+		"date-utils": {
+			"version": "1.2.21",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/date-utils/-/date-utils-1.2.21.tgz",
+			"integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
 		},
 		"debug": {
 			"version": "3.1.0",
 			"resolved": "http://bbnpm.azurewebsites.net/debug/-/debug-3.1.0.tgz",
 			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
@@ -464,10 +1097,31 @@
 			"resolved": "http://bbnpm.azurewebsites.net/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
+		"deep-eql": {
+			"version": "3.0.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/deep-eql/-/deep-eql-3.0.1.tgz",
+			"integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+			"requires": {
+				"type-detect": "^4.0.0"
+			}
+		},
+		"deep-equal": {
+			"version": "1.0.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/deep-equal/-/deep-equal-1.0.1.tgz",
+			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "http://bbnpm.azurewebsites.net/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+		},
+		"define-property": {
+			"version": "1.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/define-property/-/define-property-1.0.0.tgz",
+			"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+			"requires": {
+				"is-descriptor": "^1.0.0"
+			}
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
@@ -479,14 +1133,59 @@
 			"resolved": "http://bbnpm.azurewebsites.net/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
+		"documentdb": {
+			"version": "1.14.5",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/documentdb/-/documentdb-1.14.5.tgz",
+			"integrity": "sha1-NWhR8KpefxiuDtIC3g3ROwWz92I=",
+			"requires": {
+				"big-integer": "^1.6.25",
+				"binary-search-bounds": "2.0.3",
+				"int64-buffer": "^0.1.9",
+				"priorityqueuejs": "1.0.0",
+				"semaphore": "1.0.5",
+				"tunnel": "0.0.5",
+				"underscore": "1.8.3"
+			}
+		},
+		"dotenv": {
+			"version": "5.0.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/dotenv/-/dotenv-5.0.1.tgz",
+			"integrity": "sha1-pTF0Wb09eauIz/bkQFemo/ux/O8="
+		},
+		"duplexer": {
+			"version": "0.1.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/duplexer/-/duplexer-0.1.1.tgz",
+			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+		},
 		"ecc-jsbn": {
 			"version": "0.1.1",
 			"resolved": "http://bbnpm.azurewebsites.net/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1"
+				"jsbn": "~0.1.0"
 			}
+		},
+		"ecdsa-sig-formatter": {
+			"version": "1.0.10",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+			"integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"requires": {
+				"iconv-lite": "~0.4.13"
+			}
+		},
+		"es6-denodeify": {
+			"version": "0.1.5",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/es6-denodeify/-/es6-denodeify-0.1.5.tgz",
+			"integrity": "sha1-MdTV/pxVA+ElRgQ5MQ4WoqPznB8="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -498,11 +1197,11 @@
 			"resolved": "http://bbnpm.azurewebsites.net/escodegen/-/escodegen-1.9.1.tgz",
 			"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
 			"requires": {
-				"esprima": "3.1.3",
-				"estraverse": "4.2.0",
-				"esutils": "2.0.2",
-				"optionator": "0.8.2",
-				"source-map": "0.6.1"
+				"esprima": "^3.1.3",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -533,14 +1232,19 @@
 			"resolved": "http://bbnpm.azurewebsites.net/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			}
+		},
+		"extend": {
+			"version": "3.0.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
 		},
 		"extsprintf": {
 			"version": "1.3.0",
@@ -562,12 +1266,75 @@
 			"resolved": "http://bbnpm.azurewebsites.net/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
+		"fastparse": {
+			"version": "1.1.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fastparse/-/fastparse-1.1.1.tgz",
+			"integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
+		},
+		"fetch-cookie": {
+			"version": "0.7.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fetch-cookie/-/fetch-cookie-0.7.2.tgz",
+			"integrity": "sha1-W+US9xIbC80uNENQrXF3J6w7Gl0=",
+			"requires": {
+				"es6-denodeify": "^0.1.1",
+				"tough-cookie": "^2.3.1"
+			}
+		},
+		"fetch-ponyfill": {
+			"version": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
+			"from": "github:amarzavery/fetch-ponyfill#master",
+			"requires": {
+				"fetch-cookie": "~0.6.0",
+				"node-fetch": "~1.7.1"
+			},
+			"dependencies": {
+				"fetch-cookie": {
+					"version": "0.6.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fetch-cookie/-/fetch-cookie-0.6.0.tgz",
+					"integrity": "sha1-T+xOQIzAAH9sBOVTYYr0s97jf2k=",
+					"requires": {
+						"es6-denodeify": "^0.1.1",
+						"tough-cookie": "^2.3.1"
+					}
+				}
+			}
+		},
+		"filename-reserved-regex": {
+			"version": "2.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
+		},
+		"filenamify": {
+			"version": "2.1.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/filenamify/-/filenamify-2.1.0.tgz",
+			"integrity": "sha1-iPr0lfsbR6v9YSMAACoWIoxnfuk=",
+			"requires": {
+				"filename-reserved-regex": "^2.0.0",
+				"strip-outer": "^1.0.0",
+				"trim-repeated": "^1.0.0"
+			}
+		},
 		"find-up": {
 			"version": "2.1.0",
 			"resolved": "http://bbnpm.azurewebsites.net/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"requires": {
-				"locate-path": "2.0.0"
+				"locate-path": "^2.0.0"
+			}
+		},
+		"flat": {
+			"version": "4.1.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/flat/-/flat-4.1.0.tgz",
+			"integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
+			"requires": {
+				"is-buffer": "~2.0.3"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.3",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-buffer/-/is-buffer-2.0.3.tgz",
+					"integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU="
+				}
 			}
 		},
 		"forever-agent": {
@@ -580,9 +1347,19 @@
 			"resolved": "http://bbnpm.azurewebsites.net/form-data/-/form-data-2.3.2.tgz",
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"requires": {
-				"asynckit": "0.4.0",
+				"asynckit": "^0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "2.1.18"
+				"mime-types": "^2.1.12"
+			}
+		},
+		"fs-extra": {
+			"version": "7.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fs-extra/-/fs-extra-7.0.0.tgz",
+			"integrity": "sha1-jMP0fOB+97NZOhG5+yRffjTAQdY=",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
 			}
 		},
 		"fs.realpath": {
@@ -590,10 +1367,36 @@
 			"resolved": "http://bbnpm.azurewebsites.net/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
+		"fstream": {
+			"version": "0.1.31",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/fstream/-/fstream-0.1.31.tgz",
+			"integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
+			"requires": {
+				"graceful-fs": "~3.0.2",
+				"inherits": "~2.0.0",
+				"mkdirp": "0.5",
+				"rimraf": "2"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "3.0.11",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/graceful-fs/-/graceful-fs-3.0.11.tgz",
+					"integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+					"requires": {
+						"natives": "^1.1.0"
+					}
+				}
+			}
+		},
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "http://bbnpm.azurewebsites.net/get-caller-file/-/get-caller-file-1.0.2.tgz",
 			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+		},
+		"get-func-name": {
+			"version": "2.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/get-func-name/-/get-func-name-2.0.0.tgz",
+			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
 		},
 		"get-stream": {
 			"version": "3.0.0",
@@ -605,7 +1408,7 @@
 			"resolved": "http://bbnpm.azurewebsites.net/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -613,18 +1416,23 @@
 			"resolved": "http://bbnpm.azurewebsites.net/glob/-/glob-7.1.2.tgz",
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
 			"version": "4.1.11",
 			"resolved": "http://bbnpm.azurewebsites.net/graceful-fs/-/graceful-fs-4.1.11.tgz",
 			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"grapheme-splitter": {
+			"version": "1.0.4",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+			"integrity": "sha1-nPOmZcYkdHmJaDSvNc8du0QAdn4="
 		},
 		"growl": {
 			"version": "1.10.3",
@@ -637,10 +1445,10 @@
 			"resolved": "http://bbnpm.azurewebsites.net/handlebars/-/handlebars-4.0.11.tgz",
 			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 			"requires": {
-				"async": "1.5.2",
-				"optimist": "0.6.1",
-				"source-map": "0.4.4",
-				"uglify-js": "2.8.29"
+				"async": "^1.4.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.4.4",
+				"uglify-js": "^2.6"
 			}
 		},
 		"har-schema": {
@@ -653,8 +1461,8 @@
 			"resolved": "http://bbnpm.azurewebsites.net/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"ajv": "5.5.2",
-				"har-schema": "2.0.0"
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has-ansi": {
@@ -663,7 +1471,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -679,15 +1487,24 @@
 			"resolved": "http://bbnpm.azurewebsites.net/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
+		"hash-base": {
+			"version": "3.0.4",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/hash-base/-/hash-base-3.0.4.tgz",
+			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"hawk": {
 			"version": "6.0.2",
 			"resolved": "http://bbnpm.azurewebsites.net/hawk/-/hawk-6.0.2.tgz",
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
 			"requires": {
-				"boom": "4.3.1",
-				"cryptiles": "3.1.2",
-				"hoek": "4.2.1",
-				"sntp": "2.1.0"
+				"boom": "4.x.x",
+				"cryptiles": "3.x.x",
+				"hoek": "4.x.x",
+				"sntp": "2.x.x"
 			}
 		},
 		"he": {
@@ -706,22 +1523,35 @@
 			"resolved": "http://bbnpm.azurewebsites.net/hoek/-/hoek-4.2.1.tgz",
 			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
 		},
+		"homedir-polyfill": {
+			"version": "1.0.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+			"requires": {
+				"parse-passwd": "^1.0.0"
+			}
+		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
 			"resolved": "http://bbnpm.azurewebsites.net/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"requires": {
-				"whatwg-encoding": "1.0.3"
+				"whatwg-encoding": "^1.0.1"
 			}
+		},
+		"html-entities": {
+			"version": "1.2.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/html-entities/-/html-entities-1.2.1.tgz",
+			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
 		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "http://bbnpm.azurewebsites.net/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.1"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"iconv-lite": {
@@ -734,14 +1564,19 @@
 			"resolved": "http://bbnpm.azurewebsites.net/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "http://bbnpm.azurewebsites.net/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"int64-buffer": {
+			"version": "0.1.10",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/int64-buffer/-/int64-buffer-0.1.10.tgz",
+			"integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
 		},
 		"interpret": {
 			"version": "1.1.0",
@@ -753,15 +1588,70 @@
 			"resolved": "http://bbnpm.azurewebsites.net/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
 		},
+		"is-accessor-descriptor": {
+			"version": "1.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+			"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+			"requires": {
+				"kind-of": "^6.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+				}
+			}
+		},
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "http://bbnpm.azurewebsites.net/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
+		"is-data-descriptor": {
+			"version": "1.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+			"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+			"requires": {
+				"kind-of": "^6.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+				}
+			}
+		},
+		"is-descriptor": {
+			"version": "1.0.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+			"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+			"requires": {
+				"is-accessor-descriptor": "^1.0.0",
+				"is-data-descriptor": "^1.0.0",
+				"kind-of": "^6.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
+				}
+			}
+		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "http://bbnpm.azurewebsites.net/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+		},
+		"is-number": {
+			"version": "3.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			}
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -772,6 +1662,11 @@
 			"version": "1.0.0",
 			"resolved": "http://bbnpm.azurewebsites.net/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -795,8 +1690,8 @@
 			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.0"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			},
 			"dependencies": {
 				"esprima": {
@@ -813,30 +1708,48 @@
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 			"optional": true
 		},
+		"jschardet": {
+			"version": "1.6.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jschardet/-/jschardet-1.6.0.tgz",
+			"integrity": "sha1-x9GnHtz/KDnbL57DD8XV69PBpng="
+		},
 		"jsdom": {
 			"version": "9.12.0",
 			"resolved": "http://bbnpm.azurewebsites.net/jsdom/-/jsdom-9.12.0.tgz",
 			"integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
 			"requires": {
-				"abab": "1.0.4",
-				"acorn": "4.0.13",
-				"acorn-globals": "3.1.0",
-				"array-equal": "1.0.0",
-				"content-type-parser": "1.0.2",
-				"cssom": "0.3.2",
-				"cssstyle": "0.2.37",
-				"escodegen": "1.9.1",
-				"html-encoding-sniffer": "1.0.2",
-				"nwmatcher": "1.4.4",
-				"parse5": "1.5.1",
-				"request": "2.83.0",
-				"sax": "1.2.4",
-				"symbol-tree": "3.2.2",
-				"tough-cookie": "2.3.4",
-				"webidl-conversions": "4.0.2",
-				"whatwg-encoding": "1.0.3",
-				"whatwg-url": "4.8.0",
-				"xml-name-validator": "2.0.1"
+				"abab": "^1.0.3",
+				"acorn": "^4.0.4",
+				"acorn-globals": "^3.1.0",
+				"array-equal": "^1.0.0",
+				"content-type-parser": "^1.0.1",
+				"cssom": ">= 0.3.2 < 0.4.0",
+				"cssstyle": ">= 0.2.37 < 0.3.0",
+				"escodegen": "^1.6.1",
+				"html-encoding-sniffer": "^1.0.1",
+				"nwmatcher": ">= 1.3.9 < 2.0.0",
+				"parse5": "^1.5.1",
+				"request": "^2.79.0",
+				"sax": "^1.2.1",
+				"symbol-tree": "^3.2.1",
+				"tough-cookie": "^2.3.2",
+				"webidl-conversions": "^4.0.0",
+				"whatwg-encoding": "^1.0.1",
+				"whatwg-url": "^4.3.0",
+				"xml-name-validator": "^2.0.1"
+			}
+		},
+		"jsesc": {
+			"version": "0.5.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jsesc/-/jsesc-0.5.0.tgz",
+			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+		},
+		"json-edm-parser": {
+			"version": "0.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
+			"integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
+			"requires": {
+				"jsonparse": "~1.2.0"
 			}
 		},
 		"json-schema": {
@@ -859,7 +1772,29 @@
 			"resolved": "http://bbnpm.azurewebsites.net/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 			"requires": {
-				"graceful-fs": "4.1.11"
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"jsonparse": {
+			"version": "1.2.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jsonparse/-/jsonparse-1.2.0.tgz",
+			"integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
+		},
+		"jsonwebtoken": {
+			"version": "8.0.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
+			"integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
+			"requires": {
+				"jws": "^3.1.4",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.0.0",
+				"xtend": "^4.0.1"
 			}
 		},
 		"jsprim": {
@@ -878,12 +1813,31 @@
 			"resolved": "http://bbnpm.azurewebsites.net/just-extend/-/just-extend-1.1.27.tgz",
 			"integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
 		},
+		"jwa": {
+			"version": "1.1.6",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jwa/-/jwa-1.1.6.tgz",
+			"integrity": "sha1-hyQOdsmAjb3hh4PPImTvSSnuUOY=",
+			"requires": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.10",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"jws": {
+			"version": "3.1.5",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jws/-/jws-3.1.5.tgz",
+			"integrity": "sha1-gNEtBbKT0ehB58uLTmnlYa3Pg08=",
+			"requires": {
+				"jwa": "^1.1.5",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"kind-of": {
 			"version": "3.2.2",
 			"resolved": "http://bbnpm.azurewebsites.net/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
-				"is-buffer": "1.1.6"
+				"is-buffer": "^1.1.5"
 			}
 		},
 		"lazy-cache": {
@@ -897,7 +1851,7 @@
 			"resolved": "http://bbnpm.azurewebsites.net/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"requires": {
-				"invert-kv": "1.0.0"
+				"invert-kv": "^1.0.0"
 			}
 		},
 		"lcov-parse": {
@@ -911,8 +1865,8 @@
 			"resolved": "http://bbnpm.azurewebsites.net/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"locate-path": {
@@ -920,8 +1874,8 @@
 			"resolved": "http://bbnpm.azurewebsites.net/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
@@ -929,10 +1883,80 @@
 			"resolved": "http://bbnpm.azurewebsites.net/lodash/-/lodash-4.17.5.tgz",
 			"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
 		},
+		"lodash.escaperegexp": {
+			"version": "4.1.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+			"integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "http://bbnpm.azurewebsites.net/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+		},
+		"lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+		},
+		"lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+		},
+		"lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+		},
+		"lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+		},
+		"lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+		},
+		"lodash.last": {
+			"version": "3.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.last/-/lodash.last-3.0.0.tgz",
+			"integrity": "sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw="
+		},
+		"lodash.max": {
+			"version": "4.0.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.max/-/lodash.max-4.0.1.tgz",
+			"integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
+		},
+		"lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+		},
+		"lodash.tonumber": {
+			"version": "4.0.3",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
+			"integrity": "sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="
+		},
+		"lodash.trimend": {
+			"version": "4.5.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
+			"integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
 		},
 		"log-driver": {
 			"version": "1.2.7",
@@ -955,21 +1979,62 @@
 			"resolved": "http://bbnpm.azurewebsites.net/lru-cache/-/lru-cache-4.1.2.tgz",
 			"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
+		},
+		"make-error": {
+			"version": "1.3.5",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/make-error/-/make-error-1.3.5.tgz",
+			"integrity": "sha1-7+ToH22yjK3WBccPKcgxtY73dsg="
 		},
 		"marked": {
 			"version": "0.3.17",
 			"resolved": "http://bbnpm.azurewebsites.net/marked/-/marked-0.3.17.tgz",
 			"integrity": "sha512-+AKbNsjZl6jFfLPwHhWmGTqE009wTKn3RTmn9K8oUKHrX/abPJjtcRtXpYB/FFrwPJRUA86LX/de3T0knkPCmQ=="
 		},
+		"match-stream": {
+			"version": "0.0.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/match-stream/-/match-stream-0.0.2.tgz",
+			"integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
+			"requires": {
+				"buffers": "~0.1.1",
+				"readable-stream": "~1.0.0"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				}
+			}
+		},
+		"md5.js": {
+			"version": "1.3.4",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/md5.js/-/md5.js-1.3.4.tgz",
+			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
+			}
+		},
 		"mem": {
 			"version": "1.1.0",
 			"resolved": "http://bbnpm.azurewebsites.net/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"requires": {
-				"mimic-fn": "1.2.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"mime-db": {
@@ -982,7 +2047,7 @@
 			"resolved": "http://bbnpm.azurewebsites.net/mime-types/-/mime-types-2.1.18.tgz",
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"requires": {
-				"mime-db": "1.33.0"
+				"mime-db": "~1.33.0"
 			}
 		},
 		"mimic-fn": {
@@ -995,7 +2060,7 @@
 			"resolved": "http://bbnpm.azurewebsites.net/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -1007,7 +2072,6 @@
 			"version": "0.5.1",
 			"resolved": "http://bbnpm.azurewebsites.net/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			},
@@ -1015,8 +2079,7 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "http://bbnpm.azurewebsites.net/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				}
 			}
 		},
@@ -1050,27 +2113,210 @@
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
 		},
+		"moment": {
+			"version": "2.22.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/moment/-/moment-2.22.2.tgz",
+			"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "http://bbnpm.azurewebsites.net/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"ms-rest": {
+			"version": "2.3.6",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms-rest/-/ms-rest-2.3.6.tgz",
+			"integrity": "sha1-mYT+kyjNB+MXK1INtd/wrLaPH3o=",
+			"requires": {
+				"duplexer": "^0.1.1",
+				"is-buffer": "^1.1.6",
+				"is-stream": "^1.1.0",
+				"moment": "^2.21.0",
+				"request": "^2.87.0",
+				"through": "^2.3.8",
+				"tunnel": "0.0.5",
+				"uuid": "^3.2.1"
+			},
+			"dependencies": {
+				"aws4": {
+					"version": "1.8.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/aws4/-/aws4-1.8.0.tgz",
+					"integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+				},
+				"har-validator": {
+					"version": "5.1.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/har-validator/-/har-validator-5.1.0.tgz",
+					"integrity": "sha1-RGV/VoiiLP1LckhugbOj+xF0LCk=",
+					"requires": {
+						"ajv": "^5.3.0",
+						"har-schema": "^2.0.0"
+					}
+				},
+				"mime-db": {
+					"version": "1.36.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/mime-db/-/mime-db-1.36.0.tgz",
+					"integrity": "sha1-UCBHjbPH/pOq17vMTc+GnEM2M5c="
+				},
+				"mime-types": {
+					"version": "2.1.20",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/mime-types/-/mime-types-2.1.20.tgz",
+					"integrity": "sha1-kwy3GdVx6QNzhSD4RwkRVIyizBk=",
+					"requires": {
+						"mime-db": "~1.36.0"
+					}
+				},
+				"oauth-sign": {
+					"version": "0.9.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
+					"integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+				},
+				"qs": {
+					"version": "6.5.2",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/qs/-/qs-6.5.2.tgz",
+					"integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+				},
+				"request": {
+					"version": "2.88.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/request/-/request-2.88.0.tgz",
+					"integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+					"requires": {
+						"aws-sign2": "~0.7.0",
+						"aws4": "^1.8.0",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.6",
+						"extend": "~3.0.2",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.3.2",
+						"har-validator": "~5.1.0",
+						"http-signature": "~1.2.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.19",
+						"oauth-sign": "~0.9.0",
+						"performance-now": "^2.1.0",
+						"qs": "~6.5.2",
+						"safe-buffer": "^5.1.2",
+						"tough-cookie": "~2.4.3",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.3.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				}
+			}
+		},
+		"ms-rest-azure": {
+			"version": "2.5.7",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms-rest-azure/-/ms-rest-azure-2.5.7.tgz",
+			"integrity": "sha1-jUpo7ZONIUiLpuZrRSX+Loy9+y0=",
+			"requires": {
+				"adal-node": "^0.1.28",
+				"async": "2.6.0",
+				"moment": "^2.22.2",
+				"ms-rest": "^2.3.2",
+				"uuid": "^3.2.1"
+			},
+			"dependencies": {
+				"async": {
+					"version": "2.6.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/async/-/async-2.6.0.tgz",
+					"integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
+					"requires": {
+						"lodash": "^4.14.0"
+					}
+				}
+			}
+		},
+		"ms-rest-js": {
+			"version": "0.2.8",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ms-rest-js/-/ms-rest-js-0.2.8.tgz",
+			"integrity": "sha1-mk4QQyexPtf2puUFri4WrVTD2DQ=",
+			"requires": {
+				"@types/form-data": "^2.2.1",
+				"@types/is-stream": "^1.1.0",
+				"@types/node": "^9.4.6",
+				"@types/node-fetch": "^1.6.7",
+				"@types/uuid": "^3.4.3",
+				"fetch-cookie": "^0.7.0",
+				"fetch-ponyfill": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
+				"form-data": "^2.3.2",
+				"is-buffer": "^2.0.0",
+				"is-stream": "^1.1.0",
+				"moment": "^2.21.0",
+				"url-parse": "^1.2.0",
+				"uuid": "^3.2.1"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.3",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-buffer/-/is-buffer-2.0.3.tgz",
+					"integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU="
+				}
+			}
+		},
+		"mstranslator": {
+			"version": "3.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/mstranslator/-/mstranslator-3.0.0.tgz",
+			"integrity": "sha1-ancOpFD/tMZfaNXmruBRuC3gXPM="
+		},
+		"natives": {
+			"version": "1.1.5",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/natives/-/natives-1.1.5.tgz",
+			"integrity": "sha1-O9vbQQQCPl3SObVvx+89mhesxqo="
 		},
 		"nise": {
 			"version": "1.4.2",
 			"resolved": "http://bbnpm.azurewebsites.net/nise/-/nise-1.4.2.tgz",
 			"integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
 			"requires": {
-				"@sinonjs/formatio": "2.0.0",
-				"just-extend": "1.1.27",
-				"lolex": "2.7.1",
-				"path-to-regexp": "1.7.0",
-				"text-encoding": "0.6.4"
+				"@sinonjs/formatio": "^2.0.0",
+				"just-extend": "^1.1.27",
+				"lolex": "^2.3.2",
+				"path-to-regexp": "^1.7.0",
+				"text-encoding": "^0.6.4"
+			}
+		},
+		"nock": {
+			"version": "9.6.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/nock/-/nock-9.6.1.tgz",
+			"integrity": "sha1-2W4Jm+m8HQGJp39EkLu7Jlw4G0k=",
+			"requires": {
+				"chai": "^4.1.2",
+				"debug": "^3.1.0",
+				"deep-equal": "^1.0.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.17.5",
+				"mkdirp": "^0.5.0",
+				"propagate": "^1.0.0",
+				"qs": "^6.5.1",
+				"semver": "^5.5.0"
+			}
+		},
+		"node-fetch": {
+			"version": "1.7.3",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
+			"requires": {
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
 			}
 		},
 		"npm-run-path": {
@@ -1078,7 +2324,7 @@
 			"resolved": "http://bbnpm.azurewebsites.net/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -1091,17 +2337,2325 @@
 			"resolved": "http://bbnpm.azurewebsites.net/nwmatcher/-/nwmatcher-1.4.4.tgz",
 			"integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ=="
 		},
+		"nyc": {
+			"version": "11.9.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/nyc/-/nyc-11.9.0.tgz",
+			"integrity": "sha1-QQbono++c2I6H8i27Lerqica4eQ=",
+			"requires": {
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^1.0.0",
+				"convert-source-map": "^1.5.1",
+				"debug-log": "^1.0.1",
+				"default-require-extensions": "^1.0.0",
+				"find-cache-dir": "^0.1.1",
+				"find-up": "^2.1.0",
+				"foreground-child": "^1.5.3",
+				"glob": "^7.0.6",
+				"istanbul-lib-coverage": "^1.1.2",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^1.10.0",
+				"istanbul-lib-report": "^1.1.3",
+				"istanbul-lib-source-maps": "^1.2.3",
+				"istanbul-reports": "^1.4.0",
+				"md5-hex": "^1.2.0",
+				"merge-source-map": "^1.1.0",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.0",
+				"resolve-from": "^2.0.0",
+				"rimraf": "^2.6.2",
+				"signal-exit": "^3.0.1",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^4.2.0",
+				"yargs": "11.1.0",
+				"yargs-parser": "^8.0.0"
+			},
+			"dependencies": {
+				"align-text": {
+					"version": "0.1.4",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2",
+						"longest": "^1.0.1",
+						"repeat-string": "^1.5.2"
+					}
+				},
+				"amdefine": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"bundled": true
+				},
+				"append-transform": {
+					"version": "0.4.0",
+					"bundled": true,
+					"requires": {
+						"default-require-extensions": "^1.0.0"
+					}
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"bundled": true
+				},
+				"arr-flatten": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"arr-union": {
+					"version": "3.1.0",
+					"bundled": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"bundled": true
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"assign-symbols": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"async": {
+					"version": "1.5.2",
+					"bundled": true
+				},
+				"atob": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"babel-code-frame": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"chalk": "^1.1.3",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.2"
+					}
+				},
+				"babel-generator": {
+					"version": "6.26.1",
+					"bundled": true,
+					"requires": {
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"detect-indent": "^4.0.0",
+						"jsesc": "^1.3.0",
+						"lodash": "^4.17.4",
+						"source-map": "^0.5.7",
+						"trim-right": "^1.0.1"
+					}
+				},
+				"babel-messages": {
+					"version": "6.23.0",
+					"bundled": true,
+					"requires": {
+						"babel-runtime": "^6.22.0"
+					}
+				},
+				"babel-runtime": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"core-js": "^2.4.0",
+						"regenerator-runtime": "^0.11.0"
+					}
+				},
+				"babel-template": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"babel-runtime": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"lodash": "^4.17.4"
+					}
+				},
+				"babel-traverse": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"babel-code-frame": "^6.26.0",
+						"babel-messages": "^6.23.0",
+						"babel-runtime": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"debug": "^2.6.8",
+						"globals": "^9.18.0",
+						"invariant": "^2.2.2",
+						"lodash": "^4.17.4"
+					}
+				},
+				"babel-types": {
+					"version": "6.26.0",
+					"bundled": true,
+					"requires": {
+						"babel-runtime": "^6.26.0",
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.4",
+						"to-fast-properties": "^1.0.3"
+					}
+				},
+				"babylon": {
+					"version": "6.18.0",
+					"bundled": true
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"base": {
+					"version": "0.11.2",
+					"bundled": true,
+					"requires": {
+						"cache-base": "^1.0.1",
+						"class-utils": "^0.3.5",
+						"component-emitter": "^1.2.1",
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.1",
+						"mixin-deep": "^1.2.0",
+						"pascalcase": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"bundled": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"cache-base": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"collection-visit": "^1.0.0",
+						"component-emitter": "^1.2.1",
+						"get-value": "^2.0.6",
+						"has-value": "^1.0.0",
+						"isobject": "^3.0.1",
+						"set-value": "^2.0.0",
+						"to-object-path": "^0.3.0",
+						"union-value": "^1.0.0",
+						"unset-value": "^1.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"caching-transform": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"md5-hex": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"write-file-atomic": "^1.1.4"
+					}
+				},
+				"camelcase": {
+					"version": "1.2.1",
+					"bundled": true,
+					"optional": true
+				},
+				"center-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"align-text": "^0.1.3",
+						"lazy-cache": "^1.0.3"
+					}
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"bundled": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"class-utils": {
+					"version": "0.3.6",
+					"bundled": true,
+					"requires": {
+						"arr-union": "^3.1.0",
+						"define-property": "^0.2.5",
+						"isobject": "^3.0.0",
+						"static-extend": "^0.1.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
+						"wordwrap": "0.0.2"
+					},
+					"dependencies": {
+						"wordwrap": {
+							"version": "0.0.2",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"collection-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"map-visit": "^1.0.0",
+						"object-visit": "^1.0.0"
+					}
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"component-emitter": {
+					"version": "1.2.1",
+					"bundled": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"bundled": true
+				},
+				"copy-descriptor": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"core-js": {
+					"version": "2.5.6",
+					"bundled": true
+				},
+				"cross-spawn": {
+					"version": "4.0.2",
+					"bundled": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
+					}
+				},
+				"debug": {
+					"version": "2.6.9",
+					"bundled": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"debug-log": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"default-require-extensions": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"is-descriptor": "^1.0.2",
+						"isobject": "^3.0.1"
+					},
+					"dependencies": {
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"detect-indent": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"repeating": "^2.0.0"
+					}
+				},
+				"error-ex": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"is-arrayish": "^0.2.1"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"bundled": true
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"bundled": true
+				},
+				"execa": {
+					"version": "0.7.0",
+					"bundled": true,
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "5.1.0",
+							"bundled": true,
+							"requires": {
+								"lru-cache": "^4.0.1",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"bundled": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"extend-shallow": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"assign-symbols": "^1.0.0",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"bundled": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"find-cache-dir": {
+					"version": "0.1.1",
+					"bundled": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"mkdirp": "^0.5.1",
+						"pkg-dir": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"for-in": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"foreground-child": {
+					"version": "1.5.6",
+					"bundled": true,
+					"requires": {
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
+					}
+				},
+				"fragment-cache": {
+					"version": "0.2.1",
+					"bundled": true,
+					"requires": {
+						"map-cache": "^0.2.2"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"get-caller-file": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"get-value": {
+					"version": "2.0.6",
+					"bundled": true
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"globals": {
+					"version": "9.18.0",
+					"bundled": true
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true
+				},
+				"handlebars": {
+					"version": "4.0.11",
+					"bundled": true,
+					"requires": {
+						"async": "^1.4.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.4.4",
+						"uglify-js": "^2.6"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.4.4",
+							"bundled": true,
+							"requires": {
+								"amdefine": ">=0.0.4"
+							}
+						}
+					}
+				},
+				"has-ansi": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"has-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"get-value": "^2.0.6",
+						"has-values": "^1.0.0",
+						"isobject": "^3.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"has-values": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"kind-of": "^4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"kind-of": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"hosted-git-info": {
+					"version": "2.6.0",
+					"bundled": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"invariant": {
+					"version": "2.2.4",
+					"bundled": true,
+					"requires": {
+						"loose-envify": "^1.0.0"
+					}
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"is-accessor-descriptor": {
+					"version": "0.1.6",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"is-buffer": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"builtin-modules": "^1.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "0.1.4",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-descriptor": {
+					"version": "0.1.6",
+					"bundled": true,
+					"requires": {
+						"is-accessor-descriptor": "^0.1.6",
+						"is-data-descriptor": "^0.1.4",
+						"kind-of": "^5.0.0"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "5.1.0",
+							"bundled": true
+						}
+					}
+				},
+				"is-extendable": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"is-finite": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"is-odd": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-number": "^4.0.0"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "4.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"bundled": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"is-utf8": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"is-windows": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"bundled": true
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"istanbul-lib-hook": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"append-transform": "^0.4.0"
+					}
+				},
+				"istanbul-lib-instrument": {
+					"version": "1.10.1",
+					"bundled": true,
+					"requires": {
+						"babel-generator": "^6.18.0",
+						"babel-template": "^6.16.0",
+						"babel-traverse": "^6.18.0",
+						"babel-types": "^6.18.0",
+						"babylon": "^6.18.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"semver": "^5.3.0"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "1.1.3",
+					"bundled": true,
+					"requires": {
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"path-parse": "^1.0.5",
+						"supports-color": "^3.1.2"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "3.2.3",
+							"bundled": true,
+							"requires": {
+								"has-flag": "^1.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "1.2.3",
+					"bundled": true,
+					"requires": {
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.1.2",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "3.1.0",
+							"bundled": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-reports": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"handlebars": "^4.0.3"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"jsesc": {
+					"version": "1.3.0",
+					"bundled": true
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"bundled": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				},
+				"lazy-cache": {
+					"version": "1.0.4",
+					"bundled": true,
+					"optional": true
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"invert-kv": "^1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					},
+					"dependencies": {
+						"path-exists": {
+							"version": "3.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"lodash": {
+					"version": "4.17.10",
+					"bundled": true
+				},
+				"longest": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"loose-envify": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "4.1.3",
+					"bundled": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"map-cache": {
+					"version": "0.2.2",
+					"bundled": true
+				},
+				"map-visit": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"object-visit": "^1.0.0"
+					}
+				},
+				"md5-hex": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"md5-o-matic": "^0.1.1"
+					}
+				},
+				"md5-o-matic": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"mem": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"merge-source-map": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"source-map": "^0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true
+						}
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"bundled": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true
+				},
+				"mixin-deep": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"for-in": "^1.0.2",
+						"is-extendable": "^1.0.1"
+					},
+					"dependencies": {
+						"is-extendable": {
+							"version": "1.0.1",
+							"bundled": true,
+							"requires": {
+								"is-plain-object": "^2.0.4"
+							}
+						}
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"nanomatch": {
+					"version": "1.2.9",
+					"bundled": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"is-odd": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"kind-of": "^6.0.2",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "4.0.0",
+							"bundled": true
+						},
+						"array-unique": {
+							"version": "0.3.2",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"bundled": true,
+					"requires": {
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"path-key": "^2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true
+				},
+				"object-copy": {
+					"version": "0.1.0",
+					"bundled": true,
+					"requires": {
+						"copy-descriptor": "^0.1.0",
+						"define-property": "^0.2.5",
+						"kind-of": "^3.0.3"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"object-visit": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"isobject": "^3.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"object.pick": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"os-locale": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
+					}
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"p-limit": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"bundled": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"pascalcase": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"path-parse": {
+					"version": "1.0.5",
+					"bundled": true
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"bundled": true
+				},
+				"pinkie": {
+					"version": "2.0.4",
+					"bundled": true
+				},
+				"pinkie-promise": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"pinkie": "^2.0.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"find-up": "^1.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"requires": {
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						}
+					}
+				},
+				"posix-character-classes": {
+					"version": "0.1.1",
+					"bundled": true
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "1.1.2",
+							"bundled": true,
+							"requires": {
+								"path-exists": "^2.0.0",
+								"pinkie-promise": "^2.0.0"
+							}
+						}
+					}
+				},
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"bundled": true
+				},
+				"regex-not": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^3.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"repeat-element": {
+					"version": "1.1.2",
+					"bundled": true
+				},
+				"repeat-string": {
+					"version": "1.6.1",
+					"bundled": true
+				},
+				"repeating": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"is-finite": "^1.0.0"
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"resolve-from": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"resolve-url": {
+					"version": "0.2.1",
+					"bundled": true
+				},
+				"ret": {
+					"version": "0.1.15",
+					"bundled": true
+				},
+				"right-align": {
+					"version": "0.1.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"align-text": "^0.1.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"requires": {
+						"glob": "^7.0.5"
+					}
+				},
+				"safe-regex": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"ret": "~0.1.10"
+					}
+				},
+				"semver": {
+					"version": "5.5.0",
+					"bundled": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"set-value": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.3",
+						"split-string": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"slide": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"snapdragon": {
+					"version": "0.8.2",
+					"bundled": true,
+					"requires": {
+						"base": "^0.11.1",
+						"debug": "^2.2.0",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"map-cache": "^0.2.2",
+						"source-map": "^0.5.6",
+						"source-map-resolve": "^0.5.0",
+						"use": "^3.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"snapdragon-node": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"define-property": "^1.0.0",
+						"isobject": "^3.0.0",
+						"snapdragon-util": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"snapdragon-util": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.2.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"bundled": true
+				},
+				"source-map-resolve": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"atob": "^2.0.0",
+						"decode-uri-component": "^0.2.0",
+						"resolve-url": "^0.2.1",
+						"source-map-url": "^0.4.0",
+						"urix": "^0.1.0"
+					}
+				},
+				"source-map-url": {
+					"version": "0.4.0",
+					"bundled": true
+				},
+				"spawn-wrap": {
+					"version": "1.4.2",
+					"bundled": true,
+					"requires": {
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
+					}
+				},
+				"spdx-correct": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.1.0",
+					"bundled": true
+				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"split-string": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"extend-shallow": "^3.0.0"
+					}
+				},
+				"static-extend": {
+					"version": "0.1.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "^0.2.5",
+						"object-copy": "^0.1.0"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"bundled": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						}
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"is-utf8": "^0.2.0"
+					}
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"test-exclude": {
+					"version": "4.2.1",
+					"bundled": true,
+					"requires": {
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
+					},
+					"dependencies": {
+						"arr-diff": {
+							"version": "4.0.0",
+							"bundled": true
+						},
+						"array-unique": {
+							"version": "0.3.2",
+							"bundled": true
+						},
+						"braces": {
+							"version": "2.3.2",
+							"bundled": true,
+							"requires": {
+								"arr-flatten": "^1.1.0",
+								"array-unique": "^0.3.2",
+								"extend-shallow": "^2.0.1",
+								"fill-range": "^4.0.0",
+								"isobject": "^3.0.1",
+								"repeat-element": "^1.1.2",
+								"snapdragon": "^0.8.1",
+								"snapdragon-node": "^2.0.1",
+								"split-string": "^3.0.2",
+								"to-regex": "^3.0.1"
+							},
+							"dependencies": {
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "^0.1.0"
+									}
+								}
+							}
+						},
+						"expand-brackets": {
+							"version": "2.1.4",
+							"bundled": true,
+							"requires": {
+								"debug": "^2.3.3",
+								"define-property": "^0.2.5",
+								"extend-shallow": "^2.0.1",
+								"posix-character-classes": "^0.1.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "0.2.5",
+									"bundled": true,
+									"requires": {
+										"is-descriptor": "^0.1.0"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "^0.1.0"
+									}
+								},
+								"is-accessor-descriptor": {
+									"version": "0.1.6",
+									"bundled": true,
+									"requires": {
+										"kind-of": "^3.0.2"
+									},
+									"dependencies": {
+										"kind-of": {
+											"version": "3.2.2",
+											"bundled": true,
+											"requires": {
+												"is-buffer": "^1.1.5"
+											}
+										}
+									}
+								},
+								"is-data-descriptor": {
+									"version": "0.1.4",
+									"bundled": true,
+									"requires": {
+										"kind-of": "^3.0.2"
+									},
+									"dependencies": {
+										"kind-of": {
+											"version": "3.2.2",
+											"bundled": true,
+											"requires": {
+												"is-buffer": "^1.1.5"
+											}
+										}
+									}
+								},
+								"is-descriptor": {
+									"version": "0.1.6",
+									"bundled": true,
+									"requires": {
+										"is-accessor-descriptor": "^0.1.6",
+										"is-data-descriptor": "^0.1.4",
+										"kind-of": "^5.0.0"
+									}
+								},
+								"kind-of": {
+									"version": "5.1.0",
+									"bundled": true
+								}
+							}
+						},
+						"extglob": {
+							"version": "2.0.4",
+							"bundled": true,
+							"requires": {
+								"array-unique": "^0.3.2",
+								"define-property": "^1.0.0",
+								"expand-brackets": "^2.1.4",
+								"extend-shallow": "^2.0.1",
+								"fragment-cache": "^0.2.1",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.1"
+							},
+							"dependencies": {
+								"define-property": {
+									"version": "1.0.0",
+									"bundled": true,
+									"requires": {
+										"is-descriptor": "^1.0.0"
+									}
+								},
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "^0.1.0"
+									}
+								}
+							}
+						},
+						"fill-range": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"extend-shallow": "^2.0.1",
+								"is-number": "^3.0.0",
+								"repeat-string": "^1.6.1",
+								"to-regex-range": "^2.1.0"
+							},
+							"dependencies": {
+								"extend-shallow": {
+									"version": "2.0.1",
+									"bundled": true,
+									"requires": {
+										"is-extendable": "^0.1.0"
+									}
+								}
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-data-descriptor": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^6.0.0"
+							}
+						},
+						"is-descriptor": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"is-accessor-descriptor": "^1.0.0",
+								"is-data-descriptor": "^1.0.0",
+								"kind-of": "^6.0.2"
+							}
+						},
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"bundled": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						},
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						},
+						"micromatch": {
+							"version": "3.1.10",
+							"bundled": true,
+							"requires": {
+								"arr-diff": "^4.0.0",
+								"array-unique": "^0.3.2",
+								"braces": "^2.3.1",
+								"define-property": "^2.0.2",
+								"extend-shallow": "^3.0.2",
+								"extglob": "^2.0.4",
+								"fragment-cache": "^0.2.1",
+								"kind-of": "^6.0.2",
+								"nanomatch": "^1.2.9",
+								"object.pick": "^1.3.0",
+								"regex-not": "^1.0.0",
+								"snapdragon": "^0.8.1",
+								"to-regex": "^3.0.2"
+							}
+						}
+					}
+				},
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"bundled": true
+				},
+				"to-object-path": {
+					"version": "0.3.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				},
+				"to-regex": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"regex-not": "^1.0.2",
+						"safe-regex": "^1.1.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					},
+					"dependencies": {
+						"is-number": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							}
+						}
+					}
+				},
+				"trim-right": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"uglify-js": {
+					"version": "2.8.29",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"source-map": "~0.5.1",
+						"uglify-to-browserify": "~1.0.0",
+						"yargs": "~3.10.0"
+					},
+					"dependencies": {
+						"yargs": {
+							"version": "3.10.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"camelcase": "^1.0.2",
+								"cliui": "^2.1.0",
+								"decamelize": "^1.0.0",
+								"window-size": "0.1.0"
+							}
+						}
+					}
+				},
+				"uglify-to-browserify": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"union-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"arr-union": "^3.1.0",
+						"get-value": "^2.0.6",
+						"is-extendable": "^0.1.1",
+						"set-value": "^0.4.3"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"set-value": {
+							"version": "0.4.3",
+							"bundled": true,
+							"requires": {
+								"extend-shallow": "^2.0.1",
+								"is-extendable": "^0.1.1",
+								"is-plain-object": "^2.0.1",
+								"to-object-path": "^0.3.0"
+							}
+						}
+					}
+				},
+				"unset-value": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"has-value": "^0.3.1",
+						"isobject": "^3.0.0"
+					},
+					"dependencies": {
+						"has-value": {
+							"version": "0.3.1",
+							"bundled": true,
+							"requires": {
+								"get-value": "^2.0.3",
+								"has-values": "^0.1.4",
+								"isobject": "^2.0.0"
+							},
+							"dependencies": {
+								"isobject": {
+									"version": "2.1.0",
+									"bundled": true,
+									"requires": {
+										"isarray": "1.0.0"
+									}
+								}
+							}
+						},
+						"has-values": {
+							"version": "0.1.4",
+							"bundled": true
+						},
+						"isobject": {
+							"version": "3.0.1",
+							"bundled": true
+						}
+					}
+				},
+				"urix": {
+					"version": "0.1.0",
+					"bundled": true
+				},
+				"use": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"kind-of": "^6.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "6.0.2",
+							"bundled": true
+						}
+					}
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.3",
+					"bundled": true,
+					"requires": {
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
+					}
+				},
+				"which": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"bundled": true,
+					"optional": true
+				},
+				"wordwrap": {
+					"version": "0.0.3",
+					"bundled": true
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					},
+					"dependencies": {
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"slide": "^1.1.5"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"bundled": true
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"bundled": true
+				},
+				"yargs": {
+					"version": "11.1.0",
+					"bundled": true,
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true
+						},
+						"cliui": {
+							"version": "4.1.0",
+							"bundled": true,
+							"requires": {
+								"string-width": "^2.1.1",
+								"strip-ansi": "^4.0.0",
+								"wrap-ansi": "^2.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						},
+						"yargs-parser": {
+							"version": "9.0.2",
+							"bundled": true,
+							"requires": {
+								"camelcase": "^4.1.0"
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "8.1.0",
+					"bundled": true,
+					"requires": {
+						"camelcase": "^4.1.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "4.1.0",
+							"bundled": true
+						}
+					}
+				}
+			}
+		},
 		"oauth-sign": {
 			"version": "0.8.2",
 			"resolved": "http://bbnpm.azurewebsites.net/oauth-sign/-/oauth-sign-0.8.2.tgz",
 			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "http://bbnpm.azurewebsites.net/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"optimist": {
@@ -1109,8 +4663,8 @@
 			"resolved": "http://bbnpm.azurewebsites.net/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"requires": {
-				"minimist": "0.0.10",
-				"wordwrap": "0.0.3"
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
 			}
 		},
 		"optionator": {
@@ -1118,12 +4672,12 @@
 			"resolved": "http://bbnpm.azurewebsites.net/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -1138,10 +4692,15 @@
 			"resolved": "http://bbnpm.azurewebsites.net/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"requires": {
-				"execa": "0.7.0",
-				"lcid": "1.0.0",
-				"mem": "1.1.0"
+				"execa": "^0.7.0",
+				"lcid": "^1.0.0",
+				"mem": "^1.1.0"
 			}
+		},
+		"over": {
+			"version": "0.0.5",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/over/-/over-0.0.5.tgz",
+			"integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg="
 		},
 		"p-finally": {
 			"version": "1.0.0",
@@ -1153,7 +4712,7 @@
 			"resolved": "http://bbnpm.azurewebsites.net/p-limit/-/p-limit-1.2.0.tgz",
 			"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 			"requires": {
-				"p-try": "1.0.0"
+				"p-try": "^1.0.0"
 			}
 		},
 		"p-locate": {
@@ -1161,13 +4720,18 @@
 			"resolved": "http://bbnpm.azurewebsites.net/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"requires": {
-				"p-limit": "1.2.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "http://bbnpm.azurewebsites.net/p-try/-/p-try-1.0.0.tgz",
 			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+		},
+		"parse-passwd": {
+			"version": "1.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
 		},
 		"parse5": {
 			"version": "1.5.1",
@@ -1209,25 +4773,92 @@
 				}
 			}
 		},
+		"pathval": {
+			"version": "1.1.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/pathval/-/pathval-1.1.0.tgz",
+			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "http://bbnpm.azurewebsites.net/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+		},
+		"please-upgrade-node": {
+			"version": "3.1.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
+			"integrity": "sha1-7TIAUd/MUCT65pZxLIKImTWV6Kw=",
+			"requires": {
+				"semver-compare": "^1.0.0"
+			}
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "http://bbnpm.azurewebsites.net/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
+		"priorityqueuejs": {
+			"version": "1.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz",
+			"integrity": "sha1-LuTyPCVgkT4IwHzlzN1t498sWvg="
+		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+		},
+		"process-nextick-args": {
+			"version": "1.0.7",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+		},
 		"progress": {
 			"version": "2.0.0",
 			"resolved": "http://bbnpm.azurewebsites.net/progress/-/progress-2.0.0.tgz",
 			"integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
 		},
+		"propagate": {
+			"version": "1.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/propagate/-/propagate-1.0.0.tgz",
+			"integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk="
+		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "http://bbnpm.azurewebsites.net/pseudomap/-/pseudomap-1.0.2.tgz",
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+		},
+		"psl": {
+			"version": "1.1.29",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/psl/-/psl-1.1.29.tgz",
+			"integrity": "sha1-YPWA02AXC7cip5fMcEQR5tqFDGc="
+		},
+		"pullstream": {
+			"version": "0.4.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/pullstream/-/pullstream-0.4.1.tgz",
+			"integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
+			"requires": {
+				"over": ">= 0.0.5 < 1",
+				"readable-stream": "~1.0.31",
+				"setimmediate": ">= 1.0.2 < 2",
+				"slice-stream": ">= 1.0.0 < 2"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				}
+			}
 		},
 		"punycode": {
 			"version": "1.4.1",
@@ -1239,12 +4870,72 @@
 			"resolved": "http://bbnpm.azurewebsites.net/qs/-/qs-6.5.1.tgz",
 			"integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
 		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+		},
+		"querystringify": {
+			"version": "2.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/querystringify/-/querystringify-2.0.0.tgz",
+			"integrity": "sha1-+j7W5o6xUVlFfImze8ZHKDMZV1U="
+		},
+		"read-text-file": {
+			"version": "1.1.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/read-text-file/-/read-text-file-1.1.0.tgz",
+			"integrity": "sha1-0MPxh2iCj5EH1huws2jue5D3GJM=",
+			"requires": {
+				"iconv-lite": "^0.4.17",
+				"jschardet": "^1.4.2"
+			}
+		},
+		"readable-stream": {
+			"version": "2.0.6",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/readable-stream/-/readable-stream-2.0.6.tgz",
+			"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~1.0.6",
+				"string_decoder": "~0.10.x",
+				"util-deprecate": "~1.0.1"
+			}
+		},
 		"rechoir": {
 			"version": "0.6.2",
 			"resolved": "http://bbnpm.azurewebsites.net/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
-				"resolve": "1.5.0"
+				"resolve": "^1.1.6"
+			}
+		},
+		"regenerate": {
+			"version": "1.4.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/regenerate/-/regenerate-1.4.0.tgz",
+			"integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE="
+		},
+		"regexpu-core": {
+			"version": "1.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/regexpu-core/-/regexpu-core-1.0.0.tgz",
+			"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+			"requires": {
+				"regenerate": "^1.2.1",
+				"regjsgen": "^0.2.0",
+				"regjsparser": "^0.1.4"
+			}
+		},
+		"regjsgen": {
+			"version": "0.2.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/regjsgen/-/regjsgen-0.2.0.tgz",
+			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+		},
+		"regjsparser": {
+			"version": "0.1.5",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/regjsparser/-/regjsparser-0.1.5.tgz",
+			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+			"requires": {
+				"jsesc": "~0.5.0"
 			}
 		},
 		"repeat-string": {
@@ -1257,9 +4948,9 @@
 			"resolved": "http://bbnpm.azurewebsites.net/replace-in-file/-/replace-in-file-3.2.0.tgz",
 			"integrity": "sha512-9jagYHGHhGgMNovv4f9wplU22tG07fRN7U+SbPfObKrFwSWwPIFGOQBTKhQn0D/7VrVWC79M8emAoeXSMTJQtA==",
 			"requires": {
-				"chalk": "2.3.2",
-				"glob": "7.1.2",
-				"yargs": "11.0.0"
+				"chalk": "^2.3.0",
+				"glob": "^7.1.2",
+				"yargs": "^11.0.0"
 			}
 		},
 		"request": {
@@ -1267,28 +4958,28 @@
 			"resolved": "http://bbnpm.azurewebsites.net/request/-/request-2.83.0.tgz",
 			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.6.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.2",
-				"har-validator": "5.0.3",
-				"hawk": "6.0.2",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.18",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.1",
-				"safe-buffer": "5.1.1",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.4",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.3.2"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"hawk": "~6.0.2",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"stringstream": "~0.0.5",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
 			},
 			"dependencies": {
 				"extend": {
@@ -1296,6 +4987,24 @@
 					"resolved": "http://bbnpm.azurewebsites.net/extend/-/extend-3.0.1.tgz",
 					"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
 				}
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"requires": {
+				"lodash": "^4.13.1"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "^1.1.0",
+				"tough-cookie": ">=2.3.3"
 			}
 		},
 		"require-directory": {
@@ -1308,12 +5017,17 @@
 			"resolved": "http://bbnpm.azurewebsites.net/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+		},
 		"resolve": {
 			"version": "1.5.0",
 			"resolved": "http://bbnpm.azurewebsites.net/resolve/-/resolve-1.5.0.tgz",
 			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
 			"requires": {
-				"path-parse": "1.0.5"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"right-align": {
@@ -1322,8 +5036,21 @@
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
 			"optional": true,
 			"requires": {
-				"align-text": "0.1.4"
+				"align-text": "^0.1.1"
 			}
+		},
+		"rimraf": {
+			"version": "2.6.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/rimraf/-/rimraf-2.6.2.tgz",
+			"integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+			"requires": {
+				"glob": "^7.0.5"
+			}
+		},
+		"rsa-pem-from-mod-exp": {
+			"version": "0.8.4",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
+			"integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
@@ -1340,23 +5067,45 @@
 			"resolved": "http://bbnpm.azurewebsites.net/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
+		"semaphore": {
+			"version": "1.0.5",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/semaphore/-/semaphore-1.0.5.tgz",
+			"integrity": "sha1-tJJXbmavGT25XWXiXsU/Xxl5jWA="
+		},
 		"semver": {
 			"version": "5.5.0",
 			"resolved": "http://bbnpm.azurewebsites.net/semver/-/semver-5.5.0.tgz",
-			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-			"dev": true
+			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+		},
+		"semver-compare": {
+			"version": "1.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/semver-compare/-/semver-compare-1.0.0.tgz",
+			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+		},
+		"semver-dsl": {
+			"version": "1.0.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/semver-dsl/-/semver-dsl-1.0.1.tgz",
+			"integrity": "sha1-02eN5VVeimH2Ke7QJTZq5fJzQKA=",
+			"requires": {
+				"semver": "^5.3.0"
+			}
 		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "http://bbnpm.azurewebsites.net/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "http://bbnpm.azurewebsites.net/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -1369,10 +5118,58 @@
 			"resolved": "http://bbnpm.azurewebsites.net/shelljs/-/shelljs-0.7.8.tgz",
 			"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
 			"requires": {
-				"glob": "7.1.2",
-				"interpret": "1.1.0",
-				"rechoir": "0.6.2"
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
 			}
+		},
+		"should": {
+			"version": "13.2.3",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/should/-/should-13.2.3.tgz",
+			"integrity": "sha1-ltjlrPPpe0nYm1H+qlro0H71jxA=",
+			"requires": {
+				"should-equal": "^2.0.0",
+				"should-format": "^3.0.3",
+				"should-type": "^1.4.0",
+				"should-type-adaptors": "^1.0.1",
+				"should-util": "^1.0.0"
+			}
+		},
+		"should-equal": {
+			"version": "2.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/should-equal/-/should-equal-2.0.0.tgz",
+			"integrity": "sha1-YHLPgwRzYIZ+aOmLCdcRQ9BO4MM=",
+			"requires": {
+				"should-type": "^1.4.0"
+			}
+		},
+		"should-format": {
+			"version": "3.0.3",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/should-format/-/should-format-3.0.3.tgz",
+			"integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+			"requires": {
+				"should-type": "^1.3.0",
+				"should-type-adaptors": "^1.0.1"
+			}
+		},
+		"should-type": {
+			"version": "1.4.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/should-type/-/should-type-1.4.0.tgz",
+			"integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM="
+		},
+		"should-type-adaptors": {
+			"version": "1.1.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+			"integrity": "sha1-QB5/M7VTMDOUTVzYvytlAneS4no=",
+			"requires": {
+				"should-type": "^1.3.0",
+				"should-util": "^1.0.0"
+			}
+		},
+		"should-util": {
+			"version": "1.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/should-util/-/should-util-1.0.0.tgz",
+			"integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM="
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -1384,14 +5181,14 @@
 			"resolved": "http://bbnpm.azurewebsites.net/sinon/-/sinon-6.1.4.tgz",
 			"integrity": "sha512-NFEts+4D4jp2sBjL94fQpZk5o73kzn/g58+I9Dp15i9vsnT4Lk1UEyUf2jACODWLG6Pz/llF0sArYUw47Aarmg==",
 			"requires": {
-				"@sinonjs/formatio": "2.0.0",
-				"@sinonjs/samsam": "2.0.0",
-				"diff": "3.5.0",
-				"lodash.get": "4.4.2",
-				"lolex": "2.7.1",
-				"nise": "1.4.2",
-				"supports-color": "5.4.0",
-				"type-detect": "4.0.8"
+				"@sinonjs/formatio": "^2.0.0",
+				"@sinonjs/samsam": "^2.0.0",
+				"diff": "^3.5.0",
+				"lodash.get": "^4.4.2",
+				"lolex": "^2.7.1",
+				"nise": "^1.4.2",
+				"supports-color": "^5.4.0",
+				"type-detect": "^4.0.8"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -1399,7 +5196,33 @@
 					"resolved": "http://bbnpm.azurewebsites.net/supports-color/-/supports-color-5.4.0.tgz",
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"slice-stream": {
+			"version": "1.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/slice-stream/-/slice-stream-1.0.0.tgz",
+			"integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
+			"requires": {
+				"readable-stream": "~1.0.31"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
 					}
 				}
 			}
@@ -1409,7 +5232,7 @@
 			"resolved": "http://bbnpm.azurewebsites.net/sntp/-/sntp-2.1.0.tgz",
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"requires": {
-				"hoek": "4.2.1"
+				"hoek": "4.x.x"
 			}
 		},
 		"source-map": {
@@ -1417,7 +5240,23 @@
 			"resolved": "http://bbnpm.azurewebsites.net/source-map/-/source-map-0.4.4.tgz",
 			"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 			"requires": {
-				"amdefine": "1.0.1"
+				"amdefine": ">=0.0.4"
+			}
+		},
+		"source-map-support": {
+			"version": "0.5.9",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/source-map-support/-/source-map-support-0.5.9.tgz",
+			"integrity": "sha1-QbyVOyU0Jn6i1gW8z6e/oxEc7V8=",
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+				}
 			}
 		},
 		"sprintf-js": {
@@ -1431,24 +5270,34 @@
 			"resolved": "http://bbnpm.azurewebsites.net/sshpk/-/sshpk-1.14.1.tgz",
 			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
 			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"tweetnacl": "~0.14.0"
 			}
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
 		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "http://bbnpm.azurewebsites.net/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"requires": {
-				"is-fullwidth-code-point": "2.0.0",
-				"strip-ansi": "4.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
 			}
+		},
+		"string_decoder": {
+			"version": "0.10.31",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 		},
 		"stringstream": {
 			"version": "0.0.5",
@@ -1460,20 +5309,38 @@
 			"resolved": "http://bbnpm.azurewebsites.net/strip-ansi/-/strip-ansi-4.0.0.tgz",
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 			"requires": {
-				"ansi-regex": "3.0.0"
+				"ansi-regex": "^3.0.0"
 			}
+		},
+		"strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 		},
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "http://bbnpm.azurewebsites.net/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+		},
+		"strip-outer": {
+			"version": "1.0.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/strip-outer/-/strip-outer-1.0.1.tgz",
+			"integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
+			"requires": {
+				"escape-string-regexp": "^1.0.2"
+			}
+		},
 		"supports-color": {
 			"version": "5.3.0",
 			"resolved": "http://bbnpm.azurewebsites.net/supports-color/-/supports-color-5.3.0.tgz",
 			"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 			"requires": {
-				"has-flag": "3.0.0"
+				"has-flag": "^3.0.0"
 			}
 		},
 		"symbol-tree": {
@@ -1486,13 +5353,18 @@
 			"resolved": "http://bbnpm.azurewebsites.net/text-encoding/-/text-encoding-0.6.4.tgz",
 			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
 		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+		},
 		"to-markdown": {
 			"version": "3.1.1",
 			"resolved": "http://bbnpm.azurewebsites.net/to-markdown/-/to-markdown-3.1.1.tgz",
 			"integrity": "sha1-JR4kG4x0x60XcpLmxSzBlckmjBE=",
 			"requires": {
 				"collapse-whitespace": "1.1.2",
-				"jsdom": "9.12.0"
+				"jsdom": "^9.0.0"
 			}
 		},
 		"tough-cookie": {
@@ -1500,13 +5372,61 @@
 			"resolved": "http://bbnpm.azurewebsites.net/tough-cookie/-/tough-cookie-2.3.4.tgz",
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"requires": {
-				"punycode": "1.4.1"
+				"punycode": "^1.4.1"
 			}
 		},
 		"tr46": {
 			"version": "0.0.3",
 			"resolved": "http://bbnpm.azurewebsites.net/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+		},
+		"traverse": {
+			"version": "0.3.9",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/traverse/-/traverse-0.3.9.tgz",
+			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
+		},
+		"trim-repeated": {
+			"version": "1.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/trim-repeated/-/trim-repeated-1.0.0.tgz",
+			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+			"requires": {
+				"escape-string-regexp": "^1.0.2"
+			}
+		},
+		"ts-node": {
+			"version": "4.1.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ts-node/-/ts-node-4.1.0.tgz",
+			"integrity": "sha1-NtlSnHuQu5kzBsQIzQf3dD3iBxI=",
+			"requires": {
+				"arrify": "^1.0.0",
+				"chalk": "^2.3.0",
+				"diff": "^3.1.0",
+				"make-error": "^1.1.1",
+				"minimist": "^1.2.0",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.5.0",
+				"tsconfig": "^7.0.0",
+				"v8flags": "^3.0.0",
+				"yn": "^2.0.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"tsconfig": {
+			"version": "7.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tsconfig/-/tsconfig-7.0.0.tgz",
+			"integrity": "sha1-hFOIdaTcIW5cSlQys6Tew9VOkbc=",
+			"requires": {
+				"@types/strip-bom": "^3.0.0",
+				"@types/strip-json-comments": "0.0.30",
+				"strip-bom": "^3.0.0",
+				"strip-json-comments": "^2.0.0"
+			}
 		},
 		"tslib": {
 			"version": "1.9.3",
@@ -1520,18 +5440,18 @@
 			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"builtin-modules": "1.1.1",
-				"chalk": "2.3.2",
-				"commander": "2.17.1",
-				"diff": "3.5.0",
-				"glob": "7.1.2",
-				"js-yaml": "3.11.0",
-				"minimatch": "3.0.4",
-				"resolve": "1.5.0",
-				"semver": "5.5.0",
-				"tslib": "1.9.3",
-				"tsutils": "2.29.0"
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.27.2"
 			},
 			"dependencies": {
 				"commander": {
@@ -1554,7 +5474,7 @@
 			"integrity": "sha512-gHVEIkTcMB9lS6UPEgEznV5ZmyhDs/aHyBS9E89S8aJiK1qLv22DmfCcda53S024T+WQkGAhLHUQF4Qn4nzCAA==",
 			"dev": true,
 			"requires": {
-				"tsutils": "2.28.0"
+				"tsutils": "^2.12.1 <2.29.0"
 			},
 			"dependencies": {
 				"tsutils": {
@@ -1563,7 +5483,7 @@
 					"integrity": "sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==",
 					"dev": true,
 					"requires": {
-						"tslib": "1.9.3"
+						"tslib": "^1.8.1"
 					}
 				}
 			}
@@ -1574,7 +5494,7 @@
 			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
 			"dev": true,
 			"requires": {
-				"tslib": "1.9.3"
+				"tslib": "^1.8.1"
 			},
 			"dependencies": {
 				"tslib": {
@@ -1585,12 +5505,17 @@
 				}
 			}
 		},
+		"tunnel": {
+			"version": "0.0.5",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/tunnel/-/tunnel-0.0.5.tgz",
+			"integrity": "sha1-0VMiVHSe02Yg/NEBCGVJWh+p0K4="
+		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "http://bbnpm.azurewebsites.net/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -1604,7 +5529,7 @@
 			"resolved": "http://bbnpm.azurewebsites.net/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"type-detect": {
@@ -1624,15 +5549,15 @@
 				"@types/marked": "0.3.0",
 				"@types/minimatch": "2.0.29",
 				"@types/shelljs": "0.7.0",
-				"fs-extra": "4.0.3",
-				"handlebars": "4.0.11",
-				"highlight.js": "9.12.0",
-				"lodash": "4.17.5",
-				"marked": "0.3.17",
-				"minimatch": "3.0.4",
-				"progress": "2.0.0",
-				"shelljs": "0.7.8",
-				"typedoc-default-themes": "0.5.0",
+				"fs-extra": "^4.0.0",
+				"handlebars": "^4.0.6",
+				"highlight.js": "^9.0.0",
+				"lodash": "^4.13.1",
+				"marked": "^0.3.5",
+				"minimatch": "^3.0.0",
+				"progress": "^2.0.0",
+				"shelljs": "^0.7.0",
+				"typedoc-default-themes": "^0.5.0",
 				"typescript": "2.4.1"
 			},
 			"dependencies": {
@@ -1646,9 +5571,9 @@
 					"resolved": "http://bbnpm.azurewebsites.net/fs-extra/-/fs-extra-4.0.3.tgz",
 					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "4.0.0",
-						"universalify": "0.1.1"
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
 					}
 				}
 			}
@@ -1668,7 +5593,7 @@
 			"resolved": "http://bbnpm.azurewebsites.net/typedoc-plugin-markdown/-/typedoc-plugin-markdown-1.0.14.tgz",
 			"integrity": "sha512-4wv3LraonQq5N0UddgD/A/+BuS8BQfYjjv9pak34V95nFt/LpsZ0WIsQ8Nr5vLMy+PR2YbGw6KfJ++B0XZxY/A==",
 			"requires": {
-				"to-markdown": "3.1.1"
+				"to-markdown": "^3.1.1"
 			}
 		},
 		"typescript": {
@@ -1682,9 +5607,9 @@
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
 			"optional": true,
 			"requires": {
-				"source-map": "0.5.7",
-				"uglify-to-browserify": "1.0.2",
-				"yargs": "3.10.0"
+				"source-map": "~0.5.1",
+				"uglify-to-browserify": "~1.0.0",
+				"yargs": "~3.10.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -1699,8 +5624,8 @@
 					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
 					"optional": true,
 					"requires": {
-						"center-align": "0.1.3",
-						"right-align": "0.1.3",
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
 						"wordwrap": "0.0.2"
 					}
 				},
@@ -1722,9 +5647,9 @@
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
 					"optional": true,
 					"requires": {
-						"camelcase": "1.2.1",
-						"cliui": "2.1.0",
-						"decamelize": "1.2.0",
+						"camelcase": "^1.0.2",
+						"cliui": "^2.1.0",
+						"decamelize": "^1.0.0",
 						"window-size": "0.1.0"
 					}
 				}
@@ -1736,24 +5661,118 @@
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
 			"optional": true
 		},
+		"underscore": {
+			"version": "1.8.3",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/underscore/-/underscore-1.8.3.tgz",
+			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+		},
 		"universalify": {
 			"version": "0.1.1",
 			"resolved": "http://bbnpm.azurewebsites.net/universalify/-/universalify-0.1.1.tgz",
 			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+		},
+		"unzip": {
+			"version": "0.1.11",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/unzip/-/unzip-0.1.11.tgz",
+			"integrity": "sha1-iXScY7BY19kNYZ+GuYqhU107l/A=",
+			"requires": {
+				"binary": ">= 0.3.0 < 1",
+				"fstream": ">= 0.1.30 < 1",
+				"match-stream": ">= 0.0.2 < 1",
+				"pullstream": ">= 0.4.1 < 1",
+				"readable-stream": "~1.0.31",
+				"setimmediate": ">= 1.0.1 < 2"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				}
+			}
+		},
+		"url": {
+			"version": "0.11.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/url/-/url-0.11.0.tgz",
+			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+			"requires": {
+				"punycode": "1.3.2",
+				"querystring": "0.2.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.3.2",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/punycode/-/punycode-1.3.2.tgz",
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+				}
+			}
+		},
+		"url-parse": {
+			"version": "1.4.3",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/url-parse/-/url-parse-1.4.3.tgz",
+			"integrity": "sha1-v67kVciJAjIZ11fgRfpqaE7DbBU=",
+			"requires": {
+				"querystringify": "^2.0.0",
+				"requires-port": "^1.0.0"
+			}
+		},
+		"util": {
+			"version": "0.10.3",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/util/-/util-0.10.3.tgz",
+			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+			"requires": {
+				"inherits": "2.0.1"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.1",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/inherits/-/inherits-2.0.1.tgz",
+					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+				}
+			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "http://bbnpm.azurewebsites.net/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
+		"v8flags": {
+			"version": "3.1.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/v8flags/-/v8flags-3.1.1.tgz",
+			"integrity": "sha1-QiWaFGHAg5fjf+HU8c+1nK2FoFM=",
+			"requires": {
+				"homedir-polyfill": "^1.0.1"
+			}
+		},
+		"validator": {
+			"version": "9.4.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/validator/-/validator-9.4.1.tgz",
+			"integrity": "sha1-q/Rm05i1Yc0kMFARLG/x3mzBJmM="
+		},
 		"verror": {
 			"version": "1.10.0",
 			"resolved": "http://bbnpm.azurewebsites.net/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"void-elements": {
@@ -1779,8 +5798,8 @@
 			"resolved": "http://bbnpm.azurewebsites.net/whatwg-url/-/whatwg-url-4.8.0.tgz",
 			"integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
 			"requires": {
-				"tr46": "0.0.3",
-				"webidl-conversions": "3.0.1"
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			},
 			"dependencies": {
 				"webidl-conversions": {
@@ -1795,7 +5814,7 @@
 			"resolved": "http://bbnpm.azurewebsites.net/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"which-module": {
@@ -1819,8 +5838,8 @@
 			"resolved": "http://bbnpm.azurewebsites.net/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -1833,7 +5852,7 @@
 					"resolved": "http://bbnpm.azurewebsites.net/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"string-width": {
@@ -1841,9 +5860,9 @@
 					"resolved": "http://bbnpm.azurewebsites.net/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -1851,7 +5870,7 @@
 					"resolved": "http://bbnpm.azurewebsites.net/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				}
 			}
@@ -1865,6 +5884,41 @@
 			"version": "2.0.1",
 			"resolved": "http://bbnpm.azurewebsites.net/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
 			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+		},
+		"xml2js": {
+			"version": "0.2.8",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/xml2js/-/xml2js-0.2.8.tgz",
+			"integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
+			"requires": {
+				"sax": "0.5.x"
+			},
+			"dependencies": {
+				"sax": {
+					"version": "0.5.8",
+					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/sax/-/sax-0.5.8.tgz",
+					"integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+				}
+			}
+		},
+		"xmlbuilder": {
+			"version": "0.4.3",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/xmlbuilder/-/xmlbuilder-0.4.3.tgz",
+			"integrity": "sha1-xGFLp04K0ZbmCcknLNnh3bKKilg="
+		},
+		"xmldom": {
+			"version": "0.1.27",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/xmldom/-/xmldom-0.1.27.tgz",
+			"integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+		},
+		"xpath.js": {
+			"version": "1.1.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/xpath.js/-/xpath.js-1.1.0.tgz",
+			"integrity": "sha1-OBakTtS7NSCRCD0AKjg91RBKX/E="
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
 			"version": "3.2.1",
@@ -1881,18 +5935,18 @@
 			"resolved": "http://bbnpm.azurewebsites.net/yargs/-/yargs-11.0.0.tgz",
 			"integrity": "sha1-wFKTEAbF7udGEOX8A1S+39CKIBs=",
 			"requires": {
-				"cliui": "4.0.0",
-				"decamelize": "1.2.0",
-				"find-up": "2.1.0",
-				"get-caller-file": "1.0.2",
-				"os-locale": "2.1.0",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "2.1.1",
-				"which-module": "2.0.0",
-				"y18n": "3.2.1",
-				"yargs-parser": "9.0.2"
+				"cliui": "^4.0.0",
+				"decamelize": "^1.1.1",
+				"find-up": "^2.1.0",
+				"get-caller-file": "^1.0.1",
+				"os-locale": "^2.0.0",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^1.0.1",
+				"set-blocking": "^2.0.0",
+				"string-width": "^2.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^3.2.1",
+				"yargs-parser": "^9.0.2"
 			}
 		},
 		"yargs-parser": {
@@ -1900,8 +5954,13 @@
 			"resolved": "http://bbnpm.azurewebsites.net/yargs-parser/-/yargs-parser-9.0.2.tgz",
 			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 			"requires": {
-				"camelcase": "4.1.0"
+				"camelcase": "^4.1.0"
 			}
+		},
+		"yn": {
+			"version": "2.0.0",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/yn/-/yn-2.0.0.tgz",
+			"integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -240,6 +240,11 @@
 				"tweetnacl": "0.14.5"
 			}
 		},
+		"bignumber.js": {
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+			"integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+		},
 		"block-elements": {
 			"version": "1.2.0",
 			"resolved": "http://bbnpm.azurewebsites.net/block-elements/-/block-elements-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "update-versions": "lerna run set-version && npm run set-dependency-versions"
     },
     "dependencies": {
+        "bignumber.js": "^7.2.1",
         "replace-in-file": "^3.1.1",
         "sinon": "^6.1.4",
         "typedoc": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
         "update-versions": "lerna run set-version && npm run set-dependency-versions"
     },
     "dependencies": {
-        "bignumber.js": "^7.2.1",
         "replace-in-file": "^3.1.1",
         "sinon": "^6.1.4",
         "typedoc": "^0.9.0",


### PR DESCRIPTION
Updated recognizers dependencies to latest verison: 1.1.0
- @microsoft/recognizers-text-suite
- @microsoft/recognizers-text-choice
- @microsoft/recognizers-text-number
- @microsoft/recognizers-text-date-time

This changes were tested using an adapted version of samples\multiple-prompts-bot-es6.
Additionally, we tweaked the libraries to install bignumber.js which should be fixed in the recognizers as well. This PR can be merged independently of those recognizers fixes.