### PR TITLE
LuisRecognizer.prepareErrorMessage() ignores errors without `response.statusCode`

### DIFF
--- a/libraries/botbuilder-ai/src/luisRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizer.ts
@@ -1,4 +1,3 @@
-// tslint:disable
 /**
  * @module botbuilder-ai
  */
@@ -233,8 +232,7 @@ export class LuisRecognizer {
 
     private prepareErrorMessage(error: Error): void {
         // If the `error` received is a azure-cognitiveservices-luis-runtime error, it may have a `response` property and `response.statusCode`.
-        // If these properties exist, we should populate the error with a correct and informative 
-        // error message.
+        // If these properties exist, we should populate the error with a correct and informative error message.
         if ((error as any).response && (error as any).response.statusCode) {
             switch ((error as any).response.statusCode) {
                 case 400:

--- a/libraries/botbuilder-ai/src/luisRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizer.ts
@@ -1,3 +1,4 @@
+// tslint:disable
 /**
  * @module botbuilder-ai
  */
@@ -230,33 +231,37 @@ export class LuisRecognizer {
         });
     }
 
-    private prepareErrorMessage(error: Error): Error {
-        switch ((error as any).response.statusCode) {
-            case 400:
-                error.message = `Response 400: The request's body or parameters are incorrect, meaning they are missing, malformed, or too large.`;
-                break;
-            case 401:
-                error.message = `Response 401: The key used is invalid, malformed, empty, or doesn't match the region.`;
-                break;
-            case 403:
-                error.message = `Response 403: Total monthly key quota limit exceeded.`;
-                break;
-            case 409:
-                error.message = `Response 409: Application loading in progress, please try again.`;
-                break;
-            case 410:
-                error.message = `Response 410: Please retrain and republish your application.`;
-                break;
-            case 414:
-                error.message = `Response 414: The query is too long. Please reduce the query length to 500 or less characters.`;
-                break;
-            case 429:
-                error.message = `Response 429: Too many requests.`;
-                break;
-            default:
-                error.message = `Response ${(error as any).response.statusCode}: Unexpected status code received. Please verify that your LUIS application is properly setup.`;
+    private prepareErrorMessage(error: Error): void {
+        // If the `error` received is a azure-cognitiveservices-luis-runtime error, it may have a `response` property and `response.statusCode`.
+        // If these properties exist, we should populate the error with a correct and informative 
+        // error message.
+        if ((error as any).response && (error as any).response.statusCode) {
+            switch ((error as any).response.statusCode) {
+                case 400:
+                    error.message = `Response 400: The request's body or parameters are incorrect, meaning they are missing, malformed, or too large.`;
+                    break;
+                case 401:
+                    error.message = `Response 401: The key used is invalid, malformed, empty, or doesn't match the region.`;
+                    break;
+                case 403:
+                    error.message = `Response 403: Total monthly key quota limit exceeded.`;
+                    break;
+                case 409:
+                    error.message = `Response 409: Application loading in progress, please try again.`;
+                    break;
+                case 410:
+                    error.message = `Response 410: Please retrain and republish your application.`;
+                    break;
+                case 414:
+                    error.message = `Response 414: The query is too long. Please reduce the query length to 500 or less characters.`;
+                    break;
+                case 429:
+                    error.message = `Response 429: Too many requests.`;
+                    break;
+                default:
+                    error.message = `Response ${(error as any).response.statusCode}: Unexpected status code received. Please verify that your LUIS application is properly setup.`;
+            }
         }
-        return error;
     }
 
     private normalizeName(name: string): string {

--- a/libraries/botbuilder-ai/tests/luisRecognizer.test.js
+++ b/libraries/botbuilder-ai/tests/luisRecognizer.test.js
@@ -22,6 +22,21 @@ class TestContext extends TurnContext {
     }
 }
 
+class ThrowErrorRecognizer extends LuisRecognizer {
+    constructor() {
+        super({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true, includeInstanceData: true }, true);
+    }
+
+    recognize(turnContext) {
+        return new Promise((resolve, reject) => {
+            reject(new Error('Test'));
+        }).catch(error => {
+            this.prepareErrorMessage(error);
+            throw error;
+        });
+    }
+}
+
 function WithinDelta(token1, token2, delta, compare) {
     var within = true;
     if (token1 == null || token2 == null) {
@@ -350,9 +365,9 @@ describe('LuisRecognizer', function () {
     it('should call prepareErrorMessage when a non-200 status code is received.', done => {
         nock.cleanAll();
         ReturnErrorStatusCode(400);
-        var recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
-        var context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
+        const context = new TestContext({ text: 'Hello world!' });
+        recognizer.recognize(context).catch(error => {
             expectedError = `Response 400: The request's body or parameters are incorrect, meaning they are missing, malformed, or too large.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
@@ -363,9 +378,9 @@ describe('LuisRecognizer', function () {
     it('should throw expected 401 error message.', done => {
         nock.cleanAll();
         ReturnErrorStatusCode(401);
-        var recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
-        var context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
+        const context = new TestContext({ text: 'Hello world!' });
+        recognizer.recognize(context).catch(error => {
             expectedError = `Response 401: The key used is invalid, malformed, empty, or doesn't match the region.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
@@ -376,9 +391,9 @@ describe('LuisRecognizer', function () {
     it('should throw expected 403 error message.', done => {
         nock.cleanAll();
         ReturnErrorStatusCode(403);
-        var recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
-        var context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
+        const context = new TestContext({ text: 'Hello world!' });
+        recognizer.recognize(context).catch(error => {
             expectedError = `Response 403: Total monthly key quota limit exceeded.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
@@ -389,9 +404,9 @@ describe('LuisRecognizer', function () {
     it('should throw expected 409 error message.', done => {
         nock.cleanAll();
         ReturnErrorStatusCode(409);
-        var recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
-        var context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
+        const context = new TestContext({ text: 'Hello world!' });
+        recognizer.recognize(context).catch(error => {
             expectedError = `Response 409: Application loading in progress, please try again.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
@@ -402,9 +417,9 @@ describe('LuisRecognizer', function () {
     it('should throw expected 410 error message.', done => {
         nock.cleanAll();
         ReturnErrorStatusCode(410);
-        var recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
-        var context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
+        const context = new TestContext({ text: 'Hello world!' });
+        recognizer.recognize(context).catch(error => {
             expectedError = `Response 410: Please retrain and republish your application.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
@@ -415,9 +430,9 @@ describe('LuisRecognizer', function () {
     it('should throw expected 414 error message.', done => {
         nock.cleanAll();
         ReturnErrorStatusCode(414);
-        var recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
-        var context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
+        const context = new TestContext({ text: 'Hello world!' });
+        recognizer.recognize(context).catch(error => {
             expectedError = `Response 414: The query is too long. Please reduce the query length to 500 or less characters.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
@@ -428,9 +443,9 @@ describe('LuisRecognizer', function () {
     it('should throw expected 429 error message.', done => {
         nock.cleanAll();
         ReturnErrorStatusCode(429);
-        var recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
-        var context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
+        const context = new TestContext({ text: 'Hello world!' });
+        recognizer.recognize(context).catch(error => {
             expectedError = `Response 429: Too many requests.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
@@ -442,13 +457,24 @@ describe('LuisRecognizer', function () {
         nock.cleanAll();
         const statusCode = 404;
         ReturnErrorStatusCode(statusCode);
-        var recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
-        var context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
+        const context = new TestContext({ text: 'Hello world!' });
+        recognizer.recognize(context).catch(error => {
             expectedError = `Response ${statusCode}: Unexpected status code received. Please verify that your LUIS application is properly setup.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
             done();
         });
     });
+
+    it('.prepareErrorMessage() should not change `error.message` if `error.response.statusCode` does not exist.',
+        done => {
+            const recognizer = new ThrowErrorRecognizer();
+            const context = new TestContext({ text: 'Hello world!' });
+            recognizer.recognize(context).catch(error => {
+                expectedError = 'Test';
+                assert(error.message === expectedError, `unexpected error message thrown.`);
+                done();
+            })
+        });
 });


### PR DESCRIPTION
and shouldn't blow up on these errors!