### PR TITLE
[4.1] Added DC.consultDialog() method and plumbed through everywhere. **DO NOT MERGE**

### DIFF
--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 import { TurnContext } from 'botbuilder-core';
-import { Dialog, DialogInstance, DialogReason, DialogTurnResult, DialogTurnStatus } from './dialog';
+import { Dialog, DialogInstance, DialogReason, DialogTurnResult, DialogTurnStatus, DialogConsultResult } from './dialog';
 import { DialogContext, DialogState } from './dialogContext';
 import { DialogSet } from './dialogSet';
 
@@ -96,6 +96,13 @@ export class ComponentDialog<O extends object = {}> extends Dialog<O> {
         }
     }
 
+    public async consultDialog(outerDC: DialogContext): Promise<DialogConsultResult> {
+        // Consult with inner dialog.
+        const dialogState: any = outerDC.activeDialog.state[PERSISTED_DIALOG_STATE];
+        const innerDC: DialogContext = new DialogContext(this.dialogs, outerDC.context, dialogState);
+        return await this.onConsultDialog(innerDC);
+    }
+
     public async continueDialog(outerDC: DialogContext): Promise<DialogTurnResult> {
         // Continue execution of inner dialog.
         const dialogState: any = outerDC.activeDialog.state[PERSISTED_DIALOG_STATE];
@@ -181,6 +188,19 @@ export class ComponentDialog<O extends object = {}> extends Dialog<O> {
      */
     protected onBeginDialog(innerDC: DialogContext, options?: O): Promise<DialogTurnResult> {
         return innerDC.beginDialog(this.initialDialogId, options);
+    }
+
+    /**
+     * Called anytime an instance of the component has been asked for its confidence that its 
+     * active child dialog understands the current activity.
+     * 
+     * @remarks
+     * SHOULD be overridden by components that wish to perform custom consultation. The 
+     * default implementation calls `innerDC.consultDialog()`. 
+     * @param innerDC Dialog context for the components internal `DialogSet`.
+     */
+    protected onConsultDialog(innerDC: DialogContext): Promise<DialogConsultResult> {
+        return innerDC.consultDialog();
     }
 
     /**

--- a/libraries/botbuilder-dialogs/src/dialog.ts
+++ b/libraries/botbuilder-dialogs/src/dialog.ts
@@ -127,6 +127,21 @@ export interface DialogTurnResult<T = any> {
     result?: T;
 }
 
+export interface DialogConsultResult {
+    /**
+     * Gets or sets the current status of the stack.
+     */
+    status: DialogTurnStatus;
+
+    /**
+     * Gets or sets a score for how confident the active dialog is that it understands the current activity.
+     * 
+     * @remarks
+     * The score should be a value between 0.0 and 1.0.
+     */
+    score: number;
+}
+
 /**
  * Base class for all dialogs.
  */
@@ -160,6 +175,20 @@ export abstract class Dialog<O extends object = {}> {
      * @param options (Optional) arguments that were passed to the dialog in the call to `DialogContext.beginDialog()`.
      */
     public abstract beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult>;
+
+    /**
+     * Called when a parent dialog would like to ask the active dialog how confident it is that
+     * it understands the current activity.
+     * 
+     * @remarks
+     * MAY be overridden by dialogs that support multi-turn conversations and have specific set of
+     * activities that they're listening for. The default implementation returns a confidence score
+     * of `0.5`.
+     * @param dc The dialog context for the current turn of conversation.
+     */
+    public consultDialog(dc: DialogContext): Promise<DialogConsultResult> {
+        return Promise.resolve({ status: DialogTurnStatus.waiting, score: 0.5 });
+    }
 
     /**
      * Called when an instance of the dialog is the active dialog and a new activity is received. 

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -7,7 +7,7 @@
  */
 import { Activity, TurnContext } from 'botbuilder-core';
 import { Choice } from './choices';
-import { Dialog, DialogInstance, DialogReason, DialogTurnResult, DialogTurnStatus } from './dialog';
+import { Dialog, DialogInstance, DialogReason, DialogTurnResult, DialogTurnStatus, DialogConsultResult } from './dialog';
 import { DialogSet } from './dialogSet';
 import { PromptOptions } from './prompts';
 
@@ -169,6 +169,23 @@ export class DialogContext {
         }
 
         return this.beginDialog(dialogId, options);
+    }
+
+    public async consultDialog(): Promise<DialogConsultResult> {
+        // Check for a dialog on the stack
+        const instance: DialogInstance<any> = this.activeDialog;
+        if (instance) {
+            // Lookup dialog
+            const dialog: Dialog<{}> = this.dialogs.find(instance.id);
+            if (!dialog) {
+                throw new Error(`DialogContext.continue(): Can't continue dialog. A dialog with an id of '${instance.id}' wasn't found.`);
+            }
+
+            // Consult with active dialog
+            return await dialog.consultDialog(this);
+        } else {
+            return { status: DialogTurnStatus.empty, score: 0.0 };
+        }
     }
 
     /**

--- a/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 import { Activity, InputHints, TurnContext } from 'botbuilder-core';
-import { Dialog, DialogInstance, DialogReason, DialogTurnResult } from '../dialog';
+import { Dialog, DialogInstance, DialogReason, DialogTurnResult, DialogConsultResult, DialogTurnStatus } from '../dialog';
 import { DialogContext } from '../dialogContext';
 import { PromptOptions, PromptRecognizerResult, PromptValidator } from './prompt';
 
@@ -19,6 +19,16 @@ import { PromptOptions, PromptRecognizerResult, PromptValidator } from './prompt
  * expected activity is received.
  */
 export abstract class ActivityPrompt extends Dialog {
+    /**
+     * The score that will be returned anytime `DialogContext.consultDialog()` is called for the
+     * prompt.
+     * 
+     * @remarks
+     * By default the activity prompt returns a score of `0.5` but this can be raised to `1.0` for 
+     * prompts that you don't want to be interruptable or lowered to `0.0` for prompts that you
+     * always want to favor interruptions.
+     */
+    public consultScore: number = 0.5;
 
     /**
      * Creates a new ActivityPrompt instance.
@@ -48,6 +58,10 @@ export abstract class ActivityPrompt extends Dialog {
         await this.onPrompt(dc.context, state.state, state.options);
 
         return Dialog.EndOfTurn;
+    }
+
+    public consultDialog(dc: DialogContext): Promise<DialogConsultResult> {
+        return Promise.resolve({ status: DialogTurnStatus.waiting, score: this.consultScore });
     }
 
     public async continueDialog(dc: DialogContext): Promise<DialogTurnResult> {

--- a/libraries/botbuilder-dialogs/src/prompts/attachmentPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/attachmentPrompt.ts
@@ -32,6 +32,11 @@ export class AttachmentPrompt extends Prompt<Attachment[]> {
             await context.sendActivity(options.prompt, undefined, InputHints.ExpectingInput);
         }
     }
+    
+    protected async onConsult(context: TurnContext, state: any, options: PromptOptions): Promise<number> {
+        const value: Attachment[] = context.activity.attachments;
+        return Array.isArray(value) && value.length > 0 ? 1.0 : 0.0;
+    }
 
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<Attachment[]>> {
         const value: Attachment[] = context.activity.attachments;

--- a/libraries/botbuilder-dialogs/src/prompts/choicePrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/choicePrompt.ts
@@ -89,9 +89,21 @@ export class ChoicePrompt extends Prompt<FoundChoice> {
         // Send prompt
         await context.sendActivity(prompt);
     }
+    
+    protected async onConsult(context: TurnContext, state: any, options: PromptOptions): Promise<number> {
+        const activity: Activity = context.activity;
+        const utterance: string = activity.text;
+        const choices: any[] = options.choices || [];
+        const opt: FindChoicesOptions = this.recognizerOptions || {} as FindChoicesOptions;
+        opt.locale = activity.locale || opt.locale || this.defaultLocale || 'en-us';
+        const results: any[]  = recognizeChoices(utterance, choices, opt);
+        if (Array.isArray(results) && results.length > 0) {
+            return results[0].resolution.score || 1.0;
+        }
+        return 0;
+    }
 
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<FoundChoice>> {
-
         const result: PromptRecognizerResult<FoundChoice> = { succeeded: false };
         const activity: Activity = context.activity;
         const utterance: string = activity.text;

--- a/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
@@ -104,6 +104,17 @@ export class ConfirmPrompt extends Prompt<boolean> {
         // Send prompt
         await context.sendActivity(prompt);
     }
+    
+    protected async onConsult(context: TurnContext, state: any, options: PromptOptions): Promise<number> {
+        const activity: Activity = context.activity;
+        const utterance: string = activity.text;
+        const locale: string = activity.locale || this.defaultLocale || 'en-us';
+        const results: any = Recognizers.recognizeBoolean(utterance, locale);
+        if (results.length > 0 && results[0].resolution) {
+            return results[0].resolution.score || 1.0;
+        }
+        return 0;
+    }
 
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<boolean>> {
         const result: PromptRecognizerResult<boolean> = { succeeded: false };

--- a/libraries/botbuilder-dialogs/src/prompts/datetimePrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/datetimePrompt.ts
@@ -63,6 +63,17 @@ export class DateTimePrompt extends Prompt<DateTimeResolution[]> {
         }
     }
 
+    protected async onConsult(context: TurnContext, state: any, options: PromptOptions): Promise<number> {
+        const activity: Activity = context.activity;
+        const utterance: string = activity.text;
+        const locale: string = activity.locale || this.defaultLocale || 'en-us';
+        const results: any[] = Recognizers.recognizeDateTime(utterance, locale);
+        if (results.length > 0 && results[0].resolution) {
+            return results[0].resolution.score || 1.0;
+        }
+        return 0;
+    }
+
     protected async onRecognize(
         context: TurnContext,
         state: any,

--- a/libraries/botbuilder-dialogs/src/prompts/numberPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/numberPrompt.ts
@@ -41,6 +41,17 @@ export class NumberPrompt extends Prompt<number> {
         }
     }
 
+    protected async onConsult(context: TurnContext, state: any, options: PromptOptions): Promise<number> {
+        const activity: Activity = context.activity;
+        const utterance: string = activity.text;
+        const locale: string = activity.locale || this.defaultLocale || 'en-us';
+        const results: any = Recognizers.recognizeNumber(utterance, locale);
+        if (results.length > 0 && results[0].resolution) {
+            return results[0].resolution.score || 1.0;
+        }
+        return 0;
+    }
+
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<number>> {
         const result: PromptRecognizerResult<number> = { succeeded: false };
         const activity: Activity = context.activity;

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -5,9 +5,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Token } from '@microsoft/recognizers-text-date-time';
-import {  Activity, ActivityTypes, Attachment, CardFactory, InputHints, MessageFactory, TokenResponse, TurnContext } from 'botbuilder-core';
-import { Dialog, DialogTurnResult } from '../dialog';
+import { Activity, ActivityTypes, Attachment, CardFactory, InputHints, MessageFactory, TokenResponse, TurnContext } from 'botbuilder-core';
+import { Dialog, DialogTurnResult, DialogConsultResult, DialogTurnStatus } from '../dialog';
 import { DialogContext } from '../dialogContext';
 import { PromptOptions, PromptRecognizerResult,  PromptValidator } from './prompt';
 
@@ -104,6 +103,16 @@ export interface OAuthPromptSettings {
  * ```
  */
 export class OAuthPrompt extends Dialog {
+    /**
+     * The score that will be returned anytime `DialogContext.consultDialog()` is called for the
+     * prompt.
+     * 
+     * @remarks
+     * By default the oauth prompt returns a score of `0.5` but this can be raised to `1.0` for 
+     * prompts that you don't want to be interruptable or lowered to `0.0` for prompts that you
+     * always want to favor interruptions.
+     */
+    public consultScore: number = 0.5;
 
     /**
      * Creates a new OAuthPrompt instance.
@@ -143,6 +152,10 @@ export class OAuthPrompt extends Dialog {
 
             return Dialog.EndOfTurn;
         }
+    }
+
+    public consultDialog(dc: DialogContext): Promise<DialogConsultResult> {
+        return Promise.resolve({ status: DialogTurnStatus.waiting, score: this.consultScore });
     }
 
     public async continueDialog(dc: DialogContext): Promise<DialogTurnResult> {

--- a/libraries/botbuilder-dialogs/src/prompts/textPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/textPrompt.ts
@@ -15,6 +15,16 @@ import { Prompt, PromptOptions, PromptRecognizerResult, PromptValidator } from '
  * By default the prompt will return to the calling dialog a `string` representing the users reply.
  */
 export class TextPrompt extends Prompt<string> {
+    /**
+     * The score that will be returned anytime `DialogContext.consultDialog()` is called for the
+     * prompt.
+     * 
+     * @remarks
+     * By default the text prompt returns a score of `0.5` but this can be raised to `1.0` for 
+     * prompts that you don't want to be interruptable or lowered to `0.0` for prompts that you
+     * always want to favor interruptions.
+     */
+    public consultScore: number = 0.5;
 
     /**
      * Creates a new TextPrompt instance.
@@ -31,6 +41,10 @@ export class TextPrompt extends Prompt<string> {
         } else if (options.prompt) {
             await context.sendActivity(options.prompt, undefined, InputHints.ExpectingInput);
         }
+    }
+
+    protected async onConsult(context: TurnContext, state: any, options: PromptOptions): Promise<number> {
+        return this.consultScore;
     }
 
     protected async onRecognize(context: TurnContext, state: any, options: PromptOptions): Promise<PromptRecognizerResult<string>> {


### PR DESCRIPTION
This change lets a parent dialog ask a child dialog, like a prompt or component dialog, if it understands the current activity before calling `DialogContext.continueDialog()`.  To use:

```JS
// Check for interruptions
const utterance = dc.context.activity.text;
if (/help/i.test(utterance)) {
    const consult = await dc.consultDialog();
    if (consult.status === DialogTurnStatus.empty || consult.score <= 0.5) {
        return await dc.beginDialog('helpDialog');
    }
}

// Continue active dialog
const result = await dc.continueDialog();
```