### PR TITLE
BotRecipe.fromJSON to use default values if arg doesn't have expected values, add BotRecipe tests

### DIFF
--- a/libraries/botframework-config/src/botRecipe.ts
+++ b/libraries/botframework-config/src/botRecipe.ts
@@ -89,8 +89,9 @@ export class BotRecipe {
 
     public static fromJSON(source: Partial<BotRecipe> = {}): BotRecipe {
         const botRecipe = new BotRecipe();
-        let { version, resources  } = source;
-        Object.assign(botRecipe, { resources, version });
+        let { version, resources } = source;
+        botRecipe.resources = resources ? resources : botRecipe.resources;
+        botRecipe.version = version ? version : botRecipe.version;
         return botRecipe;
     }
 

--- a/libraries/botframework-config/tests/bot.recipe
+++ b/libraries/botframework-config/tests/bot.recipe
@@ -1,0 +1,11 @@
+{
+  "version": "1.0",
+  "resources": [
+    {
+      "type": "endpoint",
+      "id": "176",
+      "name": "a",
+      "url": "http://localhost:3978/api/messages"
+    }
+  ]
+}

--- a/libraries/botframework-config/tests/botRecipe.test.js
+++ b/libraries/botframework-config/tests/botRecipe.test.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { BotRecipe } = require('../lib');
+
+function assertService(newService, oldService) {
+    assert(newService.type === oldService.type,
+        `newService.type [${ newService.type }] !== oldService.type [${ oldService.type }]`);
+    assert(newService.id === oldService.id,
+        `newService.id [${ newService.id }] !== oldService.id [${ oldService.id }]`);
+    assert(newService.name === oldService.name,
+        `newService.name [${ newService.name }] !== oldService.name [${ oldService.name }]`);
+    assert(newService.url === oldService.url,
+        `newService.url [${ newService.url }] !== oldService.url [${ oldService.url }]`);
+}
+
+describe('BotRecipe', () => {
+    const recipe = new BotRecipe();
+    it(`should have a default version of '1.0'.`, () => {
+        assert(recipe.version === '1.0', `expected version '1.0', instead received ${ recipe.version }`);
+    });
+
+    it(`should have default resources be an empty array.`, () => {
+        assert(Array.isArray(recipe.resources), `expected resources to be an Array, instead it is type "${ typeof recipe.resources }"`);
+        assert(recipe.resources.length === 0, `initial resources should be length 0, not ${ recipe.resources.length }`);
+    });
+
+    it('should create a new recipe using .fromJSON().', () => {
+        const filePath = path.join(__dirname, './bot.recipe');
+        const data = fs.readFileSync(filePath).toString();
+        const oldRecipe = JSON.parse(data);
+        const newRecipe = BotRecipe.fromJSON(oldRecipe);
+
+        const oldVersion = oldRecipe.version;
+        const oldResources = oldRecipe.resources;
+        const oldEndpoint = oldRecipe.resources[0];
+
+        assert(newRecipe.version === oldVersion, `expected version ${ oldVersion }, instead received ${ newRecipe.version }`);
+        assert(Array.isArray(newRecipe.resources), `expected resources to be an Array, instead it is type "${ typeof newRecipe.resources }"`);
+        assert(newRecipe.resources.length === oldResources.length, `initial resources should be length ${ oldResources.length }, not ${ newRecipe.resources.length }`);
+        assertService(newRecipe.resources[0], oldEndpoint);
+    });
+
+    it(`should create an empty recipe without any args using .fromJSON().`, () => {
+        const newRecipe = BotRecipe.fromJSON();
+        assert(newRecipe.version === '1.0', `expected version '1.0', instead received ${ newRecipe.version }`);
+        assert(newRecipe.resources.length === 0, `resources should be length 0, not ${ newRecipe.resources.length }`);
+
+        const keys = Object.keys(newRecipe).length;
+        assert(keys === 2, `expected 2 keys, found ${ keys }`);
+    });
+
+    it(`should create a new recipe with .toJSON().`, () => {
+        const newRecipe = recipe.toJSON();
+        assert(newRecipe.version === '1.0', `expected version '1.0', instead received ${ newRecipe.version }`);
+        assert(newRecipe.resources.length === 0, `resources should be length 0, not ${ newRecipe.resources.length }`);
+    });
+});


### PR DESCRIPTION
Found bug in BotRecipe.fromJSON where if no arg was passed in, the output's `version` and `resources` properties would be undefined. 

And [add test coverage for `BotRecipe`.](https://travis-ci.org/Microsoft/botbuilder-js/jobs/435057154#L1407)