### PR TITLE
Fix for working with ServerlessFramework

### DIFF
--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -548,8 +548,7 @@ export class BotFrameworkAdapter extends BotAdapter {
         return parseRequest(req).then((request: Activity) => {
             // Authenticate the incoming request
             errorCode = 401;
-            const authHeader: string = req.headers.authorization ? req.headers.authorization : req.headers.Authorization;
-			
+            const authHeader: string = req.headers.authorization || req.headers.Authorization || '';
             return this.authenticateRequest(request, authHeader).then(() => {
                 // Process received activity
                 errorCode = 500;

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -548,8 +548,8 @@ export class BotFrameworkAdapter extends BotAdapter {
         return parseRequest(req).then((request: Activity) => {
             // Authenticate the incoming request
             errorCode = 401;
-            const authHeader: string = req.headers.authorization || '';
-
+            const authHeader: string = req.headers.authorization ? req.headers.authorization : req.headers.Authorization;
+			
             return this.authenticateRequest(request, authHeader).then(() => {
                 // Process received activity
                 errorCode = 500;


### PR DESCRIPTION
Authorization was coming in empty because it was checking caps vs lowercase.