### PR TITLE
Fix activity timestamp string to Date.

### DIFF
--- a/libraries/botbuilder-core/src/transcriptLogger.ts
+++ b/libraries/botbuilder-core/src/transcriptLogger.ts
@@ -117,7 +117,8 @@ export class TranscriptLoggerMiddleware implements Middleware {
      * @param activity Activity to clone.
      */
     private cloneActivity(activity: Partial<Activity>): Activity {
-        return JSON.parse(JSON.stringify(activity));
+        const emptyActivity: Activity = {type: '', serviceUrl: '', channelId: '', from: undefined, conversation: undefined, recipient: undefined, text: '', label: '', valueType: ''};
+        return Object.assign(emptyActivity, activity);
     }
 }
 

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -777,6 +777,7 @@ function parseRequest(req: WebRequest): Promise<Activity> {
             if (typeof activity.type !== 'string') { throw new Error(`BotFrameworkAdapter.parseRequest(): missing activity type.`); }
             if (activity.timestamp && typeof activity.timestamp === 'string') { activity.timestamp = new Date(activity.timestamp); }
             if (activity.localTimestamp && typeof activity.localTimestamp === 'string') { activity.localTimestamp = new Date(activity.localTimestamp); }
+            if (activity.expiration && typeof activity.expiration === 'string') { activity.expiration = new Date(activity.expiration); }
             resolve(activity);
         }
 

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -775,9 +775,9 @@ function parseRequest(req: WebRequest): Promise<Activity> {
         function returnActivity(activity: Activity): void {
             if (typeof activity !== 'object') { throw new Error(`BotFrameworkAdapter.parseRequest(): invalid request body.`); }
             if (typeof activity.type !== 'string') { throw new Error(`BotFrameworkAdapter.parseRequest(): missing activity type.`); }
-            if (activity.timestamp && typeof activity.timestamp === 'string') { activity.timestamp = new Date(activity.timestamp); }
-            if (activity.localTimestamp && typeof activity.localTimestamp === 'string') { activity.localTimestamp = new Date(activity.localTimestamp); }
-            if (activity.expiration && typeof activity.expiration === 'string') { activity.expiration = new Date(activity.expiration); }
+            if (typeof activity.timestamp === 'string') { activity.timestamp = new Date(activity.timestamp); }
+            if (typeof activity.localTimestamp === 'string') { activity.localTimestamp = new Date(activity.localTimestamp); }
+            if (typeof activity.expiration === 'string') { activity.expiration = new Date(activity.expiration); }
             resolve(activity);
         }
 

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -775,6 +775,8 @@ function parseRequest(req: WebRequest): Promise<Activity> {
         function returnActivity(activity: Activity): void {
             if (typeof activity !== 'object') { throw new Error(`BotFrameworkAdapter.parseRequest(): invalid request body.`); }
             if (typeof activity.type !== 'string') { throw new Error(`BotFrameworkAdapter.parseRequest(): missing activity type.`); }
+            if (activity.timestamp && typeof activity.timestamp === 'string') { activity.timestamp = new Date(activity.timestamp); }
+            if (activity.localTimestamp && typeof activity.localTimestamp === 'string') { activity.localTimestamp = new Date(activity.localTimestamp); }
             resolve(activity);
         }
 

--- a/libraries/botbuilder/tests/botFrameworkAdapter.test.js
+++ b/libraries/botbuilder/tests/botFrameworkAdapter.test.js
@@ -188,6 +188,28 @@ describe(`BotFrameworkAdapter`, function () {
         });
     });
 
+    it(`should check timestamp in processActivity() sent as body.`, function (done) {
+        let called = false;
+        let message = incomingMessage;
+        message.timestamp = '2018-10-01T14:14:54.790Z';
+        message.localTimestamp = '2018-10-01T14:14:54.790Z';
+        const req = new MockBodyRequest(message);
+        const res = new MockResponse();
+        const adapter = new AdapterUnderTest();
+        adapter.processActivity(req, res, (context) => {
+            assert(context, `context not passed.`);
+            assert.equal(typeof context.activity.timestamp, 'object', `'context.activity.timestamp' is not a date`);
+            assert(context.activity.timestamp instanceof Date, `'context.activity.timestamp' is not a date`);
+            assert.equal(typeof context.activity.localTimestamp, 'object', `'context.activity.localTimestamp' is not a date`);
+            assert(context.activity.localTimestamp instanceof Date, `'context.activity.localTimestamp' is not a date`);
+            called = true;
+        }).then(() => {
+            assert(called, `bot logic not called.`);
+            assertResponse(res, 202);
+            done();
+        });
+    });
+
     it(`should reject a bogus request sent to processActivity().`, function (done) {
         const req = new MockRequest('bogus');
         const res = new MockResponse();


### PR DESCRIPTION
- Convert `string` json props from `WebRequest.body` to `Date`.
- Change `cloneActivity` method to maintain the Date properties as Date.

----
These changes are needed to save the timestamp with `transcriptLogger`.