### PR TITLE
Change Dutch translation in confirmPrompt (‘niet’ to ‘nee’)

### DIFF
--- a/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
@@ -24,7 +24,7 @@ export class ConfirmPrompt extends Prompt<boolean> {
      */
     public static defaultConfirmChoices: { [locale: string]: (string|Choice)[] } = {
         'es-es': ['Sí', 'No'],
-        'nl-nl': ['Ja', 'Niet'],
+        'nl-nl': ['Ja', 'Nee'],
         'en-us': ['Yes', 'No'],
         'fr-fr': ['Oui', 'Non'],
         'de-de': ['Ja', 'Nein'],


### PR DESCRIPTION
- Change Dutch translation in confirmPrompt (‘niet’ to ‘nee’). 
Niet could be an option, but isn't the correct translation in this 'yes / no' context.

I will have a look if I can port the Dutch .NET `BooleanRecognizer` in Recognizers-Text also to JavaScript. At the moment I only created all Dutch recognizers for C#.

Related PR in .NET repo: https://github.com/Microsoft/botbuilder-dotnet/pull/1017