### PR TITLE
use object spread instead of explicit assigns in LuisRecognizer

### DIFF
--- a/libraries/botbuilder-ai/src/luisRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizer.ts
@@ -197,6 +197,7 @@ export class LuisRecognizer {
             return this.luisClient.prediction.resolve(
                 this.application.applicationId, utterance,
                 {
+                    verbose: this.options.includeAllIntents,
                     customHeaders: { 'Ocp-Apim-Subscription-Key': this.application.endpointKey },
                     ...this.options
                 }

--- a/libraries/botbuilder-ai/src/luisRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizer.ts
@@ -197,10 +197,8 @@ export class LuisRecognizer {
             return this.luisClient.prediction.resolve(
                 this.application.applicationId, utterance,
                 {
-                    timezoneOffset: this.options.timezoneOffset,
-                    verbose: this.options.includeAllIntents,
-                    log: this.options.log,
-                    customHeaders: { 'Ocp-Apim-Subscription-Key': this.application.endpointKey }
+                    customHeaders: { 'Ocp-Apim-Subscription-Key': this.application.endpointKey },
+                    ...this.options
                 }
             )
                 .then((luisResult: LuisModels.LuisResult) => {


### PR DESCRIPTION
This will address #522 in that all of the LuisPredictionOptions are now passed in to the underlying autorest-generated client.