### PR TITLE
Bugfix BotFrameworkAdapter.createConversation

### DIFF
--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -245,7 +245,7 @@ export class BotFrameworkAdapter extends BotAdapter {
             if (!reference.serviceUrl) { throw new Error(`BotFrameworkAdapter.createConversation(): missing serviceUrl.`); }
 
             // Create conversation
-            const parameters: ConversationParameters = { bot: reference.bot } as ConversationParameters;
+            const parameters: ConversationParameters = { bot: reference.bot, members: [reference.user] } as ConversationParameters;
             const client: ConnectorClient = this.createConnectorClient(reference.serviceUrl);
 
             return client.conversations.createConversation(parameters).then((response: ConversationResourceResponse) => {


### PR DESCRIPTION
The API endpoint for creating conversations requires a `Conversation` object parameter, and as such the SDK function requires additional parameters including `members` and potentially `topicName` and `activity` as well per:

https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0#create-conversation
https://docs.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0#conversation-object