### PR TITLE
update CosmosDbStorage and CosmosDbKeyEscape

### DIFF
--- a/libraries/botbuilder-azure/src/cosmosDbKeyEscape.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbKeyEscape.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-export module CosmosDBKeyEscape {
+export module CosmosDbKeyEscape {
     const illegalKeys: string[] = ['\\', '?', '/', '#', '\t', '\n', '\r', '*'];
     const illegalKeyCharacterReplacementMap: Map<string, string> =
         illegalKeys.reduce<Map<string, string>>(

--- a/libraries/botbuilder-azure/src/cosmosDbKeyEscape.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbKeyEscape.ts
@@ -9,15 +9,21 @@
 export module CosmosDBKeyEscape {
     const illegalKeys: string[] = ['\\', '?', '/', '#', '\t', '\n', '\r', '*'];
     const illegalKeyCharacterReplacementMap: Map<string, string> =
-    illegalKeys.reduce<Map<string, string>>(
-        (map : Map<string, string>, c : string) => {
-            map.set(c, `*${c.charCodeAt(0).toString(16)}`);
+        illegalKeys.reduce<Map<string, string>>(
+            (map: Map<string, string>, c: string) => {
+                map.set(c, `*${c.charCodeAt(0).toString(16)}`);
 
-            return map;
-        },
-        new Map()
-    );
+                return map;
+            },
+            new Map()
+        );
 
+     /**
+     * Converts the key into a DocumentID that can be used safely with CosmosDB.
+     * The following characters are restricted and cannot be used in the Id property: '/', '\', '?', '#'
+     * More information at https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.resource.id?view=azure-dotnet#remarks
+      * @param key The provided key to be escaped.
+      */
     export function escapeKey(key: string): string {
         if (!key) {
             throw new Error('The \'key\' parameter is required.');
@@ -25,7 +31,7 @@ export module CosmosDBKeyEscape {
 
         const keySplitted: string[] = key.split('');
 
-        const firstIllegalCharIndex: number = keySplitted.findIndex(((c : string): boolean => illegalKeys.some((i : string) => i === c)));
+        const firstIllegalCharIndex: number = keySplitted.findIndex(((c: string): boolean => illegalKeys.some((i: string) => i === c)));
 
         // If there are no illegal characters return immediately and avoid any further processing/allocations
         if (firstIllegalCharIndex === -1) {
@@ -33,7 +39,7 @@ export module CosmosDBKeyEscape {
         }
 
         return keySplitted.reduce(
-            (result : string, c : string) =>
+            (result: string, c: string) =>
                 result + (illegalKeyCharacterReplacementMap.has(c) ? illegalKeyCharacterReplacementMap.get(c) : c),
             ''
         );

--- a/libraries/botbuilder-azure/src/cosmosDbStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbStorage.ts
@@ -183,8 +183,8 @@ export class CosmosDbStorage implements Storage {
     }
 
     public write(changes: StoreItems): Promise<void> {
-        if (!changes) {
-            throw new Error('Please provide a StoreItems with changes to persist.');
+        if (!changes || Object.keys(changes).length === 0) {
+            return Promise.resolve();
         }
 
         return this.ensureCollectionExists().then(() => {
@@ -228,6 +228,10 @@ export class CosmosDbStorage implements Storage {
     }
 
     public delete(keys: string[]): Promise<void> {
+        if (!keys || keys.length === 0) {
+            return Promise.resolve();
+        }
+
         return this.ensureCollectionExists().then(() =>
             Promise.all(keys.map((k: string) =>
                 new Promise((resolve: any, reject: any): void =>
@@ -326,14 +330,4 @@ function getOrCreateCollection(client: DocumentClient,
             });
         });
     });
-}
-
-/**
- * @private
- * Converts the key into a DocumentID that can be used safely with CosmosDB.
- * The following characters are restricted and cannot be used in the Id property: '/', '\', '?', '#'
- * More information at https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.resource.id?view=azure-dotnet#remarks
- */
-function sanitizeKey(key: string): string {
-    return CosmosDBKeyEscape.escapeKey(key);
 }

--- a/libraries/botbuilder-azure/src/cosmosDbStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbStorage.ts
@@ -9,7 +9,7 @@
 import { Storage, StoreItems } from 'botbuilder';
 import { ConnectionPolicy, DocumentClient, RequestOptions, UriFactory } from 'documentdb';
 import * as semaphore from 'semaphore';
-import { CosmosDBKeyEscape } from './cosmosDbKeyEscape';
+import { CosmosDbKeyEscape } from './cosmosDbKeyEscape';
 
 const _semaphore: semaphore.Semaphore = semaphore(1);
 
@@ -138,7 +138,7 @@ export class CosmosDbStorage implements Storage {
             value: string;
         }[] = keys.map((key: string, ix: number) => ({
             name: `@id${ix}`,
-            value: CosmosDBKeyEscape.escapeKey(key)
+            value: CosmosDbKeyEscape.escapeKey(key)
         }));
 
         const querySpec: {
@@ -195,7 +195,7 @@ export class CosmosDbStorage implements Storage {
                 // The ETag information is updated as an _etag attribute in the document metadata.
                 delete changesCopy.eTag;
                 const documentChange: DocumentStoreItem = {
-                    id: CosmosDBKeyEscape.escapeKey(k),
+                    id: CosmosDbKeyEscape.escapeKey(k),
                     realId: k,
                     document: changesCopy
                 };
@@ -236,7 +236,7 @@ export class CosmosDbStorage implements Storage {
             Promise.all(keys.map((k: string) =>
                 new Promise((resolve: any, reject: any): void =>
                     this.client.deleteDocument(
-                        UriFactory.createDocumentUri(this.settings.databaseId, this.settings.collectionId, CosmosDBKeyEscape.escapeKey(k)),
+                        UriFactory.createDocumentUri(this.settings.databaseId, this.settings.collectionId, CosmosDbKeyEscape.escapeKey(k)),
                         (err: any, data: any): void =>
                             err && err.code !== 404 ? reject(err) : resolve()
                         )

--- a/libraries/botbuilder-azure/tests/cosmosDbKeyEscape.test.js
+++ b/libraries/botbuilder-azure/tests/cosmosDbKeyEscape.test.js
@@ -1,58 +1,58 @@
 const assert = require('assert');
-const { CosmosDBKeyEscape } = require('../');
+const { CosmosDbKeyEscape } = require('../');
 
-describe('CosmosDBKeyEscape', function() {
+describe('CosmosDbKeyEscape', function() {
     it('should fail with null key', function() {
-        assert.throws(() => new CosmosDBKeyEscape(), Error, 'constructor should have thrown error about missing key parameter.')
+        assert.throws(() => new CosmosDbKeyEscape(), Error, 'constructor should have thrown error about missing key parameter.')
     });
 
     it('should fail with empty key', function() {
-        assert.throws(() => new CosmosDBKeyEscape(''), Error, 'constructor should have thrown error about missing key parameter.')
+        assert.throws(() => new CosmosDbKeyEscape(''), Error, 'constructor should have thrown error about missing key parameter.')
     });
 
     it('should fail with white spaces key', function() {
-        assert.throws(() => new CosmosDBKeyEscape('   '), Error, 'constructor should have thrown error about missing key parameter.')
+        assert.throws(() => new CosmosDbKeyEscape('   '), Error, 'constructor should have thrown error about missing key parameter.')
     });
 
     it('should not change a valid key', function() {
         let validKey = 'Abc12345';
-        let sanitizedKey = CosmosDBKeyEscape.escapeKey(validKey);
+        let sanitizedKey = CosmosDbKeyEscape.escapeKey(validKey);
         assert.equal(validKey, sanitizedKey, `${validKey} should be equal to ${sanitizedKey}`)
     });
 
     it('should escape illegal characters - case with \'?\'', function() {
         // Ascii code of "?" is "3f"
-        let sanitizedKey = CosmosDBKeyEscape.escapeKey('?test?');
+        let sanitizedKey = CosmosDbKeyEscape.escapeKey('?test?');
         assert.equal(sanitizedKey, '*3ftest*3f');
     });
 
     it('should escape illegal characters - case with \'/\'', function() {
         // Ascii code of "/" is "2f"
-        let sanitizedKey = CosmosDBKeyEscape.escapeKey('/test/');
+        let sanitizedKey = CosmosDbKeyEscape.escapeKey('/test/');
         assert.equal(sanitizedKey, '*2ftest*2f');
     });
 
     it('should escape illegal characters - case with \'\\\'', function() {        
         // Ascii code of "\" is "5c"
-        let sanitizedKey = CosmosDBKeyEscape.escapeKey('\\test\\');
+        let sanitizedKey = CosmosDbKeyEscape.escapeKey('\\test\\');
         assert.equal(sanitizedKey, '*5ctest*5c');
     })
 
     it('should escape illegal characters - case with \'#\'', function() {
         // Ascii code of "#" is "23"
-        let sanitizedKey = CosmosDBKeyEscape.escapeKey('#test#');
+        let sanitizedKey = CosmosDbKeyEscape.escapeKey('#test#');
         assert.equal(sanitizedKey, '*23test*23');
     })
 
     it('should escape illegal characters - case with \'*\'', function() {        
         // Ascii code of "*" is "2a".
-        let sanitizedKey = CosmosDBKeyEscape.escapeKey('*test*');
+        let sanitizedKey = CosmosDbKeyEscape.escapeKey('*test*');
         assert.equal(sanitizedKey, '*2atest*2a');
     });
 
     it('should escape illegal characters - compound key', function() {
         // Check a compound key
-        let compoundSanitizedKey = CosmosDBKeyEscape.escapeKey('?#/');
+        let compoundSanitizedKey = CosmosDbKeyEscape.escapeKey('?#/');
         assert.equal(compoundSanitizedKey, '*3f*23*2f');
     });
 
@@ -60,8 +60,8 @@ describe('CosmosDBKeyEscape', function() {
         let validKey1 = '*2atest*2a';
         let validKey2 = '*test*';
 
-        let escaped1 = CosmosDBKeyEscape.escapeKey(validKey1);
-        let escaped2 = CosmosDBKeyEscape.escapeKey(validKey2);
+        let escaped1 = CosmosDbKeyEscape.escapeKey(validKey1);
+        let escaped2 = CosmosDbKeyEscape.escapeKey(validKey2);
         
         assert.notEqual(escaped1, escaped2, `${escaped1} should be different that ${escaped2}`)
     });

--- a/libraries/botbuilder-azure/tests/cosmosDbStorage.test.js
+++ b/libraries/botbuilder-azure/tests/cosmosDbStorage.test.js
@@ -223,21 +223,6 @@ testStorage = function () {
         let storage = new CosmosDbStorage(getSettings(), (policyInstance) => policy = policyInstance);
 
         assert(policy != null, 'connectionPolicyConfigurator should have been called.')
-    });    
-
-    it('read with no key should return no values', function() {
-        let storage = new CosmosDbStorage(getSettings(), policyConfigurator);
-        return storage.read([])
-            .then((result) => {
-                assert(result !== null, 'read method should returns an object');
-                assert.deepEqual(result, {}, 'read method should returns an empty object');
-            });
-    });
-
-    it('write with null/undefined StoreItems should throw', function() {
-        let storage = new CosmosDbStorage(getSettings(), policyConfigurator);
-        assert.throws(() => storage.write(), Error, 'write() should have thrown error about missing changes.');
-        assert.throws(() => storage.write(null), Error, 'write() should have thrown error about missing changes.');
     });
 }
 
@@ -385,5 +370,40 @@ describe.skip('CosmosDbStorage', function () {
     before('cleanup', reset);
     testStorage();
     after('cleanup', reset);
+});
+
+// These tests use the same Cosmos DB configuration, but are not expected to call the Cosmos DB Emulator.
+describe('CosmosDbStorage - Offline tests', function () {
+    it('should return empty object when null is passed in to read()', async function () {
+        const storage = new CosmosDbStorage(getSettings(), policyConfigurator);
+        const storeItems = await storage.read(null);
+        assert.deepEqual(storeItems, {}, `did not receive empty object, instead received ${ JSON.stringify(storeItems) }`);
+    });
+
+    it('should return empty object when no keys are passed in to read()', async function () {
+        const storage = new CosmosDbStorage(getSettings(), policyConfigurator);
+        const storeItems = await storage.read([]);
+        assert.deepEqual(storeItems, {}, `did not receive empty object, instead received ${ JSON.stringify(storeItems) }`);
+    });
+
+    it('should not blow up when no changes are passed in to write()', async function () {
+        const storage = new CosmosDbStorage(getSettings(), policyConfigurator);
+        const storeItems = await storage.write({});
+    });
+
+    it('should not blow up when null is passed in to write()', async function () {
+        const storage = new CosmosDbStorage(getSettings(), policyConfigurator);
+        const storeItems = await storage.write(null);
+    });
+
+    it('should not blow up when no keys are passed in to delete()', async function () {
+        const storage = new CosmosDbStorage(getSettings(), policyConfigurator);
+        const storeItems = await storage.delete([]);
+    });
+
+    it('should not blow up when null is passed in to delete()', async function () {
+        const storage = new CosmosDbStorage(getSettings(), policyConfigurator);
+        const storeItems = await storage.delete(null);
+    });
 });
 


### PR DESCRIPTION
- Change `CosmosDbStorage.write(changes)` to not blowup with falsey or empty `changes`
- Change `CosmosDbStorage.delete(keys)` to not call Cosmos DB if `keys` are falsey or empty
- Setup **offline** CosmosDbStorage read/write/delete tests to always run
- Remove unused private method `CosmosDbStorage.sanitizeKey()`
- Add docstring to `CosmosDBKeyEscape.escapeKey()`
- Rename CosmosDBKeyEscape to Cosmos**Db**KeyEscape