### PR TITLE
Making bot code to work with prod gov

### DIFF
--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -12,7 +12,8 @@ import {
     JwtTokenValidation,
     MicrosoftAppCredentials,
     OAuthApiClient,
-    SimpleCredentialProvider
+    SimpleCredentialProvider,
+    GovernmentConstants
 } from 'botframework-connector';
 
 import {
@@ -156,6 +157,10 @@ export class BotFrameworkAdapter extends BotAdapter {
         this.isEmulatingOAuthCards = false;
         if (this.settings.openIdMetadata) {
             ChannelValidation.OpenIdMetadataEndpoint = this.settings.openIdMetadata;
+        }
+        if (JwtTokenValidation.isGovernment(this.settings.channelService)) {
+            this.credentials.oAuthEndpoint = GovernmentConstants.ToChannelFromBotLoginUrl;
+            this.credentials.oAuthScope = GovernmentConstants.ToChannelFromBotOAuthScope;
         }
     }
 

--- a/libraries/botframework-connector/src/auth/index.ts
+++ b/libraries/botframework-connector/src/auth/index.ts
@@ -10,6 +10,7 @@ export * from './microsoftAppCredentials';
 export * from './jwtTokenValidation';
 export * from './channelValidation';
 export * from './governmentChannelValidation';
+export * from './governmentConstants';
 export * from './enterpriseChannelValidation';
 export * from './emulatorValidation';
 export * from './endorsementsValidator';

--- a/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
@@ -17,7 +17,11 @@ export class MicrosoftAppCredentials implements msrest.ServiceClientCredentials 
 
     private static readonly trustedHostNames: Map<string, Date> = new Map<string, Date>([
         ['state.botframework.com', new Date(8640000000000000)],              // Date.MAX_VALUE,
-        ['api.botframework.com', new Date(8640000000000000)]                 // Date.MAX_VALUE,
+        ['api.botframework.com', new Date(8640000000000000)],                // Date.MAX_VALUE,
+        ['token.botframework.com', new Date(8640000000000000)],              // Date.MAX_VALUE,
+        ['state.botframework.azure.us', new Date(8640000000000000)],         // Date.MAX_VALUE,
+        ['api.botframework.azure.us', new Date(8640000000000000)],           // Date.MAX_VALUE,
+        ['token.botframework.azure.us', new Date(8640000000000000)],         // Date.MAX_VALUE,
     ]);
 
     private static readonly cache: Map<string, OAuthResponse> = new Map<string, OAuthResponse>();
@@ -25,8 +29,8 @@ export class MicrosoftAppCredentials implements msrest.ServiceClientCredentials 
     public appPassword: string;
     public appId: string;
 
-    public readonly oAuthEndpoint: string = Constants.ToChannelFromBotLoginUrl;
-    public readonly oAuthScope: string = Constants.ToChannelFromBotOAuthScope;
+    public oAuthEndpoint: string = Constants.ToChannelFromBotLoginUrl;
+    public oAuthScope: string = Constants.ToChannelFromBotOAuthScope;
     public readonly tokenCacheKey: string;
     private refreshingToken: Promise<OAuthResponse> | null = null;
 


### PR DESCRIPTION
Bots weren't able to communicate with Prod US Gov. 

The MicrosoftAppCredential had a fixed endpoint and scope, and these needed to change for US Gov.