### PR TITLE
stop using string-literal notation in AzureBlobTranscriptStore.ts

### DIFF
--- a/libraries/botbuilder-azure/package.json
+++ b/libraries/botbuilder-azure/package.json
@@ -22,7 +22,7 @@
   "typings": "./lib/index.d.ts",
   "dependencies": {
     "@types/node": "^9.3.0",
-    "azure-storage": "^2.3.0",
+    "azure-storage": "^2.10.2",
     "botbuilder": "^4.0.0",
     "documentdb": "1.14.5",
     "flat": "^4.0.0",

--- a/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
+++ b/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
@@ -386,8 +386,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
             getBlobToTextAsync: this.denodeify(blobService, blobService.getBlobToText),
             deleteBlobIfExistsAsync: this.denodeify(blobService, blobService.deleteBlobIfExists),
             listBlobsSegmentedWithPrefixAsync: this.denodeify(blobService, blobService.listBlobsSegmentedWithPrefix),
-            // tslint:disable-next-line:no-string-literal
-            listBlobDirectoriesSegmentedWithPrefixAsync: this.denodeify(blobService, blobService['listBlobDirectoriesSegmentedWithPrefix'])
+            listBlobDirectoriesSegmentedWithPrefixAsync: this.denodeify(blobService, blobService.listBlobDirectoriesSegmentedWithPrefix)
         });
     }
 


### PR DESCRIPTION
Fixes #382

## Description
stop using string-literal notation in AzureBlobTranscriptStore.ts

## Specific Changes
  - Bump dependency of `azure-storage` to a version with the updated .d.ts with `listBlobDirectoriesSegmentedWithPrefix()`
  - Remove the tslint ignore comment from AzureBlobTranscriptStore.ts