### PR TITLE
Intent dialog prototype *DO NOT MERGE*

### DIFF
--- a/libraries/botbuilder-dialogs/src/index.ts
+++ b/libraries/botbuilder-dialogs/src/index.ts
@@ -11,5 +11,7 @@ export * from './dialog';
 export * from './componentDialog';
 export * from './dialogContext';
 export * from './dialogSet';
+export * from './intentDialog';
+export * from './intentDialogContext';
 export * from './waterfallDialog';
 export * from './waterfallStepContext';

--- a/libraries/botbuilder-dialogs/src/intentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/intentDialog.ts
@@ -76,9 +76,9 @@ export class IntentDialog<O extends object = {}> extends Dialog<O> {
         });
     }
 
-    public endDialogIntent(name: string): this {
+    public endDialogIntent(name: string, result?: any): this {
         return this.onIntent(name, async (intent) => {
-            return await intent.endDialog();
+            return await intent.endDialog(result);
         });
     }
 

--- a/libraries/botbuilder-dialogs/src/intentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/intentDialog.ts
@@ -1,0 +1,193 @@
+/**
+ * @module botbuilder-dialogs
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { TurnContext, RecognizerResult, ActivityTypes, Activity } from 'botbuilder-core';
+import { Dialog, DialogTurnResult, DialogReason } from './dialog';
+import { DialogContext } from './dialogContext';
+import { IntentDialogContext } from './intentDialogContext';
+
+export enum CommonIntents {
+    Begin = 'Begin',
+    None = 'None',
+    Resume = 'Resume'
+}
+
+export type IntentRecognizer = { recognize(context: TurnContext): Promise<RecognizerResult>; };
+
+export class IntentDialog<O extends object = {}> extends Dialog<O> {
+    public readonly intents: { [name: string]: (intent: IntentDialogContext) => Promise<DialogTurnResult>; } = {};
+    public recognizer: IntentRecognizer|undefined;
+    public beginIntent: string = CommonIntents.Begin;
+    public noneIntent: string = CommonIntents.None;
+    public resumeIntent: string = CommonIntents.Resume;
+    public minScore: number = 0.0;
+
+    constructor(dialogId: string, recognizer?: IntentRecognizer) {
+        super(dialogId);
+        this.recognizer = recognizer;
+    }
+    
+    public async beginDialog(dc: DialogContext, options?: O): Promise<DialogTurnResult> {
+        // Initialize dialog state
+        const state: IntentDialogState = dc.activeDialog.state;
+        state.turn = -1;
+        state.options = options || {};
+        state.values = {};
+
+        // Process turn
+        return await this.processTurn(dc, DialogReason.beginCalled);
+    }
+
+    public async continueDialog(dc: DialogContext): Promise<DialogTurnResult> {
+        // Don't do anything for non-message activities
+        if (dc.context.activity.type !== ActivityTypes.Message) {
+            return Dialog.EndOfTurn;
+        }
+
+        // Process turn
+        return await this.processTurn(dc, DialogReason.continueCalled);
+    }
+
+
+    public async resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
+        // Process turn
+        return await this.processTurn(dc, reason, result);
+    }
+
+    public onIntent(name: string, handler: (intent: IntentDialogContext) => Promise<DialogTurnResult>): this {
+        if (this.hasIntent(name)) { throw new Error(`IntentDialog.onIntent(): an intent named '${name}' has already been registered.`) }
+        this.intents[name] = handler;
+        return this;
+    }
+
+    public beginDialogIntent(name: string, dialogId: string): this {
+        return this.onIntent(name, async (intent) => {
+            return await intent.beginDialog(dialogId, intent.recognized);
+        });
+    }
+
+    public cancelAllDialogsIntent(name: string): this {
+        return this.onIntent(name, async (intent) => {
+            return await intent.cancelAllDialogs();
+        });
+    }
+
+    public endDialogIntent(name: string): this {
+        return this.onIntent(name, async (intent) => {
+            return await intent.endDialog();
+        });
+    }
+
+    public replaceDialogIntent(name: string, dialogId: string): this {
+        return this.onIntent(name, async (intent) => {
+            return await intent.replaceDialog(dialogId, intent.recognized);
+        });
+    }
+
+    public repromptDialogIntent(name: string): this {
+        return this.onIntent(name, async (intent) => {
+            await intent.repromptDialog();
+            return Dialog.EndOfTurn;
+        });
+    }
+
+    public sendActivityIntent(name: string, activityOrText: string | Partial<Activity>, speak?: string, inputHint?: string): this {
+        return this.onIntent(name, async (intent) => {
+            await intent.context.sendActivity(activityOrText, speak, inputHint);
+            return Dialog.EndOfTurn;
+        });
+    }
+
+    protected async onRecognize(context: TurnContext): Promise<RecognizerResult|undefined> {
+        if (this.recognizer) {
+            return await this.recognizer.recognize(context);
+        }
+        return undefined;
+    }
+
+    protected async onRunTurn(intent: IntentDialogContext): Promise<DialogTurnResult> {
+        if (intent.reason === DialogReason.beginCalled) {
+            if (this.hasIntent(this.beginIntent)) {
+                return await this.runIntent(this.beginIntent, intent);
+            }
+        } else if (intent.reason === DialogReason.endCalled) {
+            if (this.hasIntent(this.resumeIntent)) {
+                return await this.runIntent(this.resumeIntent, intent);
+            }
+        } else if (intent.recognized) {
+            const name = this.findTopIntent(intent.recognized);
+            if (this.hasIntent(name)) {
+                return await this.runIntent(name, intent);
+            }
+        }
+        return Dialog.EndOfTurn;
+    }
+
+    protected findTopIntent(recognized?: RecognizerResult): string {
+        if (recognized && recognized.intents) {
+            // Find top scoring intent
+            let topName = this.noneIntent;
+            let topScore = 0;
+            for (const name in recognized.intents) {
+                const score = recognized.intents[name].score;
+                if (score > this.minScore && score > topScore) {
+                    topName = name;
+                    topScore = score;
+                }
+            }
+
+            // Filter to intents with dialog mappings
+            if (this.hasIntent(topName)) {
+                return topName;
+            }
+        }
+        return this.noneIntent;
+    }
+
+    protected hasIntent(name: string): boolean {
+        return this.intents.hasOwnProperty(name);
+    }
+
+    protected async runIntent(name: string, intent: IntentDialogContext): Promise<DialogTurnResult> {
+        if (!this.hasIntent(name)) { throw new Error(`IntentDialog.runIntent(): an intent handler for '${name}' couldn't be found.`) }
+        return await this.intents[name](intent);
+    }
+
+    private async processTurn(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
+        // Increment turn count
+        const state: IntentDialogState = dc.activeDialog.state;
+        state.turn++;
+
+        // Recognize results
+        let recognized: RecognizerResult = undefined;
+        if (reason === DialogReason.continueCalled) {
+            recognized = await this.onRecognize(dc.context);
+        }
+
+        // Create intent context
+        const intent: IntentDialogContext<O> = new IntentDialogContext<O>(dc, {
+            options: state.options as any,
+            reason: reason,
+            result: result,
+            turn: state.turn,
+            values: state.values,
+            recognized: recognized
+        });
+
+        // Run turn
+        return await this.onRunTurn(intent);
+    }
+}
+
+/**
+ * @private
+ */
+interface IntentDialogState {
+    turn: number;
+    options: object;
+    values: object;
+}

--- a/libraries/botbuilder-dialogs/src/intentDialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/intentDialogContext.ts
@@ -1,0 +1,107 @@
+/**
+ * @module botbuilder-dialogs
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+import { RecognizerResult } from 'botbuilder-core';
+import { DialogReason } from './dialog';
+import { DialogContext } from './dialogContext';
+
+/**
+ * Values passed to the `WaterfallStepContext` constructor.
+ */
+export interface IntentDialogInfo<O extends object> {
+    /**
+     * Any options passed to the steps waterfall dialog when it was started with
+     * `DialogContext.beginDialog()`.
+     */
+    options: O;
+
+    /**
+     * The reason the waterfall step is being executed.
+     */
+    reason: DialogReason;
+
+    /**
+     * Result returned by a dialog or prompt that was previously started using `beginDialog()`.
+     */
+    result: any;
+
+    /**
+     * 0 based index of the turn that's executing.
+     */
+    turn: number;
+
+    /**
+     * A dictionary of values which will be persisted for the lifetime of the intent dialog.
+     */
+    values: object;
+
+    /**
+     * (Optional) results returned by the recognizer that was run.
+     */
+    recognized?: RecognizerResult;
+}
+
+/**
+ * Context object passed in to `IntentDialog.onRunTurn()`.
+ * @param O (Optional) type of options passed in to the call to `IntentDialog.beginDialog()`.
+ */
+export class IntentDialogContext<O extends object = {}> extends DialogContext {
+    private _info: IntentDialogInfo<O>;
+
+    /**
+     * Creates a new IntentDialogContext instance.
+     * @param dc The dialog context for the current turn of conversation.
+     * @param info Values to initialize the step context with.
+     */
+    constructor(dc: DialogContext, info: IntentDialogInfo<O>) {
+        super(dc.dialogs, dc.context, { dialogStack: dc.stack });
+        this._info = info;
+    }
+
+    /**
+     * Any options passed to the steps waterfall dialog when it was started with
+     * `DialogContext.beginDialog()`.
+     */
+    public get options(): O {
+        return this._info.options;
+    }
+
+    /**
+     * The reason the waterfall step is being executed.
+     */
+    public get reason(): DialogReason {
+        return this._info.reason;
+    }
+
+    /**
+     * (Optional) results returned by the recognizer that was run.
+     */
+    public get recognized(): RecognizerResult|undefined {
+        return this._info.recognized;
+    }
+
+    /**
+     * Results returned by a dialog or prompt that was called in the previous waterfall step.
+     */
+    public get result(): any {
+        return this._info.result;
+    }
+
+    /**
+     * 0 based index of the turn that's executing.
+     */
+    public get turn(): number {
+        return this._info.turn;
+    }
+
+    /**
+     * A dictionary of values which will be persisted for the lifetime of the intent dialog.
+     */
+    public get values(): object {
+        return this._info.values;
+    }
+}


### PR DESCRIPTION
## Description
Prototype of a new `IntentDialog` class for review. Sample usage:

```JS
const recognizer = new LuisRecognizer(settings);
const dialog = new IntentDialog('agePrompt', recognizer)
     .sendActivityIntent('Begin', `What is your age?`)
     .sendActivityIntent('Help', `Enter a number from 1 to 100`)
     .sendActivityIntent('None', `I'm sorry I didn't recognize your input. Please enter a number.`)
     .endDialogIntent('Cancel', -1)
     .onIntent('Age', async (intent) => {
          const age = intent.recognized.entities.age;
          if (typeof age === 'number' && age > 0 && age < 101) {
              return await intent.endDialog(age);
          } else if (intent.turns >= 3) {
              return await intent.endDialog(-1);
          } else {
              await intent.context.sendActivity(`Enter a number from 1 to 100`);
          }
          return Dialog.EndOfTurn;
     });
```