### PR TITLE
Correct improper use of await in function declarations

### DIFF
--- a/libraries/botbuilder-core/src/turnContext.ts
+++ b/libraries/botbuilder-core/src/turnContext.ts
@@ -263,7 +263,7 @@ export class TurnContext {
      * This example shows how to listen for and logs outgoing `message` activities.
      *
      * ```JavaScript
-     * context.onSendActivities(await (ctx, activities, next) => {
+     * context.onSendActivities(async (ctx, activities, next) => {
      *    // Deliver activities
      *    await next();
      *
@@ -286,7 +286,7 @@ export class TurnContext {
      * This example shows how to listen for and logs updated activities.
      *
      * ```JavaScript
-     * context.onUpdateActivities(await (ctx, activity, next) => {
+     * context.onUpdateActivities(async (ctx, activity, next) => {
      *    // Replace activity
      *    await next();
      *
@@ -309,7 +309,7 @@ export class TurnContext {
      * This example shows how to listen for and logs deleted activities.
      *
      * ```JavaScript
-     * context.onDeleteActivities(await (ctx, reference, next) => {
+     * context.onDeleteActivities(async (ctx, reference, next) => {
      *    // Delete activity
      *    await next();
      *

--- a/libraries/botbuilder-core/src/turnContext.ts
+++ b/libraries/botbuilder-core/src/turnContext.ts
@@ -286,7 +286,7 @@ export class TurnContext {
      * This example shows how to listen for and logs updated activities.
      *
      * ```JavaScript
-     * context.onUpdateActivities(async (ctx, activity, next) => {
+     * context.onUpdateActivity(async (ctx, activity, next) => {
      *    // Replace activity
      *    await next();
      *
@@ -309,7 +309,7 @@ export class TurnContext {
      * This example shows how to listen for and logs deleted activities.
      *
      * ```JavaScript
-     * context.onDeleteActivities(async (ctx, reference, next) => {
+     * context.onDeleteActivity(async (ctx, reference, next) => {
      *    // Delete activity
      *    await next();
      *


### PR DESCRIPTION
Fixes #611 

We had incorrectly used await in the place of async in some function declarations _in the comments_, which then get published in our docs.

