### PR TITLE
Remove request dependency from botframework-connector library

### DIFF
--- a/libraries/botframework-connector/package-lock.json
+++ b/libraries/botframework-connector/package-lock.json
@@ -36,6 +36,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.28.tgz",
       "integrity": "sha512-LMSOxMKNJ8tGqUVs8lSIT8RGo1XGWYada/ZU2QZcbcD6AW9futXDE99tfQA0K6DK60GXcwplsGGK5KABRmI5GA=="
     },
+    "@types/node-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha512-XroxUzLpKuL+CVkQqXlffRkEPi4Gh3Oui/mWyS7ztKiyqVxiU+h3imCW5I2NQmde5jK+3q++36/Q96cyRWsweg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/request": {
       "version": "2.47.1",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
@@ -697,6 +705,11 @@
         "uuid": "^3.2.1",
         "xml2js": "^0.4.19"
       }
+    },
+    "node-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.1.tgz",
+      "integrity": "sha512-ObXBpNCD3A/vYQiQtEWl7DuqjAXjfptYFuGHLdPl5U19/6kJuZV+8uMHLrkj3wJrJoyfg4nhgyFixZdaZoAiEQ=="
     },
     "nyc": {
       "version": "11.9.0",

--- a/libraries/botframework-connector/package-lock.json
+++ b/libraries/botframework-connector/package-lock.json
@@ -4,19 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/caseless": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
-      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
-    },
-    "@types/form-data": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
-      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/jsonwebtoken": {
       "version": "7.2.8",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz",
@@ -36,25 +23,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.28.tgz",
       "integrity": "sha512-LMSOxMKNJ8tGqUVs8lSIT8RGo1XGWYada/ZU2QZcbcD6AW9futXDE99tfQA0K6DK60GXcwplsGGK5KABRmI5GA=="
     },
-    "@types/node-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha512-XroxUzLpKuL+CVkQqXlffRkEPi4Gh3Oui/mWyS7ztKiyqVxiU+h3imCW5I2NQmde5jK+3q++36/Q96cyRWsweg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/request": {
-      "version": "2.47.1",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
-      "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
-      "requires": {
-        "@types/caseless": "*",
-        "@types/form-data": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*"
-      }
-    },
     "@types/strip-bom": {
       "version": "3.0.0",
       "resolved": "http://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -66,22 +34,6 @@
       "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
-    },
-    "@types/tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ=="
-    },
-    "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
-      }
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -104,33 +56,10 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
       "version": "0.18.0",
@@ -151,14 +80,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.0.tgz",
       "integrity": "sha512-LIVmqIrIWuiqTvn4RzcrwCOuHo2DD6tKmKBPXXlr4p4n4l6BZBkwFTIa3zu1XkX5MbZgro4a6BvPi+n2Mns5Gg=="
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "botframework-schema": {
       "version": "4.0.8",
@@ -195,11 +116,6 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -210,11 +126,6 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "codelyzer": {
       "version": "4.4.4",
@@ -265,11 +176,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
     "css-selector-tokenizer": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
@@ -295,14 +201,6 @@
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
       "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
       "dev": true
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
     },
     "debug": {
       "version": "3.1.0",
@@ -336,15 +234,6 @@
       "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
       "dev": true
     },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "ecdsa-sig-formatter": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
@@ -359,26 +248,6 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
     "fastparse": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
@@ -392,11 +261,6 @@
       "requires": {
         "debug": "=3.1.0"
       }
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.3",
@@ -413,14 +277,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
     },
     "glob": {
       "version": "7.1.2",
@@ -442,20 +298,6 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
-      "requires": {
-        "ajv": "^5.3.0",
-        "har-schema": "^2.0.0"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -475,16 +317,6 @@
       "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
       }
     },
     "inflight": {
@@ -508,41 +340,11 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
     "jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "dev": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonwebtoken": {
       "version": "8.0.1",
@@ -559,17 +361,6 @@
         "lodash.once": "^4.0.0",
         "ms": "^2.0.0",
         "xtend": "^4.0.1"
-      }
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
       }
     },
     "jwa": {
@@ -692,6 +483,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "ms-rest-azure-js": {
+      "version": "1.0.179",
+      "resolved": "https://registry.npmjs.org/ms-rest-azure-js/-/ms-rest-azure-js-1.0.179.tgz",
+      "integrity": "sha512-DXVQxInEjCqqJWXUxzsLUWtL/LHKQgcooAjmMKnBPIPwhevSpRPdomlJgvZVEl+Smb9qXdQJrEGjiN98N6cBUg==",
+      "requires": {
+        "ms-rest-js": "^1.0.455",
+        "tslib": "^1.9.2"
+      }
     },
     "ms-rest-js": {
       "version": "1.0.455",
@@ -3341,11 +3141,6 @@
         }
       }
     },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3367,11 +3162,6 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "psl": {
       "version": "1.1.29",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
@@ -3381,11 +3171,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "regenerate": {
       "version": "1.4.0",
@@ -3419,33 +3204,6 @@
         "jsesc": "~0.5.0"
       }
     },
-    "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      }
-    },
     "rsa-pem-from-mod-exp": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
@@ -3455,11 +3213,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
       "version": "1.2.4",
@@ -3565,22 +3318,6 @@
       "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
       "dev": true
     },
-    "sshpk": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -3660,19 +3397,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -3685,16 +3409,6 @@
       "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
-      }
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "wrappy": {

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -21,8 +21,6 @@
   "dependencies": {
     "@types/jsonwebtoken": "7.2.8",
     "@types/node": "^9.3.0",
-    "@types/node-fetch": "^2.1.2",
-    "@types/request": "^2.47.0",
     "base64url": "^3.0.0",
     "botframework-schema": "^4.0.0",
     "form-data": "^2.3.3",
@@ -30,7 +28,6 @@
     "ms-rest-azure-js": "^1.0.176",
     "ms-rest-js": "^1.0.455",
     "node-fetch": "^2.2.1",
-    "request": "^2.87.0",
     "rsa-pem-from-mod-exp": "^0.8.4"
   },
   "devDependencies": {

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -21,12 +21,15 @@
   "dependencies": {
     "@types/jsonwebtoken": "7.2.8",
     "@types/node": "^9.3.0",
+    "@types/node-fetch": "^2.1.2",
     "@types/request": "^2.47.0",
     "base64url": "^3.0.0",
     "botframework-schema": "^4.0.0",
+    "form-data": "^2.3.3",
     "jsonwebtoken": "8.0.1",
     "ms-rest-azure-js": "^1.0.176",
     "ms-rest-js": "^1.0.455",
+    "node-fetch": "^2.2.1",
     "request": "^2.87.0",
     "rsa-pem-from-mod-exp": "^0.8.4"
   },

--- a/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
@@ -115,9 +115,7 @@ export class MicrosoftAppCredentials implements msrest.ServiceClientCredentials 
         this.refreshingToken = null;
 
         let oauthResponse: OAuthResponse;
-        if (res.ok) {
-            let access_token: string;
-            
+        if (res.ok) {          
             // `res` is equalivent to the results from the cached promise `this.refreshingToken`.
             // Because the promise has been cached, we need to see if the body has been read.
             // If the body has not been read yet, we can call res.json() to get the access_token.
@@ -130,16 +128,15 @@ export class MicrosoftAppCredentials implements msrest.ServiceClientCredentials 
                 // new token before it expires.
                 oauthResponse.expiration_time = Date.now() + (oauthResponse.expires_in * 1000) - 300000;
                 MicrosoftAppCredentials.cache.set(this.tokenCacheKey, oauthResponse);
-                access_token = oauthResponse.access_token;
+                return oauthResponse.access_token;
             } else {
                 const oAuthToken: OAuthResponse = MicrosoftAppCredentials.cache.get(this.tokenCacheKey);
                 if (oAuthToken) {
-                    access_token = oAuthToken.access_token;
+                    return oAuthToken.access_token;
                 } else {
                     return await this.getToken();
                 }
             }
-            return access_token;
         } else {
             throw new Error(res.statusText);
         }

--- a/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
@@ -6,7 +6,6 @@
  * Licensed under the MIT License.
  */
 import * as msrest from 'ms-rest-js';
-// import * as request from 'request';
 import * as url from 'url';
 import { Constants } from './constants';
 

--- a/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
@@ -10,9 +10,6 @@ import * as msrest from 'ms-rest-js';
 import * as url from 'url';
 import { Constants } from './constants';
 
-const fetch = (new Function('const env = (global || window); return "fetch" in env ? env.fetch : require("node-fetch");'))();
-const FormData = (new Function('const env = (global || window); return "FormData" in env ? env.FormData : require("form-data");'))();
-
 /**
  * MicrosoftAppCredentials auth implementation and cache
  */
@@ -143,9 +140,6 @@ export class MicrosoftAppCredentials implements msrest.ServiceClientCredentials 
 
             this.refreshingToken = fetch(this.oAuthEndpoint, {
                 method: 'POST',
-                headers: {
-                    'Content-Type': "application/x-www-form-urlencoded",
-                },
                 body: params
             });
         }

--- a/libraries/botframework-connector/src/auth/openIdMetadata.ts
+++ b/libraries/botframework-connector/src/auth/openIdMetadata.ts
@@ -21,8 +21,7 @@ export class OpenIdMetadata {
 
     public async getKey(keyId: string): Promise<IOpenIdMetadataKey | null> {
         // If keys are more than 5 days old, refresh them
-        const now: number = new Date().getTime();
-        if (this.lastUpdated < (now - 1000 * 60 * 60 * 24 * 5)) {
+        if (this.lastUpdated < (Date.now() - 1000 * 60 * 60 * 24 * 5)) {
             try {
                 await this.refreshCache();
                 

--- a/libraries/botframework-connector/src/auth/openIdMetadata.ts
+++ b/libraries/botframework-connector/src/auth/openIdMetadata.ts
@@ -5,7 +5,6 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import * as request from 'request';
 // tslint:disable-next-line:no-var-requires no-require-imports
 const getPem: any = require('rsa-pem-from-mod-exp');
 // tslint:disable-next-line:no-var-requires no-require-imports
@@ -20,67 +19,45 @@ export class OpenIdMetadata {
         this.url = url;
     }
 
-    public getKey(keyId: string): Promise<IOpenIdMetadataKey | null> {
-        return new Promise((resolve: any, reject: any): void => {
-            // If keys are more than 5 days old, refresh them
-            const now: number = new Date().getTime();
-            if (this.lastUpdated < (now - 1000 * 60 * 60 * 24 * 5)) {
-                this.refreshCache((err: any): void => {
-                    if (err) {
-                        //logger.error('Error retrieving OpenId metadata at ' + this.url + ', error: ' + err.toString());
-                        // fall through and return cached key on error
-                        reject(err);
-                    }
-
-                    // Search the cache even if we failed to refresh
-                    const key: IOpenIdMetadataKey = this.findKey(keyId);
-                    resolve(key);
-                });
-            } else {
-                // Otherwise read from cache
+    public async getKey(keyId: string): Promise<IOpenIdMetadataKey | null> {
+        // If keys are more than 5 days old, refresh them
+        const now: number = new Date().getTime();
+        if (this.lastUpdated < (now - 1000 * 60 * 60 * 24 * 5)) {
+            try {
+                await this.refreshCache();
+                
+                // Search the cache even if we failed to refresh
                 const key: IOpenIdMetadataKey = this.findKey(keyId);
-                resolve(key);
+                return key;
+            } catch (err) {
+                //logger.error('Error retrieving OpenId metadata at ' + this.url + ', error: ' + err.toString());
+                // fall through and return cached key on error
+                throw err;
             }
-        });
+        } else {
+            // Otherwise read from cache
+            const key: IOpenIdMetadataKey = this.findKey(keyId);
+            return key
+        }
     }
 
-    private refreshCache(cb: (err: Error) => void): void {
-        const options: request.Options = {
-            method: 'GET',
-            url: this.url,
-            json: true
-        };
+    private async refreshCache(): Promise<void> {
+        const res = await fetch(this.url);
 
-        request(options, (err: any, response: any, body: any) => {
-            if (!err && (response.statusCode && response.statusCode >= 400 || !body)) {
-                err = new Error(`Failed to load openID config: ${ response.statusCode }`);
-            }
+        if (res.ok) {
+            const openIdConfig = await res.json() as IOpenIdConfig;
 
-            if (err) {
-                cb(err);
+            const getKeyResponse = await fetch(openIdConfig.jwks_uri);
+            if (getKeyResponse.ok) {
+                this.lastUpdated = new Date().getTime();
+                this.keys = (await getKeyResponse.json()).keys as IKey[];
             } else {
-                const openIdConfig: IOpenIdConfig = <IOpenIdConfig>body;
-
-                const get_key_options: request.Options = {
-                    method: 'GET',
-                    url: openIdConfig.jwks_uri,
-                    json: true
-                };
-
-                request(get_key_options, (get_key_error: Error, get_key_response: any, get_key_body: any) => {
-                    if (!get_key_error && (get_key_response.statusCode && get_key_response.statusCode >= 400 || !get_key_body)) {
-                        get_key_error = new Error(`Failed to load Keys: ${ get_key_response.statusCode }`);
-                    }
-
-                    if (!get_key_error) {
-                        this.lastUpdated = new Date().getTime();
-                        this.keys = <IKey[]>get_key_body.keys;
-                    }
-
-                    cb(get_key_error);
-                });
+                throw new Error(`Failed to load Keys: ${ getKeyResponse.status }`);
             }
-        });
+
+        } else {
+            throw new Error(`Failed to load openID config: ${ res.status }`);
+        }
     }
 
     private findKey(keyId: string): IOpenIdMetadataKey | null {

--- a/libraries/botframework-connector/src/emulatorApiClient.ts
+++ b/libraries/botframework-connector/src/emulatorApiClient.ts
@@ -1,28 +1,29 @@
+/**
+ * @module botbuilder
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
 import { MicrosoftAppCredentials } from "./auth/microsoftAppCredentials";
-import * as request from 'request';
 
 export class EmulatorApiClient {
     public static async emulateOAuthCards(credentials: MicrosoftAppCredentials, emulatorUrl: string, emulate: boolean): Promise<boolean> {
         let token = await credentials.getToken();
-        return new Promise<boolean>((resolve: any, reject: any): void => {
-            let requestUrl: string = emulatorUrl + (emulatorUrl.endsWith('/') ? '' : '/') + `api/usertoken/emulateOAuthCards?emulate=${(!!emulate).toString()}`;
+        let requestUrl: string = emulatorUrl + (emulatorUrl.endsWith('/') ? '' : '/') + `api/usertoken/emulateOAuthCards?emulate=${(!!emulate).toString()}`;
 
-            const opt: request.Options = {
-                method: 'POST',
-                url: requestUrl,
-                auth: {
-                    bearer: token
-                }
-            };
-
-            request(opt, (err: any, response: any, body: any) => {
-               if (response.statusCode && response.statusCode < 300) {
-                    resolve(true);
-                } else {
-                    reject(new Error(`EmulateOAuthCards failed with status code: ${ response.statusCode }`));
-                }
-            });
+        const res = await fetch(requestUrl, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${token}`
+            }
         });
+
+        if (res.ok) {
+            return true;
+        } else {
+            throw new Error(`EmulateOAuthCards failed with status code: ${ res.status }`)
+        }
     }
 }
 

--- a/libraries/botframework-connector/src/index.ts
+++ b/libraries/botframework-connector/src/index.ts
@@ -1,3 +1,5 @@
+(new Function('require', 'const env = (global || window); if (!env.hasOwnProperty("FormData")) { env.FormData = require("form-data"); }; if (!env.hasOwnProperty("fetch")) { env.fetch = require("node-fetch"); }'))(require);
+
 import { TokenResponse } from './connectorApi/models/mappers';
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,9 +241,9 @@
       "integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw=="
     },
     "@types/node-fetch": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-1.6.9.tgz",
-      "integrity": "sha512-n2r6WLoY7+uuPT7pnEtKJCmPUGyJ+cbyBR8Avnu4+m1nzz7DwBVuyIvvlBzCZ/nrpC7rIgb3D6pNavL7rFEa9g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha512-XroxUzLpKuL+CVkQqXlffRkEPi4Gh3Oui/mWyS7ztKiyqVxiU+h3imCW5I2NQmde5jK+3q++36/Q96cyRWsweg==",
       "requires": {
         "@types/node": "*"
       }
@@ -301,7 +301,7 @@
     },
     "@types/strip-bom": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I="
     },
     "@types/strip-json-comments": {
@@ -381,10 +381,10 @@
       "resolved": "http://bbnpm.azurewebsites.net/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ansi-regex": {
@@ -411,7 +411,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-equal": {
@@ -475,7 +475,7 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "http://bbnpm.azurewebsites.net/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
@@ -529,9 +529,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -552,11 +552,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -565,7 +565,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -592,7 +592,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "big-integer": {
@@ -621,7 +621,7 @@
     },
     "boom": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "resolved": "http://bbnpm.azurewebsites.net/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
         "hoek": "4.x.x"
@@ -901,6 +901,25 @@
           "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
           "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
         },
+        "fetch-ponyfill": {
+          "version": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
+          "from": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
+          "requires": {
+            "fetch-cookie": "~0.6.0",
+            "node-fetch": "~1.7.1"
+          },
+          "dependencies": {
+            "fetch-cookie": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.6.0.tgz",
+              "integrity": "sha1-T+xOQIzAAH9sBOVTYYr0s97jf2k=",
+              "requires": {
+                "es6-denodeify": "^0.1.1",
+                "tough-cookie": "^2.3.1"
+              }
+            }
+          }
+        },
         "har-validator": {
           "version": "5.0.3",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
@@ -926,13 +945,30 @@
             "@types/node-fetch": "^1.6.7",
             "@types/uuid": "^3.4.3",
             "fetch-cookie": "^0.7.0",
-            "fetch-ponyfill": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
             "form-data": "^2.3.2",
             "is-buffer": "^2.0.0",
             "is-stream": "^1.1.0",
             "moment": "^2.21.0",
             "url-parse": "^1.2.0",
             "uuid": "^3.2.1"
+          },
+          "dependencies": {
+            "@types/node-fetch": {
+              "version": "1.6.9",
+              "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-1.6.9.tgz",
+              "integrity": "sha512-n2r6WLoY7+uuPT7pnEtKJCmPUGyJ+cbyBR8Avnu4+m1nzz7DwBVuyIvvlBzCZ/nrpC7rIgb3D6pNavL7rFEa9g==",
+              "requires": {
+                "@types/node": "*"
+              }
+            }
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "is-stream": "^1.0.1"
           }
         },
         "oauth-sign": {
@@ -1216,7 +1252,7 @@
       "resolved": "http://bbnpm.azurewebsites.net/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -1290,7 +1326,7 @@
     },
     "cryptiles": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "resolved": "http://bbnpm.azurewebsites.net/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
         "boom": "5.x.x"
@@ -1298,7 +1334,7 @@
       "dependencies": {
         "boom": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "resolved": "http://bbnpm.azurewebsites.net/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
             "hoek": "4.x.x"
@@ -1347,7 +1383,7 @@
       "resolved": "http://bbnpm.azurewebsites.net/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-urls": {
@@ -1511,7 +1547,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -1520,14 +1556,6 @@
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
       }
     },
     "es6-denodeify": {
@@ -1620,25 +1648,6 @@
         "tough-cookie": "^2.3.1"
       }
     },
-    "fetch-ponyfill": {
-      "version": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
-      "from": "github:amarzavery/fetch-ponyfill#master",
-      "requires": {
-        "fetch-cookie": "~0.6.0",
-        "node-fetch": "~1.7.1"
-      },
-      "dependencies": {
-        "fetch-cookie": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.6.0.tgz",
-          "integrity": "sha1-T+xOQIzAAH9sBOVTYYr0s97jf2k=",
-          "requires": {
-            "es6-denodeify": "^0.1.1",
-            "tough-cookie": "^2.3.1"
-          }
-        }
-      }
-    },
     "filename-reserved-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
@@ -1701,12 +1710,12 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "http://bbnpm.azurewebsites.net/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
     },
@@ -1775,7 +1784,7 @@
       "resolved": "http://bbnpm.azurewebsites.net/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -1783,12 +1792,12 @@
       "resolved": "http://bbnpm.azurewebsites.net/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "got": {
@@ -1862,7 +1871,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1902,7 +1911,7 @@
     },
     "hawk": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "resolved": "http://bbnpm.azurewebsites.net/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
         "boom": "4.x.x",
@@ -1924,7 +1933,7 @@
     },
     "hoek": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "resolved": "http://bbnpm.azurewebsites.net/hoek/-/hoek-4.2.1.tgz",
       "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "homedir-polyfill": {
@@ -1958,9 +1967,9 @@
       "resolved": "http://bbnpm.azurewebsites.net/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -1976,8 +1985,8 @@
       "resolved": "http://bbnpm.azurewebsites.net/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -2129,8 +2138,8 @@
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -2223,7 +2232,7 @@
       "resolved": "http://bbnpm.azurewebsites.net/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonparse": {
@@ -2328,8 +2337,8 @@
       "resolved": "http://bbnpm.azurewebsites.net/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "locate-path": {
@@ -2408,7 +2417,7 @@
     },
     "lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "lodash.tonumber": {
@@ -2484,7 +2493,7 @@
     },
     "md5.js": {
       "version": "1.3.4",
-      "resolved": "http://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "requires": {
         "hash-base": "^3.0.0",
@@ -2529,7 +2538,7 @@
       "resolved": "http://bbnpm.azurewebsites.net/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -2735,13 +2744,9 @@
       }
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.1.tgz",
+      "integrity": "sha512-ObXBpNCD3A/vYQiQtEWl7DuqjAXjfptYFuGHLdPl5U19/6kJuZV+8uMHLrkj3wJrJoyfg4nhgyFixZdaZoAiEQ=="
     },
     "normalize-url": {
       "version": "2.0.1",
@@ -2758,7 +2763,7 @@
       "resolved": "http://bbnpm.azurewebsites.net/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -5089,7 +5094,7 @@
       "resolved": "http://bbnpm.azurewebsites.net/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -5097,8 +5102,8 @@
       "resolved": "http://bbnpm.azurewebsites.net/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -5106,12 +5111,12 @@
       "resolved": "http://bbnpm.azurewebsites.net/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -5413,7 +5418,7 @@
       "resolved": "http://bbnpm.azurewebsites.net/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "^1.1.6"
       }
     },
     "regenerate": {
@@ -5541,7 +5546,7 @@
     },
     "request-promise-core": {
       "version": "1.1.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
         "lodash": "^4.13.1"
@@ -5549,7 +5554,7 @@
     },
     "request-promise-native": {
       "version": "1.0.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
       "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
       "requires": {
         "request-promise-core": "1.1.1",
@@ -5577,7 +5582,7 @@
       "resolved": "http://bbnpm.azurewebsites.net/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "responselike": {
@@ -5654,7 +5659,7 @@
       "resolved": "http://bbnpm.azurewebsites.net/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -5779,7 +5784,7 @@
     },
     "sntp": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "resolved": "http://bbnpm.azurewebsites.net/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
         "hoek": "4.x.x"
@@ -5830,7 +5835,7 @@
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "strict-uri-encode": {
@@ -5843,8 +5848,8 @@
       "resolved": "http://bbnpm.azurewebsites.net/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "string_decoder": {
@@ -5862,7 +5867,7 @@
       "resolved": "http://bbnpm.azurewebsites.net/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-bom": {
@@ -6073,7 +6078,7 @@
       "resolved": "http://bbnpm.azurewebsites.net/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "turndown": {
@@ -6095,7 +6100,7 @@
       "resolved": "http://bbnpm.azurewebsites.net/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -6307,9 +6312,9 @@
       "resolved": "http://bbnpm.azurewebsites.net/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "w3c-hr-time": {
@@ -6390,8 +6395,8 @@
       "resolved": "http://bbnpm.azurewebsites.net/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6404,7 +6409,7 @@
           "resolved": "http://bbnpm.azurewebsites.net/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -6412,9 +6417,9 @@
           "resolved": "http://bbnpm.azurewebsites.net/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -6422,7 +6427,7 @@
           "resolved": "http://bbnpm.azurewebsites.net/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -240,14 +240,6 @@
       "resolved": "http://bbnpm.azurewebsites.net/@types%2fnode/-/node-9.4.7.tgz",
       "integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw=="
     },
-    "@types/node-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha512-XroxUzLpKuL+CVkQqXlffRkEPi4Gh3Oui/mWyS7ztKiyqVxiU+h3imCW5I2NQmde5jK+3q++36/Q96cyRWsweg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/request": {
       "version": "2.48.0",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.0.tgz",
@@ -905,8 +897,7 @@
           "version": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
           "from": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
           "requires": {
-            "fetch-cookie": "~0.6.0",
-            "node-fetch": "~1.7.1"
+            "fetch-cookie": "~0.6.0"
           },
           "dependencies": {
             "fetch-cookie": {
@@ -960,15 +951,43 @@
               "requires": {
                 "@types/node": "*"
               }
+            },
+            "encoding": {
+              "version": "0.1.12",
+              "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+              "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+              "requires": {
+                "iconv-lite": "~0.4.13"
+              }
+            },
+            "fetch-ponyfill": {
+              "version": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
+              "from": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
+              "requires": {
+                "fetch-cookie": "~0.6.0",
+                "node-fetch": "~1.7.1"
+              },
+              "dependencies": {
+                "fetch-cookie": {
+                  "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.6.0.tgz",
+                  "integrity": "sha1-T+xOQIzAAH9sBOVTYYr0s97jf2k=",
+                  "requires": {
+                    "es6-denodeify": "^0.1.1",
+                    "tough-cookie": "^2.3.1"
+                  }
+                },
+                "node-fetch": {
+                  "version": "1.7.3",
+                  "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+                  "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+                  "requires": {
+                    "encoding": "^0.1.11",
+                    "is-stream": "^1.0.1"
+                  }
+                }
+              }
             }
-          }
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "requires": {
-            "is-stream": "^1.0.1"
           }
         },
         "oauth-sign": {


### PR DESCRIPTION
Fixes #600

## Description
This PR removes the `request` dependency in the `botframework-connector` library and instead uses `node-fetch` and `form-data` which _should_ allow `botframework-connector` to be used in the browser.

## Specific Changes
  - EmulatorApiClient, MicrosoftAppCredentials, OpenIdMetadata classes no longer use `request`
  - Reworked some of the private and internally called methods to use async syntax as opposed to Promises or worse, Promise-callback style

## Testing
- [X] All current tests still passing
- [X] Bot works with Bot Channels Registration
- [X] Browser bot (webpack without errors due to botframework-connector)