### PR TITLE
Correct NO_KEY messages in State classes for issue #610

### DIFF
--- a/libraries/botbuilder-core/src/conversationState.ts
+++ b/libraries/botbuilder-core/src/conversationState.ts
@@ -10,7 +10,7 @@ import { BotState } from './botState';
 import { Storage } from './storage';
 import { TurnContext } from './turnContext';
 
-const NO_KEY: string = `ConversationState: channelId and/or conversation missing from context.request.`;
+const NO_KEY: string = `ConversationState: overridden getStorageKey method did not return a key.`;
 
 /**
  * Reads and writes conversation state for your bot to storage.

--- a/libraries/botbuilder-core/src/privateConversationState.ts
+++ b/libraries/botbuilder-core/src/privateConversationState.ts
@@ -10,7 +10,7 @@ import { BotState } from './botState';
 import { Storage } from './storage';
 import { TurnContext } from './turnContext';
 
-const NO_KEY: string = `PrivateConversationState: channelId and/or PrivateConversation missing from context.request.`;
+const NO_KEY: string = `PrivateConversationState: overridden getStorageKey method did not return a key.`;
 
 /**
  * Reads and writes PrivateConversation state for your bot to storage.

--- a/libraries/botbuilder-core/src/userState.ts
+++ b/libraries/botbuilder-core/src/userState.ts
@@ -10,7 +10,7 @@ import { BotState } from './botState';
 import { Storage } from './storage';
 import { TurnContext } from './turnContext';
 
-const NO_KEY: string = `UserState: channelId and/or conversation missing from context.request.`;
+const NO_KEY: string = `UserState: overridden getStorageKey method did not return a key.`;
 
 /**
  * Reads and writes user state for your bot to storage.

--- a/libraries/botbuilder-core/tests/conversationState.test.js
+++ b/libraries/botbuilder-core/tests/conversationState.test.js
@@ -80,7 +80,7 @@ describe(`ConversationState`, function () {
         try {
             await conversationState.load(context, true);
         } catch (err) {
-            assert(err.message === 'ConversationState: channelId and/or conversation missing from context.request.',
+            assert(err.message === 'ConversationState: overridden getStorageKey method did not return a key.',
                 `unexpected Error.message received: ${err.message}`);
             return;
         }

--- a/libraries/botbuilder-core/tests/privateConversationState.test.js
+++ b/libraries/botbuilder-core/tests/privateConversationState.test.js
@@ -92,7 +92,7 @@ describe(`PrivateConversationState`, function () {
         try {
             await privateConversationState.load(context, true);
         } catch (err) {
-            assert(err.message === 'PrivateConversationState: channelId and/or PrivateConversation missing from context.request.',
+            assert(err.message === 'PrivateConversationState: overridden getStorageKey method did not return a key.',
                 `unexpected Error.message received: ${err.message}`);
             return;
         }

--- a/libraries/botbuilder-core/tests/userState.test.js
+++ b/libraries/botbuilder-core/tests/userState.test.js
@@ -68,7 +68,7 @@ describe(`UserState`, function () {
         try {
             await userState.load(context, true);
         } catch (err) {
-            assert(err.message === 'UserState: channelId and/or conversation missing from context.request.',
+            assert(err.message === 'UserState: overridden getStorageKey method did not return a key.',
                 `unexpected Error.message received: ${err.message}`);
             return;
         }


### PR DESCRIPTION
Fixes #610 

## Description

I have corrected the faulty `NO_KEY` messages in three files to more accurately represent the error. While the issue originally called for a simple change from `context.request` to `context.activity`, I took it upon myself to reword the messages based on the conditions I've discovered will trigger the error.

## Specific Changes

The new message `overridden getStorageKey method did not return a key` can be found in:

  - userState.ts
  - conversationState.ts
  - privateConversationState.ts

## Testing

The `NO_KEY` error messages can only be triggered if the `getStorageKey` methods are overridden because the current `getStorageKey` methods cannot return anything that evaluates to false. In order to test the messages you must override the `getStorageKey` methods and have them return `undefined` or an empty string.