### PR TITLE
Add channelService to endpoint service of bot configuration file

### DIFF
--- a/libraries/botframework-config/src/models/endpointService.ts
+++ b/libraries/botframework-config/src/models/endpointService.ts
@@ -28,6 +28,13 @@ export class EndpointService extends ConnectedService implements IEndpointServic
     public endpoint: string;
 
     /**
+     * The channel service (Azure or US Government Azure) for the bot.
+     * A value of 'https://botframework.azure.us' means the bot will be talking to a US Government Azure data center.
+     * An undefined or null value means the bot will be talking to public Azure
+     */
+    public channelService: string;
+
+    /**
      * Creates a new EndpointService instance.
      * @param source JSON based service definition.
      */

--- a/libraries/botframework-config/tests/govTest.bot
+++ b/libraries/botframework-config/tests/govTest.bot
@@ -1,0 +1,17 @@
+{
+    "name": "govTest",
+    "description": "gov test description",
+    "version": "2.0",
+    "secretKey": "",
+    "services": [
+        {
+            "type": "endpoint",
+            "name": "testEndpoint",
+            "id": "5",
+            "appId": "00000003-0000-0000-0000-000000000000",
+            "appPassword": "testpassword",
+            "endpoint": "https://test.azurewebsites.net/api/messages",
+            "channelService": "https://botframework.azure.us"
+        }
+    ]
+}

--- a/libraries/botframework-config/tests/loadAndSave.test.js
+++ b/libraries/botframework-config/tests/loadAndSave.test.js
@@ -5,6 +5,7 @@ let path = require('path');
 
 // do not save over testbot
 const testBotPath = require.resolve("./test.bot");
+const govTestBotPath = require.resolve("./govTest.bot");
 const legacyBotPath = require.resolve("./legacy.bot");
 const saveBotPath = testBotPath.replace("test.bot", "save.bot");
 
@@ -116,6 +117,32 @@ describe("LoadAndSaveTests", () => {
         }
         config2.ClearSecret();
         await config2.saveAs(saveBotPath, secret);
+    });
+
+    it("LoadAndVerifyChannelServiceSync", async () => {
+        var config = bf.BotConfiguration.loadSync(testBotPath);
+        for (let i = 0; i < config.services.length; i++) {
+            switch (config.services[i].type) {
+                case bf.ServiceTypes.Endpoint:
+                {
+                    var endpoint = config.services[i];
+                    assert.equal(undefined, endpoint.channelService);
+                }
+                break;
+            }
+        }
+        
+        var govConfig = bf.BotConfiguration.loadSync(govTestBotPath);
+        for (let i = 0; i < govConfig.services.length; i++) {
+            switch (govConfig.services[i].type) {
+                case bf.ServiceTypes.Endpoint:
+                {
+                    var endpoint = govConfig.services[i];
+                    assert.equal('https://botframework.azure.us', endpoint.channelService);
+                }
+                break;
+            }
+        }
     });
 
     it("LoadAndSaveEncrypted", async () => {


### PR DESCRIPTION
## Description
Adding channelService to the bot configuration file which controls whether the bot is talking to public Azure or US Government Azure

## Specific Changes
Add the channelService property to the endpoint service model

## Testing
Added a test to load and check the values.