### PR TITLE
Updates to validate emulator JWT tokens from US Gov

### DIFF
--- a/libraries/botframework-config/src/schema.ts
+++ b/libraries/botframework-config/src/schema.ts
@@ -64,6 +64,13 @@ export interface IEndpointService extends IConnectedService {
      * Endpoint of localhost service.
      */
     endpoint: string;
+
+    /**
+     * The channel service (Azure or US Government Azure) for the bot.
+     * A value of 'https://botframework.azure.us' means the bot will be talking to a US Government Azure data center.
+     * An undefined or null value means the bot will be talking to public Azure
+     */
+    channelService?: string;
 }
 
 /**

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -94,7 +94,7 @@ export module EmulatorValidation {
      * A token issued by the Bot Framework will FAIL this check. Only Emulator tokens will pass.
      * @param  {string} authHeader The raw HTTP header in the format: "Bearer [longString]"
      * @param  {ICredentialProvider} credentials The user defined set of valid credentials, such as the AppId.
-     * @param  {string} channelService The channelService value that distinguishes public Azure from US Government Azure
+     * @param  {string} channelService The channelService value that distinguishes public Azure from US Government Azure.
      * @returns {Promise<ClaimsIdentity>} A valid ClaimsIdentity.
      */
     export async function authenticateEmulatorToken(

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -8,8 +8,10 @@
 import * as jwt from 'jsonwebtoken';
 import { ClaimsIdentity } from './claimsIdentity';
 import { Constants } from './constants';
+import { GovernmentConstants } from './governmentConstants';
 import { ICredentialProvider } from './credentialProvider';
 import { JwtTokenExtractor } from './jwtTokenExtractor';
+import { JwtTokenValidation } from './jwtTokenValidation';
 
 /**
  * Validates and Examines JWT tokens from the Bot Framework Emulator
@@ -25,7 +27,9 @@ export module EmulatorValidation {
             'https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0',      // Auth v3.1, 2.0 token
             'https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/',                    // Auth v3.2, 1.0 token
             'https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0',      // Auth v3.2, 2.0 token
-            'https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/'                     // ???
+            'https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/',                    // ???
+            'https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/',                    // US Gov Auth, 1.0 token
+            'https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0',       // US Gov Auth, 2.0 token
         ],
         audience: undefined, // Audience validation takes place manually in code.
         clockTolerance: 5 * 60,
@@ -95,12 +99,16 @@ export module EmulatorValidation {
     export async function authenticateEmulatorToken(
         authHeader: string,
         credentials: ICredentialProvider,
+        channelService: string,
         channelId: string
     ): Promise<ClaimsIdentity> {
+        const openIdMetadataUrl = (channelService !== undefined && JwtTokenValidation.isGovernment(channelService)) ?
+            GovernmentConstants.ToBotFromEmulatorOpenIdMetadataUrl :
+            Constants.ToBotFromEmulatorOpenIdMetadataUrl;
 
         const tokenExtractor: JwtTokenExtractor = new JwtTokenExtractor(
             ToBotFromEmulatorTokenValidationParameters,
-            Constants.ToBotFromEmulatorOpenIdMetadataUrl,
+            openIdMetadataUrl,
             Constants.AllowedSigningAlgorithms);
 
         const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(authHeader, channelId);

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -94,6 +94,7 @@ export module EmulatorValidation {
      * A token issued by the Bot Framework will FAIL this check. Only Emulator tokens will pass.
      * @param  {string} authHeader The raw HTTP header in the format: "Bearer [longString]"
      * @param  {ICredentialProvider} credentials The user defined set of valid credentials, such as the AppId.
+     * @param  {string} channelService The channelService value that distinguishes public Azure from US Government Azure
      * @returns {Promise<ClaimsIdentity>} A valid ClaimsIdentity.
      */
     export async function authenticateEmulatorToken(

--- a/libraries/botframework-connector/src/auth/governmentConstants.ts
+++ b/libraries/botframework-connector/src/auth/governmentConstants.ts
@@ -30,4 +30,10 @@ export module GovernmentConstants {
      * TO BOT FROM CHANNEL: OpenID metadata document for tokens coming from MSA
      */
     export const ToBotFromChannelOpenIdMetadataUrl: string = 'https://login.botframework.azure.us/v1/.well-known/openidconfiguration';
+    
+    /**
+     * TO BOT FROM GOV EMULATOR: OpenID metadata document for tokens coming from MSA
+     */
+    export const ToBotFromEmulatorOpenIdMetadataUrl: string =
+        'https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0/.well-known/openid-configuration';
 }

--- a/libraries/botframework-connector/src/auth/jwtTokenValidation.ts
+++ b/libraries/botframework-connector/src/auth/jwtTokenValidation.ts
@@ -60,7 +60,7 @@ export module JwtTokenValidation {
         const usingEmulator: boolean = EmulatorValidation.isTokenFromEmulator(authHeader);
 
         if (usingEmulator) {
-            return await EmulatorValidation.authenticateEmulatorToken(authHeader, credentials, channelId);
+            return await EmulatorValidation.authenticateEmulatorToken(authHeader, credentials, channelService, channelId);
         }
 
         if (isPublicAzure(channelService)) {


### PR DESCRIPTION
## Description
When the emulator is configured (via the channelService property in the .bot file) to use the US Government Azure AAD endpoint, this causes a different set of issuers and a different open id metadata URL to be needed to validate the emulator's JWT token.

## Testing
Because this involves testing JWT tokens which I cannot check-in, I validated with:
1. Emulator configured to use Gov talking connecting to a local JS bot configured to use Gov running locally 
2. Emulator configured to use Gov talking connecting to an Azure hosted JS bot configured to use Gov running locally 
3. DirectLine talking to the same bot (via US Gov)
