### PR TITLE
Pin ms-rest-js and ms-rest-azure-js in botframework-connector and botframework-schema

### DIFF
--- a/libraries/botframework-connector/package-lock.json
+++ b/libraries/botframework-connector/package-lock.json
@@ -485,11 +485,11 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "ms-rest-azure-js": {
-      "version": "1.0.179",
-      "resolved": "https://registry.npmjs.org/ms-rest-azure-js/-/ms-rest-azure-js-1.0.179.tgz",
-      "integrity": "sha512-DXVQxInEjCqqJWXUxzsLUWtL/LHKQgcooAjmMKnBPIPwhevSpRPdomlJgvZVEl+Smb9qXdQJrEGjiN98N6cBUg==",
+      "version": "1.0.176",
+      "resolved": "https://registry.npmjs.org/ms-rest-azure-js/-/ms-rest-azure-js-1.0.176.tgz",
+      "integrity": "sha512-qtEBpSf/1nJ0/m1jGLkHISRnpOeHUp5n4SvzZRdFeYnGF4SQx9v/fl8a8ZwEmyujmgbUwyLNM9qKpH5PmW7pZg==",
       "requires": {
-        "ms-rest-js": "^1.0.455",
+        "ms-rest-js": "^1.0.443",
         "tslib": "^1.9.2"
       }
     },

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -25,8 +25,8 @@
     "botframework-schema": "^4.0.0",
     "form-data": "^2.3.3",
     "jsonwebtoken": "8.0.1",
-    "ms-rest-azure-js": "^1.0.176",
-    "ms-rest-js": "^1.0.455",
+    "ms-rest-azure-js": "1.0.176",
+    "ms-rest-js": "1.0.455",
     "node-fetch": "^2.2.1",
     "rsa-pem-from-mod-exp": "^0.8.4"
   },

--- a/libraries/botframework-schema/package.json
+++ b/libraries/botframework-schema/package.json
@@ -11,7 +11,7 @@
   "typings": "./lib/index.d.ts",
   "dependencies": {
     "@types/node": "^9.3.0",
-    "ms-rest-js": "^1.0.455"
+    "ms-rest-js": "1.0.455"
   },
   "devDependencies": {},
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -897,7 +897,8 @@
           "version": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
           "from": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
           "requires": {
-            "fetch-cookie": "~0.6.0"
+            "fetch-cookie": "~0.6.0",
+            "node-fetch": "~1.7.1"
           },
           "dependencies": {
             "fetch-cookie": {
@@ -936,6 +937,7 @@
             "@types/node-fetch": "^1.6.7",
             "@types/uuid": "^3.4.3",
             "fetch-cookie": "^0.7.0",
+            "fetch-ponyfill": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
             "form-data": "^2.3.2",
             "is-buffer": "^2.0.0",
             "is-stream": "^1.1.0",
@@ -952,17 +954,9 @@
                 "@types/node": "*"
               }
             },
-            "encoding": {
-              "version": "0.1.12",
-              "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-              "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-              "requires": {
-                "iconv-lite": "~0.4.13"
-              }
-            },
             "fetch-ponyfill": {
               "version": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
-              "from": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
+              "from": "github:amarzavery/fetch-ponyfill#master",
               "requires": {
                 "fetch-cookie": "~0.6.0",
                 "node-fetch": "~1.7.1"
@@ -976,18 +970,18 @@
                     "es6-denodeify": "^0.1.1",
                     "tough-cookie": "^2.3.1"
                   }
-                },
-                "node-fetch": {
-                  "version": "1.7.3",
-                  "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-                  "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-                  "requires": {
-                    "encoding": "^0.1.11",
-                    "is-stream": "^1.0.1"
-                  }
                 }
               }
             }
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
           }
         },
         "oauth-sign": {
@@ -1575,6 +1569,14 @@
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
       }
     },
     "es6-denodeify": {
@@ -2658,11 +2660,11 @@
       }
     },
     "ms-rest-azure-js": {
-      "version": "1.0.179",
-      "resolved": "https://registry.npmjs.org/ms-rest-azure-js/-/ms-rest-azure-js-1.0.179.tgz",
-      "integrity": "sha512-DXVQxInEjCqqJWXUxzsLUWtL/LHKQgcooAjmMKnBPIPwhevSpRPdomlJgvZVEl+Smb9qXdQJrEGjiN98N6cBUg==",
+      "version": "1.0.176",
+      "resolved": "https://registry.npmjs.org/ms-rest-azure-js/-/ms-rest-azure-js-1.0.176.tgz",
+      "integrity": "sha512-qtEBpSf/1nJ0/m1jGLkHISRnpOeHUp5n4SvzZRdFeYnGF4SQx9v/fl8a8ZwEmyujmgbUwyLNM9qKpH5PmW7pZg==",
       "requires": {
-        "ms-rest-js": "^1.0.455",
+        "ms-rest-js": "^1.0.443",
         "tslib": "^1.9.2"
       }
     },


### PR DESCRIPTION
Fixes #643

## Description
Breaking changes were introduced in a version of ms-rest-js greater than 1.0.455 (which is what the generated code was built to work with). The last (not deprecated) version of ms-rest-js (1.0.465) was not compatible with the generated code. 

Instead of ms-rest-js, they have deprecated it in favor of [@azure/ms-rest-js](https://www.npmjs.com/package/@azure/ms-rest-js). 

## Specific Changes
- Pin to ms-rest-js 1.0.455 in botframework-connector, botframework-schema
- Pin to ms-rest-azure-js 1.0.176 in botframework-connector 
