### PR TITLE
added QnA Maker Trace onto generateAnswer(). generateAnswer() paramet…

### DIFF
--- a/libraries/botbuilder-ai/src/qnaMaker.ts
+++ b/libraries/botbuilder-ai/src/qnaMaker.ts
@@ -199,16 +199,10 @@ export class QnAMaker {
      * @param scoreThreshold (Optional) minimum answer score needed to be considered a match to questions. Defaults to a value of `0.001`.
      */
     public async getAnswers(context: TurnContext, top?: number, scoreThreshold?: number): Promise<QnAMakerResult[]> {
-        let question: string = '';
+        let question: string = context && context.activity ? context.activity.text : '';
+        const trimmedQuestion: string = question ? question.trim() : '';
 
-        if (context) {
-            if (context.activity) 
-                question = context.activity.text;
-        }
-
-        const q: string = question ? question.trim() : '';
-
-        if (q.length > 0) {
+        if (trimmedQuestion.length > 0) {
             const answers = await this.callService(this.endpoint, question, typeof top === 'number' ? top : 1);
             const minScore: number = typeof scoreThreshold === 'number' ? scoreThreshold : 0.001;
             const sortedQnaAnswers = answers.filter(

--- a/libraries/botbuilder-ai/src/qnaMaker.ts
+++ b/libraries/botbuilder-ai/src/qnaMaker.ts
@@ -182,20 +182,30 @@ export class QnAMaker {
             return true;
         } 
         
-        return Promise.resolve(false);
+        return false;
     }
     
     /**
-     * Calls the QnA Maker service to generate answer(s) for a question
+     * Calls the QnA Maker service to generate answer(s) for a question.
      * 
      * @remarks
      * Returns an array of answers sorted by score with the top scoring answer returned first.
+     * 
+     * In addition to returning the results from QnA Maker, [getAnswers()](#getAnswers) will also
+     * emit a trace activity that contains the QnA Maker results.
+     * 
      * @param context The Turn Context that contains the user question to be queried against your knowledge base.
      * @param top (Optional) number of answers to return. Defaults to a value of `1`.
      * @param scoreThreshold (Optional) minimum answer score needed to be considered a match to questions. Defaults to a value of `0.001`.
      */
     public async getAnswers(context: TurnContext, top?: number, scoreThreshold?: number): Promise<QnAMakerResult[]> {
-        const question: string = context ? context.activity.text : '';
+        let question: string = '';
+
+        if (context) {
+            if (context.activity) 
+                question = context.activity.text;
+        }
+
         const q: string = question ? question.trim() : '';
 
         if (q.length > 0) {
@@ -212,12 +222,12 @@ export class QnAMaker {
             return sortedQnaAnswers;
         }
 
-        return Promise.resolve([]);
+        return [] as QnAMakerResult[];
     }
 
     /**
      * Calls the QnA Maker service to generate answer(s) for a question.
-     * @deprecated  Use updated version QnAMaker.getAnswers() to include QnAMaker Trace for calls to QnA Maker Service.
+     * @deprecated  Instead, favor using [QnAMaker.getAnswers()](#getAnswers) to generate answers for a question.
      * @remarks
      * Returns an array of answers sorted by score with the top scoring answer returned first.
      * @param question The question to answer.
@@ -238,7 +248,7 @@ export class QnAMaker {
             );
         }
 
-        return Promise.resolve([]);
+        return [] as QnAMakerResult[];
     }
 
     /**
@@ -252,8 +262,7 @@ export class QnAMaker {
         const headers: any = {};
         if (endpoint.host.endsWith('v2.0') || endpoint.host.endsWith('v3.0')) {
             headers['Ocp-Apim-Subscription-Key'] = endpoint.endpointKey;
-        } else 
-        {
+        } else {
             headers.Authorization = `EndpointKey ${endpoint.endpointKey}`;
         }
 

--- a/libraries/botbuilder-ai/tests/qnaMaker.test.js
+++ b/libraries/botbuilder-ai/tests/qnaMaker.test.js
@@ -46,11 +46,11 @@ describe('QnAMaker', function () {
         if (mockQnA) {
             var fileName = replaceCharacters(this.currentTest.title);
             var filePath = `${ __dirname }/TestData/${ this.test.parent.title }/`;
-            var arr = testFiles.filter(function(file) { return file.startsWith(fileName + '.')} )
+            var arr = testFiles.filter(function(file) { return file.startsWith(fileName + '.')} );
 
             arr.forEach(file => {
                 nock(`https://${ hostname }.azurewebsites.net`).post(/qnamaker/)
-                .replyWithFile(200, filePath + file)
+                .replyWithFile(200, filePath + file);
             });
         }
         done();
@@ -67,67 +67,112 @@ describe('QnAMaker', function () {
         .replace(/ /g, '_');
     }
 
-    it('should work free standing', function () {
+    it('should work free standing', async function () {
         const qna = new ai.QnAMaker(endpoint, { top: 1 });
-        let answer = 'BaseCamp: You can use a damp rag to clean around the Power Pack';
+        const answer = 'BaseCamp: You can use a damp rag to clean around the Power Pack';
 
-        return qna.generateAnswer(`how do I clean the stove?`)
-            .then(res => {
-                assert.notStrictEqual(res, true, `The response was returned as 'undefined'.`);
-                assert.strictEqual(res.length, 1, 'Should have received just one answer on the first call.');
-                assert.strictEqual(res[0].answer.startsWith(answer), true, `The answer should have started with '${ answer }' for the first call.`);
-            })
-            .then(() => qna.generateAnswer("is the stove hard to clean?"))
-            .then(res => {
-                assert.notStrictEqual(res, true, `The response was returned as 'undefined'.`);
-                assert.strictEqual(res.length, 1, 'Should have received just one answer on the second call.');
-                assert.strictEqual(res[0].answer.startsWith(answer), true, `The answer should have started with '${ answer }' for the second call.`);
-            });
+        const firstCallQnaResults = await qna.generateAnswer(`how do I clean the stove?`);
+        assert.notStrictEqual(firstCallQnaResults, true, `The response was returned as 'undefined'.`);
+        assert.strictEqual(firstCallQnaResults.length, 1, 'Should have received just one answer on the first call.');
+        assert.strictEqual(firstCallQnaResults[0].answer.startsWith(answer), true, `The answer should have started with '${answer}' for the first call.`);
+
+        const secondCallQnaResults = await qna.generateAnswer("is the stove hard to clean?");
+        assert.notStrictEqual(secondCallQnaResults, true, `The response was returned as 'undefined'.`);
+        assert.strictEqual(secondCallQnaResults.length, 1, 'Should have received just one answer on the second call.');
+        assert.strictEqual(secondCallQnaResults[0].answer.startsWith(answer), true, `The answer should have started with '${answer}' for the second call.`);
     });
 
-    it('should return 0 answers for a question with no answer after a succesful call', function () {
+    it('should work free standing', async function () {
+        const qna = new ai.QnAMaker(endpoint, { top: 1 });
+        const answer = 'BaseCamp: You can use a damp rag to clean around the Power Pack';
+        const context1 = new TestContext({ text: 'how do I clean the stove?' });
+        const context2 = new TestContext({ text: 'is the stove hard to clean?' });
+
+        const firstCallQnaResults = await qna.getAnswers(context1);
+        assert.notStrictEqual(firstCallQnaResults, true, `The response was returned as 'undefined'.`);
+        assert.strictEqual(firstCallQnaResults.length, 1, 'Should have received just one answer on the first call.');
+        assert.strictEqual(firstCallQnaResults[0].answer.startsWith(answer), true, `The answer should have started with '${answer}' for the first call.`);
+       
+        const secondCallQnaResults = await qna.getAnswers(context2);
+        assert.notStrictEqual(secondCallQnaResults, true, `The response was returned as 'undefined'.`);
+        assert.strictEqual(secondCallQnaResults.length, 1, 'Should have received just one answer on the second call.');
+        assert.strictEqual(secondCallQnaResults[0].answer.startsWith(answer), true, `The answer should have started with '${answer}' for the second call.`);
+    });
+
+    it('should return 0 answers for a question with no answer after a succesful call', async function () {
         const qna = new ai.QnAMaker(endpoint, { top: 1 });
         let answer = 'BaseCamp: You can use a damp rag to clean around the Power Pack';
 
-        return qna.generateAnswer(`how do I clean the stove?`)
-            .then(res => {
-                assert.notStrictEqual(res, true, `The response was returned as 'undefined'.`);
-                assert.strictEqual(res.length, 1, 'Should have received just one answer on the first call.');
-                assert.strictEqual(res[0].answer.startsWith(answer), true, `The answer should have started with '${ answer }' for the first call.`);
-            })
-            .then(() => qna.generateAnswer('how is the weather?'))
-            .then(res => {
-                assert.notStrictEqual(res, true, `The response was returned as 'undefined'.`);
-                assert.strictEqual(res.length, 0, 'Should have not received answers for a question with no answers.');
-            });
+        const resultsWithAns = await qna.generateAnswer(`how do I clean the stove?`);
+        assert.notStrictEqual(resultsWithAns, true, `The response was returned as 'undefined'.`);
+        assert.strictEqual(resultsWithAns.length, 1, 'Should have received just one answer on the first call.');
+        assert.strictEqual(resultsWithAns[0].answer.startsWith(answer), true, `The answer should have started with '${answer}' for the first call.`);
+
+        const resultsWithoutAns = await qna.generateAnswer('how is the weather?');
+        assert.notStrictEqual(resultsWithoutAns, true, `The response was returned as 'undefined'.`);
+        assert.strictEqual(resultsWithoutAns.length, 0, 'Should have not received answers for a question with no answers.');
+    });
+
+    it('should return 0 answers for a question with no answer after a succesful call', async function () {
+        const qna = new ai.QnAMaker(endpoint, { top: 1 });
+        const answer = 'BaseCamp: You can use a damp rag to clean around the Power Pack';
+        const context_questionWithAns = new TestContext({ text: 'how do I clean the stove?' });
+        const context_questionWithoutAns = new TestContext({ text: 'how is the weather?' });
+
+        const resultsWithAns = await qna.getAnswers(context_questionWithAns);
+        assert.notStrictEqual(resultsWithAns, true, `The response was returned as 'undefined'.`);
+        assert.strictEqual(resultsWithAns.length, 1, 'Should have received just one answer on the first call.');
+        assert.strictEqual(resultsWithAns[0].answer.startsWith(answer), true, `The answer should have started with '${answer}' for the first call.`);
+
+        const resultsWithoutAns = await qna.getAnswers(context_questionWithoutAns);
+        assert.notStrictEqual(resultsWithoutAns, true, `The response was returned as 'undefined'.`);
+        assert.strictEqual(resultsWithoutAns.length, 0, 'Should have not received answers for a question with no answers.');
     });
     
-    it('should return 0 answers for an empty or undefined utterance', function () {
+    it('should return 0 answers for an empty or undefined utterance', async function () {
         const qna = new ai.QnAMaker(endpoint, { top: 1 });
         
-        return qna.generateAnswer(``)
-            .then(res => {
-                assert.notStrictEqual(res, true, `The response was returned as 'undefined'.`);
-                assert.strictEqual(res.length, 0, 'Should have not received answers for an empty utterance.');
-            })
-            .then(() => qna.generateAnswer(undefined))
-            .then(res => {
-                assert.strictEqual(res.length, 0, 'Should have not received answers for an undefined utterance.');
-            });
+        const emptyQuestionResults = await qna.generateAnswer(``);
+        assert.notStrictEqual(emptyQuestionResults, true, `The response was returned as 'undefined'.`);
+        assert.strictEqual(emptyQuestionResults.length, 0, 'Should have not received answers for an empty utterance.');
+
+        const undefinedQuestionResults = await qna.generateAnswer(undefined);
+        assert.strictEqual(undefinedQuestionResults.length, 0, 'Should have not received answers for an undefined utterance.');
     });
 
-    it('should return 0 answers for questions without an answer.', function () {
+    it('should return 0 answers for an empty or undefined utterance', async function () {
+        const qna = new ai.QnAMaker(endpoint, { top: 1 });
+        const context = new TestContext({ text: '' });
+
+        const emptyQuestionResults = await qna.getAnswers(context);
+        assert.notStrictEqual(emptyQuestionResults, true, `The response was returned as 'undefined'.`);
+        assert.strictEqual(emptyQuestionResults.length, 0, 'Should have not received answers for an empty utterance.');
+        
+        const undefinedQuestionResults = await qna.getAnswers(undefined);
+        assert.strictEqual(undefinedQuestionResults.length, 0, 'Should have not received answers for an undefined utterance.');
+    });
+
+    it('should return 0 answers for questions without an answer.', async function () {
         const qna = new ai.QnAMaker(endpoint, { top: 1 });
 
-        return qna.generateAnswer(`foo`)
-            .then(res => {
-                assert.notStrictEqual(res, true, `The response was returned as 'undefined'.`);
-                assert.strictEqual(res.length, 0, `Should have not received answers for a question with no answer, it returned ${JSON.stringify(res)}.`);
-            })
-            .then(() => qna.generateAnswer(undefined))
-            .then(res => {
-                assert.strictEqual(res.length, 0, 'Should have not received answers for an undefined question.');
-            });
+        const resultsWithoutAns = await qna.generateAnswer(`foo`);
+        assert.notStrictEqual(resultsWithoutAns, true, `The response was returned as 'undefined'.`);
+        assert.strictEqual(resultsWithoutAns.length, 0, `Should have not received answers for a question with no answer, it returned ${JSON.stringify(resultsWithoutAns)}.`);
+
+        const undefinedQuestionResults = await qna.generateAnswer(undefined);
+        assert.strictEqual(undefinedQuestionResults.length, 0, 'Should have not received answers for an undefined question.');
+    });
+
+    it('should return 0 answers for questions without an answer.', async function () {
+        const qna = new ai.QnAMaker(endpoint, { top: 1 });
+        const questionWithoutAns_Context = new TestContext({ text: 'foo' });
+
+        const resultsWithoutAns = await qna.getAnswers(questionWithoutAns_Context);
+        assert.notStrictEqual(resultsWithoutAns, true, `The response was returned as 'undefined'.`);
+        assert.strictEqual(resultsWithoutAns.length, 0, `Should have not received answers for a question with no answer, it returned ${JSON.stringify(resultsWithoutAns)}.`);
+
+        const undefinedQuestionResults = await qna.getAnswers(undefined);
+        assert.strictEqual(undefinedQuestionResults.length, 0, 'Should have not received answers for an undefined question.');
     });
     
     it('should return "false" from answer() if no good answers found', function (done) {


### PR DESCRIPTION
Fixes #637 

## Description
- generates QnA Maker Trace activity when getAnswers() is called
- deprecate generateAnswers() method to favor getAnswers(), which does not have trace
- can view log in emulator

## Specific Changes

- added `getAnswers()` method, which calls `emitTraceInfo()`
-  `@deprecated` added to `generateAnswer()`
- refactored `qnaMaker.ts` and `qnaMaker.test.js` to use async/await pattern
- added unit tests for updated method `getAnswers()`