### PR TITLE
cherry-pick: add overloads to BotStatePropertAccessor.get()

### DIFF
--- a/libraries/botbuilder-core/src/botStatePropertyAccessor.ts
+++ b/libraries/botbuilder-core/src/botStatePropertyAccessor.ts
@@ -91,7 +91,9 @@ export class BotStatePropertyAccessor<T = any> implements StatePropertyAccessor<
         }
     }
 
-    public async get(context: TurnContext, defaultValue?: T): Promise<T|undefined> {
+    public async get(context: TurnContext): Promise<T|undefined>;
+    public async get(context: TurnContext, defaultValue: T): Promise<T>;
+    public async get(context: TurnContext, defaultValue?: T): Promise<T> {
         const obj: any = await this.state.load(context);
         if (!obj.hasOwnProperty(this.name) && defaultValue !== undefined) {
             const clone: any =


### PR DESCRIPTION
Fixes bug introduced in #566 for 4.1.5 branch.

(See original PR #647 against master for more information)