### PR TITLE
Fixes #640 - Use of deprecated methods causing Warnings during build…

### DIFF
--- a/libraries/botframework-config/src/encrypt.ts
+++ b/libraries/botframework-config/src/encrypt.ts
@@ -32,7 +32,7 @@ export function encryptString(plainText: string, secret: string): string {
         throw new Error('you must pass a secret');
     }
 
-    const keyBytes: Buffer = new Buffer(secret, 'base64');
+    const keyBytes: Buffer = Buffer.from(secret, 'base64');
 
     // Generates 16 byte cryptographically strong pseudo-random data as IV
     // https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback
@@ -72,8 +72,8 @@ export function decryptString(encryptedValue: string, secret: string): string {
     const ivText: string = parts[0];
     const encryptedText: string = parts[1];
 
-    const ivBytes: Buffer = new Buffer(ivText, 'base64');
-    const keyBytes: Buffer = new Buffer(secret, 'base64');
+    const ivBytes: Buffer = Buffer.from(ivText, 'base64');
+    const keyBytes: Buffer = Buffer.from(secret, 'base64');
 
     if (ivBytes.length !== 16) {
         throw new Error('The encrypted value is not a valid format');

--- a/libraries/botframework-connector/tests/connector.test.js
+++ b/libraries/botframework-connector/tests/connector.test.js
@@ -15,7 +15,7 @@ function base64_encode(file) {
   // read binary data
   var bitmap = fs.readFileSync(file);
   // convert binary data to base64 encoded string
-  return new Buffer(bitmap);
+  return Buffer.from(bitmap);
 }
 
 const BotConnector = require('../lib');

--- a/tools/scripts/unit-coverage.js
+++ b/tools/scripts/unit-coverage.js
@@ -84,7 +84,7 @@ var defaultSubscription = 'db1ab6f0-4769-4b27-930e-01e2ef9c123c';
 var defaultAccessToken = 'access_token';
 
 if (!process.env.AZURE_APNS_CERTIFICATE && process.env.AZURE_APNS_CERTIFICATE_FILE) {
-  process.env.AZURE_APNS_CERTIFICATE = new Buffer(fs.readFileSync(process.env['AZURE_APNS_CERTIFICATE_FILE'])).toString('base64');
+  process.env.AZURE_APNS_CERTIFICATE = Buffer.from(fs.readFileSync(process.env['AZURE_APNS_CERTIFICATE_FILE'])).toString('base64');
 } else if (process.env.AZURE_APNS_CERTIFICATE && process.env.AZURE_APNS_CERTIFICATE_FILE) {
   throw new Error('Only one of AZURE_APNS_CERTIFICATE or AZURE_APNS_CERTIFICATE_FILE can be set. Not both.');
 }
@@ -97,7 +97,7 @@ if (!process.env.AZURE_APNS_CERTIFICATE_KEY && process.env.AZURE_APNS_CERTIFICAT
 
 
 if (!process.env.AZURE_MPNS_CERTIFICATE && process.env.AZURE_MPNS_CERTIFICATE_FILE) {
-  process.env.AZURE_MPNS_CERTIFICATE = new Buffer(fs.readFileSync(process.env['AZURE_MPNS_CERTIFICATE_FILE'])).toString('base64');
+  process.env.AZURE_MPNS_CERTIFICATE = Buffer.from(fs.readFileSync(process.env['AZURE_MPNS_CERTIFICATE_FILE'])).toString('base64');
 } else if (process.env.AZURE_MPNS_CERTIFICATE && process.env.AZURE_MPNS_CERTIFICATE_FILE) {
   throw new Error('Only one of AZURE_MPNS_CERTIFICATE or AZURE_MPNS_CERTIFICATE_FILE can be set. Not both.');
 }
@@ -132,11 +132,11 @@ if (!process.env.NOCK_OFF && !process.env.AZURE_NOCK_RECORD) {
     process.env.AZURE_STORAGE_ACCOUNT = defaultStorageAccount;
   }
 
-  process.env.AZURE_STORAGE_ACCESS_KEY = new Buffer('fake_key').toString('base64');
+  process.env.AZURE_STORAGE_ACCESS_KEY = Buffer.from('fake_key').toString('base64');
 
   if (process.env.AZURE_SERVICEBUS_NAMESPACE !== defaultServiceBusAccount) {
     process.env.AZURE_SERVICEBUS_NAMESPACE = defaultServiceBusAccount;
-    process.env.AZURE_SERVICEBUS_ACCESS_KEY = new Buffer('fake_key').toString('base64');
+    process.env.AZURE_SERVICEBUS_ACCESS_KEY = Buffer.from('fake_key').toString('base64');
   }
 
   if (process.env.AZURE_SUBSCRIPTION_ID !== defaultSubscription) {

--- a/tools/scripts/unit.js
+++ b/tools/scripts/unit.js
@@ -74,7 +74,7 @@ var defaultSubscription = 'db1ab6f0-4769-4b27-930e-01e2ef9c123c';
 var defaultAccessToken = 'access_token';
 
 if (!process.env.AZURE_APNS_CERTIFICATE && process.env.AZURE_APNS_CERTIFICATE_FILE) {
-  process.env.AZURE_APNS_CERTIFICATE = new Buffer(fs.readFileSync(process.env['AZURE_APNS_CERTIFICATE_FILE'])).toString('base64');
+  process.env.AZURE_APNS_CERTIFICATE = Buffer.from(fs.readFileSync(process.env['AZURE_APNS_CERTIFICATE_FILE'])).toString('base64');
 } else if (process.env.AZURE_APNS_CERTIFICATE && process.env.AZURE_APNS_CERTIFICATE_FILE) {
   throw new Error('Only one of AZURE_APNS_CERTIFICATE or AZURE_APNS_CERTIFICATE_FILE can be set. Not both.');
 }
@@ -87,7 +87,7 @@ if (!process.env.AZURE_APNS_CERTIFICATE_KEY && process.env.AZURE_APNS_CERTIFICAT
 
 
 if (!process.env.AZURE_MPNS_CERTIFICATE && process.env.AZURE_MPNS_CERTIFICATE_FILE) {
-  process.env.AZURE_MPNS_CERTIFICATE = new Buffer(fs.readFileSync(process.env['AZURE_MPNS_CERTIFICATE_FILE'])).toString('base64');
+  process.env.AZURE_MPNS_CERTIFICATE = Buffer.from(fs.readFileSync(process.env['AZURE_MPNS_CERTIFICATE_FILE'])).toString('base64');
 } else if (process.env.AZURE_MPNS_CERTIFICATE && process.env.AZURE_MPNS_CERTIFICATE_FILE) {
   throw new Error('Only one of AZURE_MPNS_CERTIFICATE or AZURE_MPNS_CERTIFICATE_FILE can be set. Not both.');
 }
@@ -122,11 +122,11 @@ if (!process.env.NOCK_OFF && !process.env.AZURE_NOCK_RECORD) {
     process.env.AZURE_STORAGE_ACCOUNT = defaultStorageAccount;
   }
 
-  process.env.AZURE_STORAGE_ACCESS_KEY = new Buffer('fake_key').toString('base64');
+  process.env.AZURE_STORAGE_ACCESS_KEY = Buffer.from('fake_key').toString('base64');
 
   if (process.env.AZURE_SERVICEBUS_NAMESPACE !== defaultServiceBusAccount) {
     process.env.AZURE_SERVICEBUS_NAMESPACE = defaultServiceBusAccount;
-    process.env.AZURE_SERVICEBUS_ACCESS_KEY = new Buffer('fake_key').toString('base64');
+    process.env.AZURE_SERVICEBUS_ACCESS_KEY = Buffer.from('fake_key').toString('base64');
   }
 
   if (process.env.AZURE_SUBSCRIPTION_ID !== defaultSubscription) {


### PR DESCRIPTION

Fixes #640 

## Description
Node deprecated ‘new Buffer’ syntax, replacing it with ‘Buffer.from’ syntax.

## Specific Changes
replace deprecated calls with supported replacements.
