### PR TITLE
Lock internal dependencies to patch version

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -2,7 +2,7 @@
   "name": "botbuilder-ai",
   "author": "Microsoft Corp.",
   "description": "Cognitive services extensions for Microsoft BotBuilder.",
-  "version": "4.0.0",
+  "version": "4.1.6",
   "license": "MIT",
   "keywords": [
     "botbuilder",
@@ -25,7 +25,7 @@
     "@types/node": "^9.3.0",
     "@types/request-promise-native": "^1.0.10",
     "azure-cognitiveservices-luis-runtime": "^1.0.0",
-    "botbuilder": "^4.0.0",
+    "botbuilder": "~4.1.6",
     "html-entities": "^1.2.1",
     "moment": "^2.20.1",
     "ms-rest": "^2.3.6",

--- a/libraries/botbuilder-azure/package.json
+++ b/libraries/botbuilder-azure/package.json
@@ -2,7 +2,7 @@
   "name": "botbuilder-azure",
   "author": "Microsoft Corp.",
   "description": "Azure extensions for Microsoft BotBuilder.",
-  "version": "4.0.0",
+  "version": "4.1.6",
   "license": "MIT",
   "keywords": [
     "botbuilder",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@types/node": "^9.3.0",
     "azure-storage": "^2.10.2",
-    "botbuilder": "^4.0.0",
+    "botbuilder": "~4.1.6",
     "documentdb": "1.14.5",
     "flat": "^4.0.0",
     "semaphore": "^1.1.0"

--- a/libraries/botbuilder-core/package.json
+++ b/libraries/botbuilder-core/package.json
@@ -2,7 +2,7 @@
   "name": "botbuilder-core",
   "author": "Microsoft Corp.",
   "description": "Core components for Microsoft Bot Builder. Components in this library can run either in a browser or on the server.",
-  "version": "4.0.0",
+  "version": "4.1.6",
   "license": "MIT",
   "keywords": [
     "botbuilder",
@@ -21,7 +21,7 @@
   "typings": "./lib/index.d.ts",
   "dependencies": {
     "assert": "^1.4.1",
-    "botframework-schema": "^4.0.0"
+    "botframework-schema": "~4.1.6"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.47",

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -2,7 +2,7 @@
   "name": "botbuilder-dialogs",
   "author": "Microsoft Corp.",
   "description": "A dialog stack based conversation manager for Microsoft BotBuilder.",
-  "version": "4.0.0",
+  "version": "4.1.6",
   "license": "MIT",
   "keywords": [
     "botbuilder",
@@ -25,7 +25,7 @@
     "@microsoft/recognizers-text-number": "1.1.2",
     "@microsoft/recognizers-text-suite": "1.1.2",
     "@types/node": "^9.3.0",
-    "botbuilder-core": "^4.0.0"
+    "botbuilder-core": "~4.1.6"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.47",

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -2,7 +2,7 @@
   "name": "botbuilder",
   "author": "Microsoft Corp.",
   "description": "Bot Builder is a framework for building rich bots on virtually any platform.",
-  "version": "4.0.0",
+  "version": "4.1.6",
   "license": "MIT",
   "keywords": [
     "botbuilder",
@@ -23,8 +23,8 @@
     "@types/filenamify": "^2.0.1",
     "@types/node": "^9.3.0",
     "async-file": "^2.0.2",
-    "botbuilder-core": "^4.0.0",
-    "botframework-connector": "^4.0.0",
+    "botbuilder-core": "~4.1.6",
+    "botframework-connector": "~4.1.6",
     "filenamify": "^2.0.0",
     "rimraf": "^2.6.2"
   },

--- a/libraries/botframework-config/package.json
+++ b/libraries/botframework-config/package.json
@@ -2,7 +2,7 @@
   "name": "botframework-config",
   "author": "Microsoft Corp.",
   "description": "library for working with Bot Framework .bot configuration files",
-  "version": "4.0.0",
+  "version": "4.1.6",
   "license": "MIT",
   "keywords": [
     "bots",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -2,7 +2,7 @@
   "name": "botframework-connector",
   "author": "Microsoft Corp.",
   "description": "Bot Connector is autorest generated connector client.",
-  "version": "4.0.0",
+  "version": "4.1.6",
   "license": "MIT",
   "keywords": [
     "botconnector",
@@ -22,7 +22,7 @@
     "@types/jsonwebtoken": "7.2.8",
     "@types/node": "^9.3.0",
     "base64url": "^3.0.0",
-    "botframework-schema": "^4.0.0",
+    "botframework-schema": "~4.1.6",
     "form-data": "^2.3.3",
     "jsonwebtoken": "8.0.1",
     "ms-rest-azure-js": "1.0.176",

--- a/libraries/botframework-schema/package.json
+++ b/libraries/botframework-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-schema",
-  "version": "4.0.0",
+  "version": "4.1.6",
   "description": "Activity schema for the Microsoft Bot Framework.",
   "keywords": [
     "botconnector",


### PR DESCRIPTION
Fixes #652 

## Description

Update all the package files to change dependency on other Botbuilder libraries from any minor release (^4.0.0) to the specific minor release (~4.1.x)

This means a user installing version 4.1.7 will get all 4.1 updates, but will not automatically migrate to 4.2 which could break things.