### PR TITLE
update model_fixes.js to set CardAction.channelData as an optional property

### DIFF
--- a/libraries/swagger/model_fixes.js
+++ b/libraries/swagger/model_fixes.js
@@ -11,7 +11,7 @@ var optionalModelProperties = {
     'SigninCard': ['text'],
     'Attachment': ['content', 'contentUrl', 'name', 'thumbnailUrl'],
     'CardImage': ['alt', 'tap'],
-    'CardAction': ['image', 'displayText', 'text'],
+    'CardAction': ['channelData', 'displayText', 'image', 'text'],
     'MediaUrl': ['profile']
 };
 


### PR DESCRIPTION
First fix for #639

## Description
Add `"channelData"` as an optional property for the CardAction interface.

Note: This doesn't fix #639 directly as the library needs to be regenerated. This PR sets it up so that then the library is properly regenerated (via the `generateClient` scripts), #639 will be fixed.