### PR TITLE
Improve swagger-generation process for bf-connector & bf-schema libraries

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,14 @@
 {
   "lerna": "3.2.1",
   "packages": [
-    "libraries/*",
+    "libraries/botbuilder",
+    "libraries/botbuilder-ai",
+    "libraries/botbuilder-azure",
+    "libraries/botbuilder-core",
+    "libraries/botbuilder-dialogs",
+    "libraries/botframework-config",
+    "libraries/botframework-connector",
+    "libraries/botframework-schema",
     "transcripts"
   ],
   "version": "independent",

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -117,12 +117,12 @@ export interface ChannelAccount {
    * @member {string} [aadObjectId] This account's object ID within Azure
    * Active Directory (AAD)
    */
-  aadObjectId: string;
+  aadObjectId?: string;
   /**
    * @member {RoleTypes} [role] Role of the entity behind the account (Example:
    * User, Bot, etc.). Possible values include: 'user', 'bot'
    */
-  role: RoleTypes | string;
+  role?: RoleTypes | string;
 }
 
 /**
@@ -155,12 +155,12 @@ export interface ConversationAccount {
    * @member {string} [aadObjectId] This account's object ID within Azure
    * Active Directory (AAD)
    */
-  aadObjectId: string;
+  aadObjectId?: string;
   /**
    * @member {RoleTypes} [role] Role of the entity behind the account (Example:
    * User, Bot, etc.). Possible values include: 'user', 'bot'
    */
-  role: RoleTypes;
+  role?: RoleTypes;
 }
 
 /**
@@ -218,7 +218,7 @@ export interface CardAction {
    * @member {any} [channelData] Channel-specific data associated with this
    * action
    */
-  channelData: any;
+  channelData?: any;
 }
 
 /**

--- a/libraries/swagger/generateClient.cmd
+++ b/libraries/swagger/generateClient.cmd
@@ -1,23 +1,30 @@
-rem @echo off
+@echo off
 
+echo [92mRemoving any preexisting output folders ("connectorApi/", "tokenApi/")[0m
 rd /s /q connectorApi
-rd /s /q oAuthApi
+rd /s /q tokenApi
 
-rem call autorest connectorAPI.md --typescript
+@echo on
+call npx autorest connectorAPI.md --typescript --use=".\node_modules\@microsoft.azure\autorest.typescript"
 
-rem call node model_fixes.js
+call node model_fixes.js
 
-rem Move models to botbuilder-schema
-rem del /q ..\botframework-schema\src\index.ts
-rem move ConnectorAPI\lib\models\index.ts ..\botframework-schema\src\index.ts
+echo [92mMove models to botbuilder-schema[0m
+del /q ..\botframework-schema\src\index.ts
+move connectorAPI\lib\models\index.ts ..\botframework-schema\src\index.ts
 
-rem Move client to botframework-connector
-rem rd /s /q ..\botframework-connector\src\connectorApi
-rem move connectorApi\lib ..\botframework-connector\src\connectorApi
+echo [92mMove client to botframework-connector[0m
+rd /s /q ..\botframework-connector\src\connectorApi
+move connectorApi\lib ..\botframework-connector\src\connectorApi
 
-call autorest tokenAPI.md --typescript
+@echo on
+call npx autorest tokenAPI.md --typescript --use=".\node_modules\@microsoft.azure\autorest.typescript"
+@echo off
+
+echo [92mMove tokenAPI to botframework-connector[0m
 rd /s /q ..\botframework-connector\src\tokenApi
 move tokenApi\lib ..\botframework-connector\src\tokenApi
 
-rem rd /s /q connectorApi
+echo [92mRemoving generated folders ("connectorApi/", "tokenApi/")[0m
+rd /s /q connectorApi
 rd /s /q tokenApi

--- a/libraries/swagger/model_fixes.js
+++ b/libraries/swagger/model_fixes.js
@@ -12,6 +12,8 @@ var optionalModelProperties = {
     'Attachment': ['content', 'contentUrl', 'name', 'thumbnailUrl'],
     'CardImage': ['alt', 'tap'],
     'CardAction': ['channelData', 'displayText', 'image', 'text'],
+    'ChannelAccount': ['aadObjectId', 'role'],
+    'ConversationAccount': ['aadObjectId', 'role'],
     'MediaUrl': ['profile']
 };
 

--- a/libraries/swagger/package-lock.json
+++ b/libraries/swagger/package-lock.json
@@ -1,0 +1,39 @@
+{
+  "name": "swagger",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@microsoft.azure/autorest-core": {
+      "version": "2.0.4289",
+      "resolved": "https://registry.npmjs.org/@microsoft.azure/autorest-core/-/autorest-core-2.0.4289.tgz",
+      "integrity": "sha512-gAVclg30OZNMOKQCfCNp+tALAYHDs/1hmPgScEh546gwPQy8+M3+4BYGiWEMG5/xHVRoB/nsau2SsSkNz+zFTw==",
+      "requires": {
+        "typescript": "2.6.2"
+      }
+    },
+    "@microsoft.azure/autorest.typescript": {
+      "version": "2.0.611",
+      "resolved": "https://registry.npmjs.org/@microsoft.azure/autorest.typescript/-/autorest.typescript-2.0.611.tgz",
+      "integrity": "sha512-N7CgBQeHcyl3FId2gqAN8t03ZXZeWToPEERARhBRPnfpntuC793cPNwwUBUVFPy9QH0T/N/Zw6CO1SeB8aHxIA==",
+      "requires": {
+        "dotnet-2.0.0": "^1.4.4"
+      }
+    },
+    "autorest": {
+      "version": "2.0.4283",
+      "resolved": "https://registry.npmjs.org/autorest/-/autorest-2.0.4283.tgz",
+      "integrity": "sha512-3jU9yDR71d2thRnKdPH03DaWbla1Iqnrx2rqUUwbMrb4di36a8+nttCQaTWG7biWPJc6Ke6zSSTzFH0uhya+Nw=="
+    },
+    "dotnet-2.0.0": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/dotnet-2.0.0/-/dotnet-2.0.0-1.4.4.tgz",
+      "integrity": "sha512-KDbUncVUhwkJH2wjL9gbUWQ5NcZIe+PFEI0CGTMtX5TImFG6Nlt9CABVGBBG+oWf13zLARaBVenkD20moz1NPw=="
+    },
+    "typescript": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
+    }
+  }
+}

--- a/libraries/swagger/package.json
+++ b/libraries/swagger/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "generateclient-via-swagger",
+  "version": "1.0.0",
+  "description": "To regenerate the botframework-connector and botframework-schema libraries, install the dependencies for autorest via `npm i`, then run generateClient.cmd.",
+  "main": "generateClient.cmd",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Microsoft/botbuilder-js.git"
+  },
+  "author": "Microsoft",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Microsoft/botbuilder-js/issues"
+  },
+  "homepage": "https://github.com/Microsoft/botbuilder-js#readme",
+  "dependencies": {
+    "@microsoft.azure/autorest-core": "2.0.4289",
+    "@microsoft.azure/autorest.typescript": "2.0.611",
+    "autorest": "2.0.4283"
+  }
+}


### PR DESCRIPTION
Fixes #639 - Marks `CardAction.channelData` as optional
Fixes Microsoft/botbuilder#5187 for JS v4 - Marks `ChannelAccount` and `ConversationAccount` `aadObjectId` and `role` properties as optional.

## Description
Update process for generating connector and schema libraries, add package.json with autorest dependencies.

## Specific Changes
  - Add package.json with autorest dependencies to `swagger/`
  - Modify `generateClient.cmd` to specifically use the locally installed autorest package
  - Update lerna.json to explicitly bootstrap --hoist actual published libraries and therefore not include `libraries/swagger`
  - Improve UX in generateClient.cmd and uncomment connectorAPI-handling code

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->