### PR TITLE
Update 'master' readme to reflect 4.2 branch builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Bot Builder SDK v4
  | Branch | Description        | Build Status | Coverage Status |
  |----|---------------|--------------|-----------------|
- |Master | 4.2.* Preview Builds |[![Build status](https://travis-ci.org/Microsoft/botbuilder-js.svg?branch=master)](https://travis-ci.org/Microsoft/botbuilder-js) |[![Coverage Status](https://coveralls.io/repos/github/Microsoft/botbuilder-js/badge.svg?branch=master)](https://coveralls.io/github/Microsoft/botbuilder-js?branch=master)
+|Master | 4.2.* Preview Builds |[![Build status](https://travis-ci.org/Microsoft/botbuilder-js.svg?branch=master)](https://travis-ci.org/Microsoft/botbuilder-js) |[![Coverage Status](https://coveralls.io/repos/github/Microsoft/botbuilder-js/badge.svg?branch=master)](https://coveralls.io/github/Microsoft/botbuilder-js?branch=master)
+|4.2 | 4.2.* Preview Builds |[![Build status](https://travis-ci.org/Microsoft/botbuilder-js.svg?branch=4.2)](https://travis-ci.org/Microsoft/botbuilder-js) |[![Coverage Status](https://coveralls.io/repos/github/Microsoft/botbuilder-js/badge.svg?branch=4.2)](https://coveralls.io/github/Microsoft/botbuilder-js?branch=4.2)
  |4.1 | 4.1.* Patch Builds |[![Build status](https://travis-ci.org/Microsoft/botbuilder-js.svg?branch=4.1)](https://travis-ci.org/Microsoft/botbuilder-js) | [![Coverage Status](https://coveralls.io/repos/github/Microsoft/botbuilder-js/badge.svg?branch=4.1)](https://coveralls.io/github/Microsoft/botbuilder-js?branch=4.1)
  |4.0 | 4.0.* Patch Builds | [![Build status](https://travis-ci.org/Microsoft/botbuilder-js.svg?branch=4.0)](https://travis-ci.org/Microsoft/botbuilder-js) | [![Coverage Status](https://coveralls.io/repos/github/Microsoft/botbuilder-js/badge.svg?branch=4.0)](https://coveralls.io/github/Microsoft/botbuilder-js?branch=4.0)|
 


### PR DESCRIPTION
Update the readme to show the Build / Package badges for the 4.2 release.