### PR TITLE
Made databaseCreationRequestOptions & documentCollectionRequestOptions optional in CosmosDbStorageSettings interface

### DIFF
--- a/libraries/botbuilder-azure/src/cosmosDbStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbStorage.ts
@@ -37,13 +37,13 @@ export interface CosmosDbStorageSettings {
      */
      collectionId: string;
      /**
-      * Cosmos DB RequestOptions that are passed when the database is created.
+      * (Optional) Cosmos DB RequestOptions that are passed when the database is created.
       */
-     databaseCreationRequestOptions: RequestOptions;
+     databaseCreationRequestOptions?: RequestOptions;
      /**
-      * Cosmos DB RequestOptiones that are passed when the document collection is created.
+      * (Optional) Cosmos DB RequestOptiones that are passed when the document collection is created.
       */
-     documentCollectionRequestOptions: RequestOptions;
+     documentCollectionRequestOptions?: RequestOptions;
 }
 
 /**


### PR DESCRIPTION
Fixes #691

## Description
`CosmosDbStorageSettings` currently _requires_:
- `databaseCreationRequestOptions` 
- `documentCollectionRequestOptions`

 -- they should be _optional_

## Specific Changes
  - changed properties `databaseCreationRequestOptions` & `documentCollectionRequestOptions` in `CosmosDbStorageSettings` interface