### PR TITLE
Added ComponentDialog.run() method and unit tests **DO NOT MERGE**

### DIFF
--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -328,7 +328,7 @@ export class ComponentDialog<O extends object = {}> extends Dialog<O> {
 
         // Start the component if it wasn't already running
         if (result.status === DialogTurnStatus.empty) {
-            result = await dc.beginDialog(this.id, options);
+            result = await dc.beginDialog(this.id, options.dialogOptions);
         }
         return result;
 

--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -5,12 +5,28 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { TurnContext, BotTelemetryClient, NullTelemetryClient } from 'botbuilder-core';
+import { TurnContext, BotTelemetryClient, NullTelemetryClient, StatePropertyAccessor } from 'botbuilder-core';
 import { Dialog, DialogInstance, DialogReason, DialogTurnResult, DialogTurnStatus } from './dialog';
 import { DialogContext, DialogState } from './dialogContext';
 import { DialogSet } from './dialogSet';
 
 const PERSISTED_DIALOG_STATE: string = 'dialogs';
+
+/**
+ * Additional options that can be passed into the `ComponentDialog.run()` method.
+ */
+export interface ComponentDialogRunOptions {
+    /**
+     * (Optional) options to pass to the component when its first started.
+     */
+    dialogOptions?: object;
+
+    /**
+     * (Optional) object used to persist the components state. If omitted the 
+     * `StatePropertyAccessor<DialogState>` passed to the components constructor will be used. 
+     */
+    dialogState?: DialogState;
+}
 
 /**
  * Base class for a dialog that contains other child dialogs.
@@ -77,7 +93,19 @@ export class ComponentDialog<O extends object = {}> extends Dialog<O> {
      * This defaults to the ID of the first child dialog added using [addDialog()](#adddialog).
      */
     protected initialDialogId: string;
-    private dialogs: DialogSet = new DialogSet(null);
+    private readonly dialogs: DialogSet = new DialogSet(null);
+    private readonly mainDialogSet: DialogSet;
+
+    /**
+     * Creates a new ComponentDialog instance.
+     * @param dialogId Unique ID of the component within its parents dialog set.
+     * @param dialogState (Optional) state property used to persists the components dialog state when the `run()` method is called.
+     */
+    constructor(dialogId: string, dialogState?: StatePropertyAccessor<DialogState>) {
+        super(dialogId);
+        this.mainDialogSet = new DialogSet(dialogState);
+        this.mainDialogSet.add(this);
+    }
 
     public async beginDialog(outerDC: DialogContext, options?: O): Promise<DialogTurnResult> {
         // Start the inner dialog.
@@ -173,26 +201,25 @@ export class ComponentDialog<O extends object = {}> extends Dialog<O> {
      * Called anytime an instance of the component has been started.
      *
      * @remarks
-     * SHOULD be overridden by components that wish to perform custom interruption logic. The
-     * default implementation calls `innerDC.beginDialog()` with the dialog assigned to
-     * [initialDialogId](#initialdialogid).
+     * CAN be overridden by components that wish to perform custom startup logic. The
+     * default implementation simply calls [onRunTurn()](#onrunturn).
      * @param innerDC Dialog context for the components internal `DialogSet`.
      * @param options (Optional) options that were passed to the component by its parent.
      */
     protected onBeginDialog(innerDC: DialogContext, options?: O): Promise<DialogTurnResult> {
-        return innerDC.beginDialog(this.initialDialogId, options);
+        return this.onRunTurn(innerDC, options);
     }
 
     /**
      * Called anytime a multi-turn component receives additional activities.
      *
      * @remarks
-     * SHOULD be overridden by components that wish to perform custom interruption logic. The
-     * default implementation calls `innerDC.continueDialog()`.
+     * CAN be overridden by components that wish to perform custom continuation logic. The
+     * default implementation simply calls [onRunTurn()](#onrunturn).
      * @param innerDC Dialog context for the components internal `DialogSet`.
      */
     protected onContinueDialog(innerDC: DialogContext): Promise<DialogTurnResult> {
-        return innerDC.continueDialog();
+        return this.onRunTurn(innerDC);
     }
 
     /**
@@ -219,6 +246,30 @@ export class ComponentDialog<O extends object = {}> extends Dialog<O> {
      */
     protected onRepromptDialog(context: TurnContext, instance: DialogInstance): Promise<void> {
         return Promise.resolve();
+    }
+
+    /**
+     * Called anytime an instance of the component has been started or has received additional 
+     * activities.
+     * 
+     * @remarks
+     * This method creates a single override for listing to both [onBeginDialog()](#onbegindialog) 
+     * and [onContinueDialog()](#oncontinuedialog) calls.
+     * 
+     * SHOULD be overridden by components that wish to perform custom interruption logic. The
+     * default implementation first calls `innerDC.continueDialog()` and if there was no active
+     * dialog it will then call `innerDC.beginDialog()` with the dialog assigned to
+     * [initialDialogId](#initialdialogid).
+     * @param innerDC Dialog context for the components internal `DialogSet`.
+     * @param options (Optional) options that were passed to the component by its parent.
+     */
+    protected async onRunTurn(innerDC: DialogContext, options?: O): Promise<DialogTurnResult> {
+        let result = await innerDC.continueDialog();
+        if (result.status === DialogTurnStatus.empty) {
+            result = await innerDC.beginDialog(this.initialDialogId, options);
+        }
+
+        return result;
     }
 
     /**
@@ -249,6 +300,38 @@ export class ComponentDialog<O extends object = {}> extends Dialog<O> {
      */
     public get telemetryClient(): BotTelemetryClient {
         return this._telemetryClient;
+    }
+
+    /**
+     * Called from within the bots logic handler to route a received activity to the appropriate 
+     * dialog.
+     * 
+     * @remarks
+     * This method lets any component be run in isolation without having to be added to another 
+     * `ComponentDialog` or `DialogSet`. 
+     * @param context Context for the current turn of conversation with the user.
+     * @param options (Optional) options that can be used to control the running of the component.
+     */
+    public async run(context: TurnContext, options?: ComponentDialogRunOptions): Promise<DialogTurnResult> {
+        options = options || {};
+
+        // Create a dialog context
+        let dc: DialogContext;
+        if (options.dialogState) {
+            dc = new DialogContext(this.mainDialogSet, context, options.dialogState);
+        } else {
+            dc = await this.mainDialogSet.createContext(context);
+        }
+
+        // Attempt to continue execution of the components current dialog
+        let result = await dc.continueDialog();
+
+        // Start the component if it wasn't already running
+        if (result.status === DialogTurnStatus.empty) {
+            result = await dc.beginDialog(this.id, options);
+        }
+        return result;
+
     }
 
 }

--- a/libraries/botbuilder-dialogs/tests/componentDialog.test.js
+++ b/libraries/botbuilder-dialogs/tests/componentDialog.test.js
@@ -149,7 +149,7 @@ describe('ComponentDialog', function () {
         component.addDialog(startDialog);
 
         const adapter = new TestAdapter(async turnContext => {
-            await component.run(turnContext, { foo: 'bar' });
+            await component.run(turnContext, { dialogOptions: { foo: 'bar' } });
             await conversationState.saveChanges(turnContext);
         });
 

--- a/libraries/botbuilder-dialogs/tests/componentDialog.test.js
+++ b/libraries/botbuilder-dialogs/tests/componentDialog.test.js
@@ -49,8 +49,113 @@ describe('ComponentDialog', function () {
             const results = await dc.beginDialog('composite', { foo: 'bar' });
         });
 
-        adapter.send('Hi');
-        done();
+        adapter.send('Hi')
+               .then(() => done());
+    });
+
+    it('should start ComponentDialog using run() method.', (done) => {
+        const conversationState = new ConversationState(new MemoryStorage());
+        const dialogState = conversationState.createProperty('dialog');
+
+        const startDialog = new WaterfallDialog('start', [
+            async (step) => {
+                simpleStepContextCheck(step);
+                await step.context.sendActivity(`First Step`);
+                return await step.endDialog();
+            }
+        ]);
+        const component = new ComponentDialog('composite', dialogState);
+        component.addDialog(startDialog);
+
+        const adapter = new TestAdapter(async turnContext => {
+            const result = await component.run(turnContext);
+            assert(result.status === DialogTurnStatus.complete);
+            await conversationState.saveChanges(turnContext);
+        });
+
+        adapter.send('Hi')
+               .assertReply(`First Step`)
+               .then(() => done());
+    });
+
+    it('should continue ComponentDialog using run() method.', (done) => {
+        const conversationState = new ConversationState(new MemoryStorage());
+        const dialogState = conversationState.createProperty('dialog');
+
+        const startDialog = new WaterfallDialog('start', [
+            async (step) => {
+                await step.context.sendActivity(`First Step`);
+                return Dialog.EndOfTurn;
+            },
+            async (step) => {
+                await step.context.sendActivity(`Last Step`);
+                return await step.endDialog();
+            }
+        ]);
+        const component = new ComponentDialog('composite', dialogState);
+        component.addDialog(startDialog);
+
+        const adapter = new TestAdapter(async turnContext => {
+            await component.run(turnContext);
+            await conversationState.saveChanges(turnContext);
+        });
+
+        adapter.send('Hi')
+               .assertReply(`First Step`)
+               .send('continue')
+               .assertReply(`Last Step`)
+               .then(() => done());
+    });
+
+    it('should use external dialog state passed into run() method.', (done) => {
+        const startDialog = new WaterfallDialog('start', [
+            async (step) => {
+                await step.context.sendActivity(`First Step`);
+                return Dialog.EndOfTurn;
+            },
+            async (step) => {
+                await step.context.sendActivity(`Last Step`);
+                return await step.endDialog();
+            }
+        ]);
+        const component = new ComponentDialog('composite');
+        component.addDialog(startDialog);
+
+        const state = {};
+        const adapter = new TestAdapter(async turnContext => {
+            await component.run(turnContext, { dialogState: state });
+        });
+
+        adapter.send('Hi')
+               .assertReply(`First Step`)
+               .send('continue')
+               .assertReply(`Last Step`)
+               .then(() => done());
+    });
+
+    it('should pass through dialogOptions when using run() method.', (done) => {
+        const conversationState = new ConversationState(new MemoryStorage());
+        const dialogState = conversationState.createProperty('dialog');
+
+        const startDialog = new WaterfallDialog('start', [
+            async (step) => {
+                simpleStepContextCheck(step);
+                assert(step.options.foo === 'bar');
+                await step.context.sendActivity(`First Step`);
+                return await step.endDialog();
+            }
+        ]);
+        const component = new ComponentDialog('composite', dialogState);
+        component.addDialog(startDialog);
+
+        const adapter = new TestAdapter(async turnContext => {
+            await component.run(turnContext, { foo: 'bar' });
+            await conversationState.saveChanges(turnContext);
+        });
+
+        adapter.send('Hi')
+               .assertReply(`First Step`)
+               .then(() => done());
     });
 
     it('should throw an error up if child dialog does not return DialogTurnResult on beginDialog.', (done) => {


### PR DESCRIPTION
For [DCR 5235](https://github.com/Microsoft/BotBuilder/issues/5235)

## Description
This PR adds new `ComponentDialog.run()` and `ComponentDialog.onRunTurn()` methods which simplify the root dialog driver code for bots.

My implementation gives you two ways of persisting the components state.

1. You can pass a `StatePropertyAccessor` to the components constructor and the state will be automatically persisted to that property when run() is called.
2. You can pass in the backing state object when you call run() and your code will be responsible for persisting the state after run() is called.

## Testing
Added unit tests for new run() method.
