### PR TITLE
Change OAuthPrompt default timeout from 54000000 to 900000 ms

### DIFF
--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -32,7 +32,7 @@ export interface OAuthPromptSettings {
 
     /**
      * (Optional) number of milliseconds the prompt will wait for the user to authenticate.
-     * Defaults to a value `54,000,000` (15 minutes.)
+     * Defaults to a value `900,000` (15 minutes.)
      */
     timeout?: number;
 }
@@ -126,7 +126,7 @@ export class OAuthPrompt extends Dialog {
         }
 
         // Initialize prompt state
-        const timeout: number = typeof this.settings.timeout === 'number' ? this.settings.timeout : 54000000;
+        const timeout: number = typeof this.settings.timeout === 'number' ? this.settings.timeout : 900000;
         const state: OAuthPromptState = dc.activeDialog.state as OAuthPromptState;
         state.state = {};
         state.options = o;


### PR DESCRIPTION
Fixes https://github.com/Microsoft/botbuilder-dotnet/issues/1307

## Description
This pull request changes the default timeout in oauthPrompt.ts from 54000000 (15 hours in milliseconds) to 900000 (15 minutes in milliseconds). The comments always said it was 15 minutes so this change will make the actual value match the comments.