### PR TITLE
Made linting fixes to QnAMaker

### DIFF
--- a/libraries/botbuilder-ai/src/qnaMaker.ts
+++ b/libraries/botbuilder-ai/src/qnaMaker.ts
@@ -7,9 +7,9 @@
  */
 import {  Activity, TurnContext } from 'botbuilder';
 import * as entities from 'html-entities';
-import * as request from 'request-promise-native';
-const pjson: any = require('../package.json');
 import * as os from 'os';
+const pjson: any = require('../package.json');
+import * as request from 'request-promise-native';
 
 const QNAMAKER_TRACE_TYPE: string = 'https://www.qnamaker.ai/schemas/trace';
 const QNAMAKER_TRACE_NAME: string = 'QnAMaker';
@@ -183,18 +183,18 @@ export class QnAMaker {
             throw new TypeError('QnAMaker requires valid QnAMakerEndpoint.');
         }
 
-        const { 
+        const {
             scoreThreshold = 0.3,
             top = 1,
             strictFilters = [] as QnAMakerMetadata[],
             metadataBoost = [] as QnAMakerMetadata[]
         } = options;
 
-        this._options = { 
-            scoreThreshold, 
-            top, 
+        this._options = {
+            scoreThreshold,
+            top,
             strictFilters,
-            metadataBoost 
+            metadataBoost
         } as QnAMakerOptions;
 
         this.validateOptions(this._options);
@@ -202,13 +202,13 @@ export class QnAMaker {
 
     /**
      * Calls the QnA Maker service to generate answer(s) for a question.
-     * 
+     *
      * @remarks
      * Returns an array of answers sorted by score with the top scoring answer returned first.
-     * 
+     *
      * In addition to returning the results from QnA Maker, [getAnswers()](#getAnswers) will also
      * emit a trace activity that contains the QnA Maker results.
-     * 
+     *
      * @param context The Turn Context that contains the user question to be queried against your knowledge base.
      * @param options (Optional) The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.
      */
@@ -217,15 +217,15 @@ export class QnAMaker {
             throw new TypeError('QnAMaker.getAnswers() requires a TurnContext.');
         }
 
-        const queryResult = [] as QnAMakerResult[];
+        const queryResult: QnAMakerResult[] = [] as QnAMakerResult[];
         const question: string = this.getTrimmedMessageText(context);
-        const queryOptions = { ...this._options, ...options } as QnAMakerOptions;
-        
+        const queryOptions: QnAMakerOptions = { ...this._options, ...options } as QnAMakerOptions;
+
         this.validateOptions(queryOptions);
 
         if (question.length > 0) {
             const answers: QnAMakerResult[] = await this.queryQnaService(this.endpoint, question, queryOptions);
-            const sortedQnaAnswers = this.sortAnswersWithinThreshold(answers, queryOptions);
+            const sortedQnaAnswers: QnAMakerResult[] = this.sortAnswersWithinThreshold(answers, queryOptions);
 
             queryResult.push(...sortedQnaAnswers);
         }
@@ -236,159 +236,9 @@ export class QnAMaker {
     }
 
     /**
-     * Gets the message from the Activity in the TurnContext, trimmed of whitespaces.
-     */
-    private getTrimmedMessageText(context: TurnContext): string {
-        const question: string = (context && context.activity && context.activity.text) ? context.activity.text : '';
-        const trimmedQuestion: string = question.trim();
-
-        return trimmedQuestion;
-    }
-
-    /**
-     * Called internally to query the QnA Maker service.
-     */
-    private async queryQnaService(endpoint: QnAMakerEndpoint, question: string, options?: QnAMakerOptions): Promise<QnAMakerResult[]> {
-        const url: string = `${endpoint.host}/knowledgebases/${endpoint.knowledgeBaseId}/generateanswer`;
-        const headers: any = this.getHeaders(endpoint);
-        const queryOptions = { ...this._options, ...options } as QnAMakerOptions;
-        
-        this.validateOptions(queryOptions);
-
-        const qnaResult = await request({
-            url: url,
-            method: 'POST',
-            headers: headers,
-            json: {
-                question: question,
-                ...queryOptions
-            }
-        });
-
-        const formattedQnaResult = this.formatQnaResult(qnaResult);
-
-        return formattedQnaResult;
-    }
-
-    /**
-     * Sorts all QnAMakerResult from highest-to-lowest scoring. 
-     * Filters QnAMakerResults within threshold specified (default threshold: .001).
-     */
-    private sortAnswersWithinThreshold(answers: QnAMakerResult[] = [] as QnAMakerResult[], queryOptions: QnAMakerOptions): QnAMakerResult[] {
-        const minScore: number = typeof queryOptions.scoreThreshold === 'number' ? queryOptions.scoreThreshold : 0.001;
-        const sortedQnaAnswers = answers.filter(
-            (ans: QnAMakerResult) => ans.score >= minScore
-        ).sort(
-            (a: QnAMakerResult, b: QnAMakerResult) => b.score - a.score
-        );
-
-        return sortedQnaAnswers;
-    }
-
-    /**
-     * Emits a trace event detailing a QnA Maker call and its results.
-     *
-     * @param context Context for the current turn of conversation with the user.
-     * @param answers Answers returned by QnA Maker.
-     */
-    private emitTraceInfo(context: TurnContext, answers: QnAMakerResult[], queryOptions: QnAMakerOptions): Promise<any> {
-        const requestOptions = { ...this._options, ...queryOptions };
-        const { scoreThreshold, top, strictFilters, metadataBoost } = requestOptions;
-        
-        const traceInfo: QnAMakerTraceInfo = {
-            message: context.activity,
-            queryResults: answers,
-            knowledgeBaseId: this.endpoint.knowledgeBaseId,
-            scoreThreshold,
-            top,
-            strictFilters,
-            metadataBoost
-        };
-
-        return context.sendActivity({
-            type: 'trace',
-            valueType: QNAMAKER_TRACE_TYPE,
-            name: QNAMAKER_TRACE_NAME,
-            label: QNAMAKER_TRACE_LABEL,
-            value: traceInfo
-        });
-    }
-
-    /**
-     * Sets headers for request to QnAMaker service. 
-     * 
-     * The [QnAMakerEndpointKey](#QnAMakerEndpoint.QnAMakerEndpointKey) is set as the value of 
-     * `Authorization` header for v4.0 and later of QnAMaker service.
-     * 
-     * Legacy QnAMaker services use the `Ocp-Apim-Subscription-Key` header for the QnAMakerEndpoint value instead.
-     * 
-     * [QnAMaker.getHeaders()](#QnAMaker.getHeaders) also gets the User-Agent header value.
-     */
-    private getHeaders(endpoint: QnAMakerEndpoint) {
-        const headers: any = {};
-        const isLegacyProtocol = endpoint.host.endsWith('v2.0') || endpoint.host.endsWith('v3.0');
-
-        if (isLegacyProtocol) {
-            headers['Ocp-Apim-Subscription-Key'] = endpoint.endpointKey;
-        } else {
-            headers.Authorization = `EndpointKey ${endpoint.endpointKey}`;
-        }
-
-        headers['User-Agent'] = this.getUserAgent();
-
-        return headers;
-    }
-
-    private getUserAgent() : string {
-        const packageUserAgent = `${pjson.name}/${pjson.version}`;
-        const platformUserAgent = `(${os.arch()}-${os.type()}-${os.release()}; Node.js,Version=${process.version})`;
-        const userAgent = `${packageUserAgent} ${platformUserAgent}`;
-        
-        return userAgent;
-    }
-
-    private validateOptions(options: QnAMakerOptions): void {
-        const { scoreThreshold, top } = options;
-
-        if (scoreThreshold) {
-            this.validateScoreThreshold(scoreThreshold);
-        }
-
-        if (top) {
-            this.validateTop(top);
-        }
-    }
-
-    private validateScoreThreshold(scoreThreshold: number): void {
-        if (typeof scoreThreshold !== 'number' || !(scoreThreshold > 0 && scoreThreshold < 1)) {
-            throw new TypeError(`"${scoreThreshold}" is an invalid scoreThreshold. QnAMakerOptions.scoreThreshold must have a value between 0 and 1.`);
-        }
-    }
-
-    private validateTop(qnaOptionTop: number): void { 
-        if (!Number.isInteger(qnaOptionTop) || qnaOptionTop < 1) {
-            throw new RangeError(`"${qnaOptionTop}" is an invalid top value. QnAMakerOptions.top must be an integer greater than 0.`);
-        }
-    }
-
-    private formatQnaResult(qnaResult: any) {
-        return qnaResult.answers.map((ans: any) => {
-            ans.score = ans.score / 100;
-            ans.answer = htmlentities.decode(ans.answer);
-
-            if (ans.qnaId) {
-                ans.id = ans.qnaId;
-                delete ans.qnaId;
-            }
-
-            return ans as QnAMakerResult;
-        });
-    }
-
-    /**
      * Calls [generateAnswer()](#generateanswer) and sends the resulting answer as a reply to the user.
      * @deprecated Instead, favor using [QnAMaker.getAnswers()](#getAnswers) to generate answers for a question.
-     * 
+     *
      * @remarks
      * Returns a value of `true` if an answer was found and sent. If multiple answers are
      * returned the first one will be delivered.
@@ -409,8 +259,8 @@ export class QnAMaker {
             await context.sendActivity({ text: answers[0].answer, type: 'message' });
 
             return true;
-        } 
-        
+        }
+
         return false;
     }
 
@@ -418,10 +268,10 @@ export class QnAMaker {
      * Calls the QnA Maker service to generate answer(s) for a question.
      *
      * @deprecated Instead, favor using [QnAMaker.getAnswers()](#getAnswers) to generate answers for a question.
-     * 
+     *
      * @remarks
      * Returns an array of answers sorted by score with the top scoring answer returned first.
-     * 
+     *
      * @param question The question to answer.
      * @param top (Optional) number of answers to return. Defaults to a value of `1`.
      * @param scoreThreshold (Optional) minimum answer score needed to be considered a match to questions. Defaults to a value of `0.001`.
@@ -430,14 +280,12 @@ export class QnAMaker {
         const trimmedAnswer: string = question ? question.trim() : '';
 
         if (trimmedAnswer.length > 0) {
-            const answers = await this.callService(this.endpoint, question, typeof top === 'number' ? top : 1);
+            const answers: QnAMakerResult[] = await this.callService(this.endpoint, question, typeof top === 'number' ? top : 1);
             const minScore: number = typeof scoreThreshold === 'number' ? scoreThreshold : 0.001;
 
             return answers.filter(
-                (ans: QnAMakerResult) => ans.score >= minScore
-            ).sort(
-                (a: QnAMakerResult, b: QnAMakerResult) => b.score - a.score
-            );
+                (ans: QnAMakerResult) => ans.score >= minScore)
+                .sort((a: QnAMakerResult, b: QnAMakerResult) => b.score - a.score);
         }
 
         return [] as QnAMakerResult[];
@@ -451,5 +299,150 @@ export class QnAMaker {
      */
     protected async callService(endpoint: QnAMakerEndpoint, question: string, top: number): Promise<QnAMakerResult[]> {
         return this.queryQnaService(endpoint, question, { top } as QnAMakerOptions);
+    }
+
+    /**
+     * Gets the message from the Activity in the TurnContext, trimmed of whitespaces.
+     */
+    private getTrimmedMessageText(context: TurnContext): string {
+        const question: string = (context && context.activity && context.activity.text) ? context.activity.text : '';
+
+        return question.trim();
+    }
+
+    /**
+     * Called internally to query the QnA Maker service.
+     */
+    private async queryQnaService(endpoint: QnAMakerEndpoint, question: string, options?: QnAMakerOptions): Promise<QnAMakerResult[]> {
+        const url: string = `${endpoint.host}/knowledgebases/${endpoint.knowledgeBaseId}/generateanswer`;
+        const headers: any = this.getHeaders(endpoint);
+        const queryOptions: QnAMakerOptions = { ...this._options, ...options } as QnAMakerOptions;
+
+        this.validateOptions(queryOptions);
+
+        const qnaResult: any = await request({
+            url: url,
+            method: 'POST',
+            headers: headers,
+            json: {
+                question: question,
+                ...queryOptions
+            }
+        });
+
+        return this.formatQnaResult(qnaResult);
+    }
+
+    /**
+     * Sorts all QnAMakerResult from highest-to-lowest scoring.
+     * Filters QnAMakerResults within threshold specified (default threshold: .001).
+     */
+    private sortAnswersWithinThreshold(answers: QnAMakerResult[] = [] as QnAMakerResult[], queryOptions: QnAMakerOptions)
+        : QnAMakerResult[] {
+        const minScore: number = typeof queryOptions.scoreThreshold === 'number' ? queryOptions.scoreThreshold : 0.001;
+
+        return answers.filter((ans: QnAMakerResult) => ans.score >= minScore)
+            .sort((a: QnAMakerResult, b: QnAMakerResult) => b.score - a.score);
+    }
+
+    /**
+     * Emits a trace event detailing a QnA Maker call and its results.
+     *
+     * @param context Context for the current turn of conversation with the user.
+     * @param answers Answers returned by QnA Maker.
+     */
+    private async emitTraceInfo(context: TurnContext, answers: QnAMakerResult[], queryOptions: QnAMakerOptions): Promise<any> {
+        const requestOptions: QnAMakerOptions = { ...this._options, ...queryOptions };
+        const { scoreThreshold, top, strictFilters, metadataBoost } = requestOptions;
+
+        const traceInfo: QnAMakerTraceInfo = {
+            message: context.activity,
+            queryResults: answers,
+            knowledgeBaseId: this.endpoint.knowledgeBaseId,
+            scoreThreshold,
+            top,
+            strictFilters,
+            metadataBoost
+        };
+
+        return context.sendActivity({
+            type: 'trace',
+            valueType: QNAMAKER_TRACE_TYPE,
+            name: QNAMAKER_TRACE_NAME,
+            label: QNAMAKER_TRACE_LABEL,
+            value: traceInfo
+        });
+    }
+
+    /**
+     * Sets headers for request to QnAMaker service.
+     *
+     * The [QnAMakerEndpointKey](#QnAMakerEndpoint.QnAMakerEndpointKey) is set as the value of
+     * `Authorization` header for v4.0 and later of QnAMaker service.
+     *
+     * Legacy QnAMaker services use the `Ocp-Apim-Subscription-Key` header for the QnAMakerEndpoint value instead.
+     *
+     * [QnAMaker.getHeaders()](#QnAMaker.getHeaders) also gets the User-Agent header value.
+     */
+    private getHeaders(endpoint: QnAMakerEndpoint): any {
+        const headers: any = {};
+        const isLegacyProtocol: boolean = endpoint.host.endsWith('v2.0') || endpoint.host.endsWith('v3.0');
+
+        if (isLegacyProtocol) {
+            headers['Ocp-Apim-Subscription-Key'] = endpoint.endpointKey;
+        } else {
+            headers.Authorization = `EndpointKey ${endpoint.endpointKey}`;
+        }
+
+        headers['User-Agent'] = this.getUserAgent();
+
+        return headers;
+    }
+
+    private getUserAgent() : string {
+        const packageUserAgent: string = `${pjson.name}/${pjson.version}`;
+        const platformUserAgent: string = `(${os.arch()}-${os.type()}-${os.release()}; Node.js,Version=${process.version})`;
+
+        return `${packageUserAgent} ${platformUserAgent}`;
+    }
+
+    private validateOptions(options: QnAMakerOptions): void {
+        const { scoreThreshold, top } = options;
+
+        if (scoreThreshold) {
+            this.validateScoreThreshold(scoreThreshold);
+        }
+
+        if (top) {
+            this.validateTop(top);
+        }
+    }
+
+    private validateScoreThreshold(scoreThreshold: number): void {
+        if (typeof scoreThreshold !== 'number' || !(scoreThreshold > 0 && scoreThreshold < 1)) {
+            throw new TypeError(
+                `"${scoreThreshold}" is an invalid scoreThreshold. QnAMakerOptions.scoreThreshold must have a value between 0 and 1.`
+            );
+        }
+    }
+
+    private validateTop(qnaOptionTop: number): void {
+        if (!Number.isInteger(qnaOptionTop) || qnaOptionTop < 1) {
+            throw new RangeError(`"${qnaOptionTop}" is an invalid top value. QnAMakerOptions.top must be an integer greater than 0.`);
+        }
+    }
+
+    private formatQnaResult(qnaResult: any): QnAMakerResult[] {
+        return qnaResult.answers.map((ans: any) => {
+            ans.score = ans.score / 100;
+            ans.answer = htmlentities.decode(ans.answer);
+
+            if (ans.qnaId) {
+                ans.id = ans.qnaId;
+                delete ans.qnaId;
+            }
+
+            return ans as QnAMakerResult;
+        });
     }
 }


### PR DESCRIPTION
## Description
Turned on tslint and fixed linting errors from PR #704 

## Specific Changes

  - got rid of trailing whitepsaces
  - added types on variables missing typing
  - moved deprecated methods to appear before `private` methods, as they are of `public` or `protected` accessibility 
