### PR TITLE
Prevent Cortana from trying to use suggested actions in prompts

### DIFF
--- a/libraries/botbuilder-dialogs/src/choices/choiceFactory.ts
+++ b/libraries/botbuilder-dialogs/src/choices/choiceFactory.ts
@@ -107,11 +107,9 @@ export class ChoiceFactory {
 
         // Determine list style
         const supportsSuggestedActions: boolean = channel.supportsSuggestedActions(channelId, choices.length);
-        const supportsCardActions: boolean = channel.supportsCardActions(channelId, choices.length);
         const maxActionTitleLength: number = channel.maxActionTitleLength(channelId);
-        const hasMessageFeed: boolean = channel.hasMessageFeed(channelId);
         const longTitles: boolean = maxTitleLength > maxActionTitleLength;
-        if (!longTitles && (supportsSuggestedActions || (!hasMessageFeed && supportsCardActions))) {
+        if (!longTitles && supportsSuggestedActions) {
             // We always prefer showing choices using suggested actions. If the titles are too long, however,
             // we'll have to show them as a text list.
             return ChoiceFactory.suggestedAction(list, text, speak);

--- a/libraries/botbuilder-dialogs/tests/choices_choiceFactory.test.js
+++ b/libraries/botbuilder-dialogs/tests/choices_choiceFactory.test.js
@@ -21,6 +21,7 @@ function assertActivity(received, expected) {
 }
 
 const colorChoices = ['red', 'green', 'blue'];
+const extraChoices = ['red', 'green', 'blue', 'alpha'];
 
 const choicesWithActionTitle = [
     {
@@ -167,6 +168,18 @@ describe('ChoiceFactory', function() {
         done();
     });
 
+    it('should choose correct styles for Cortana.', done => {
+        const inlineActivity = ChoiceFactory.forChannel('cortana', colorChoices, 'select from:');
+        assertActivity(inlineActivity, {
+            text: `select from: (1) red, (2) green, or (3) blue`
+        });
+        const listActivity = ChoiceFactory.forChannel('cortana', extraChoices, 'select from:');
+        assertActivity(listActivity, {
+            text: `select from:\n\n   1. red\n   2. green\n   3. blue\n   4. alpha`
+        });
+        done();
+    });
+    
     it('should use action.title to populate action.value if action.value is falsey.', done => {
         const preparedChoices = ChoiceFactory.toChoices(choicesWithActionTitle);
         assertChoices(preparedChoices, ['Red Color', 'Green Color', 'Blue Color']);


### PR DESCRIPTION
Fixes  https://github.com/Microsoft/botbuilder-dotnet/issues/1173

## Description
I have modified choiceFactory.ts by removing `hasMessageFeed` and `supportsCardActions` from the `if` condition so that now a channel _must_ support suggested actions in order for the SDK to automatically select them as the list style. I have also deleted those local variables for cleanliness since they aren't being used anywhere else.