### PR TITLE
Added ability to call dialogs within a parent component.

### DIFF
--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -84,6 +84,7 @@ export class ComponentDialog<O extends object = {}> extends Dialog<O> {
         const dialogState: DialogState = { dialogStack: [] };
         outerDC.activeDialog.state[PERSISTED_DIALOG_STATE] = dialogState;
         const innerDC: DialogContext = new DialogContext(this.dialogs, outerDC.context, dialogState);
+        innerDC.parent = outerDC;
         const turnResult: DialogTurnResult<any> = await this.onBeginDialog(innerDC, options);
 
         // Check for end of inner dialog
@@ -100,6 +101,7 @@ export class ComponentDialog<O extends object = {}> extends Dialog<O> {
         // Continue execution of inner dialog.
         const dialogState: any = outerDC.activeDialog.state[PERSISTED_DIALOG_STATE];
         const innerDC: DialogContext = new DialogContext(this.dialogs, outerDC.context, dialogState);
+        innerDC.parent = outerDC;
         const turnResult: DialogTurnResult<any> = await this.onContinueDialog(innerDC);
 
         // Check for end of inner dialog

--- a/libraries/botbuilder-dialogs/src/waterfallDialog.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallDialog.ts
@@ -238,14 +238,15 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
      */
      public async endDialog(context: TurnContext, instance: DialogInstance, reason: DialogReason) {
 
-        const instanceId = instance.state.values['instanceId'];
+        const state: WaterfallDialogState = instance.state as WaterfallDialogState
+        const instanceId = state.values['instanceId'];
         if (reason === DialogReason.endCalled) {
             this.telemetryClient.trackEvent({name: "WaterfallComplete", properties: {
                 "DialogId": this.id,
                 "InstanceId": instanceId,
             }});
         } else if (reason === DialogReason.cancelCalled) {
-            var index = instance.state[instance.state.stepIndex];
+            var index = instance.state[state.stepIndex];
             var stepName = this.waterfallStepName(index);
             this.telemetryClient.trackEvent({name: "WaterfallCancel", properties: {
                 "DialogId": this.id,

--- a/libraries/botbuilder-dialogs/src/waterfallStepContext.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallStepContext.ts
@@ -61,6 +61,7 @@ export class WaterfallStepContext<O extends object = {}> extends DialogContext {
     constructor(dc: DialogContext, info: WaterfallStepInfo<O>) {
         super(dc.dialogs, dc.context, { dialogStack: dc.stack });
         this._info = info;
+        this.parent = dc.parent;
     }
 
     /**

--- a/libraries/botbuilder-dialogs/tests/componentDialog.test.js
+++ b/libraries/botbuilder-dialogs/tests/componentDialog.test.js
@@ -294,6 +294,59 @@ describe('ComponentDialog', function () {
             .assertReply('Cancelling all component dialog dialogs.')
             .assertReply('Cancelled successfully.');
     });
+
+    it('should call a dialog defined in a parent component.', (done) => {
+        const conversationState = new ConversationState(new MemoryStorage());
+        const dialogState = conversationState.createProperty('dialog');
+
+        const childComponent = new ComponentDialog('childComponent');
+        childComponent.addDialog(new WaterfallDialog('childDialog', [
+            async step => {
+                await step.context.sendActivity('Child started.');
+                return await step.beginDialog('parentDialog', { value: 'test' });
+            },
+            async step => {
+                assert(step.result === 'test');
+                await step.context.sendActivity('Child finished.');
+                return await step.endDialog();
+            }
+        ]));
+
+        const parentComponent = new ComponentDialog('parentComponent');
+        parentComponent.addDialog(childComponent);
+        parentComponent.addDialog(new WaterfallDialog('parentDialog', [
+            async step => {
+                assert(step.options.value);
+                await step.context.sendActivity(`Parent called with: ${step.options.value}`);
+                return await step.endDialog(step.options.value);
+            }
+        ]));
+
+
+        const dialogs = new DialogSet(dialogState);
+        dialogs.add(parentComponent);
+
+        const adapter = new TestAdapter(async turnContext => {
+            const dc = await dialogs.createContext(turnContext);
+            const results = await dc.continueDialog();
+
+            if (results.status === DialogTurnStatus.empty) {
+                await dc.beginDialog('parentComponent');
+            } else {
+                assert(results.status === DialogTurnStatus.complete, `results.status should be 'complete' not ${ results.status }`);
+                assert(results.result === undefined, `results.result should be undefined, not ${ results.result }`);
+                await turnContext.sendActivity('Done.');
+                done();
+            }
+            await conversationState.saveChanges(turnContext);
+        });
+
+        adapter.send('Hi')
+            .assertReply('Child started.')
+            .assertReply('Parent called with: test')
+            .assertReply('Child finished.')
+            .then(() => done());
+    });
 });
 
 class ContinueDialog extends ComponentDialog {


### PR DESCRIPTION
Implements [this DCR](https://github.com/Microsoft/BotBuilder/issues/5242)

## Description
Currently, dialogs can only start sibling dialogs that are defined within the same DialogSet. This PR adds the ability for a dialogs to also start dialogs that are defined in a parents dialog set.

## Specific Changes
- Added a public `DialogContext.parent` property which can be used to assign a parent DC. 
- Added a public `DialogContext.findDialog()` method which will first search the local DialogSet for a dialog and then search its parents DC if not found.
- Updated all dialog lookups in the DialogContext class to use new findDialog() method.
- Updated `ComponentDialog` to wire up a parent DC chain it works through the dialog stack.
- Updated `WaterfallStepContext` class to properly clone parent DC.

## Testing
Added new Unit Tests to verify that a dialog in a component can call a dialog in its parent component.
