### PR TITLE
Make ActivityPrompt a normal class - remove abstract

### DIFF
--- a/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/activityPrompt.ts
@@ -18,7 +18,7 @@ import { PromptOptions, PromptRecognizerResult, PromptValidator } from './prompt
  * activities like an event to be received. The validator can ignore received events until the
  * expected activity is received.
  */
-export abstract class ActivityPrompt extends Dialog {
+export class ActivityPrompt extends Dialog {
 
     /**
      * Creates a new ActivityPrompt instance.


### PR DESCRIPTION
Fixes #703

## Description

Allow developers to use ActivityPrompt directly, rather than forcing them to derive a new class.

## Specific Changes

Remove the abstract keyword