### PR TITLE
Ability to test OAuthPrompt and mock OAuth APIs

### DIFF
--- a/libraries/botbuilder-core/src/index.ts
+++ b/libraries/botbuilder-core/src/index.ts
@@ -29,3 +29,4 @@ export * from './testAdapter';
 export * from './transcriptLogger';
 export * from './turnContext';
 export * from './userState';
+export * from './userTokenProvider';

--- a/libraries/botbuilder-core/src/userTokenProvider.ts
+++ b/libraries/botbuilder-core/src/userTokenProvider.ts
@@ -1,0 +1,47 @@
+/**
+ * @module botbuilder
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { TurnContext } from './turnContext';
+import { TokenResponse } from 'botframework-schema';
+
+/**
+ * Interface for User Token OAuth APIs for BotAdapters
+ */
+export interface IUserTokenProvider {
+    /**
+     * Retrieves the OAuth token for a user that is in a sign-in flow.
+     * @param context Context for the current turn of conversation with the user.
+     * @param connectionName Name of the auth connection to use.
+     * @param magicCode (Optional) Optional user entered code to validate.
+     */
+    getUserToken(context: TurnContext, connectionName: string, magicCode?: string): Promise<TokenResponse>;
+
+    /**
+     * Signs the user out with the token server.
+     * @param context Context for the current turn of conversation with the user.
+     * @param connectionName Name of the auth connection to use.
+     */
+    signOutUser(context: TurnContext, connectionName: string): Promise<void>;
+
+    /**
+     * Gets a signin link from the token server that can be sent as part of a SigninCard.
+     * @param context Context for the current turn of conversation with the user.
+     * @param connectionName Name of the auth connection to use.
+     */
+    getSignInLink(context: TurnContext, connectionName: string): Promise<string>;
+
+    /**
+     * Signs the user out with the token server.
+     * @param context Context for the current turn of conversation with the user.
+     * @param connectionName Name of the auth connection to use.
+     */
+    getAadTokens(context: TurnContext, connectionName: string, resourceUrls: string[]): Promise<{
+        [propertyName: string]: TokenResponse;
+    }>;
+}
+

--- a/libraries/botbuilder-core/tests/testAdapter.test.js
+++ b/libraries/botbuilder-core/tests/testAdapter.test.js
@@ -348,4 +348,114 @@ describe(`TestAdapter`, function () {
         }
         throw new Error(`TestAdapter.testActivities() should not have succeeded without activities argument.`);
     });
+
+    it(`getUserToken returns null`, function (done) {
+        const adapter = new TestAdapter((context) => {
+            context.adapter.getUserToken(context, 'myConnection').then(token => {
+                assert(!token);
+                done();
+            });
+        });
+        adapter.send('hi');
+    });
+
+    it(`getUserToken returns null with code`, function (done) {
+        const adapter = new TestAdapter((context) => {
+            context.adapter.getUserToken(context, 'myConnection', '123456').then(token => {
+                assert(!token);
+                done();
+            });
+        });
+        adapter.send('hi');
+    });
+
+    it(`getUserToken returns token`, function (done) {
+        const adapter = new TestAdapter((context) => {
+            context.adapter.getUserToken(context, 'myConnection').then(token => {
+                assert(token);
+                assert(token.token);
+                assert(token.connectionName);
+                done();
+            });
+        });
+        adapter.addUserToken('myConnection', 'test', 'user', '123abc');
+        adapter.send('hi');
+    });
+
+    it(`getUserToken returns token with code`, function (done) {
+        const adapter = new TestAdapter((context) => {
+            context.adapter.getUserToken(context, 'myConnection').then(token => {
+                assert(!token);
+                context.adapter.getUserToken(context, 'myConnection', '888777').then(token2 => {
+                    assert(token2);
+                    assert(token2.token);
+                    assert(token2.connectionName);
+                    context.adapter.getUserToken(context, 'myConnection').then(token3 => {
+                        assert(token3);
+                        assert(token3.token);
+                        assert(token3.connectionName);
+                        done();
+                    });
+                });
+            });
+        });
+        adapter.addUserToken('myConnection', 'test', 'user', '123abc', '888777');
+        adapter.send('hi');
+    });
+
+    it(`getSignInLink returns token with code`, function (done) {
+        const adapter = new TestAdapter((context) => {
+            context.adapter.getSignInLink(context, 'myConnection').then(link => {
+                assert(link);
+                done();
+            });
+        });
+        adapter.send('hi');
+    });
+
+    it(`signOutUser is noop`, function (done) {
+        const adapter = new TestAdapter((context) => {
+            context.adapter.signOutUser(context, 'myConnection').then(x => {
+                done();
+            });
+        });
+        adapter.send('hi');
+    });
+
+    it(`signOutUser logs out user`, function (done) {
+        const adapter = new TestAdapter((context) => {
+            context.adapter.getUserToken(context, 'myConnection').then(token => {
+                assert(token);
+                assert(token.token);
+                assert(token.connectionName);
+                context.adapter.signOutUser(context, 'myConnection').then(x => {
+                    context.adapter.getUserToken(context, 'myConnection').then(token2 => {
+                        assert(!token2);
+                        done();
+                    });
+                });
+            });
+        });
+        adapter.addUserToken('myConnection', 'test', 'user', '123abc');
+        adapter.send('hi');
+    });
+
+    it(`signOutUser with no connectionName signs all out`, function (done) {
+        const adapter = new TestAdapter((context) => {
+            context.adapter.getUserToken(context, 'myConnection').then(token => {
+                assert(token);
+                assert(token.token);
+                assert(token.connectionName);
+                context.adapter.signOutUser(context, undefined).then(x => {
+                    context.adapter.getUserToken(context, 'myConnection').then(token2 => {
+                        assert(!token2);
+                        done();
+                    });
+                });
+            });
+        });
+        adapter.addUserToken('myConnection', 'test', 'user', '123abc');
+        adapter.addUserToken('myConnection2', 'test', 'user', 'def456');
+        adapter.send('hi');
+    });
 });

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 import { Token } from '@microsoft/recognizers-text-date-time';
-import {  Activity, ActivityTypes, Attachment, CardFactory, InputHints, MessageFactory, TokenResponse, TurnContext } from 'botbuilder-core';
+import { Activity, ActivityTypes, Attachment, CardFactory, InputHints, MessageFactory, TokenResponse, TurnContext, IUserTokenProvider } from 'botbuilder-core';
 import { Dialog, DialogTurnResult } from '../dialog';
 import { DialogContext } from '../dialogContext';
 import { PromptOptions, PromptRecognizerResult,  PromptValidator } from './prompt';
@@ -196,7 +196,7 @@ export class OAuthPrompt extends Dialog {
         }
 
         // Get the token and call validator
-        const adapter: any = context.adapter as any; // cast to BotFrameworkAdapter
+        const adapter: IUserTokenProvider = context.adapter as IUserTokenProvider;
 
         return await adapter.getUserToken(context, this.settings.connectionName, code);
     }
@@ -223,7 +223,7 @@ export class OAuthPrompt extends Dialog {
         }
 
         // Sign out user
-        const adapter: any = context.adapter as any; // cast to BotFrameworkAdapter
+        const adapter: IUserTokenProvider = context.adapter as IUserTokenProvider;
 
         return adapter.signOutUser(context, this.settings.connectionName);
     }

--- a/libraries/botbuilder-dialogs/tests/oauthPrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/oauthPrompt.test.js
@@ -1,0 +1,128 @@
+const { ActivityTypes, ConversationState, MemoryStorage, TestAdapter, CardFactory } = require('botbuilder-core');
+const { OAuthPrompt, OAuthPromptSettings, DialogSet, DialogTurnStatus, ListStyle } = require('../');
+const assert = require('assert');
+
+const beginMessage = { text: `begin`, type: 'message' };
+const answerMessage = { text: `yes`, type: 'message' };
+const invalidMessage = { text: `what?`, type: 'message' };
+
+describe('OAuthPrompt', function () {
+    this.timeout(5000);
+
+    it('should call OAuthPrompt', async function () {
+        var connectionName = "myConnection";
+        var token = "abc123";
+
+        // Initialize TestAdapter.
+        const adapter = new TestAdapter(async (turnContext) => {
+            const dc = await dialogs.createContext(turnContext);
+
+            const results = await dc.continueDialog();
+            if (results.status === DialogTurnStatus.empty) {
+                await dc.prompt('prompt', { });
+            } else if (results.status === DialogTurnStatus.complete) {
+                if (results.result.token) {
+                    await turnContext.sendActivity(`Logged in.`);
+                }
+                else {
+                    await turnContext.sendActivity(`Failed`);
+                }
+            }
+            await convoState.saveChanges(turnContext);
+        });
+
+        // Create new ConversationState with MemoryStorage and register the state as middleware.
+        const convoState = new ConversationState(new MemoryStorage());
+
+        // Create a DialogState property, DialogSet and AttachmentPrompt.
+        const dialogState = convoState.createProperty('dialogState');
+        const dialogs = new DialogSet(dialogState);
+        dialogs.add(new OAuthPrompt('prompt', {
+                connectionName,
+                title: 'Login',
+                timeout: 300000
+            }));
+
+        await adapter.send('Hello')
+            .assertReply(activity  => {
+                assert(activity.attachments.length === 1);
+                assert(activity.attachments[0].contentType === CardFactory.contentTypes.oauthCard);
+
+                // send a mock EventActivity back to the bot with the token
+                adapter.addUserToken(connectionName, activity.channelId, activity.recipient.id, token);
+
+                var eventActivity = createReply(activity);
+                eventActivity.type = ActivityTypes.Event;
+                var from = eventActivity.from;
+                eventActivity.from = eventActivity.recipient;
+                eventActivity.recipient = from;
+                eventActivity.name = "tokens/response";
+                eventActivity.value = {
+                    connectionName,
+                    token
+                };
+
+                adapter.send(eventActivity);
+            })
+            .assertReply('Logged in.');
+    });
+
+    it('should call OAuthPrompt with code', async function () {
+        var connectionName = "myConnection";
+        var token = "abc123";
+        var magicCode = "888999";
+
+        // Initialize TestAdapter.
+        const adapter = new TestAdapter(async (turnContext) => {
+            const dc = await dialogs.createContext(turnContext);
+
+            const results = await dc.continueDialog();
+            if (results.status === DialogTurnStatus.empty) {
+                await dc.prompt('prompt', { });
+            } else if (results.status === DialogTurnStatus.complete) {
+                if (results.result.token) {
+                    await turnContext.sendActivity(`Logged in.`);
+                }
+                else {
+                    await turnContext.sendActivity(`Failed`);
+                }
+            }
+            await convoState.saveChanges(turnContext);
+        });
+
+        // Create new ConversationState with MemoryStorage and register the state as middleware.
+        const convoState = new ConversationState(new MemoryStorage());
+
+        // Create a DialogState property, DialogSet and AttachmentPrompt.
+        const dialogState = convoState.createProperty('dialogState');
+        const dialogs = new DialogSet(dialogState);
+        dialogs.add(new OAuthPrompt('prompt', {
+                connectionName,
+                title: 'Login',
+                timeout: 300000
+            }));
+
+        await adapter.send('Hello')
+            .assertReply(activity  => {
+                assert(activity.attachments.length === 1);
+                assert(activity.attachments[0].contentType === CardFactory.contentTypes.oauthCard);
+
+                // send a mock EventActivity back to the bot with the token
+                adapter.addUserToken(connectionName, activity.channelId, activity.recipient.id, token, magicCode);
+            })
+            .send(magicCode)
+            .assertReply('Logged in.');
+    });
+});
+
+function createReply(activity) {
+    return {
+        type: ActivityTypes.Message,
+        from: { id: activity.recipient.id, name: activity.recipient.name },
+        recipient: { id: activity.from.id, name: activity.from.name },
+        replyToId: activity.id,
+        serviceUrl: activity.serviceUrl,
+        channelId: activity.channelId,
+        conversation: { isGroup: activity.conversation.isGroup, id: activity.conversation.id, name: activity.conversation.name },
+    };
+}

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -6,10 +6,9 @@
  * Licensed under the MIT License.
  */
 
-import { Activity, ActivityTypes, BotAdapter, ChannelAccount, ConversationAccount, ConversationParameters, ConversationReference, ConversationsResult, ResourceResponse, TurnContext } from 'botbuilder-core';
+import { Activity, ActivityTypes, BotAdapter, ChannelAccount, ConversationAccount, ConversationParameters, ConversationReference, ConversationsResult, IUserTokenProvider, ResourceResponse, TokenResponse, TurnContext } from 'botbuilder-core';
 import { ChannelValidation, ConnectorClient, EmulatorApiClient, GovernmentConstants, JwtTokenValidation, MicrosoftAppCredentials, SimpleCredentialProvider, TokenApiClient, TokenApiModels } from 'botframework-connector';
 import * as os from 'os';
-
 
 /**
  * Express or Restify Request object.
@@ -105,7 +104,7 @@ const INVOKE_RESPONSE_KEY: symbol = Symbol('invokeResponse');
  * });
  * ```
  */
-export class BotFrameworkAdapter extends BotAdapter {
+export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvider {
     protected readonly credentials: MicrosoftAppCredentials;
     protected readonly credentialsProvider: SimpleCredentialProvider;
     protected readonly settings: BotFrameworkAdapterSettings;
@@ -359,7 +358,7 @@ export class BotFrameworkAdapter extends BotAdapter {
      * @param connectionName Name of the auth connection to use.
      * @param magicCode (Optional) Optional user entered code to validate.
      */
-    public async getUserToken(context: TurnContext, connectionName: string, magicCode?: string): Promise<TokenApiModels.TokenResponse> {
+    public async getUserToken(context: TurnContext, connectionName: string, magicCode?: string): Promise<TokenResponse> {
         if (!context.activity.from || !context.activity.from.id) {
             throw new Error(`BotFrameworkAdapter.getUserToken(): missing from or from.id`);
         }
@@ -372,7 +371,7 @@ export class BotFrameworkAdapter extends BotAdapter {
         if (!result || !result.token || result._response.status == 404) {
             return undefined;
         } else {
-            return result;
+            return <TokenResponse>result;
         }
     }
 
@@ -418,7 +417,7 @@ export class BotFrameworkAdapter extends BotAdapter {
      * @param connectionName Name of the auth connection to use.
      */
     public async getAadTokens(context: TurnContext, connectionName: string, resourceUrls: string[]): Promise<{
-        [propertyName: string]: TokenApiModels.TokenResponse;
+        [propertyName: string]: TokenResponse;
     }> {
         if (!context.activity.from || !context.activity.from.id) {
             throw new Error(`BotFrameworkAdapter.getAadTokens(): missing from or from.id`);
@@ -428,7 +427,7 @@ export class BotFrameworkAdapter extends BotAdapter {
         const url: string = this.oauthApiUrl(context);
         const client: TokenApiClient = this.createTokenApiClient(url);
 
-        return (await client.userToken.getAadTokens(userId, connectionName, { resourceUrls: resourceUrls }))._response.parsedBody;
+        return <{[propertyName: string]: TokenResponse; }>(await client.userToken.getAadTokens(userId, connectionName, { resourceUrls: resourceUrls }))._response.parsedBody;
     }
 
     /**


### PR DESCRIPTION
## Description
Ability to mock the OAuth APIs on a BotAdapter
Implementation of mock in TestAdapter
Ensure OAuthPrompt uses the new interface
Sample unit tests for how to test OAuth APIs and the OAuthPrompt

## Testing
Yes, tests on TestAdapter and OAuthPrompt