### PR TITLE
Fixes 762: libraries\swagger\generateClient.sh out of sync with generateClient.cmd

### DIFF
--- a/libraries/swagger/generateClient.sh
+++ b/libraries/swagger/generateClient.sh
@@ -1,14 +1,49 @@
-rm -rf generated
+#!/bin/bash
 
+# clean up any left over folders
+echo "Cleaning up temp folders"
+rm -rf ./connectorAPI
+rm -rf ./tokenApi
+
+# install replace-in-file, used by `node model_fixes.js`
+echo "Installing local node modules"
 npm i replace-in-file
-autorest README.md --typescript
+
+# generate connector API client
+echo "Generating Connector API client"
+autorest ConnectorAPI.md --typescript
 
 node model_fixes.js
 
-#  Move models to botbuilder-schema
-rm ../botbuilder-schema/src/index.ts
-mv generated/models/index.ts ../botbuilder-schema/src/index.ts
+# move models to botbuilder-schema
+echo "Moving models to botbuilder-schema folder"
+rm -rf ../botframework-schema/src/index.ts
+mv ./connectorAPI/lib/models/index.ts ../botframework-schema/src/index.ts
 
-#  Move client to botframework-connector
-rm -rf ../botframework-connector/src/generated
-mv generated ../botframework-connector/src/
+# move client to botframework-connector
+echo "Moving client to botframework-connector folder"
+rm -rf ../botframework-connector/src/connectorApi
+mv ./connectorApi/lib ../botframework-connector/src/connectorApi
+
+# generate tokenAPI client
+echo "Generating Token API client"
+autorest TokenAPI.md --typescript
+
+# move tokenAPI to botframework-connector
+echo "Moving tokenAPI to botframework-connector folder"
+rm -rf ../botframework-connector/src/tokenApi
+mv ./tokenApi/lib ../botframework-connector/src/tokenApi
+
+# removing generated folders ("connectorApi/", "tokenApi/")
+echo "Removing temp folders ('./connectApi', './tokenApi')"
+rm -rf ./connectorApi
+rm -rf ./tokenApi
+
+# removing local node_modules folder
+echo "Removing local node_modules"
+rm -rf ./node_modules
+
+echo "Done generating autorest clients"
+
+
+


### PR DESCRIPTION
Fixes #762 

## Description
macOS shell script to generate swagger generated clients was out of date with the windows version

## Specific Changes
update macOS `generateClient.sh` to be aligned to the windows version of `generateClient.cmd`