### PR TITLE
Fixes 764: Outdated transcript-test package is causing GitHub warnings

### DIFF
--- a/transcripts/package-lock.json
+++ b/transcripts/package-lock.json
@@ -4,77 +4,208 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.2.tgz",
+			"integrity": "sha512-f3QCuPppXxtZOEm5GWPra/uYUjmNQlu9pbAD8D/9jze4pTY83rTtB1igTBSwvkeNlC5gR24zFFkz+2WHLFQhqQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.3.2",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.10",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/template": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.2.tgz",
+			"integrity": "sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==",
+			"dev": true
+		},
+		"@babel/template": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+			"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.2.2",
+				"@babel/types": "^7.2.2"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+			"integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/generator": "^7.2.2",
+				"@babel/helper-function-name": "^7.1.0",
+				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/parser": "^7.2.3",
+				"@babel/types": "^7.2.2",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.10"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.2.tgz",
+			"integrity": "sha512-3Y6H8xlUlpbGR+XvawiH0UXehqydTmNmEpozWcXymqwcrwYAl5KMvKtQ+TF6f6E08V6Jur7v/ykdDSF+WDEIXQ==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.10",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
 		"@microsoft/recognizers-text": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text/-/recognizers-text-1.0.1.tgz",
-			"integrity": "sha512-BZbI6YiLrWRd/jAYgSpLQ+Otl3WYMctefh7Myw6jqMdHhADaj5WpwOdf+yfJHZHOJWQh7lK2v50R6Y0g3TJ18w=="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text/-/recognizers-text-1.1.4.tgz",
+			"integrity": "sha512-hlSVXcaX5i8JcjuUJpVxmy2Z/GxvFXarF0KVySCFop57wNEnrLWMHe4I4DjP866G19VyIKRw+vPA32pkGhZgTg=="
 		},
 		"@microsoft/recognizers-text-choice": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-choice/-/recognizers-text-choice-1.0.1.tgz",
-			"integrity": "sha512-2Vy2b4YVysm+3DnZObTfco2KSbGzgPKKI4TxrcY0tEsLJDfLxj9Nyxm2CJ6kd2X1MFlc53UB5ZWRhO32V2FAmw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-choice/-/recognizers-text-choice-1.1.2.tgz",
+			"integrity": "sha512-4hFdqxusM0YrOXYM2RVYPl2rLjItSh6VkRiACjWB95GKC/DBGjJRYQpTxhzuZAsJSkDMinu/aLf8DvQtwUaLtA==",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.0.1",
+				"@microsoft/recognizers-text": "~1.1.2",
 				"grapheme-splitter": "^1.0.2"
 			}
 		},
 		"@microsoft/recognizers-text-date-time": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-date-time/-/recognizers-text-date-time-1.0.1.tgz",
-			"integrity": "sha512-Tb8j+nDYSMe65pQhXh7hlm8uibfqliwbsUx6MY3g6ZlZnTzhq9cnzHYY1LILkJqlY5QtaGlUXr4BvW+a4SD8ew==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-date-time/-/recognizers-text-date-time-1.1.2.tgz",
+			"integrity": "sha512-tsdsl2Z3OMFhfWicFQSS4sbk/c0pVTIXhCglDXm/cfSNuQgNgy2NFFRquiQ6MkVwiIk2I7k76TnkoDZt7PD4Dg==",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.0.1",
-				"@microsoft/recognizers-text-number": "~1.0.1",
-				"@microsoft/recognizers-text-number-with-unit": "~1.0.1",
+				"@microsoft/recognizers-text": "~1.1.2",
+				"@microsoft/recognizers-text-number": "~1.1.2",
+				"@microsoft/recognizers-text-number-with-unit": "~1.1.2",
 				"lodash.isequal": "^4.5.0",
 				"lodash.tonumber": "^4.0.3"
 			}
 		},
 		"@microsoft/recognizers-text-number": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number/-/recognizers-text-number-1.0.1.tgz",
-			"integrity": "sha512-eMhzRfWmzGaGdeBi+1vTtJ6AtTqhHNetJ+Rdt6isiv+R3+i18bzR2YzIOzIdHRhnApf0mbJG3wMEbWdWQBhvyg==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number/-/recognizers-text-number-1.1.4.tgz",
+			"integrity": "sha512-6EmlR+HR+eJBIX7sQby1vs6LJB64wxLowHaGpIU9OCXFvZ5Nb0QT8qh10rC40v3Mtrz4DpScXfSXr9tWkIO5MQ==",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.0.1",
-				"bignumber.js": "^4.1.0",
+				"@microsoft/recognizers-text": "~1.1.4",
+				"bignumber.js": "^7.2.1",
 				"lodash.escaperegexp": "^4.1.2",
 				"lodash.sortby": "^4.7.0",
-				"lodash.trimend": "^4.5.1",
-				"xregexp": "^3.2.0"
+				"lodash.trimend": "^4.5.1"
 			}
 		},
 		"@microsoft/recognizers-text-number-with-unit": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number-with-unit/-/recognizers-text-number-with-unit-1.0.1.tgz",
-			"integrity": "sha512-g4Tum3sxkbeI52eYQX+h8t97Ww1TJi6M+bIpjB4/go7trmq/w005oFxnARmrJQNMQUukEHeQ0GGqR/uMe75SzA==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number-with-unit/-/recognizers-text-number-with-unit-1.1.4.tgz",
+			"integrity": "sha512-zl+CfmfWK0x/x+iSgaBAevKTYO0F4+z7SYHAHztaaaGuX8FERw2jmUjSgVetm5KA3EveyCx0XYGU1mRNY8p7Eg==",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.0.1",
-				"@microsoft/recognizers-text-number": "~1.0.1",
+				"@microsoft/recognizers-text": "~1.1.4",
+				"@microsoft/recognizers-text-number": "~1.1.4",
 				"lodash.escaperegexp": "^4.1.2",
 				"lodash.last": "^3.0.0",
 				"lodash.max": "^4.0.1"
 			}
 		},
 		"@microsoft/recognizers-text-sequence": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-sequence/-/recognizers-text-sequence-1.0.1.tgz",
-			"integrity": "sha512-Dim6fpiW6xupx8aI4GLAqEunDkjxNZ5Ax9IjVVWhD9Qo9gG8EUQkt5l49zT2E5c5ZQAfU62XI7+KWll8Ymtf/g==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-sequence/-/recognizers-text-sequence-1.1.4.tgz",
+			"integrity": "sha512-rb5j8/aE7HSOdIxaVfCGFrj0wWPpSq0CuykFg/A/iJNPP+FnAU71bgP5HexrwQcpCsDinauisX7u0DKIChrHRA==",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.0.1",
+				"@microsoft/recognizers-text": "~1.1.4",
 				"grapheme-splitter": "^1.0.2"
 			}
 		},
 		"@microsoft/recognizers-text-suite": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-suite/-/recognizers-text-suite-1.0.1.tgz",
-			"integrity": "sha512-7v1K1UjrLHSSKIcha8Dj0XyymkfyJ3BjXcWkC5YxN68XXzwM7gsJoHMBRkA8wPL0DRkRnu9dTTtMGTsBFvpWYw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-suite/-/recognizers-text-suite-1.1.2.tgz",
+			"integrity": "sha512-w3WCsKa//64jE1fGPFlV02rRg9+b3oDp+K5/skPAn4KDr80LjXxD1ulIgiJ2Ll/2OoBl8ociCiCjYA7zS3LpdQ==",
 			"requires": {
-				"@microsoft/recognizers-text": "~1.0.1",
-				"@microsoft/recognizers-text-choice": "~1.0.1",
-				"@microsoft/recognizers-text-date-time": "~1.0.1",
-				"@microsoft/recognizers-text-number": "~1.0.1",
-				"@microsoft/recognizers-text-number-with-unit": "~1.0.1",
-				"@microsoft/recognizers-text-sequence": "~1.0.1"
+				"@microsoft/recognizers-text": "~1.1.2",
+				"@microsoft/recognizers-text-choice": "~1.1.2",
+				"@microsoft/recognizers-text-date-time": "~1.1.2",
+				"@microsoft/recognizers-text-number": "~1.1.2",
+				"@microsoft/recognizers-text-number-with-unit": "~1.1.2",
+				"@microsoft/recognizers-text-sequence": "~1.1.2"
+			}
+		},
+		"@types/bunyan": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.5.tgz",
+			"integrity": "sha512-7n8ANtxh2c5A/NfCuv8cVtWcgSLdq76MQbtmbInpzXuPw4TSAReUJ+MGHK4m67I4zI3ynCJoABfaeHYJaYSeRg==",
+			"requires": {
+				"@types/node": "*"
 			}
 		},
 		"@types/caseless": {
@@ -93,13 +224,6 @@
 			"integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
 			"requires": {
 				"@types/node": "*"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "10.12.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
-					"integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
-				}
 			}
 		},
 		"@types/html-entities": {
@@ -107,67 +231,28 @@
 			"resolved": "https://registry.npmjs.org/@types/html-entities/-/html-entities-1.2.16.tgz",
 			"integrity": "sha512-CI6fHfFvkTtX2Nlr4JBA6yIFTfA4p9E6w9ky64X6PrfXiTALhUh/SOa+Sxvv2p87m+y5AH71lAUrx0lSYx4hKQ=="
 		},
-		"@types/is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
-			"requires": {
-				"@types/node": "*"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "10.12.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
-					"integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
-				}
-			}
-		},
 		"@types/jsonwebtoken": {
-			"version": "7.2.5",
-			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.5.tgz",
-			"integrity": "sha512-8CIcK1Vzq4w5TJyJYkLVhqASmCo1FSO1XIPQM1qv+Xo2nnb9RoRHxx8pkIzSZ4Tm9r3V4ZyFbF/fBewNPdclwA==",
+			"version": "7.2.8",
+			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz",
+			"integrity": "sha512-XENN3YzEB8D6TiUww0O8SRznzy1v+77lH7UmuN54xq/IHIsyWjWOzZuFFTtoiRuaE782uAoRwBe/wwow+vQXZw==",
 			"requires": {
 				"@types/node": "*"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "10.12.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
-					"integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
-				}
 			}
 		},
-		"@types/node-fetch": {
-			"version": "1.6.9",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-1.6.9.tgz",
-			"integrity": "sha512-n2r6WLoY7+uuPT7pnEtKJCmPUGyJ+cbyBR8Avnu4+m1nzz7DwBVuyIvvlBzCZ/nrpC7rIgb3D6pNavL7rFEa9g==",
-			"requires": {
-				"@types/node": "*"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "10.12.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
-					"integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
-				}
-			}
+		"@types/node": {
+			"version": "10.12.24",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.24.tgz",
+			"integrity": "sha512-GWWbvt+z9G5otRBW8rssOFgRY87J9N/qbhqfjMZ+gUuL6zoL+Hm6gP/8qQBG4jjimqdaNLCehcVapZ/Fs2WjCQ=="
 		},
 		"@types/request": {
-			"version": "2.47.1",
-			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
-			"integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
+			"version": "2.48.1",
+			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
+			"integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
 			"requires": {
 				"@types/caseless": "*",
 				"@types/form-data": "*",
 				"@types/node": "*",
 				"@types/tough-cookie": "*"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "10.12.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
-					"integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
-				}
 			}
 		},
 		"@types/request-promise-native": {
@@ -178,58 +263,47 @@
 				"@types/request": "*"
 			}
 		},
-		"@types/tough-cookie": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
-			"integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ=="
+		"@types/restify": {
+			"version": "7.2.7",
+			"resolved": "https://registry.npmjs.org/@types/restify/-/restify-7.2.7.tgz",
+			"integrity": "sha512-6uANL/O61lJnn+WIF/XO7GBkmBxlm7+VRGfPwHbs/dxdL6n39mGQUF5cMUM0hVWx90nD4fLphENv3A0whLiPDg==",
+			"requires": {
+				"@types/bunyan": "*",
+				"@types/node": "*",
+				"@types/spdy": "*"
+			}
 		},
-		"@types/uuid": {
+		"@types/spdy": {
 			"version": "3.4.4",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
-			"integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
+			"resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.4.tgz",
+			"integrity": "sha512-N9LBlbVRRYq6HgYpPkqQc3a9HJ/iEtVZToW6xlTtJiMhmRJ7jJdV7TaZQJw/Ve/1ePUsQiCTDc4JMuzzag94GA==",
 			"requires": {
 				"@types/node": "*"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "10.12.0",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
-					"integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
-				}
 			}
 		},
-		"adal-node": {
-			"version": "0.1.28",
-			"resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.1.28.tgz",
-			"integrity": "sha1-RoxLs+u9lrEnBmn0ucuk4AZepIU=",
-			"requires": {
-				"@types/node": "^8.0.47",
-				"async": ">=0.6.0",
-				"date-utils": "*",
-				"jws": "3.x.x",
-				"request": ">= 2.52.0",
-				"underscore": ">= 1.3.1",
-				"uuid": "^3.1.0",
-				"xmldom": ">= 0.1.x",
-				"xpath.js": "~1.1.0"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "8.10.36",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.36.tgz",
-					"integrity": "sha512-SL6KhfM7PTqiFmbCW3eVNwVBZ+88Mrzbuvn9olPsfv43mbiWaFY+nRcz/TGGku0/lc2FepdMbImdMY1JrQ+zbw=="
-				}
-			}
+		"@types/tough-cookie": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
+			"integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
 		},
 		"ajv": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+			"version": "6.8.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.8.1.tgz",
+			"integrity": "sha512-eqxCp82P+JfqL683wwsL73XmFs1eG6qjw+RD3YHx+Jll1r0jNd4dh8QG9NYAeNGA/hnZjeEDgtTskgJULbxpWQ==",
 			"requires": {
-				"co": "^4.6.0",
-				"fast-deep-equal": "^1.0.0",
+				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
 			}
 		},
 		"asn1": {
@@ -258,14 +332,6 @@
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
 			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
 		},
-		"async": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-			"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-			"requires": {
-				"lodash": "^4.14.0"
-			}
-		},
 		"async-file": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/async-file/-/async-file-2.0.2.tgz",
@@ -289,12 +355,21 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 		},
-		"azure-cognitiveservices-luis-runtime": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/azure-cognitiveservices-luis-runtime/-/azure-cognitiveservices-luis-runtime-1.0.0.tgz",
-			"integrity": "sha512-UYqHe4efmO0QhBuJ+T3PM/Vtt+zy+wWNZBDYyKzfqnQ6eSPXEPC0eDrw0exT7bzETyg/TqTeksT5bEsRy5Rg1w==",
+		"axios": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+			"integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
 			"requires": {
-				"ms-rest": "^2.3.3"
+				"follow-redirects": "^1.3.0",
+				"is-buffer": "^1.1.5"
+			}
+		},
+		"azure-cognitiveservices-luis-runtime": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/azure-cognitiveservices-luis-runtime/-/azure-cognitiveservices-luis-runtime-1.2.0.tgz",
+			"integrity": "sha512-8A71ZfDs5uB+t7SX7GdESuAxgAOR+jKmhnRprx09Pk5gfdJd1HSC2moLxUhqJsS1WQ6I+g7ShG7kLXWmQIXQyg==",
+			"requires": {
+				"ms-rest": "^2.5.0"
 			}
 		},
 		"balanced-match": {
@@ -303,9 +378,9 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base64url": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-			"integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+			"integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -316,131 +391,141 @@
 			}
 		},
 		"bignumber.js": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-			"integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
-		},
-		"boom": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-			"requires": {
-				"hoek": "4.x.x"
-			}
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+			"integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
 		},
 		"botbuilder": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.0.8.tgz",
-			"integrity": "sha512-xwDRHxstFVEh2k32L1bgxd9FB35gxwXE/h/0htYE6IE6JmTuyPejCBtUrBat0wziqeqTBzyRYmjQJgWidbVIPQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.2.1.tgz",
+			"integrity": "sha512-58664aLhN1WQwAxMBK7LZQhFh8DHwenvpgz6ADFgeZLZS28NACfX+Uta8k2+WF6RK3g+VKoGOhV/yI71c5ccVg==",
 			"requires": {
 				"@types/filenamify": "^2.0.1",
 				"@types/node": "^9.3.0",
 				"async-file": "^2.0.2",
-				"botbuilder-core": "^4.0.8",
-				"botframework-connector": "^4.0.8",
+				"botbuilder-core": "^4.2.1",
+				"botframework-connector": "^4.2.1",
 				"filenamify": "^2.0.0",
 				"rimraf": "^2.6.2"
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "9.6.35",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.35.tgz",
-					"integrity": "sha512-h5zvHS8wXHGa+Gcqs9K8vqCgOtqjr0+NqG/DDJmQIX1wpR9HivAfgV8bjcD3mGM4bPfQw5Aneb2Pn8355L83jA=="
+					"version": "9.6.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.42.tgz",
+					"integrity": "sha512-SpeVQJFekfnEaZZO1yl4je/36upII36L7gOT4DBx51B1GeAB45mmDb3a5OBQB+ZeFxVVOP37r8Owsl940G/fBg=="
 				}
 			}
 		},
 		"botbuilder-ai": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/botbuilder-ai/-/botbuilder-ai-4.0.8.tgz",
-			"integrity": "sha512-cF0jlF9enqAs6vO22ihLPg5fm1cGBYiVI/U8GnTdJw9JlqpU46eJhjhTHfqsEOrty2uWeumLAelXRa75bmizkw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/botbuilder-ai/-/botbuilder-ai-4.2.1.tgz",
+			"integrity": "sha512-gej7KR0iFIK38M4eIkGFOn+Tk7sMpzGTJgMVy/ctz21m6vQDGfqFLjJzDk4GRG9oLaZfq5bqUw5sLtepLAZcUg==",
 			"requires": {
-				"@microsoft/recognizers-text-date-time": "1.0.1",
+				"@microsoft/recognizers-text-date-time": "1.1.2",
 				"@types/html-entities": "^1.2.16",
 				"@types/node": "^9.3.0",
 				"@types/request-promise-native": "^1.0.10",
 				"azure-cognitiveservices-luis-runtime": "^1.0.0",
-				"botbuilder": "^4.0.8",
+				"botbuilder": "^4.2.1",
 				"html-entities": "^1.2.1",
 				"moment": "^2.20.1",
 				"ms-rest": "^2.3.6",
 				"mstranslator": "^3.0.0",
-				"nock": "^9.6.1",
-				"request": "2.83.0",
+				"request": "^2.87.0",
 				"request-promise-native": "1.0.5"
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "9.6.35",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.35.tgz",
-					"integrity": "sha512-h5zvHS8wXHGa+Gcqs9K8vqCgOtqjr0+NqG/DDJmQIX1wpR9HivAfgV8bjcD3mGM4bPfQw5Aneb2Pn8355L83jA=="
+					"version": "9.6.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.42.tgz",
+					"integrity": "sha512-SpeVQJFekfnEaZZO1yl4je/36upII36L7gOT4DBx51B1GeAB45mmDb3a5OBQB+ZeFxVVOP37r8Owsl940G/fBg=="
 				}
 			}
 		},
 		"botbuilder-core": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.0.8.tgz",
-			"integrity": "sha512-fL2lYHav+PBiAhODsE9hZtIe4aiU0hZhfSRToWC7K+4vyvKwD78e9vfXISQ+ZHKLjslqCLY/jsVzHUzo+59Cag==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.2.1.tgz",
+			"integrity": "sha512-U8n+eY9Cjce0GkMyyE0mv4HBjCjtyuczz6usl9XF2N7nY61jYDah4W5e4zqYdLdlqnBwfxG8ptS9pdnmVsC2ww==",
 			"requires": {
 				"assert": "^1.4.1",
-				"botframework-schema": "^4.0.8"
+				"botframework-schema": "^4.2.1"
 			}
 		},
 		"botbuilder-dialogs": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/botbuilder-dialogs/-/botbuilder-dialogs-4.0.8.tgz",
-			"integrity": "sha512-KipRujmBPW4RHnzR02XLx4D/nKNLaCa0/Dx3nc8OQxH3h2ZNEGpdEaXqeylr7kBnUoq98oU4MXsVdtOtzHAVUA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/botbuilder-dialogs/-/botbuilder-dialogs-4.2.1.tgz",
+			"integrity": "sha512-QHD9WigzC7rOJT0hb9Xzs/yHs1g/MOabJey8qxlZPdnnQqK5X8KJaZEEDnRqcUmLj/ydbxnxqImLEsMD5zlGag==",
 			"requires": {
-				"@microsoft/recognizers-text-choice": "1.0.1",
-				"@microsoft/recognizers-text-date-time": "1.0.1",
-				"@microsoft/recognizers-text-number": "1.0.1",
-				"@microsoft/recognizers-text-suite": "1.0.1",
+				"@microsoft/recognizers-text-choice": "1.1.2",
+				"@microsoft/recognizers-text-date-time": "1.1.2",
+				"@microsoft/recognizers-text-number": "1.1.2",
+				"@microsoft/recognizers-text-suite": "1.1.2",
 				"@types/node": "^9.3.0",
-				"botbuilder-core": "^4.0.8"
+				"botbuilder-core": "^4.2.1"
 			},
 			"dependencies": {
+				"@microsoft/recognizers-text-number": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number/-/recognizers-text-number-1.1.2.tgz",
+					"integrity": "sha512-GESjSF42dllym83diyd6pmlzFwdzidewoq/qSQz89lSoTx9HdJQHjbXxwdBp7w4Ax/Jroo2lcAedM3B7alZhYQ==",
+					"requires": {
+						"@microsoft/recognizers-text": "~1.1.2",
+						"bignumber.js": "^7.2.1",
+						"lodash.escaperegexp": "^4.1.2",
+						"lodash.sortby": "^4.7.0",
+						"lodash.trimend": "^4.5.1"
+					}
+				},
 				"@types/node": {
-					"version": "9.6.35",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.35.tgz",
-					"integrity": "sha512-h5zvHS8wXHGa+Gcqs9K8vqCgOtqjr0+NqG/DDJmQIX1wpR9HivAfgV8bjcD3mGM4bPfQw5Aneb2Pn8355L83jA=="
+					"version": "9.6.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.42.tgz",
+					"integrity": "sha512-SpeVQJFekfnEaZZO1yl4je/36upII36L7gOT4DBx51B1GeAB45mmDb3a5OBQB+ZeFxVVOP37r8Owsl940G/fBg=="
 				}
 			}
 		},
 		"botframework-connector": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.0.8.tgz",
-			"integrity": "sha512-tNJrhizeH3bcm3KfZ8QSWE/Yi8jvO1HUiGMdvX0pRmvTU9KYEYxrL0lJ8M37Vah6n8k5uZ+CuotmM3VdBha3dA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.2.1.tgz",
+			"integrity": "sha512-O2RmSG4AFyNc7h9zD2a7kdIBw8jF3Thpl8Pwfs/BpKGhRrCIJAMasV0+UbIV2Iwi2NEl7WzdpXjUsnpmB57XgQ==",
 			"requires": {
-				"@types/jsonwebtoken": "7.2.5",
+				"@types/jsonwebtoken": "7.2.8",
 				"@types/node": "^9.3.0",
-				"@types/request": "^2.47.0",
-				"base64url": "^2.0.0",
-				"botframework-schema": "^4.0.8",
+				"base64url": "^3.0.0",
+				"botframework-schema": "^4.2.1",
+				"form-data": "^2.3.3",
 				"jsonwebtoken": "8.0.1",
-				"ms-rest-azure": "^2.5.0",
-				"ms-rest-js": "0.2.8",
-				"request": "2.83.0",
+				"ms-rest-azure-js": "1.0.176",
+				"ms-rest-js": "1.0.455",
+				"nock": "^10.0.3",
+				"node-fetch": "^2.2.1",
 				"rsa-pem-from-mod-exp": "^0.8.4"
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "9.6.35",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.35.tgz",
-					"integrity": "sha512-h5zvHS8wXHGa+Gcqs9K8vqCgOtqjr0+NqG/DDJmQIX1wpR9HivAfgV8bjcD3mGM4bPfQw5Aneb2Pn8355L83jA=="
+					"version": "9.6.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.42.tgz",
+					"integrity": "sha512-SpeVQJFekfnEaZZO1yl4je/36upII36L7gOT4DBx51B1GeAB45mmDb3a5OBQB+ZeFxVVOP37r8Owsl940G/fBg=="
+				},
+				"node-fetch": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+					"integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
 				}
 			}
 		},
 		"botframework-schema": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.0.8.tgz",
-			"integrity": "sha512-UrcLojusq+aR+xMkH1FYeRr+od3oYGSc58o+KErMZP7Wib+GaFBKg2LM+u/p1pO5GWW+7b9ceQ4FXrzELPMdcg==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.2.1.tgz",
+			"integrity": "sha512-0aJ5UIjs6dKZYdovnlnoIb7+wBId3cubQzwC0tH6S//JhayqrKqMcD8vPPgwZHhBhBx8ZFNmKD3MJtCvZZ1GYA==",
 			"requires": {
-				"@types/node": "^9.3.0"
+				"@types/node": "^9.3.0",
+				"ms-rest-js": "1.0.455"
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "9.6.35",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.35.tgz",
-					"integrity": "sha512-h5zvHS8wXHGa+Gcqs9K8vqCgOtqjr0+NqG/DDJmQIX1wpR9HivAfgV8bjcD3mGM4bPfQw5Aneb2Pn8355L83jA=="
+					"version": "9.6.42",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.42.tgz",
+					"integrity": "sha512-SpeVQJFekfnEaZZO1yl4je/36upII36L7gOT4DBx51B1GeAB45mmDb3a5OBQB+ZeFxVVOP37r8Owsl940G/fBg=="
 				}
 			}
 		},
@@ -476,15 +561,36 @@
 				"type-detect": "^4.0.5"
 			}
 		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
 		},
-		"co": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.7",
@@ -504,24 +610,6 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
-		"cryptiles": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-			"requires": {
-				"boom": "5.x.x"
-			},
-			"dependencies": {
-				"boom": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-					"requires": {
-						"hoek": "4.x.x"
-					}
-				}
-			}
-		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -530,17 +618,12 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
-		"date-utils": {
-			"version": "1.2.21",
-			"resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
-			"integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
-		},
 		"debug": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 			"requires": {
-				"ms": "^2.1.1"
+				"ms": "2.0.0"
 			}
 		},
 		"deep-eql": {
@@ -563,7 +646,7 @@
 		},
 		"duplexer": {
 			"version": "0.1.1",
-			"resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 		},
 		"ecc-jsbn": {
@@ -583,23 +666,16 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"encoding": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"requires": {
-				"iconv-lite": "~0.4.13"
-			}
-		},
-		"es6-denodeify": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/es6-denodeify/-/es6-denodeify-0.1.5.tgz",
-			"integrity": "sha1-MdTV/pxVA+ElRgQ5MQ4WoqPznB8="
-		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"extend": {
 			"version": "3.0.2",
@@ -612,42 +688,14 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-		},
-		"fetch-cookie": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.7.2.tgz",
-			"integrity": "sha512-Udm6ls1tV/pR9+EOjTYW2aGBadN03zOgVwu6grybxOg9ufACq7wE1HY/jh06DOykXH9FLYJC2RbUD3kJZcJBRg==",
-			"requires": {
-				"es6-denodeify": "^0.1.1",
-				"tough-cookie": "^2.3.1"
-			}
-		},
-		"fetch-ponyfill": {
-			"version": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
-			"from": "github:amarzavery/fetch-ponyfill#master",
-			"requires": {
-				"fetch-cookie": "~0.6.0",
-				"node-fetch": "~1.7.1"
-			},
-			"dependencies": {
-				"fetch-cookie": {
-					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.6.0.tgz",
-					"integrity": "sha1-T+xOQIzAAH9sBOVTYYr0s97jf2k=",
-					"requires": {
-						"es6-denodeify": "^0.1.1",
-						"tough-cookie": "^2.3.1"
-					}
-				}
-			}
 		},
 		"filename-reserved-regex": {
 			"version": "2.0.0",
@@ -662,6 +710,14 @@
 				"filename-reserved-regex": "^2.0.0",
 				"strip-outer": "^1.0.0",
 				"trim-repeated": "^1.0.0"
+			}
+		},
+		"follow-redirects": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
+			"integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+			"requires": {
+				"debug": "=3.1.0"
 			}
 		},
 		"forever-agent": {
@@ -710,6 +766,12 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
+		"globals": {
+			"version": "11.10.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+			"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
+			"dev": true
+		},
 		"grapheme-splitter": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
@@ -721,29 +783,19 @@
 			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
 			"requires": {
-				"ajv": "^5.1.0",
+				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
 			}
 		},
-		"hawk": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-			"requires": {
-				"boom": "4.x.x",
-				"cryptiles": "3.x.x",
-				"hoek": "4.x.x",
-				"sntp": "2.x.x"
-			}
-		},
-		"hoek": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-			"integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"html-entities": {
 			"version": "1.2.1",
@@ -758,14 +810,6 @@
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
 				"sshpk": "^1.7.0"
-			}
-		},
-		"iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
 		"inflight": {
@@ -802,10 +846,43 @@
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
+		"istanbul-lib-coverage": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+			"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+			"dev": true
+		},
+		"istanbul-lib-instrument": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+			"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+			"dev": true,
+			"requires": {
+				"@babel/generator": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
+				"istanbul-lib-coverage": "^2.0.3",
+				"semver": "^5.5.0"
+			}
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
@@ -813,9 +890,9 @@
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
@@ -851,9 +928,9 @@
 			}
 		},
 		"jwa": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
-			"integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.2.0.tgz",
+			"integrity": "sha512-Grku9ZST5NNQ3hqNUodSkDfEBqAmGA1R8yiyPHOnLzEKI0GaCQC/XhFmsheXYuXzFQJdILbh+lYBiliqG5R/Vg==",
 			"requires": {
 				"buffer-equal-constant-time": "1.0.1",
 				"ecdsa-sig-formatter": "1.0.10",
@@ -861,11 +938,11 @@
 			}
 		},
 		"jws": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
-			"integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.1.tgz",
+			"integrity": "sha512-bGA2omSrFUkd72dhh05bIAN832znP4wOU3lfuXtRBuGTbsmNmDXMQg28f0Vsxaxgk4myF5YkKQpz6qeRpMgX9g==",
 			"requires": {
-				"jwa": "^1.1.5",
+				"jwa": "^1.2.0",
 				"safe-buffer": "^5.0.1"
 			}
 		},
@@ -967,12 +1044,12 @@
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"requires": {
 				"minimist": "0.0.8"
@@ -1169,19 +1246,19 @@
 			}
 		},
 		"moment": {
-			"version": "2.22.2",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-			"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+			"integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
 		},
 		"ms": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"ms-rest": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.3.7.tgz",
-			"integrity": "sha512-zZwuckC/Uv8F1Jr1bW+U1tsDTErWhtH6W4mpxvRrta4YrKwkFeLMt53RsaDOWTqMFsVpjNuCfznV1uxeGUF3/g==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.5.0.tgz",
+			"integrity": "sha512-QUTg9CsmWpofDO0MR37z8B28/T9ObpQ+FM23GGDMKXw8KYDJ3cEBdK6dJTDDrtSoZG3U+S/vdmSEwJ7FNj6Kog==",
 			"requires": {
 				"duplexer": "^0.1.1",
 				"is-buffer": "^1.1.6",
@@ -1191,155 +1268,28 @@
 				"through": "^2.3.8",
 				"tunnel": "0.0.5",
 				"uuid": "^3.2.1"
-			},
-			"dependencies": {
-				"har-validator": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-					"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
-					"requires": {
-						"ajv": "^5.3.0",
-						"har-schema": "^2.0.0"
-					}
-				},
-				"oauth-sign": {
-					"version": "0.9.0",
-					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-					"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-				},
-				"request": {
-					"version": "2.88.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-					"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-					"requires": {
-						"aws-sign2": "~0.7.0",
-						"aws4": "^1.8.0",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.6",
-						"extend": "~3.0.2",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.3.2",
-						"har-validator": "~5.1.0",
-						"http-signature": "~1.2.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.19",
-						"oauth-sign": "~0.9.0",
-						"performance-now": "^2.1.0",
-						"qs": "~6.5.2",
-						"safe-buffer": "^5.1.2",
-						"tough-cookie": "~2.4.3",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.3.2"
-					}
-				},
-				"tough-cookie": {
-					"version": "2.4.3",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-					"requires": {
-						"psl": "^1.1.24",
-						"punycode": "^1.4.1"
-					}
-				}
 			}
 		},
-		"ms-rest-azure": {
-			"version": "2.5.9",
-			"resolved": "https://registry.npmjs.org/ms-rest-azure/-/ms-rest-azure-2.5.9.tgz",
-			"integrity": "sha512-qonobzWLS7Jl6qwgTuA/SfyCtnv7olvCRKrcF8nzXSj68ds4Oj3K64ntzgQajroKa0hKVMcPUFbTk1IYMGvu8w==",
+		"ms-rest-azure-js": {
+			"version": "1.0.176",
+			"resolved": "https://registry.npmjs.org/ms-rest-azure-js/-/ms-rest-azure-js-1.0.176.tgz",
+			"integrity": "sha512-qtEBpSf/1nJ0/m1jGLkHISRnpOeHUp5n4SvzZRdFeYnGF4SQx9v/fl8a8ZwEmyujmgbUwyLNM9qKpH5PmW7pZg==",
 			"requires": {
-				"adal-node": "^0.1.28",
-				"async": "2.6.0",
-				"moment": "^2.22.2",
-				"ms-rest": "^2.3.2",
-				"request": "^2.88.0",
-				"uuid": "^3.2.1"
-			},
-			"dependencies": {
-				"har-validator": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-					"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
-					"requires": {
-						"ajv": "^5.3.0",
-						"har-schema": "^2.0.0"
-					}
-				},
-				"oauth-sign": {
-					"version": "0.9.0",
-					"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-					"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-				},
-				"request": {
-					"version": "2.88.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-					"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-					"requires": {
-						"aws-sign2": "~0.7.0",
-						"aws4": "^1.8.0",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.6",
-						"extend": "~3.0.2",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.3.2",
-						"har-validator": "~5.1.0",
-						"http-signature": "~1.2.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.19",
-						"oauth-sign": "~0.9.0",
-						"performance-now": "^2.1.0",
-						"qs": "~6.5.2",
-						"safe-buffer": "^5.1.2",
-						"tough-cookie": "~2.4.3",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.3.2"
-					}
-				},
-				"tough-cookie": {
-					"version": "2.4.3",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-					"requires": {
-						"psl": "^1.1.24",
-						"punycode": "^1.4.1"
-					}
-				}
+				"ms-rest-js": "^1.0.443",
+				"tslib": "^1.9.2"
 			}
 		},
 		"ms-rest-js": {
-			"version": "0.2.8",
-			"resolved": "http://registry.npmjs.org/ms-rest-js/-/ms-rest-js-0.2.8.tgz",
-			"integrity": "sha512-KgiSsbJzKcPLx0Zaca5PEdGOwm8X4Np+aTukK6stMl2eAqSrHvncjteyeXi6v6O0ECLYeUWVbqcPJfpw1PjnZQ==",
+			"version": "1.0.455",
+			"resolved": "https://registry.npmjs.org/ms-rest-js/-/ms-rest-js-1.0.455.tgz",
+			"integrity": "sha512-RUDnFFNhk4ZdvOACg0yfaxmp5OzNwUcTIwgh/rVBeuNzgA7hOoVh5zFW06XmOtaBHXL2Bu/vWoQtzloEUlv9tw==",
 			"requires": {
-				"@types/form-data": "^2.2.1",
-				"@types/is-stream": "^1.1.0",
-				"@types/node": "^9.4.6",
-				"@types/node-fetch": "^1.6.7",
-				"@types/uuid": "^3.4.3",
-				"fetch-cookie": "^0.7.0",
-				"fetch-ponyfill": "github:amarzavery/fetch-ponyfill#136e6f8192bdb2aa0b7983f0b3b4361c357be9db",
+				"axios": "^0.18.0",
 				"form-data": "^2.3.2",
-				"is-buffer": "^2.0.0",
-				"is-stream": "^1.1.0",
-				"moment": "^2.21.0",
-				"url-parse": "^1.2.0",
-				"uuid": "^3.2.1"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "9.6.35",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.35.tgz",
-					"integrity": "sha512-h5zvHS8wXHGa+Gcqs9K8vqCgOtqjr0+NqG/DDJmQIX1wpR9HivAfgV8bjcD3mGM4bPfQw5Aneb2Pn8355L83jA=="
-				},
-				"is-buffer": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-					"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
-				}
+				"tough-cookie": "^2.4.3",
+				"tslib": "^1.9.2",
+				"uuid": "^3.2.1",
+				"xml2js": "^0.4.19"
 			}
 		},
 		"mstranslator": {
@@ -1348,12 +1298,12 @@
 			"integrity": "sha1-ancOpFD/tMZfaNXmruBRuC3gXPM="
 		},
 		"nock": {
-			"version": "9.6.1",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-9.6.1.tgz",
-			"integrity": "sha512-EDgl/WgNQ0C1BZZlASOQkQdE6tAWXJi8QQlugqzN64JJkvZ7ILijZuG24r4vCC7yOfnm6HKpne5AGExLGCeBWg==",
+			"version": "10.0.6",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
+			"integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
 			"requires": {
 				"chai": "^4.1.2",
-				"debug": "^3.1.0",
+				"debug": "^4.1.0",
 				"deep-equal": "^1.0.0",
 				"json-stringify-safe": "^5.0.1",
 				"lodash": "^4.17.5",
@@ -1361,21 +1311,1061 @@
 				"propagate": "^1.0.0",
 				"qs": "^6.5.1",
 				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+				}
 			}
 		},
-		"node-fetch": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+		"nyc": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-13.2.0.tgz",
+			"integrity": "sha512-gQBlOqvfpYt9b2PZ7qElrHWt8x4y8ApNfbMBoDPdl3sY4/4RJwCxDGTSqhA9RnaguZjS5nW7taW8oToe86JLgQ==",
+			"dev": true,
 			"requires": {
-				"encoding": "^0.1.11",
-				"is-stream": "^1.0.1"
+				"archy": "^1.0.0",
+				"arrify": "^1.0.1",
+				"caching-transform": "^3.0.1",
+				"convert-source-map": "^1.6.0",
+				"find-cache-dir": "^2.0.0",
+				"find-up": "^3.0.0",
+				"foreground-child": "^1.5.6",
+				"glob": "^7.1.3",
+				"istanbul-lib-coverage": "^2.0.3",
+				"istanbul-lib-hook": "^2.0.3",
+				"istanbul-lib-instrument": "^3.0.1",
+				"istanbul-lib-report": "^2.0.4",
+				"istanbul-lib-source-maps": "^3.0.2",
+				"istanbul-reports": "^2.1.0",
+				"make-dir": "^1.3.0",
+				"merge-source-map": "^1.1.0",
+				"resolve-from": "^4.0.0",
+				"rimraf": "^2.6.3",
+				"signal-exit": "^3.0.2",
+				"spawn-wrap": "^1.4.2",
+				"test-exclude": "^5.1.0",
+				"uuid": "^3.3.2",
+				"yargs": "^12.0.5",
+				"yargs-parser": "^11.1.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"append-transform": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"default-require-extensions": "^2.0.0"
+					}
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"arrify": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"async": {
+					"version": "2.6.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.10"
+					}
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"builtin-modules": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"caching-transform": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"hasha": "^3.0.0",
+						"make-dir": "^1.3.0",
+						"package-hash": "^3.0.0",
+						"write-file-atomic": "^2.3.0"
+					}
+				},
+				"camelcase": {
+					"version": "5.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"cliui": {
+					"version": "4.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
+					}
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"commander": {
+					"version": "2.17.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"convert-source-map": {
+					"version": "1.6.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.1.1"
+					}
+				},
+				"cross-spawn": {
+					"version": "4.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"default-require-extensions": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"end-of-stream": {
+					"version": "1.4.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"once": "^1.4.0"
+					}
+				},
+				"error-ex": {
+					"version": "1.3.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-arrayish": "^0.2.1"
+					}
+				},
+				"es6-error": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"execa": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					},
+					"dependencies": {
+						"cross-spawn": {
+							"version": "6.0.5",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"nice-try": "^1.0.4",
+								"path-key": "^2.0.1",
+								"semver": "^5.5.0",
+								"shebang-command": "^1.2.0",
+								"which": "^1.2.9"
+							}
+						}
+					}
+				},
+				"find-cache-dir": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^1.0.0",
+						"pkg-dir": "^3.0.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"foreground-child": {
+					"version": "1.5.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^4",
+						"signal-exit": "^3.0.0"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"get-caller-file": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.15",
+					"bundled": true,
+					"dev": true
+				},
+				"handlebars": {
+					"version": "4.0.12",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"async": "^2.5.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.6.1",
+						"uglify-js": "^3.1.4"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"hasha": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-stream": "^1.0.1"
+					}
+				},
+				"hosted-git-info": {
+					"version": "2.7.1",
+					"bundled": true,
+					"dev": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true,
+					"dev": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"invert-kv": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-arrayish": {
+					"version": "0.2.1",
+					"bundled": true,
+					"dev": true
+				},
+				"is-builtin-module": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"builtin-modules": "^1.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"istanbul-lib-coverage": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"istanbul-lib-hook": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"append-transform": "^1.0.0"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "2.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"istanbul-lib-coverage": "^2.0.3",
+						"make-dir": "^1.3.0",
+						"supports-color": "^6.0.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "6.1.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"debug": "^4.1.1",
+						"istanbul-lib-coverage": "^2.0.3",
+						"make-dir": "^1.3.0",
+						"rimraf": "^2.6.2",
+						"source-map": "^0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"istanbul-reports": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"handlebars": "^4.0.11"
+					}
+				},
+				"json-parse-better-errors": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"lcid": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"invert-kv": "^2.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.11",
+					"bundled": true,
+					"dev": true
+				},
+				"lodash.flattendeep": {
+					"version": "4.4.0",
+					"bundled": true,
+					"dev": true
+				},
+				"lru-cache": {
+					"version": "4.1.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"make-dir": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"map-age-cleaner": {
+					"version": "0.1.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-defer": "^1.0.0"
+					}
+				},
+				"mem": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"map-age-cleaner": "^0.1.1",
+						"mimic-fn": "^1.0.0",
+						"p-is-promise": "^1.1.0"
+					}
+				},
+				"merge-source-map": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"source-map": "^0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.10",
+					"bundled": true,
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"nice-try": {
+					"version": "1.0.5",
+					"bundled": true,
+					"dev": true
+				},
+				"normalize-package-data": {
+					"version": "2.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "^2.1.4",
+						"is-builtin-module": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"path-key": "^2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"optimist": {
+					"version": "0.6.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "~0.0.1",
+						"wordwrap": "~0.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"os-locale": {
+					"version": "3.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"execa": "^1.0.0",
+						"lcid": "^2.0.0",
+						"mem": "^4.0.0"
+					}
+				},
+				"p-defer": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"p-is-promise": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"p-limit": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"package-hash": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.15",
+						"hasha": "^3.0.0",
+						"lodash.flattendeep": "^4.4.0",
+						"release-zalgo": "^1.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-type": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0"
+					}
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"pump": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"read-pkg": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0",
+						"read-pkg": "^3.0.0"
+					}
+				},
+				"release-zalgo": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"es6-error": "^4.0.1"
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"rimraf": {
+					"version": "2.6.3",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"bundled": true,
+					"dev": true
+				},
+				"semver": {
+					"version": "5.6.0",
+					"bundled": true,
+					"dev": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"spawn-wrap": {
+					"version": "1.4.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"foreground-child": "^1.5.6",
+						"mkdirp": "^0.5.0",
+						"os-homedir": "^1.0.1",
+						"rimraf": "^2.6.2",
+						"signal-exit": "^3.0.2",
+						"which": "^1.3.0"
+					}
+				},
+				"spdx-correct": {
+					"version": "3.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"test-exclude": {
+					"version": "5.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"arrify": "^1.0.1",
+						"minimatch": "^3.0.4",
+						"read-pkg-up": "^4.0.0",
+						"require-main-filename": "^1.0.1"
+					}
+				},
+				"uglify-js": {
+					"version": "3.4.9",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"commander": "~2.17.1",
+						"source-map": "~0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"uuid": {
+					"version": "3.3.2",
+					"bundled": true,
+					"dev": true
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"wordwrap": {
+					"version": "0.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"wrap-ansi": {
+					"version": "2.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"write-file-atomic": {
+					"version": "2.4.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"bundled": true,
+					"dev": true
+				},
+				"yargs": {
+					"version": "12.0.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^3.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^11.1.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "11.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
 			}
 		},
 		"oauth-sign": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
 		},
 		"once": {
 			"version": "1.4.0",
@@ -1406,52 +2396,66 @@
 			"integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk="
 		},
 		"psl": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+			"version": "1.1.31",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
 		},
 		"punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-		},
-		"querystringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-			"integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
+			"integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
 		},
 		"request": {
-			"version": "2.83.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+			"version": "2.88.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"requires": {
 				"aws-sign2": "~0.7.0",
-				"aws4": "^1.6.0",
+				"aws4": "^1.8.0",
 				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.5",
-				"extend": "~3.0.1",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.1",
-				"har-validator": "~5.0.3",
-				"hawk": "~6.0.2",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.0",
 				"http-signature": "~1.2.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
 				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.17",
-				"oauth-sign": "~0.8.2",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
 				"performance-now": "^2.1.0",
-				"qs": "~6.5.1",
-				"safe-buffer": "^5.1.1",
-				"stringstream": "~0.0.5",
-				"tough-cookie": "~2.3.3",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.4.3",
 				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.1.0"
+				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				},
+				"qs": {
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				}
 			}
 		},
 		"request-promise-core": {
@@ -1472,17 +2476,12 @@
 				"tough-cookie": ">=2.3.3"
 			}
 		},
-		"requires-port": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-		},
 		"rimraf": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "^7.1.3"
 			}
 		},
 		"rsa-pem-from-mod-exp": {
@@ -1500,23 +2499,26 @@
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
 		"semver": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
 			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
 		},
-		"sntp": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-			"requires": {
-				"hoek": "4.x.x"
-			}
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
 		},
 		"sshpk": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
-			"integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -1534,11 +2536,6 @@
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
 		},
-		"stringstream": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-			"integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
-		},
 		"strip-outer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
@@ -1547,17 +2544,33 @@
 				"escape-string-regexp": "^1.0.2"
 			}
 		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
+		},
 		"tough-cookie": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 			"requires": {
-				"punycode": "^1.4.1"
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
 			}
 		},
 		"trim-repeated": {
@@ -1567,6 +2580,17 @@
 			"requires": {
 				"escape-string-regexp": "^1.0.2"
 			}
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
 		},
 		"tunnel": {
 			"version": "0.0.5",
@@ -1591,18 +2615,12 @@
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
 		},
-		"underscore": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-			"integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-		},
-		"url-parse": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
-			"integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
 			"requires": {
-				"querystringify": "^2.0.0",
-				"requires-port": "^1.0.0"
+				"punycode": "^2.1.0"
 			}
 		},
 		"util": {
@@ -1640,20 +2658,19 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
-		"xmldom": {
-			"version": "0.1.27",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-			"integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+		"xml2js": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+			"requires": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~9.0.1"
+			}
 		},
-		"xpath.js": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-			"integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
-		},
-		"xregexp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.2.0.tgz",
-			"integrity": "sha1-yzYBmHv+JpW1hAAMGPHEqMMih44="
+		"xmlbuilder": {
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 		},
 		"xtend": {
 			"version": "4.0.1",

--- a/transcripts/package.json
+++ b/transcripts/package.json
@@ -9,13 +9,13 @@
     "license": "MIT",
     "dependencies": {
         "@types/node": "^10.12.18",
-        "@types/restify": "^5.0.7",
-        "botbuilder": "^4.0.8",
-        "botbuilder-ai": "^4.0.8",
-        "botbuilder-dialogs": "^4.0.8"
+        "@types/restify": "^7.2.1",
+        "botbuilder": "^4.2.1",
+        "botbuilder-ai": "^4.2.1",
+        "botbuilder-dialogs": "^4.2.1"
     },
     "devDependencies": {
         "mocha": "^5.2.0",
-        "nyc": "^11.4.1"
+        "nyc": "^13.2.0"
     }
 }


### PR DESCRIPTION
fix GH warnings due to outdated packages
