### PR TITLE
Set Line endings on pacakge.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# .gitattributes in project root
+package.json text eol=lf
+package-lock.json text eol=lf


### PR DESCRIPTION
Addresses #758 

I'm not sure if it will fix the issue, however it seems sensible to set either way. 

This PR defines how package.json and package-lock.json files are handled with respect to EOF markers. This area has all sorts of weird NPM bugs (see linked issue). 