### PR TITLE
add support for LUIS endpoint to LuisRecognizer, tests

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "@types/mocha": "^2.2.47",
-    "@types/url-parse": "^1.4.3",
     "codelyzer": "^4.1.0",
     "mocha": "^5.2.0",
     "nock": "^10.0.1",

--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -31,10 +31,12 @@
     "ms-rest": "^2.3.6",
     "mstranslator": "^3.0.0",
     "request": "^2.87.0",
-    "request-promise-native": "1.0.5"
+    "request-promise-native": "1.0.5",
+    "url-parse": "^1.4.4"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.47",
+    "@types/url-parse": "^1.4.3",
     "codelyzer": "^4.1.0",
     "mocha": "^5.2.0",
     "nock": "^10.0.1",

--- a/libraries/botbuilder-ai/tests/luisRecognizer.test.js
+++ b/libraries/botbuilder-ai/tests/luisRecognizer.test.js
@@ -506,22 +506,24 @@ describe('LuisRecognizer', function () {
     });
 
     it('should throw an error when parsing application endpoint with no subscription-key.', () => {
-        const endpointWithNoSubscriptionKey = 'https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&q='
+        const endpointWithNoSubscriptionKey = 'https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&q=';
+        const expectedSubscriptionKey = undefined;
         try {
             const recognizer = new LuisRecognizer(endpointWithNoSubscriptionKey);
             assert(false, 'should have thrown an error.');
         } catch (e) {
-            assert(e.message === `Unable to parse \`endpointKey\` ("subscription-key") from passed in LUIS endpoint's query string ${endpointWithNoSubscriptionKey}.\nPlease make sure your endpoint is a valid LUIS Endpoint.`);
+            assert(e.message === `Invalid \`endpointKey\` value detected: ${expectedSubscriptionKey}\nPlease make sure your endpointKey is a valid LUIS Endpoint Key, e.g. "048ec46dc58e495482b0c447cfdbd291".`);
         }
     });
 
+    const expectedApplicationId = undefined;
     it('should throw an error when parsing application endpoint with no application ID.', () => {
         const endpointWithNoAppId = 'https://westus.api.cognitive.microsoft.com?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=';
         try {
             const recognizer = new LuisRecognizer(endpointWithNoAppId);
             assert(false, 'should have thrown an error.');
         } catch (e) {
-            assert(e.message === `Unable to parse \`applicationId\` value (e.g. "b31aeaf3-3511-495b-a07f-571fc873214b") not detected in LUIS endpoint ${endpointWithNoAppId}.\nPlease make sure your endpoint is a valid LUIS Endpoint.`);
+            assert(e.message === `Invalid \`applicationId\` value detected: ${expectedApplicationId}\nPlease make sure your applicationId is a valid LUIS Application Id, e.g. "b31aeaf3-3511-495b-a07f-571fc873214b".`);
         }
     });
 
@@ -530,7 +532,7 @@ describe('LuisRecognizer', function () {
             const recognizer = new LuisRecognizer('this.is.not.a.url');
             assert(false, 'should have thrown an error.');
         } catch (e) {
-            assert(e.message === `Unable to parse \`endpoint\` value (e.g. "https://westus.api.cognitive.microsoft.com") from LUIS endpoint this.is.not.a.url.\nPlease make sure your endpoint is a valid LUIS Endpoint.`);
+            assert(e.message === `Invalid \`applicationId\` value detected: ${expectedApplicationId}\nPlease make sure your applicationId is a valid LUIS Application Id, e.g. "b31aeaf3-3511-495b-a07f-571fc873214b".`);
         }
     });
 });

--- a/libraries/botbuilder-ai/tests/luisRecognizer.test.js
+++ b/libraries/botbuilder-ai/tests/luisRecognizer.test.js
@@ -492,4 +492,45 @@ describe('LuisRecognizer', function () {
             done();
         });
     });
+
+    it('should successfully construct with valid endpoint.', () => {
+        // Note this is NOT a real LUIS application ID nor a real LUIS subscription-key.
+        // These are GUIDs edited to look right to the parsing and validation code.
+        const mockedEndpoint = 'https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=';
+
+        const recognizer = new LuisRecognizer(mockedEndpoint);
+
+        assert(recognizer.application.applicationId === 'b31aeaf3-3511-495b-a07f-571fc873214b');
+        assert(recognizer.application.endpointKey === '048ec46dc58e495482b0c447cfdbd291');
+        assert(recognizer.application.endpoint === 'https://westus.api.cognitive.microsoft.com');
+    });
+
+    it('should throw an error when parsing application endpoint with no subscription-key.', () => {
+        const endpointWithNoSubscriptionKey = 'https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&q='
+        try {
+            const recognizer = new LuisRecognizer(endpointWithNoSubscriptionKey);
+            assert(false, 'should have thrown an error.');
+        } catch (e) {
+            assert(e.message === `Unable to parse \`endpointKey\` ("subscription-key") from passed in LUIS endpoint's query string ${endpointWithNoSubscriptionKey}.\nPlease make sure your endpoint is a valid LUIS Endpoint.`);
+        }
+    });
+
+    it('should throw an error when parsing application endpoint with no application ID.', () => {
+        const endpointWithNoAppId = 'https://westus.api.cognitive.microsoft.com?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=';
+        try {
+            const recognizer = new LuisRecognizer(endpointWithNoAppId);
+            assert(false, 'should have thrown an error.');
+        } catch (e) {
+            assert(e.message === `Unable to parse \`applicationId\` value (e.g. "b31aeaf3-3511-495b-a07f-571fc873214b") not detected in LUIS endpoint ${endpointWithNoAppId}.\nPlease make sure your endpoint is a valid LUIS Endpoint.`);
+        }
+    });
+
+    it('should throw an error when parsing non-URL value.', () => {
+        try {
+            const recognizer = new LuisRecognizer('this.is.not.a.url');
+            assert(false, 'should have thrown an error.');
+        } catch (e) {
+            assert(e.message === `Unable to parse \`endpoint\` value (e.g. "https://westus.api.cognitive.microsoft.com") from LUIS endpoint this.is.not.a.url.\nPlease make sure your endpoint is a valid LUIS Endpoint.`);
+        }
+    });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -296,7 +296,7 @@
 		},
 		"@types/strip-bom": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
 			"integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I="
 		},
 		"@types/strip-json-comments": {
@@ -464,14 +464,12 @@
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-			"optional": true
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
 		},
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-			"optional": true
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -523,8 +521,7 @@
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-			"optional": true
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
 		},
 		"async": {
 			"version": "2.6.0",
@@ -578,8 +575,7 @@
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-			"optional": true
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
 		"away": {
 			"version": "1.0.0",
@@ -663,7 +659,7 @@
 				},
 				"readable-stream": {
 					"version": "2.0.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
 					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -681,7 +677,7 @@
 				},
 				"string_decoder": {
 					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"xml2js": {
@@ -1253,7 +1249,6 @@
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-			"optional": true,
 			"requires": {
 				"cache-base": "^1.0.1",
 				"class-utils": "^0.3.5",
@@ -1268,7 +1263,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"optional": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -1277,7 +1271,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -1286,7 +1279,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -1295,7 +1287,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"optional": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -1305,14 +1296,12 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"optional": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"optional": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -1563,7 +1552,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-			"optional": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
 				"component-emitter": "^1.2.1",
@@ -1579,8 +1567,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"optional": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -1698,7 +1685,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -1729,7 +1716,6 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-			"optional": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"define-property": "^0.2.5",
@@ -1741,7 +1727,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"optional": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -1749,8 +1734,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"optional": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -1829,7 +1813,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-			"optional": true,
 			"requires": {
 				"map-visit": "^1.0.0",
 				"object-visit": "^1.0.0"
@@ -1870,8 +1853,7 @@
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-			"optional": true
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1898,8 +1880,7 @@
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-			"optional": true
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"core-js": {
 			"version": "2.6.4",
@@ -2038,7 +2019,7 @@
 		},
 		"decamelize": {
 			"version": "1.2.0",
-			"resolved": "http://bbnpm.azurewebsites.net/decamelize/-/decamelize-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
 		"decode-uri-component": {
@@ -2081,7 +2062,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-			"optional": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
 				"isobject": "^3.0.1"
@@ -2091,7 +2071,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -2100,7 +2079,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -2109,7 +2087,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"optional": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -2119,14 +2096,12 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"optional": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"optional": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -2192,7 +2167,7 @@
 		},
 		"dotenv": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
 			"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
 		},
 		"duplexer": {
@@ -2249,7 +2224,7 @@
 			"dependencies": {
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "http://bbnpm.azurewebsites.net/source-map/-/source-map-0.6.1.tgz",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"optional": true
 				}
@@ -2295,7 +2270,7 @@
 		},
 		"expand-range": {
 			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"optional": true,
 			"requires": {
@@ -2311,7 +2286,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-			"optional": true,
 			"requires": {
 				"assign-symbols": "^1.0.0",
 				"is-extendable": "^1.0.1"
@@ -2321,7 +2295,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"optional": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -2440,8 +2413,7 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"optional": true
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
 		},
 		"for-own": {
 			"version": "0.1.5",
@@ -2471,7 +2443,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-			"optional": true,
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
@@ -2522,8 +2493,7 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -2541,13 +2511,11 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -2560,18 +2528,15 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2674,8 +2639,7 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2685,7 +2649,6 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2698,20 +2661,17 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -2728,7 +2688,6 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2801,8 +2760,7 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2812,7 +2770,6 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2888,8 +2845,7 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2919,7 +2875,6 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2937,7 +2892,6 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2976,13 +2930,11 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				}
 			}
 		},
@@ -3025,8 +2977,7 @@
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-			"optional": true
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -3063,7 +3014,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"optional": true,
 			"requires": {
 				"is-glob": "^2.0.0"
 			}
@@ -3175,7 +3125,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-			"optional": true,
 			"requires": {
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
@@ -3185,8 +3134,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"optional": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -3194,7 +3142,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-			"optional": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"kind-of": "^4.0.0"
@@ -3204,7 +3151,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"optional": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -3213,7 +3159,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"optional": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -3224,7 +3169,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"optional": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -3343,7 +3287,7 @@
 		},
 		"into-stream": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
 			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
 			"requires": {
 				"from2": "^2.1.1",
@@ -3367,7 +3311,6 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-			"optional": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
@@ -3390,7 +3333,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-			"optional": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
@@ -3399,7 +3341,6 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-			"optional": true,
 			"requires": {
 				"is-accessor-descriptor": "^0.1.6",
 				"is-data-descriptor": "^0.1.4",
@@ -3409,8 +3350,7 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"optional": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
@@ -3432,14 +3372,12 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-			"optional": true
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-			"optional": true
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 		},
 		"is-finite": {
 			"version": "1.0.2",
@@ -3458,7 +3396,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-			"optional": true,
 			"requires": {
 				"is-extglob": "^1.0.0"
 			}
@@ -3486,7 +3423,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"optional": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			},
@@ -3494,8 +3430,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"optional": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -3648,7 +3583,7 @@
 		},
 		"jsesc": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+			"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
 			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
 		},
 		"json-buffer": {
@@ -3681,7 +3616,7 @@
 		},
 		"json5": {
 			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsonfile": {
@@ -3768,7 +3703,6 @@
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"optional": true,
 			"requires": {
 				"is-buffer": "^1.1.5"
 			}
@@ -3983,14 +3917,12 @@
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-			"optional": true
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
 		},
 		"map-visit": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-			"optional": true,
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
@@ -4011,7 +3943,7 @@
 			"dependencies": {
 				"readable-stream": {
 					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -4022,7 +3954,7 @@
 				},
 				"string_decoder": {
 					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
@@ -4035,7 +3967,7 @@
 		},
 		"md5.js": {
 			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+			"resolved": "http://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
 			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
 			"requires": {
 				"hash-base": "^3.0.0",
@@ -4113,7 +4045,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-			"optional": true,
 			"requires": {
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
@@ -4123,7 +4054,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"optional": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -4410,7 +4340,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"optional": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
 			}
@@ -4480,7 +4409,6 @@
 				"align-text": {
 					"version": "0.1.4",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"kind-of": "^3.0.2",
 						"longest": "^1.0.1",
@@ -5512,8 +5440,7 @@
 				},
 				"longest": {
 					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
@@ -6762,7 +6689,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-			"optional": true,
 			"requires": {
 				"copy-descriptor": "^0.1.0",
 				"define-property": "^0.2.5",
@@ -6773,7 +6699,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"optional": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -6784,7 +6709,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-			"optional": true,
 			"requires": {
 				"isobject": "^3.0.0"
 			},
@@ -6792,8 +6716,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"optional": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -6811,7 +6734,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-			"optional": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			},
@@ -6819,8 +6741,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"optional": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -6863,7 +6784,7 @@
 		},
 		"os-homedir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
@@ -6878,7 +6799,7 @@
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"output-file-sync": {
@@ -6898,7 +6819,7 @@
 		},
 		"p-cancelable": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+			"resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
 			"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
 		},
 		"p-defer": {
@@ -6981,8 +6902,7 @@
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-			"optional": true
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
 		},
 		"path-exists": {
 			"version": "3.0.0",
@@ -7110,7 +7030,7 @@
 			"dependencies": {
 				"readable-stream": {
 					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -7121,7 +7041,7 @@
 				},
 				"string_decoder": {
 					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
@@ -7138,7 +7058,7 @@
 		},
 		"query-string": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
 			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
 			"requires": {
 				"decode-uri-component": "^0.2.0",
@@ -7150,6 +7070,11 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
 			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+		},
+		"querystringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+			"integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
 		},
 		"randomatic": {
 			"version": "3.1.1",
@@ -7189,7 +7114,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -7205,7 +7130,7 @@
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
 				"core-util-is": "~1.0.0",
@@ -7244,8 +7169,7 @@
 				"array-unique": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"optional": true
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"braces": {
 					"version": "2.3.2",
@@ -7485,8 +7409,7 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"optional": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				},
 				"micromatch": {
 					"version": "3.1.10",
@@ -7552,7 +7475,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-			"optional": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
@@ -7600,7 +7522,7 @@
 			"dependencies": {
 				"jsesc": {
 					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
 			}
@@ -7608,8 +7530,7 @@
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"optional": true
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"remove-value": {
 			"version": "1.0.0",
@@ -7619,14 +7540,12 @@
 		"repeat-element": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-			"optional": true
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"optional": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"repeating": {
 			"version": "2.0.1",
@@ -7729,6 +7648,11 @@
 			"resolved": "http://bbnpm.azurewebsites.net/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+		},
 		"resolve": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
@@ -7740,8 +7664,7 @@
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-			"optional": true
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
 		"responselike": {
 			"version": "1.0.2",
@@ -7754,8 +7677,7 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"optional": true
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"rimraf": {
 			"version": "2.6.3",
@@ -7777,9 +7699,8 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-			"optional": true,
 			"requires": {
 				"ret": "~0.1.10"
 			}
@@ -7826,7 +7747,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-			"optional": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -7838,7 +7758,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"optional": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -7972,7 +7891,7 @@
 			"dependencies": {
 				"readable-stream": {
 					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -7983,7 +7902,7 @@
 				},
 				"string_decoder": {
 					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
@@ -7992,7 +7911,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-			"optional": true,
 			"requires": {
 				"base": "^0.11.1",
 				"debug": "^2.2.0",
@@ -8008,7 +7926,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"optional": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -8017,7 +7934,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"optional": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -8082,8 +7998,7 @@
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"optional": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -8113,7 +8028,6 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-			"optional": true,
 			"requires": {
 				"atob": "^2.1.1",
 				"decode-uri-component": "^0.2.0",
@@ -8141,14 +8055,12 @@
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-			"optional": true
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-			"optional": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
 			}
@@ -8183,7 +8095,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-			"optional": true,
 			"requires": {
 				"define-property": "^0.2.5",
 				"object-copy": "^0.1.0"
@@ -8193,7 +8104,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"optional": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -8236,7 +8146,7 @@
 		},
 		"string_decoder": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
 				"safe-buffer": "~5.1.0"
@@ -8307,7 +8217,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-			"optional": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
@@ -8316,7 +8225,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-			"optional": true,
 			"requires": {
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
@@ -8406,7 +8314,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"v8flags": {
@@ -8610,7 +8518,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-			"optional": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
@@ -8622,7 +8529,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"optional": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -8631,7 +8537,6 @@
 					"version": "0.4.3",
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"optional": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-extendable": "^0.1.1",
@@ -8650,7 +8555,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-			"optional": true,
 			"requires": {
 				"has-value": "^0.3.1",
 				"isobject": "^3.0.0"
@@ -8660,7 +8564,6 @@
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-					"optional": true,
 					"requires": {
 						"get-value": "^2.0.3",
 						"has-values": "^0.1.4",
@@ -8671,7 +8574,6 @@
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-							"optional": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -8681,20 +8583,17 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-					"optional": true
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
 				},
 				"isarray": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"optional": true
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"optional": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				}
 			}
 		},
@@ -8713,7 +8612,7 @@
 			"dependencies": {
 				"readable-stream": {
 					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -8724,7 +8623,7 @@
 				},
 				"string_decoder": {
 					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
@@ -8740,8 +8639,7 @@
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-			"optional": true
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
 		"url": {
 			"version": "0.11.0",
@@ -8757,6 +8655,15 @@
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
 					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
 				}
+			}
+		},
+		"url-parse": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+			"integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+			"requires": {
+				"querystringify": "^2.0.0",
+				"requires-port": "^1.0.0"
 			}
 		},
 		"url-parse-lax": {
@@ -8775,8 +8682,7 @@
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-			"optional": true
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
 		"user-home": {
 			"version": "1.1.1",
@@ -8818,7 +8724,7 @@
 		},
 		"validator": {
 			"version": "9.4.1",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
+			"resolved": "http://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
 			"integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
 		},
 		"verror": {


### PR DESCRIPTION
Fixes Microsoft/BotBuilder#5255

## Specific Changes
  - Adds support for passing in a LUIS Application Endpoint as retrieved from the LUIS.ai portals
  - Adds overload for passing in string instead of `LuisApplication` instance
  - Adds unittests for new feature
 
## Notes:
This PR differs from the C# PR in that `LuisApplication` is an interface in TS, not a class. Therefore the parsing logic for the endpoint is performed inside of the constructor for `LuisRecognizer`.

C# parity PR is located here: Microsoft/botbuilder-dotnet#1378