### PR TITLE
Change test description to match implementation

### DIFF
--- a/libraries/botbuilder/tests/botFrameworkAdapter.test.js
+++ b/libraries/botbuilder/tests/botFrameworkAdapter.test.js
@@ -788,7 +788,7 @@ describe(`BotFrameworkAdapter`, function () {
         assert(false, `should have thrown an error message`);
     });
 
-    it(`should throw error if missing from in signOutUser()`, async function () {
+    it(`should throw error if missing from in getAadTokens()`, async function () {
         try {
             const adapter = new AdapterUnderTest();
             await adapter.getAadTokens({ activity: {} });


### PR DESCRIPTION
Fixes #799 

## Description
The description of the test was modified to match the method it was testing. 

## Specific Changes
  - Change 'signOutUser()' to 'getAadTokens()' in the test description 

## Testing
No testing required