### PR TITLE
Add lerna to package.json devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "@types/jsonwebtoken": "7.2.8",
         "@types/lodash": "^4.14.116",
         "coveralls": "^3.0.2",
+        "lerna": "^3.2.1",
         "mocha": "^5.2.0",
         "tslint": "^5.11.0",
         "tslint-microsoft-contrib": "^5.2.1"


### PR DESCRIPTION
Fixes #774 

## Description
Even though it is necessary to have lerna installed globally to run commands such as `npm i` and `npm run build`, it is not listed on the devDependencies. This causes issues when trying to intall.
To avoid this, we added lerna as a devDependency on the `package.json` file.

## Specific Changes
  - Add the `"lerna": "^3.2.1"` line to the `package.json`

## Testing
Before adding the line:
![imagen](https://user-images.githubusercontent.com/22912283/53411348-ffc48600-39a4-11e9-92ba-d66895b8aa77.png)

After adding the line:
![imagen](https://user-images.githubusercontent.com/22912283/53424314-be8e9f00-39c1-11e9-8717-7fc8647c38ee.png)

