### PR TITLE
Replace async-file with fs-extra to match other packages

### DIFF
--- a/libraries/botbuilder/package-lock.json
+++ b/libraries/botbuilder/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "botbuilder",
+  "version": "4.1.6",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    }
+  }
+}

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -22,10 +22,10 @@
   "dependencies": {
     "@types/filenamify": "^2.0.1",
     "@types/node": "^10.12.18",
-    "async-file": "^2.0.2",
     "botbuilder-core": "~4.1.6",
     "botframework-connector": "~4.1.6",
-    "filenamify": "^2.0.0"
+    "filenamify": "^2.0.0",
+    "fs-extra": "^7.0.1"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.47",

--- a/libraries/botbuilder/src/fileTranscriptStore.ts
+++ b/libraries/botbuilder/src/fileTranscriptStore.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import * as fs from 'async-file';
+import * as fs from 'fs-extra';
 import { Activity, PagedResult, TranscriptInfo, TranscriptStore } from 'botbuilder-core';
 import * as filenamify from 'filenamify';
 import * as path from 'path';
@@ -78,7 +78,7 @@ export class FileTranscriptStore implements TranscriptStore {
         const pagedResult: PagedResult<Activity> = { items: [], continuationToken: undefined };
         const transcriptFolder: string = this.getTranscriptFolder(channelId, conversationId);
 
-        const exists = await fs.exists(transcriptFolder);
+        const exists = await fs.pathExists(transcriptFolder);
         if (!exists) {
         	return pagedResult;
 		}
@@ -116,7 +116,7 @@ export class FileTranscriptStore implements TranscriptStore {
         const pagedResult: PagedResult<TranscriptInfo> = { items: [], continuationToken: undefined };
         const channelFolder: string = this.getChannelFolder(channelId);
 
-        const exists = await fs.exists(channelFolder);
+        const exists = await fs.pathExists(channelFolder);
         if (!exists) {
         	return pagedResult;
 		}
@@ -145,13 +145,13 @@ export class FileTranscriptStore implements TranscriptStore {
 
         const transcriptFolder: string = this.getTranscriptFolder(channelId, conversationId);
 
-        return fs.delete(transcriptFolder);
+        return fs.remove(transcriptFolder);
     }
 
     private async saveActivity(activity: Activity, transcriptPath: string, activityFilename: string): Promise<void> {
         const json: string = JSON.stringify(activity, null, '\t');
 
-        const exists = await fs.exists(transcriptPath);
+        const exists = await fs.pathExists(transcriptPath);
         if (!exists) {
         	await fs.mkdirp(transcriptPath);
 		}

--- a/libraries/botbuilder/tests/fileTranscriptStore.test.js
+++ b/libraries/botbuilder/tests/fileTranscriptStore.test.js
@@ -3,7 +3,7 @@ const { FileTranscriptStore } = require('../');
 const assert = require('assert');
 const path = require('path');
 const os = require('os');
-const fs = require('async-file');
+const fs = require('fs-extra');
 const uuid = require('uuid');
 const { ActivityTypes } = require('botbuilder-core');
 
@@ -13,10 +13,10 @@ describe('The FileTranscriptStore', () => {
 	let storage;
 	const startDate = new Date();
 	before(async () => {
-		await fs.delete(workingFolder);
+		await fs.remove(workingFolder);
 		storage = new FileTranscriptStore(workingFolder);
 	});
-	after(() => fs.delete(workingFolder));
+	after(() => fs.remove(workingFolder));
 
 	it('should delete transcripts', async () => {
 		const [activity] = createActivities('deleteActivitySpec', startDate, 1);
@@ -155,7 +155,7 @@ describe('The FileTranscriptStore', () => {
 			storage = new FileTranscriptStore(workingFolder);
 			return Promise.all(activities.map(activity => storage.logActivity(activity)));
 		});
-		after(() => fs.delete(workingFolder));
+		after(() => fs.remove(workingFolder));
 
 		it('with a continuationToken when the page size is smaller than the number of activities stored', async () => {
 			let pagedResult = await storage.getTranscriptActivities('test', conversationId);
@@ -224,7 +224,7 @@ describe('The FileTranscriptStore', () => {
 			storage = new FileTranscriptStore(workingFolder);
 			return Promise.all(activities.map(activity => storage.logActivity(activity)));
 		});
-		after(() => fs.delete(workingFolder));
+		after(() => fs.remove(workingFolder));
 
 		it('for a given conversation and page through them as expected', async () => {
 			let pagedResult = {};

--- a/libraries/botframework-config/package-lock.json
+++ b/libraries/botframework-config/package-lock.json
@@ -1,0 +1,38 @@
+{
+	"name": "botframework-config",
+	"version": "4.1.6",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"fs-extra": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.15",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+				},
+				"jsonfile": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
+				},
+				"universalify": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+					"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+				}
+			}
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,867 @@
 				"xml2js": "^0.4.19"
 			}
 		},
+		"@lerna/add": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.13.1.tgz",
+			"integrity": "sha512-cXk42YbuhzEnADCK8Qte5laC9Qo03eJLVnr0qKY85jQUM/T4URe3IIUemqpg0CpVATrB+Vz+iNdeqw9ng1iALw==",
+			"dev": true,
+			"requires": {
+				"@lerna/bootstrap": "3.13.1",
+				"@lerna/command": "3.13.1",
+				"@lerna/filter-options": "3.13.0",
+				"@lerna/npm-conf": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
+				"dedent": "^0.7.0",
+				"npm-package-arg": "^6.1.0",
+				"p-map": "^1.2.0",
+				"pacote": "^9.5.0",
+				"semver": "^5.5.0"
+			}
+		},
+		"@lerna/batch-packages": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.13.0.tgz",
+			"integrity": "sha512-TgLBTZ7ZlqilGnzJ3xh1KdAHcySfHytgNRTdG9YomfriTU6kVfp1HrXxKJYVGs7ClPUNt2CTFEOkw0tMBronjw==",
+			"dev": true,
+			"requires": {
+				"@lerna/package-graph": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/bootstrap": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.13.1.tgz",
+			"integrity": "sha512-mKdi5Ds5f82PZwEFyB9/W60I3iELobi1i87sTeVrbJh/um7GvqpSPy7kG/JPxyOdMpB2njX6LiJgw+7b6BEPWw==",
+			"dev": true,
+			"requires": {
+				"@lerna/batch-packages": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/filter-options": "3.13.0",
+				"@lerna/has-npm-version": "3.13.0",
+				"@lerna/npm-install": "3.13.0",
+				"@lerna/package-graph": "3.13.0",
+				"@lerna/pulse-till-done": "3.13.0",
+				"@lerna/rimraf-dir": "3.13.0",
+				"@lerna/run-lifecycle": "3.13.0",
+				"@lerna/run-parallel-batches": "3.13.0",
+				"@lerna/symlink-binary": "3.13.0",
+				"@lerna/symlink-dependencies": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
+				"dedent": "^0.7.0",
+				"get-port": "^3.2.0",
+				"multimatch": "^2.1.0",
+				"npm-package-arg": "^6.1.0",
+				"npmlog": "^4.1.2",
+				"p-finally": "^1.0.0",
+				"p-map": "^1.2.0",
+				"p-map-series": "^1.0.0",
+				"p-waterfall": "^1.0.0",
+				"read-package-tree": "^5.1.6",
+				"semver": "^5.5.0"
+			}
+		},
+		"@lerna/changed": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.13.1.tgz",
+			"integrity": "sha512-BRXitEJGOkoudbxEewW7WhjkLxFD+tTk4PrYpHLyCBk63pNTWtQLRE6dc1hqwh4emwyGncoyW6RgXfLgMZgryw==",
+			"dev": true,
+			"requires": {
+				"@lerna/collect-updates": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/listable": "3.13.0",
+				"@lerna/output": "3.13.0",
+				"@lerna/version": "3.13.1"
+			}
+		},
+		"@lerna/check-working-tree": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.13.0.tgz",
+			"integrity": "sha512-dsdO15NXX5To+Q53SYeCrBEpiqv4m5VkaPZxbGQZNwoRen1MloXuqxSymJANQn+ZLEqarv5V56gydebeROPH5A==",
+			"dev": true,
+			"requires": {
+				"@lerna/describe-ref": "3.13.0",
+				"@lerna/validation-error": "3.13.0"
+			}
+		},
+		"@lerna/child-process": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.13.0.tgz",
+			"integrity": "sha512-0iDS8y2jiEucD4fJHEzKoc8aQJgm7s+hG+0RmDNtfT0MM3n17pZnf5JOMtS1FJp+SEXOjMKQndyyaDIPFsnp6A==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.3.1",
+				"execa": "^1.0.0",
+				"strong-log-transformer": "^2.0.0"
+			},
+			"dependencies": {
+				"execa": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@lerna/clean": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.13.1.tgz",
+			"integrity": "sha512-myGIaXv7RUO2qCFZXvx8SJeI+eN6y9SUD5zZ4/LvNogbOiEIlujC5lUAqK65rAHayQ9ltSa/yK6Xv510xhZXZQ==",
+			"dev": true,
+			"requires": {
+				"@lerna/command": "3.13.1",
+				"@lerna/filter-options": "3.13.0",
+				"@lerna/prompt": "3.13.0",
+				"@lerna/pulse-till-done": "3.13.0",
+				"@lerna/rimraf-dir": "3.13.0",
+				"p-map": "^1.2.0",
+				"p-map-series": "^1.0.0",
+				"p-waterfall": "^1.0.0"
+			}
+		},
+		"@lerna/cli": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.13.0.tgz",
+			"integrity": "sha512-HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==",
+			"dev": true,
+			"requires": {
+				"@lerna/global-options": "3.13.0",
+				"dedent": "^0.7.0",
+				"npmlog": "^4.1.2",
+				"yargs": "^12.0.1"
+			}
+		},
+		"@lerna/collect-updates": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.13.0.tgz",
+			"integrity": "sha512-uR3u6uTzrS1p46tHQ/mlHog/nRJGBqskTHYYJbgirujxm6FqNh7Do+I1Q/7zSee407G4lzsNxZdm8IL927HemQ==",
+			"dev": true,
+			"requires": {
+				"@lerna/child-process": "3.13.0",
+				"@lerna/describe-ref": "3.13.0",
+				"minimatch": "^3.0.4",
+				"npmlog": "^4.1.2",
+				"slash": "^1.0.0"
+			}
+		},
+		"@lerna/command": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.13.1.tgz",
+			"integrity": "sha512-SYWezxX+iheWvzRoHCrbs8v5zHPaxAx3kWvZhqi70vuGsdOVAWmaG4IvHLn11ztS+Vpd5PM+ztBWSbnykpLFKQ==",
+			"dev": true,
+			"requires": {
+				"@lerna/child-process": "3.13.0",
+				"@lerna/package-graph": "3.13.0",
+				"@lerna/project": "3.13.1",
+				"@lerna/validation-error": "3.13.0",
+				"@lerna/write-log-file": "3.13.0",
+				"dedent": "^0.7.0",
+				"execa": "^1.0.0",
+				"is-ci": "^1.0.10",
+				"lodash": "^4.17.5",
+				"npmlog": "^4.1.2"
+			},
+			"dependencies": {
+				"execa": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@lerna/conventional-commits": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.13.0.tgz",
+			"integrity": "sha512-BeAgcNXuocmLhPxnmKU2Vy8YkPd/Uo+vu2i/p3JGsUldzrPC8iF3IDxH7fuXpEFN2Nfogu7KHachd4tchtOppA==",
+			"dev": true,
+			"requires": {
+				"@lerna/validation-error": "3.13.0",
+				"conventional-changelog-angular": "^5.0.3",
+				"conventional-changelog-core": "^3.1.6",
+				"conventional-recommended-bump": "^4.0.4",
+				"fs-extra": "^7.0.0",
+				"get-stream": "^4.0.0",
+				"npm-package-arg": "^6.1.0",
+				"npmlog": "^4.1.2",
+				"pify": "^3.0.0",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@lerna/create": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.13.1.tgz",
+			"integrity": "sha512-pLENMXgTkQuvKxAopjKeoLOv9fVUCnpTUD7aLrY5d95/1xqSZlnsOcQfUYcpMf3GpOvHc8ILmI5OXkPqjAf54g==",
+			"dev": true,
+			"requires": {
+				"@lerna/child-process": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/npm-conf": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
+				"camelcase": "^5.0.0",
+				"dedent": "^0.7.0",
+				"fs-extra": "^7.0.0",
+				"globby": "^8.0.1",
+				"init-package-json": "^1.10.3",
+				"npm-package-arg": "^6.1.0",
+				"p-reduce": "^1.0.0",
+				"pacote": "^9.5.0",
+				"pify": "^3.0.0",
+				"semver": "^5.5.0",
+				"slash": "^1.0.0",
+				"validate-npm-package-license": "^3.0.3",
+				"validate-npm-package-name": "^3.0.0",
+				"whatwg-url": "^7.0.0"
+			},
+			"dependencies": {
+				"whatwg-url": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
+			}
+		},
+		"@lerna/create-symlink": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.13.0.tgz",
+			"integrity": "sha512-PTvg3jAAJSAtLFoZDsuTMv1wTOC3XYIdtg54k7uxIHsP8Ztpt+vlilY/Cni0THAqEMHvfiToel76Xdta4TU21Q==",
+			"dev": true,
+			"requires": {
+				"cmd-shim": "^2.0.2",
+				"fs-extra": "^7.0.0",
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/describe-ref": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.13.0.tgz",
+			"integrity": "sha512-UJefF5mLxLae9I2Sbz5RLYGbqbikRuMqdgTam0MS5OhXnyuuKYBUpwBshCURNb1dPBXTQhSwc7+oUhORx8ojCg==",
+			"dev": true,
+			"requires": {
+				"@lerna/child-process": "3.13.0",
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/diff": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.13.1.tgz",
+			"integrity": "sha512-cKqmpONO57mdvxtp8e+l5+tjtmF04+7E+O0QEcLcNUAjC6UR2OSM77nwRCXDukou/1h72JtWs0jjcdYLwAmApg==",
+			"dev": true,
+			"requires": {
+				"@lerna/child-process": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/validation-error": "3.13.0",
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/exec": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.13.1.tgz",
+			"integrity": "sha512-I34wEP9lrAqqM7tTXLDxv/6454WFzrnXDWpNDbiKQiZs6SIrOOjmm6I4FiQsx+rU3o9d+HkC6tcUJRN5mlJUgA==",
+			"dev": true,
+			"requires": {
+				"@lerna/batch-packages": "3.13.0",
+				"@lerna/child-process": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/filter-options": "3.13.0",
+				"@lerna/run-parallel-batches": "3.13.0",
+				"@lerna/validation-error": "3.13.0"
+			}
+		},
+		"@lerna/filter-options": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.13.0.tgz",
+			"integrity": "sha512-SRp7DCo9zrf+7NkQxZMkeyO1GRN6GICoB9UcBAbXhLbWisT37Cx5/6+jh49gYB63d/0/WYHSEPMlheUrpv1Srw==",
+			"dev": true,
+			"requires": {
+				"@lerna/collect-updates": "3.13.0",
+				"@lerna/filter-packages": "3.13.0",
+				"dedent": "^0.7.0"
+			}
+		},
+		"@lerna/filter-packages": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.13.0.tgz",
+			"integrity": "sha512-RWiZWyGy3Mp7GRVBn//CacSnE3Kw82PxE4+H6bQ3pDUw/9atXn7NRX+gkBVQIYeKamh7HyumJtyOKq3Pp9BADQ==",
+			"dev": true,
+			"requires": {
+				"@lerna/validation-error": "3.13.0",
+				"multimatch": "^2.1.0",
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/get-npm-exec-opts": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.13.0.tgz",
+			"integrity": "sha512-Y0xWL0rg3boVyJk6An/vurKzubyJKtrxYv2sj4bB8Mc5zZ3tqtv0ccbOkmkXKqbzvNNF7VeUt1OJ3DRgtC/QZw==",
+			"dev": true,
+			"requires": {
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/get-packed": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/get-packed/-/get-packed-3.13.0.tgz",
+			"integrity": "sha512-EgSim24sjIjqQDC57bgXD9l22/HCS93uQBbGpkzEOzxAVzEgpZVm7Fm1t8BVlRcT2P2zwGnRadIvxTbpQuDPTg==",
+			"dev": true,
+			"requires": {
+				"fs-extra": "^7.0.0",
+				"ssri": "^6.0.1",
+				"tar": "^4.4.8"
+			},
+			"dependencies": {
+				"tar": {
+					"version": "4.4.8",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+					"dev": true,
+					"requires": {
+						"chownr": "^1.1.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.2"
+					}
+				}
+			}
+		},
+		"@lerna/github-client": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.13.1.tgz",
+			"integrity": "sha512-iPLUp8FFoAKGURksYEYZzfuo9TRA+NepVlseRXFaWlmy36dCQN20AciINpoXiXGoHcEUHXUKHQvY3ARFdMlf3w==",
+			"dev": true,
+			"requires": {
+				"@lerna/child-process": "3.13.0",
+				"@octokit/plugin-enterprise-rest": "^2.1.1",
+				"@octokit/rest": "^16.16.0",
+				"git-url-parse": "^11.1.2",
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/global-options": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.13.0.tgz",
+			"integrity": "sha512-SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ==",
+			"dev": true
+		},
+		"@lerna/has-npm-version": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.13.0.tgz",
+			"integrity": "sha512-Oqu7DGLnrMENPm+bPFGOHnqxK8lCnuYr6bk3g/CoNn8/U0qgFvHcq6Iv8/Z04TsvleX+3/RgauSD2kMfRmbypg==",
+			"dev": true,
+			"requires": {
+				"@lerna/child-process": "3.13.0",
+				"semver": "^5.5.0"
+			}
+		},
+		"@lerna/import": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.13.1.tgz",
+			"integrity": "sha512-A1Vk1siYx1XkRl6w+zkaA0iptV5TIynVlHPR9S7NY0XAfhykjztYVvwtxarlh6+VcNrO9We6if0+FXCrfDEoIg==",
+			"dev": true,
+			"requires": {
+				"@lerna/child-process": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/prompt": "3.13.0",
+				"@lerna/pulse-till-done": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
+				"dedent": "^0.7.0",
+				"fs-extra": "^7.0.0",
+				"p-map-series": "^1.0.0"
+			}
+		},
+		"@lerna/init": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.13.1.tgz",
+			"integrity": "sha512-M59WACqim8WkH5FQEGOCEZ89NDxCKBfFTx4ZD5ig3LkGyJ8RdcJq5KEfpW/aESuRE9JrZLzVr0IjKbZSxzwEMA==",
+			"dev": true,
+			"requires": {
+				"@lerna/child-process": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"fs-extra": "^7.0.0",
+				"p-map": "^1.2.0",
+				"write-json-file": "^2.3.0"
+			}
+		},
+		"@lerna/link": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.13.1.tgz",
+			"integrity": "sha512-N3h3Fj1dcea+1RaAoAdy4g2m3fvU7m89HoUn5X/Zcw5n2kPoK8kTO+NfhNAatfRV8VtMXst8vbNrWQQtfm0FFw==",
+			"dev": true,
+			"requires": {
+				"@lerna/command": "3.13.1",
+				"@lerna/package-graph": "3.13.0",
+				"@lerna/symlink-dependencies": "3.13.0",
+				"p-map": "^1.2.0",
+				"slash": "^1.0.0"
+			}
+		},
+		"@lerna/list": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.13.1.tgz",
+			"integrity": "sha512-635iRbdgd9gNvYLLIbYdQCQLr+HioM5FGJLFS0g3DPGygr6iDR8KS47hzCRGH91LU9NcM1mD1RoT/AChF+QbiA==",
+			"dev": true,
+			"requires": {
+				"@lerna/command": "3.13.1",
+				"@lerna/filter-options": "3.13.0",
+				"@lerna/listable": "3.13.0",
+				"@lerna/output": "3.13.0"
+			}
+		},
+		"@lerna/listable": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.13.0.tgz",
+			"integrity": "sha512-liYJ/WBUYP4N4MnSVZuLUgfa/jy3BZ02/1Om7xUY09xGVSuNVNEeB8uZUMSC+nHqFHIsMPZ8QK9HnmZb1E/eTA==",
+			"dev": true,
+			"requires": {
+				"@lerna/batch-packages": "3.13.0",
+				"chalk": "^2.3.1",
+				"columnify": "^1.5.4"
+			}
+		},
+		"@lerna/log-packed": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.13.0.tgz",
+			"integrity": "sha512-Rmjrcz+6aM6AEcEVWmurbo8+AnHOvYtDpoeMMJh9IZ9SmZr2ClXzmD7wSvjTQc8BwOaiWjjC/ukcT0UYA2m7wg==",
+			"dev": true,
+			"requires": {
+				"byte-size": "^4.0.3",
+				"columnify": "^1.5.4",
+				"has-unicode": "^2.0.1",
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/npm-conf": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.13.0.tgz",
+			"integrity": "sha512-Jg2kANsGnhg+fbPEzE0X9nX5oviEAvWj0nYyOkcE+cgWuT7W0zpnPXC4hA4C5IPQGhwhhh0IxhWNNHtjTuw53g==",
+			"dev": true,
+			"requires": {
+				"config-chain": "^1.1.11",
+				"pify": "^3.0.0"
+			}
+		},
+		"@lerna/npm-dist-tag": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.13.0.tgz",
+			"integrity": "sha512-mcuhw34JhSRFrbPn0vedbvgBTvveG52bR2lVE3M3tfE8gmR/cKS/EJFO4AUhfRKGCTFn9rjaSEzlFGYV87pemQ==",
+			"dev": true,
+			"requires": {
+				"figgy-pudding": "^3.5.1",
+				"npm-package-arg": "^6.1.0",
+				"npm-registry-fetch": "^3.9.0",
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/npm-install": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.13.0.tgz",
+			"integrity": "sha512-qNyfts//isYQxore6fsPorNYJmPVKZ6tOThSH97tP0aV91zGMtrYRqlAoUnDwDdAjHPYEM16hNujg2wRmsqqIw==",
+			"dev": true,
+			"requires": {
+				"@lerna/child-process": "3.13.0",
+				"@lerna/get-npm-exec-opts": "3.13.0",
+				"fs-extra": "^7.0.0",
+				"npm-package-arg": "^6.1.0",
+				"npmlog": "^4.1.2",
+				"signal-exit": "^3.0.2",
+				"write-pkg": "^3.1.0"
+			}
+		},
+		"@lerna/npm-publish": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.13.0.tgz",
+			"integrity": "sha512-y4WO0XTaf9gNRkI7as6P2ItVDOxmYHwYto357fjybcnfXgMqEA94c3GJ++jU41j0A9vnmYC6/XxpTd9sVmH9tA==",
+			"dev": true,
+			"requires": {
+				"@lerna/run-lifecycle": "3.13.0",
+				"figgy-pudding": "^3.5.1",
+				"fs-extra": "^7.0.0",
+				"libnpmpublish": "^1.1.1",
+				"npmlog": "^4.1.2",
+				"pify": "^3.0.0",
+				"read-package-json": "^2.0.13"
+			}
+		},
+		"@lerna/npm-run-script": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.13.0.tgz",
+			"integrity": "sha512-hiL3/VeVp+NFatBjkGN8mUdX24EfZx9rQlSie0CMgtjc7iZrtd0jCguLomSCRHYjJuvqgbp+LLYo7nHVykfkaQ==",
+			"dev": true,
+			"requires": {
+				"@lerna/child-process": "3.13.0",
+				"@lerna/get-npm-exec-opts": "3.13.0",
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/output": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.13.0.tgz",
+			"integrity": "sha512-7ZnQ9nvUDu/WD+bNsypmPG5MwZBwu86iRoiW6C1WBuXXDxM5cnIAC1m2WxHeFnjyMrYlRXM9PzOQ9VDD+C15Rg==",
+			"dev": true,
+			"requires": {
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/pack-directory": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/pack-directory/-/pack-directory-3.13.1.tgz",
+			"integrity": "sha512-kXnyqrkQbCIZOf1054N88+8h0ItC7tUN5v9ca/aWpx298gsURpxUx/1TIKqijL5TOnHMyIkj0YJmnH/PyBVLKA==",
+			"dev": true,
+			"requires": {
+				"@lerna/get-packed": "3.13.0",
+				"@lerna/package": "3.13.0",
+				"@lerna/run-lifecycle": "3.13.0",
+				"figgy-pudding": "^3.5.1",
+				"npm-packlist": "^1.4.1",
+				"npmlog": "^4.1.2",
+				"tar": "^4.4.8",
+				"temp-write": "^3.4.0"
+			},
+			"dependencies": {
+				"tar": {
+					"version": "4.4.8",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+					"dev": true,
+					"requires": {
+						"chownr": "^1.1.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.2"
+					}
+				}
+			}
+		},
+		"@lerna/package": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.13.0.tgz",
+			"integrity": "sha512-kSKO0RJQy093BufCQnkhf1jB4kZnBvL7kK5Ewolhk5gwejN+Jofjd8DGRVUDUJfQ0CkW1o6GbUeZvs8w8VIZDg==",
+			"dev": true,
+			"requires": {
+				"load-json-file": "^4.0.0",
+				"npm-package-arg": "^6.1.0",
+				"write-pkg": "^3.1.0"
+			}
+		},
+		"@lerna/package-graph": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.13.0.tgz",
+			"integrity": "sha512-3mRF1zuqFE1HEFmMMAIggXy+f+9cvHhW/jzaPEVyrPNLKsyfJQtpTNzeI04nfRvbAh+Gd2aNksvaW/w3xGJnnw==",
+			"dev": true,
+			"requires": {
+				"@lerna/validation-error": "3.13.0",
+				"npm-package-arg": "^6.1.0",
+				"semver": "^5.5.0"
+			}
+		},
+		"@lerna/project": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.13.1.tgz",
+			"integrity": "sha512-/GoCrpsCCTyb9sizk1+pMBrIYchtb+F1uCOn3cjn9yenyG/MfYEnlfrbV5k/UDud0Ei75YBLbmwCbigHkAKazQ==",
+			"dev": true,
+			"requires": {
+				"@lerna/package": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
+				"cosmiconfig": "^5.1.0",
+				"dedent": "^0.7.0",
+				"dot-prop": "^4.2.0",
+				"glob-parent": "^3.1.0",
+				"globby": "^8.0.1",
+				"load-json-file": "^4.0.0",
+				"npmlog": "^4.1.2",
+				"p-map": "^1.2.0",
+				"resolve-from": "^4.0.0",
+				"write-json-file": "^2.3.0"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+					"dev": true,
+					"requires": {
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.0"
+					}
+				}
+			}
+		},
+		"@lerna/prompt": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.13.0.tgz",
+			"integrity": "sha512-P+lWSFokdyvYpkwC3it9cE0IF2U5yy2mOUbGvvE4iDb9K7TyXGE+7lwtx2thtPvBAfIb7O13POMkv7df03HJeA==",
+			"dev": true,
+			"requires": {
+				"inquirer": "^6.2.0",
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/publish": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.13.1.tgz",
+			"integrity": "sha512-KhCJ9UDx76HWCF03i5TD7z5lX+2yklHh5SyO8eDaLptgdLDQ0Z78lfGj3JhewHU2l46FztmqxL/ss0IkWHDL+g==",
+			"dev": true,
+			"requires": {
+				"@lerna/batch-packages": "3.13.0",
+				"@lerna/check-working-tree": "3.13.0",
+				"@lerna/child-process": "3.13.0",
+				"@lerna/collect-updates": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/describe-ref": "3.13.0",
+				"@lerna/log-packed": "3.13.0",
+				"@lerna/npm-conf": "3.13.0",
+				"@lerna/npm-dist-tag": "3.13.0",
+				"@lerna/npm-publish": "3.13.0",
+				"@lerna/output": "3.13.0",
+				"@lerna/pack-directory": "3.13.1",
+				"@lerna/prompt": "3.13.0",
+				"@lerna/pulse-till-done": "3.13.0",
+				"@lerna/run-lifecycle": "3.13.0",
+				"@lerna/run-parallel-batches": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
+				"@lerna/version": "3.13.1",
+				"figgy-pudding": "^3.5.1",
+				"fs-extra": "^7.0.0",
+				"libnpmaccess": "^3.0.1",
+				"npm-package-arg": "^6.1.0",
+				"npm-registry-fetch": "^3.9.0",
+				"npmlog": "^4.1.2",
+				"p-finally": "^1.0.0",
+				"p-map": "^1.2.0",
+				"p-pipe": "^1.2.0",
+				"p-reduce": "^1.0.0",
+				"pacote": "^9.5.0",
+				"semver": "^5.5.0"
+			}
+		},
+		"@lerna/pulse-till-done": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/pulse-till-done/-/pulse-till-done-3.13.0.tgz",
+			"integrity": "sha512-1SOHpy7ZNTPulzIbargrgaJX387csN7cF1cLOGZiJQA6VqnS5eWs2CIrG8i8wmaUavj2QlQ5oEbRMVVXSsGrzA==",
+			"dev": true,
+			"requires": {
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/resolve-symlink": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.13.0.tgz",
+			"integrity": "sha512-Lc0USSFxwDxUs5JvIisS8JegjA6SHSAWJCMvi2osZx6wVRkEDlWG2B1JAfXUzCMNfHoZX0/XX9iYZ+4JIpjAtg==",
+			"dev": true,
+			"requires": {
+				"fs-extra": "^7.0.0",
+				"npmlog": "^4.1.2",
+				"read-cmd-shim": "^1.0.1"
+			}
+		},
+		"@lerna/rimraf-dir": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.13.0.tgz",
+			"integrity": "sha512-kte+pMemulre8cmPqljxIYjCmdLByz8DgHBHXB49kz2EiPf8JJ+hJFt0PzEubEyJZ2YE2EVAx5Tv5+NfGNUQyQ==",
+			"dev": true,
+			"requires": {
+				"@lerna/child-process": "3.13.0",
+				"npmlog": "^4.1.2",
+				"path-exists": "^3.0.0",
+				"rimraf": "^2.6.2"
+			}
+		},
+		"@lerna/run": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.13.1.tgz",
+			"integrity": "sha512-nv1oj7bsqppWm1M4ifN+/IIbVu9F4RixrbQD2okqDGYne4RQPAXyb5cEZuAzY/wyGTWWiVaZ1zpj5ogPWvH0bw==",
+			"dev": true,
+			"requires": {
+				"@lerna/batch-packages": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/filter-options": "3.13.0",
+				"@lerna/npm-run-script": "3.13.0",
+				"@lerna/output": "3.13.0",
+				"@lerna/run-parallel-batches": "3.13.0",
+				"@lerna/timer": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
+				"p-map": "^1.2.0"
+			}
+		},
+		"@lerna/run-lifecycle": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.13.0.tgz",
+			"integrity": "sha512-oyiaL1biZdjpmjh6X/5C4w07wNFyiwXSSHH5GQB4Ay4BPwgq9oNhCcxRoi0UVZlZ1YwzSW8sTwLgj8emkIo3Yg==",
+			"dev": true,
+			"requires": {
+				"@lerna/npm-conf": "3.13.0",
+				"figgy-pudding": "^3.5.1",
+				"npm-lifecycle": "^2.1.0",
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/run-parallel-batches": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.13.0.tgz",
+			"integrity": "sha512-bICFBR+cYVF1FFW+Tlm0EhWDioTUTM6dOiVziDEGE1UZha1dFkMYqzqdSf4bQzfLS31UW/KBd/2z8jy2OIjEjg==",
+			"dev": true,
+			"requires": {
+				"p-map": "^1.2.0",
+				"p-map-series": "^1.0.0"
+			}
+		},
+		"@lerna/symlink-binary": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.13.0.tgz",
+			"integrity": "sha512-obc4Y6jxywkdaCe+DB0uTxYqP0IQ8mFWvN+k/YMbwH4G2h7M7lCBWgPy8e7xw/50+1II9tT2sxgx+jMus1sTJg==",
+			"dev": true,
+			"requires": {
+				"@lerna/create-symlink": "3.13.0",
+				"@lerna/package": "3.13.0",
+				"fs-extra": "^7.0.0",
+				"p-map": "^1.2.0"
+			}
+		},
+		"@lerna/symlink-dependencies": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.13.0.tgz",
+			"integrity": "sha512-7CyN5WYEPkbPLbqHBIQg/YiimBzb5cIGQB0E9IkLs3+racq2vmUNQZn38LOaazQacAA83seB+zWSxlI6H+eXSg==",
+			"dev": true,
+			"requires": {
+				"@lerna/create-symlink": "3.13.0",
+				"@lerna/resolve-symlink": "3.13.0",
+				"@lerna/symlink-binary": "3.13.0",
+				"fs-extra": "^7.0.0",
+				"p-finally": "^1.0.0",
+				"p-map": "^1.2.0",
+				"p-map-series": "^1.0.0"
+			}
+		},
+		"@lerna/timer": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/timer/-/timer-3.13.0.tgz",
+			"integrity": "sha512-RHWrDl8U4XNPqY5MQHkToWS9jHPnkLZEt5VD+uunCKTfzlxGnRCr3/zVr8VGy/uENMYpVP3wJa4RKGY6M0vkRw==",
+			"dev": true
+		},
+		"@lerna/validation-error": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.13.0.tgz",
+			"integrity": "sha512-SiJP75nwB8GhgwLKQfdkSnDufAaCbkZWJqEDlKOUPUvVOplRGnfL+BPQZH5nvq2BYSRXsksXWZ4UHVnQZI/HYA==",
+			"dev": true,
+			"requires": {
+				"npmlog": "^4.1.2"
+			}
+		},
+		"@lerna/version": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.13.1.tgz",
+			"integrity": "sha512-WpfKc5jZBBOJ6bFS4atPJEbHSiywQ/Gcd+vrwaEGyQHWHQZnPTvhqLuq3q9fIb9sbuhH5pSY6eehhuBrKqTnjg==",
+			"dev": true,
+			"requires": {
+				"@lerna/batch-packages": "3.13.0",
+				"@lerna/check-working-tree": "3.13.0",
+				"@lerna/child-process": "3.13.0",
+				"@lerna/collect-updates": "3.13.0",
+				"@lerna/command": "3.13.1",
+				"@lerna/conventional-commits": "3.13.0",
+				"@lerna/github-client": "3.13.1",
+				"@lerna/output": "3.13.0",
+				"@lerna/prompt": "3.13.0",
+				"@lerna/run-lifecycle": "3.13.0",
+				"@lerna/validation-error": "3.13.0",
+				"chalk": "^2.3.1",
+				"dedent": "^0.7.0",
+				"minimatch": "^3.0.4",
+				"npmlog": "^4.1.2",
+				"p-map": "^1.2.0",
+				"p-pipe": "^1.2.0",
+				"p-reduce": "^1.0.0",
+				"p-waterfall": "^1.0.0",
+				"semver": "^5.5.0",
+				"slash": "^1.0.0",
+				"temp-write": "^3.4.0"
+			}
+		},
+		"@lerna/write-log-file": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.13.0.tgz",
+			"integrity": "sha512-RibeMnDPvlL8bFYW5C8cs4mbI3AHfQef73tnJCQ/SgrXZHehmHnsyWUiE7qDQCAo+B1RfTapvSyFF69iPj326A==",
+			"dev": true,
+			"requires": {
+				"npmlog": "^4.1.2",
+				"write-file-atomic": "^2.3.0"
+			}
+		},
 		"@microsoft/recognizers-text": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/@microsoft/recognizers-text/-/recognizers-text-1.1.4.tgz",
@@ -102,6 +963,71 @@
 				"@microsoft/recognizers-text-sequence": "~1.1.2"
 			}
 		},
+		"@mrmlnc/readdir-enhanced": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+			"dev": true,
+			"requires": {
+				"call-me-maybe": "^1.0.1",
+				"glob-to-regexp": "^0.3.0"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+			"dev": true
+		},
+		"@octokit/endpoint": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.3.tgz",
+			"integrity": "sha512-vAWzeoj9Lzpl3V3YkWKhGzmDUoMfKpyxJhpq74/ohMvmLXDoEuAGnApy/7TRi3OmnjyX2Lr+e9UGGAD0919ohA==",
+			"dev": true,
+			"requires": {
+				"deepmerge": "3.2.0",
+				"is-plain-object": "^2.0.4",
+				"universal-user-agent": "^2.0.1",
+				"url-template": "^2.0.8"
+			}
+		},
+		"@octokit/plugin-enterprise-rest": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-2.2.0.tgz",
+			"integrity": "sha512-/uXIvjK5bxmMKI1MDZXxVSiheiyvqv7GCWjoN1s43jF3MMrfqnErOwbZkreeL0CgO1R2lNW6dESDV5NbRiWEQA==",
+			"dev": true
+		},
+		"@octokit/request": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.4.1.tgz",
+			"integrity": "sha512-nN8W24ZXEpJQJoVgMsGZeK9FOzxkc39Xn9ykseUpPpPMNEDFSvqfkCeqqKrjUiXRm72ubGLWG1SOz0aJPcgGww==",
+			"dev": true,
+			"requires": {
+				"@octokit/endpoint": "^3.1.1",
+				"deprecation": "^1.0.1",
+				"is-plain-object": "^2.0.4",
+				"node-fetch": "^2.3.0",
+				"once": "^1.4.0",
+				"universal-user-agent": "^2.0.1"
+			}
+		},
+		"@octokit/rest": {
+			"version": "16.17.0",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.17.0.tgz",
+			"integrity": "sha512-1RB7e4ptR/M+1Ik3Qn84pbppbSadBaCtpgFqgqsXn6s4ZVE6hqW9SOm6UW5yd3KT7ObVfdYUkhMlgR937oKyDw==",
+			"dev": true,
+			"requires": {
+				"@octokit/request": "2.4.1",
+				"before-after-hook": "^1.4.0",
+				"btoa-lite": "^1.0.0",
+				"lodash.get": "^4.4.2",
+				"lodash.set": "^4.3.2",
+				"lodash.uniq": "^4.5.0",
+				"octokit-pagination-methods": "^1.1.0",
+				"universal-user-agent": "^2.0.0",
+				"url-template": "^2.0.8"
+			}
+		},
 		"@sindresorhus/is": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -161,7 +1087,7 @@
 		},
 		"@types/events": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
 			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
 		},
 		"@types/filenamify": {
@@ -263,9 +1189,9 @@
 			}
 		},
 		"@types/restify": {
-			"version": "7.2.7",
-			"resolved": "https://registry.npmjs.org/@types/restify/-/restify-7.2.7.tgz",
-			"integrity": "sha512-6uANL/O61lJnn+WIF/XO7GBkmBxlm7+VRGfPwHbs/dxdL6n39mGQUF5cMUM0hVWx90nD4fLphENv3A0whLiPDg==",
+			"version": "7.2.8",
+			"resolved": "https://registry.npmjs.org/@types/restify/-/restify-7.2.8.tgz",
+			"integrity": "sha512-p4glB4g8WJKtJFVEAgkC0C0oFaZVbNBFdXPSluPvjNC1n/HjYpr9O1oUrPzTw6vAT3LhqaBUrku1QnMO5rRaTw==",
 			"requires": {
 				"@types/bunyan": "*",
 				"@types/node": "*",
@@ -296,7 +1222,7 @@
 		},
 		"@types/strip-bom": {
 			"version": "3.0.0",
-			"resolved": "http://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
 			"integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I="
 		},
 		"@types/strip-json-comments": {
@@ -317,10 +1243,26 @@
 				"@types/node": "*"
 			}
 		},
+		"JSONStream": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+			"dev": true,
+			"requires": {
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
+			}
+		},
 		"abab": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
 			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
+		},
+		"abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
 		},
 		"acorn": {
 			"version": "5.7.3",
@@ -371,6 +1313,24 @@
 				}
 			}
 		},
+		"agent-base": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+			"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+			"dev": true,
+			"requires": {
+				"es6-promisify": "^5.0.0"
+			}
+		},
+		"agentkeepalive": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+			"integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+			"dev": true,
+			"requires": {
+				"humanize-ms": "^1.2.1"
+			}
+		},
 		"ajv": {
 			"version": "6.6.1",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
@@ -381,6 +1341,12 @@
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
 			}
+		},
+		"ansi-escapes": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
@@ -434,6 +1400,22 @@
 			"resolved": "https://registry.npmjs.org/applicationinsights-js/-/applicationinsights-js-1.0.20.tgz",
 			"integrity": "sha512-vN6fEv2fNPZtw76/mv5OJ44cTP/VzSDahdXVIGnRB5Apnf2/9PIl4IyWpwS9biG53I1sWvkw83RjdrAnsIKoRQ=="
 		},
+		"aproba": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
+		},
+		"are-we-there-yet": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+			"dev": true,
+			"requires": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^2.0.6"
+			}
+		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "http://bbnpm.azurewebsites.net/argparse/-/argparse-1.0.10.tgz",
@@ -470,15 +1452,48 @@
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
+		"array-differ": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+			"dev": true
+		},
 		"array-equal": {
 			"version": "1.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/array-equal/-/array-equal-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+		},
+		"array-find-index": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+			"dev": true
 		},
 		"array-from": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
 			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
+		},
+		"array-ify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+			"dev": true
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"dev": true,
+			"requires": {
+				"array-uniq": "^1.0.1"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
@@ -490,6 +1505,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
+		"asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+			"dev": true
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -509,7 +1530,7 @@
 		},
 		"assert-plus": {
 			"version": "1.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/assert-plus/-/assert-plus-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assertion-error": {
@@ -559,7 +1580,7 @@
 		},
 		"asynckit": {
 			"version": "0.4.0",
-			"resolved": "http://bbnpm.azurewebsites.net/asynckit/-/asynckit-0.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"atob": {
@@ -577,7 +1598,7 @@
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
-			"resolved": "http://bbnpm.azurewebsites.net/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
 			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
@@ -600,23 +1621,6 @@
 			"integrity": "sha512-8A71ZfDs5uB+t7SX7GdESuAxgAOR+jKmhnRprx09Pk5gfdJd1HSC2moLxUhqJsS1WQ6I+g7ShG7kLXWmQIXQyg==",
 			"requires": {
 				"ms-rest": "^2.5.0"
-			},
-			"dependencies": {
-				"ms-rest": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/ms-rest/-/ms-rest-2.5.0.tgz",
-					"integrity": "sha512-QUTg9CsmWpofDO0MR37z8B28/T9ObpQ+FM23GGDMKXw8KYDJ3cEBdK6dJTDDrtSoZG3U+S/vdmSEwJ7FNj6Kog==",
-					"requires": {
-						"duplexer": "^0.1.1",
-						"is-buffer": "^1.1.6",
-						"is-stream": "^1.1.0",
-						"moment": "^2.21.0",
-						"request": "^2.88.0",
-						"through": "^2.3.8",
-						"tunnel": "0.0.5",
-						"uuid": "^3.2.1"
-					}
-				}
 			}
 		},
 		"azure-storage": {
@@ -649,7 +1653,7 @@
 				},
 				"readable-stream": {
 					"version": "2.0.6",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
 					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -667,7 +1671,7 @@
 				},
 				"string_decoder": {
 					"version": "0.10.31",
-					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				},
 				"xml2js": {
@@ -704,7 +1708,7 @@
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
-			"resolved": "http://bbnpm.azurewebsites.net/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"requires": {
 				"chalk": "^1.1.3",
@@ -1232,7 +2236,7 @@
 		},
 		"balanced-match": {
 			"version": "1.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/balanced-match/-/balanced-match-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
@@ -1308,10 +2312,16 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
+		"before-after-hook": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
+			"integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==",
+			"dev": true
+		},
 		"big-integer": {
-			"version": "1.6.41",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.41.tgz",
-			"integrity": "sha512-d5AT9lMTYJ/ZE/4gzxb+5ttPcRWljVsvv7lF1w9KzkPhVUhBtHrjDo1J8swfZKepfLsliDhYa31zRYwcD0Yg9w=="
+			"version": "1.6.42",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.42.tgz",
+			"integrity": "sha512-3UQFKcRMx+5Z+IK5vYTMYK2jzLRJkt+XqyDdacgWgtMjjuifKpKTFneJLEgeBElOE2/lXZ1LcMcb5s8pwG2U8Q=="
 		},
 		"bignumber.js": {
 			"version": "7.2.1",
@@ -1338,152 +2348,100 @@
 			"resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz",
 			"integrity": "sha1-X/hhbW3SylOIvIWy1iZuK52lAtw="
 		},
+		"block-stream": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+			"dev": true,
+			"requires": {
+				"inherits": "~2.0.0"
+			}
+		},
+		"bluebird": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+			"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+			"dev": true
+		},
 		"botbuilder": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.2.1.tgz",
-			"integrity": "sha512-58664aLhN1WQwAxMBK7LZQhFh8DHwenvpgz6ADFgeZLZS28NACfX+Uta8k2+WF6RK3g+VKoGOhV/yI71c5ccVg==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.3.2.tgz",
+			"integrity": "sha512-l7Y83WxytYSBcsFCSoqc8RqXhctnApV131nn72K/mA627DQWAK+M63gYqTFYJBjsO8ok9mNHEzPWQSE9TaJ03Q==",
 			"requires": {
 				"@types/filenamify": "^2.0.1",
-				"@types/node": "^9.3.0",
+				"@types/node": "^10.12.18",
 				"async-file": "^2.0.2",
-				"botbuilder-core": "^4.2.1",
-				"botframework-connector": "^4.2.1",
-				"filenamify": "^2.0.0",
-				"rimraf": "^2.6.2"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "9.6.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.42.tgz",
-					"integrity": "sha512-SpeVQJFekfnEaZZO1yl4je/36upII36L7gOT4DBx51B1GeAB45mmDb3a5OBQB+ZeFxVVOP37r8Owsl940G/fBg=="
-				}
+				"botbuilder-core": "^4.3.2",
+				"botframework-connector": "^4.3.2",
+				"filenamify": "^2.0.0"
 			}
 		},
 		"botbuilder-ai": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/botbuilder-ai/-/botbuilder-ai-4.2.1.tgz",
-			"integrity": "sha512-gej7KR0iFIK38M4eIkGFOn+Tk7sMpzGTJgMVy/ctz21m6vQDGfqFLjJzDk4GRG9oLaZfq5bqUw5sLtepLAZcUg==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/botbuilder-ai/-/botbuilder-ai-4.3.2.tgz",
+			"integrity": "sha512-1JDiaiEWR3RjkBC8f8/d27thLeGROlQhQyNyefNyZDwdpCeFfa8d6fuVNBD0C1j6BqdMnBu1zF5rmFW/m300fw==",
 			"requires": {
 				"@microsoft/recognizers-text-date-time": "1.1.2",
 				"@types/html-entities": "^1.2.16",
-				"@types/node": "^9.3.0",
+				"@types/node": "^10.12.18",
 				"@types/request-promise-native": "^1.0.10",
-				"azure-cognitiveservices-luis-runtime": "^1.0.0",
-				"botbuilder": "^4.2.1",
+				"azure-cognitiveservices-luis-runtime": "1.2.0",
+				"botbuilder-core": "^4.3.2",
 				"html-entities": "^1.2.1",
 				"moment": "^2.20.1",
-				"ms-rest": "^2.3.6",
-				"mstranslator": "^3.0.0",
+				"ms-rest": "2.5.0",
 				"request": "^2.87.0",
-				"request-promise-native": "1.0.5"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "9.6.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.42.tgz",
-					"integrity": "sha512-SpeVQJFekfnEaZZO1yl4je/36upII36L7gOT4DBx51B1GeAB45mmDb3a5OBQB+ZeFxVVOP37r8Owsl940G/fBg=="
-				}
+				"request-promise-native": "1.0.5",
+				"url-parse": "^1.4.4"
 			}
 		},
 		"botbuilder-core": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.2.1.tgz",
-			"integrity": "sha512-U8n+eY9Cjce0GkMyyE0mv4HBjCjtyuczz6usl9XF2N7nY61jYDah4W5e4zqYdLdlqnBwfxG8ptS9pdnmVsC2ww==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.3.2.tgz",
+			"integrity": "sha512-iKaSjOffhb4b40B3N/k1vjFq0AD5QBtx9/Tg8GdeXgxWtbY0QXiFekU7pKfPBAOS3MhY8h/u7w8SmOnrENk62w==",
 			"requires": {
 				"assert": "^1.4.1",
-				"botframework-schema": "^4.2.1"
+				"botframework-schema": "^4.3.2"
 			}
 		},
 		"botbuilder-dialogs": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/botbuilder-dialogs/-/botbuilder-dialogs-4.2.1.tgz",
-			"integrity": "sha512-QHD9WigzC7rOJT0hb9Xzs/yHs1g/MOabJey8qxlZPdnnQqK5X8KJaZEEDnRqcUmLj/ydbxnxqImLEsMD5zlGag==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/botbuilder-dialogs/-/botbuilder-dialogs-4.3.2.tgz",
+			"integrity": "sha512-ui/iSMs46ghkv1PtIfOqfVUGEc7LRyuycR0cs3Q3kArWuy1/Hn3XYOt3NVM1UXeb11/NUKWeiuwZoNvfT44FNA==",
 			"requires": {
 				"@microsoft/recognizers-text-choice": "1.1.2",
 				"@microsoft/recognizers-text-date-time": "1.1.2",
 				"@microsoft/recognizers-text-number": "1.1.2",
 				"@microsoft/recognizers-text-suite": "1.1.2",
-				"@types/node": "^9.3.0",
-				"botbuilder-core": "^4.2.1"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "9.6.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.42.tgz",
-					"integrity": "sha512-SpeVQJFekfnEaZZO1yl4je/36upII36L7gOT4DBx51B1GeAB45mmDb3a5OBQB+ZeFxVVOP37r8Owsl940G/fBg=="
-				}
+				"@types/node": "^10.12.18",
+				"botbuilder-core": "^4.3.2"
 			}
 		},
 		"botframework-connector": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.2.1.tgz",
-			"integrity": "sha512-O2RmSG4AFyNc7h9zD2a7kdIBw8jF3Thpl8Pwfs/BpKGhRrCIJAMasV0+UbIV2Iwi2NEl7WzdpXjUsnpmB57XgQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.3.2.tgz",
+			"integrity": "sha512-nwAAULKFMV2uvXf123R2MRcq3slNMYypBLdoa6KMt6Ri+S2FqVIC4vn+y+pIfFDYbOPOkXErh/JlbunOcfTteA==",
 			"requires": {
+				"@azure/ms-rest-js": "1.2.6",
 				"@types/jsonwebtoken": "7.2.8",
-				"@types/node": "^9.3.0",
+				"@types/node": "^10.12.18",
 				"base64url": "^3.0.0",
-				"botframework-schema": "^4.2.1",
+				"botframework-schema": "^4.3.2",
 				"form-data": "^2.3.3",
 				"jsonwebtoken": "8.0.1",
-				"ms-rest-azure-js": "1.0.176",
-				"ms-rest-js": "1.0.455",
 				"nock": "^10.0.3",
 				"node-fetch": "^2.2.1",
 				"rsa-pem-from-mod-exp": "^0.8.4"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "9.6.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.42.tgz",
-					"integrity": "sha512-SpeVQJFekfnEaZZO1yl4je/36upII36L7gOT4DBx51B1GeAB45mmDb3a5OBQB+ZeFxVVOP37r8Owsl940G/fBg=="
-				},
-				"ms-rest-js": {
-					"version": "1.0.455",
-					"resolved": "https://registry.npmjs.org/ms-rest-js/-/ms-rest-js-1.0.455.tgz",
-					"integrity": "sha512-RUDnFFNhk4ZdvOACg0yfaxmp5OzNwUcTIwgh/rVBeuNzgA7hOoVh5zFW06XmOtaBHXL2Bu/vWoQtzloEUlv9tw==",
-					"requires": {
-						"axios": "^0.18.0",
-						"form-data": "^2.3.2",
-						"tough-cookie": "^2.4.3",
-						"tslib": "^1.9.2",
-						"uuid": "^3.2.1",
-						"xml2js": "^0.4.19"
-					}
-				}
 			}
 		},
 		"botframework-schema": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.2.1.tgz",
-			"integrity": "sha512-0aJ5UIjs6dKZYdovnlnoIb7+wBId3cubQzwC0tH6S//JhayqrKqMcD8vPPgwZHhBhBx8ZFNmKD3MJtCvZZ1GYA==",
-			"requires": {
-				"@types/node": "^9.3.0",
-				"ms-rest-js": "1.0.455"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "9.6.42",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.42.tgz",
-					"integrity": "sha512-SpeVQJFekfnEaZZO1yl4je/36upII36L7gOT4DBx51B1GeAB45mmDb3a5OBQB+ZeFxVVOP37r8Owsl940G/fBg=="
-				},
-				"ms-rest-js": {
-					"version": "1.0.455",
-					"resolved": "https://registry.npmjs.org/ms-rest-js/-/ms-rest-js-1.0.455.tgz",
-					"integrity": "sha512-RUDnFFNhk4ZdvOACg0yfaxmp5OzNwUcTIwgh/rVBeuNzgA7hOoVh5zFW06XmOtaBHXL2Bu/vWoQtzloEUlv9tw==",
-					"requires": {
-						"axios": "^0.18.0",
-						"form-data": "^2.3.2",
-						"tough-cookie": "^2.4.3",
-						"tslib": "^1.9.2",
-						"uuid": "^3.2.1",
-						"xml2js": "^0.4.19"
-					}
-				}
-			}
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.3.2.tgz",
+			"integrity": "sha512-++y/EOu52rRz+TWNkFbOu3Dj7fVyXRlrJktMFo6npr2ISnNNntWY5U0U3ouAUDt7aDKRsB1Rcn2LISdS5FRCoA=="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "http://bbnpm.azurewebsites.net/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
 				"balanced-match": "^1.0.0",
@@ -1517,6 +2475,12 @@
 			"resolved": "https://registry.npmjs.org/browserify-mime/-/browserify-mime-1.2.9.tgz",
 			"integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
 		},
+		"btoa-lite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+			"dev": true
+		},
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -1534,9 +2498,49 @@
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
-			"resolved": "http://bbnpm.azurewebsites.net/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 			"dev": true
+		},
+		"builtins": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+			"dev": true
+		},
+		"byline": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
+			"dev": true
+		},
+		"byte-size": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/byte-size/-/byte-size-4.0.4.tgz",
+			"integrity": "sha512-82RPeneC6nqCdSwCX2hZUz3JPOvN5at/nTEw/CMf05Smu3Hrpo9Psb7LjN+k+XndNArG1EY8L4+BM3aTM4BCvw==",
+			"dev": true
+		},
+		"cacache": {
+			"version": "11.3.2",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+			"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+			"dev": true,
+			"requires": {
+				"bluebird": "^3.5.3",
+				"chownr": "^1.1.1",
+				"figgy-pudding": "^3.5.1",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.1.15",
+				"lru-cache": "^5.1.1",
+				"mississippi": "^3.0.0",
+				"mkdirp": "^0.5.1",
+				"move-concurrently": "^1.0.1",
+				"promise-inflight": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"ssri": "^6.0.1",
+				"unique-filename": "^1.1.1",
+				"y18n": "^4.0.0"
+			}
 		},
 		"cache-base": {
 			"version": "1.0.1",
@@ -1582,14 +2586,63 @@
 				}
 			}
 		},
+		"call-me-maybe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+			"dev": true
+		},
+		"caller-callsite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+			"dev": true,
+			"requires": {
+				"callsites": "^2.0.0"
+			}
+		},
+		"caller-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+			"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+			"dev": true,
+			"requires": {
+				"caller-callsite": "^2.0.0"
+			}
+		},
+		"callsites": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+			"dev": true
+		},
 		"camelcase": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
 			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
 		},
+		"camelcase-keys": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+			"dev": true,
+			"requires": {
+				"camelcase": "^4.1.0",
+				"map-obj": "^2.0.0",
+				"quick-lru": "^1.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
+				}
+			}
+		},
 		"caseless": {
 			"version": "0.12.0",
-			"resolved": "http://bbnpm.azurewebsites.net/caseless/-/caseless-0.12.0.tgz",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"chai": {
@@ -1641,10 +2694,16 @@
 				}
 			}
 		},
+		"chardet": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"dev": true
+		},
 		"chatdown": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/chatdown/-/chatdown-1.1.0.tgz",
-			"integrity": "sha512-te0fomcph6NYnQmD4Aal3VyGuLQ3Ww4QEGRsKx2JfT54VMiIh7aqFXVuZ4MgvjIWcL4eXTdtQRmNOJmSOTULQg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/chatdown/-/chatdown-1.2.0.tgz",
+			"integrity": "sha512-cy+eUhr04VGk1/7SDRdN9K07HXUG0u29exVhHofXzB640Jkc+IwJUTNli4dleGT+JXL7TFkNzXJHe4CVIR3zDQ==",
 			"requires": {
 				"botframework-schema": "^4.0.0-preview1.2",
 				"chalk": "2.4.1",
@@ -1675,7 +2734,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -1701,6 +2760,18 @@
 				"path-is-absolute": "^1.0.0",
 				"readdirp": "^2.0.0"
 			}
+		},
+		"chownr": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+			"dev": true
+		},
+		"ci-info": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+			"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+			"dev": true
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -1728,6 +2799,15 @@
 				}
 			}
 		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
+			"requires": {
+				"restore-cursor": "^2.0.0"
+			}
+		},
 		"cli-table3": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
@@ -1737,6 +2817,12 @@
 				"object-assign": "^4.1.0",
 				"string-width": "^2.1.1"
 			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
 		},
 		"cliui": {
 			"version": "4.1.0",
@@ -1763,6 +2849,12 @@
 				}
 			}
 		},
+		"clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+			"dev": true
+		},
 		"clone-response": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -1781,9 +2873,19 @@
 				"semver": "^5.4.1"
 			}
 		},
+		"cmd-shim": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+			"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"mkdirp": "~0.5.0"
+			}
+		},
 		"code-point-at": {
 			"version": "1.1.0",
-			"resolved": "http://bbnpm.azurewebsites.net/code-point-at/-/code-point-at-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"codelyzer": {
@@ -1818,7 +2920,7 @@
 		},
 		"color-name": {
 			"version": "1.1.3",
-			"resolved": "http://bbnpm.azurewebsites.net/color-name/-/color-name-1.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"colors": {
@@ -1826,6 +2928,16 @@
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
 			"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
 			"optional": true
+		},
+		"columnify": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+			"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+			"dev": true,
+			"requires": {
+				"strip-ansi": "^3.0.0",
+				"wcwidth": "^1.0.0"
+			}
 		},
 		"combined-stream": {
 			"version": "1.0.7",
@@ -1840,6 +2952,27 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
 			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
 		},
+		"compare-func": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
+			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+			"dev": true,
+			"requires": {
+				"array-ify": "^1.0.0",
+				"dot-prop": "^3.0.0"
+			},
+			"dependencies": {
+				"dot-prop": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+					"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+					"dev": true,
+					"requires": {
+						"is-obj": "^1.0.0"
+					}
+				}
+			}
+		},
 		"component-emitter": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -1847,8 +2980,152 @@
 		},
 		"concat-map": {
 			"version": "0.0.1",
-			"resolved": "http://bbnpm.azurewebsites.net/concat-map/-/concat-map-0.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
+			}
+		},
+		"config-chain": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+			"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+			"dev": true,
+			"requires": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			}
+		},
+		"console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+			"dev": true
+		},
+		"conventional-changelog-angular": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
+			"integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
+			"dev": true,
+			"requires": {
+				"compare-func": "^1.3.1",
+				"q": "^1.5.1"
+			}
+		},
+		"conventional-changelog-core": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.1.6.tgz",
+			"integrity": "sha512-5teTAZOtJ4HLR6384h50nPAaKdDr+IaU0rnD2Gg2C3MS7hKsEPH8pZxrDNqam9eOSPQg9tET6uZY79zzgSz+ig==",
+			"dev": true,
+			"requires": {
+				"conventional-changelog-writer": "^4.0.3",
+				"conventional-commits-parser": "^3.0.1",
+				"dateformat": "^3.0.0",
+				"get-pkg-repo": "^1.0.0",
+				"git-raw-commits": "2.0.0",
+				"git-remote-origin-url": "^2.0.0",
+				"git-semver-tags": "^2.0.2",
+				"lodash": "^4.2.1",
+				"normalize-package-data": "^2.3.5",
+				"q": "^1.5.1",
+				"read-pkg": "^3.0.0",
+				"read-pkg-up": "^3.0.0",
+				"through2": "^2.0.0"
+			}
+		},
+		"conventional-changelog-preset-loader": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.0.2.tgz",
+			"integrity": "sha512-pBY+qnUoJPXAXXqVGwQaVmcye05xi6z231QM98wHWamGAmu/ghkBprQAwmF5bdmyobdVxiLhPY3PrCfSeUNzRQ==",
+			"dev": true
+		},
+		"conventional-changelog-writer": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.3.tgz",
+			"integrity": "sha512-bIlpSiQtQZ1+nDVHEEh798Erj2jhN/wEjyw9sfxY9es6h7pREE5BNJjfv0hXGH/FTrAsEpHUq4xzK99eePpwuA==",
+			"dev": true,
+			"requires": {
+				"compare-func": "^1.3.1",
+				"conventional-commits-filter": "^2.0.1",
+				"dateformat": "^3.0.0",
+				"handlebars": "^4.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash": "^4.2.1",
+				"meow": "^4.0.0",
+				"semver": "^5.5.0",
+				"split": "^1.0.0",
+				"through2": "^2.0.0"
+			},
+			"dependencies": {
+				"handlebars": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+					"integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+					"dev": true,
+					"requires": {
+						"async": "^2.5.0",
+						"optimist": "^0.6.1",
+						"source-map": "^0.6.1",
+						"uglify-js": "^3.1.4"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"conventional-commits-filter": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.1.tgz",
+			"integrity": "sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==",
+			"dev": true,
+			"requires": {
+				"is-subset": "^0.1.1",
+				"modify-values": "^1.0.0"
+			}
+		},
+		"conventional-commits-parser": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
+			"integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
+			"dev": true,
+			"requires": {
+				"JSONStream": "^1.0.4",
+				"is-text-path": "^1.0.0",
+				"lodash": "^4.2.1",
+				"meow": "^4.0.0",
+				"split2": "^2.0.0",
+				"through2": "^2.0.0",
+				"trim-off-newlines": "^1.0.0"
+			}
+		},
+		"conventional-recommended-bump": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-4.0.4.tgz",
+			"integrity": "sha512-9mY5Yoblq+ZMqJpBzgS+RpSq+SUfP2miOR3H/NR9drGf08WCrY9B6HAGJZEm6+ThsVP917VHAahSOjM6k1vhPg==",
+			"dev": true,
+			"requires": {
+				"concat-stream": "^1.6.0",
+				"conventional-changelog-preset-loader": "^2.0.2",
+				"conventional-commits-filter": "^2.0.1",
+				"conventional-commits-parser": "^3.0.1",
+				"git-raw-commits": "2.0.0",
+				"git-semver-tags": "^2.0.2",
+				"meow": "^4.0.0",
+				"q": "^1.5.1"
+			}
 		},
 		"convert-source-map": {
 			"version": "1.6.0",
@@ -1858,20 +3135,47 @@
 				"safe-buffer": "~5.1.1"
 			}
 		},
+		"copy-concurrently": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"dev": true,
+			"requires": {
+				"aproba": "^1.1.1",
+				"fs-write-stream-atomic": "^1.0.8",
+				"iferr": "^0.1.5",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4",
+				"run-queue": "^1.0.0"
+			}
+		},
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"core-js": {
-			"version": "2.6.4",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
-			"integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A=="
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+			"integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
-			"resolved": "http://bbnpm.azurewebsites.net/core-util-is/-/core-util-is-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"cosmiconfig": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
+			"integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
+			"dev": true,
+			"requires": {
+				"import-fresh": "^2.0.0",
+				"is-directory": "^0.3.1",
+				"js-yaml": "^3.9.0",
+				"lodash.get": "^4.4.2",
+				"parse-json": "^4.0.0"
+			}
 		},
 		"coveralls": {
 			"version": "3.0.2",
@@ -1955,9 +3259,33 @@
 				"cssom": "0.3.x"
 			}
 		},
+		"currently-unhandled": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"dev": true,
+			"requires": {
+				"array-find-index": "^1.0.1"
+			}
+		},
+		"cyclist": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+			"dev": true
+		},
+		"dargs": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
+			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
+			"dev": true,
+			"requires": {
+				"number-is-nan": "^1.0.0"
+			}
+		},
 		"dashdash": {
 			"version": "1.14.1",
-			"resolved": "http://bbnpm.azurewebsites.net/dashdash/-/dashdash-1.14.1.tgz",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
 				"assert-plus": "^1.0.0"
@@ -1990,6 +3318,12 @@
 			"resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
 			"integrity": "sha1-YfsWzcEnSzyayq/+n8ad+HIKK2Q="
 		},
+		"dateformat": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+			"dev": true
+		},
 		"debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1998,10 +3332,34 @@
 				"ms": "2.0.0"
 			}
 		},
+		"debuglog": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+			"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+			"dev": true
+		},
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"decamelize-keys": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+			"dev": true,
+			"requires": {
+				"decamelize": "^1.1.0",
+				"map-obj": "^1.0.0"
+			},
+			"dependencies": {
+				"map-obj": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+					"dev": true
+				}
+			}
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
@@ -2015,6 +3373,12 @@
 			"requires": {
 				"mimic-response": "^1.0.0"
 			}
+		},
+		"dedent": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+			"dev": true
 		},
 		"deep-eql": {
 			"version": "3.0.1",
@@ -2036,8 +3400,23 @@
 		},
 		"deep-is": {
 			"version": "0.1.3",
-			"resolved": "http://bbnpm.azurewebsites.net/deep-is/-/deep-is-0.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+		},
+		"deepmerge": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
+			"integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==",
+			"dev": true
+		},
+		"defaults": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+			"dev": true,
+			"requires": {
+				"clone": "^1.0.2"
+			}
 		},
 		"define-property": {
 			"version": "2.0.2",
@@ -2088,8 +3467,20 @@
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+			"dev": true
+		},
+		"deprecation": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-1.0.1.tgz",
+			"integrity": "sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==",
+			"dev": true
 		},
 		"detect-indent": {
 			"version": "4.0.0",
@@ -2097,6 +3488,16 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"requires": {
 				"repeating": "^2.0.0"
+			}
+		},
+		"dezalgo": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+			"integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+			"dev": true,
+			"requires": {
+				"asap": "^2.0.0",
+				"wrappy": "1"
 			}
 		},
 		"diagnostic-channel": {
@@ -2116,6 +3517,16 @@
 			"version": "3.5.0",
 			"resolved": "http://bbnpm.azurewebsites.net/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI="
+		},
+		"dir-glob": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"dev": true,
+			"requires": {
+				"arrify": "^1.0.1",
+				"path-type": "^3.0.0"
+			}
 		},
 		"documentdb": {
 			"version": "1.14.5",
@@ -2146,9 +3557,18 @@
 				"webidl-conversions": "^4.0.2"
 			}
 		},
+		"dot-prop": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+			"dev": true,
+			"requires": {
+				"is-obj": "^1.0.0"
+			}
+		},
 		"dotenv": {
 			"version": "5.0.1",
-			"resolved": "http://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
 			"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
 		},
 		"duplexer": {
@@ -2160,6 +3580,18 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
 			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+		},
+		"duplexify": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0",
+				"stream-shift": "^1.0.0"
+			}
 		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
@@ -2186,9 +3618,57 @@
 				"shimmer": "^1.2.0"
 			}
 		},
+		"encoding": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
+			"requires": {
+				"iconv-lite": "~0.4.13"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
+		"err-code": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+			"dev": true
+		},
+		"error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es6-promise": {
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+			"integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+			"dev": true
+		},
+		"es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"dev": true,
+			"requires": {
+				"es6-promise": "^4.0.3"
+			}
+		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
-			"resolved": "http://bbnpm.azurewebsites.net/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
@@ -2213,17 +3693,17 @@
 		},
 		"esprima": {
 			"version": "3.1.3",
-			"resolved": "http://bbnpm.azurewebsites.net/esprima/-/esprima-3.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
 			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
 		},
 		"estraverse": {
 			"version": "4.2.0",
-			"resolved": "http://bbnpm.azurewebsites.net/estraverse/-/estraverse-4.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
 			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
 		},
 		"esutils": {
 			"version": "2.0.2",
-			"resolved": "http://bbnpm.azurewebsites.net/esutils/-/esutils-2.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"execa": {
@@ -2251,7 +3731,7 @@
 		},
 		"expand-range": {
 			"version": "1.8.2",
-			"resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"optional": true,
 			"requires": {
@@ -2282,6 +3762,17 @@
 				}
 			}
 		},
+		"external-editor": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+			"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+			"dev": true,
+			"requires": {
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
+				"tmp": "^0.0.33"
+			}
+		},
 		"extglob": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -2293,7 +3784,7 @@
 		},
 		"extsprintf": {
 			"version": "1.3.0",
-			"resolved": "http://bbnpm.azurewebsites.net/extsprintf/-/extsprintf-1.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
@@ -2301,20 +3792,361 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
 			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
 		},
+		"fast-glob": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
+			"integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
+			"dev": true,
+			"requires": {
+				"@mrmlnc/readdir-enhanced": "^2.2.1",
+				"@nodelib/fs.stat": "^1.1.2",
+				"glob-parent": "^3.1.0",
+				"is-glob": "^4.0.0",
+				"merge2": "^1.2.3",
+				"micromatch": "^3.1.10"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"glob-parent": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+					"dev": true,
+					"requires": {
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
+					},
+					"dependencies": {
+						"is-glob": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+							"dev": true,
+							"requires": {
+								"is-extglob": "^2.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				}
+			}
+		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
-			"resolved": "http://bbnpm.azurewebsites.net/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"fastparse": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
 			"integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
+		},
+		"figgy-pudding": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+			"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+			"dev": true
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
+			}
 		},
 		"filename-regex": {
 			"version": "2.0.1",
@@ -2373,6 +4205,16 @@
 				}
 			}
 		},
+		"flush-write-stream": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+			"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.3.6"
+			}
+		},
 		"follow-redirects": {
 			"version": "1.5.10",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
@@ -2407,7 +4249,7 @@
 		},
 		"forever-agent": {
 			"version": "0.6.1",
-			"resolved": "http://bbnpm.azurewebsites.net/forever-agent/-/forever-agent-0.6.1.tgz",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
@@ -2447,14 +4289,35 @@
 				"universalify": "^0.1.0"
 			}
 		},
+		"fs-minipass": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+			"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+			"dev": true,
+			"requires": {
+				"minipass": "^2.2.1"
+			}
+		},
 		"fs-readdir-recursive": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
 			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
 		},
+		"fs-write-stream-atomic": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"iferr": "^0.1.5",
+				"imurmurhash": "^0.1.4",
+				"readable-stream": "1 || 2"
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
@@ -2940,6 +4803,50 @@
 				}
 			}
 		},
+		"gauge": {
+			"version": "2.7.4",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"dev": true,
+			"requires": {
+				"aproba": "^1.0.3",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.0",
+				"object-assign": "^4.1.0",
+				"signal-exit": "^3.0.0",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wide-align": "^1.1.0"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				}
+			}
+		},
+		"genfun": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
+			"integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
+			"dev": true
+		},
 		"get-caller-file": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -2950,9 +4857,204 @@
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
 		},
+		"get-pkg-repo": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
+			"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "^2.1.4",
+				"meow": "^3.3.0",
+				"normalize-package-data": "^2.3.0",
+				"parse-github-repo-url": "^1.3.0",
+				"through2": "^2.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+					"dev": true
+				},
+				"camelcase-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^2.0.0",
+						"map-obj": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
+					"requires": {
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"indent-string": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+					"dev": true,
+					"requires": {
+						"repeating": "^2.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"map-obj": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+					"dev": true
+				},
+				"meow": {
+					"version": "3.7.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+					"dev": true,
+					"requires": {
+						"camelcase-keys": "^2.0.0",
+						"decamelize": "^1.1.2",
+						"loud-rejection": "^1.0.0",
+						"map-obj": "^1.0.1",
+						"minimist": "^1.1.3",
+						"normalize-package-data": "^2.3.4",
+						"object-assign": "^4.0.1",
+						"read-pkg-up": "^1.0.1",
+						"redent": "^1.0.0",
+						"trim-newlines": "^1.0.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
+					"requires": {
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
+					}
+				},
+				"redent": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+					"dev": true,
+					"requires": {
+						"indent-string": "^2.1.0",
+						"strip-indent": "^1.0.1"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "^0.2.0"
+					}
+				},
+				"strip-indent": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+					"dev": true,
+					"requires": {
+						"get-stdin": "^4.0.1"
+					}
+				},
+				"trim-newlines": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+					"dev": true
+				}
+			}
+		},
+		"get-port": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+			"integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+			"dev": true
+		},
+		"get-stdin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+			"dev": true
+		},
 		"get-stream": {
 			"version": "3.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/get-stream/-/get-stream-3.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"get-value": {
@@ -2962,10 +5064,79 @@
 		},
 		"getpass": {
 			"version": "0.1.7",
-			"resolved": "http://bbnpm.azurewebsites.net/getpass/-/getpass-0.1.7.tgz",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
 				"assert-plus": "^1.0.0"
+			}
+		},
+		"git-raw-commits": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
+			"integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
+			"dev": true,
+			"requires": {
+				"dargs": "^4.0.1",
+				"lodash.template": "^4.0.2",
+				"meow": "^4.0.0",
+				"split2": "^2.0.0",
+				"through2": "^2.0.0"
+			}
+		},
+		"git-remote-origin-url": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+			"dev": true,
+			"requires": {
+				"gitconfiglocal": "^1.0.0",
+				"pify": "^2.3.0"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				}
+			}
+		},
+		"git-semver-tags": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.2.tgz",
+			"integrity": "sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==",
+			"dev": true,
+			"requires": {
+				"meow": "^4.0.0",
+				"semver": "^5.5.0"
+			}
+		},
+		"git-up": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
+			"integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+			"dev": true,
+			"requires": {
+				"is-ssh": "^1.3.0",
+				"parse-url": "^5.0.0"
+			}
+		},
+		"git-url-parse": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
+			"integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+			"dev": true,
+			"requires": {
+				"git-up": "^4.0.0"
+			}
+		},
+		"gitconfiglocal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+			"dev": true,
+			"requires": {
+				"ini": "^1.3.2"
 			}
 		},
 		"glob": {
@@ -2999,10 +5170,31 @@
 				"is-glob": "^2.0.0"
 			}
 		},
+		"glob-to-regexp": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+			"dev": true
+		},
 		"globals": {
 			"version": "9.18.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
 			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+		},
+		"globby": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+			"integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
+			"dev": true,
+			"requires": {
+				"array-union": "^1.0.1",
+				"dir-glob": "2.0.0",
+				"fast-glob": "^2.0.2",
+				"glob": "^7.1.2",
+				"ignore": "^3.3.5",
+				"pify": "^3.0.0",
+				"slash": "^1.0.0"
+			}
 		},
 		"got": {
 			"version": "8.3.2",
@@ -3064,7 +5256,7 @@
 		},
 		"har-schema": {
 			"version": "2.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/har-schema/-/har-schema-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
 			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
@@ -3078,7 +5270,7 @@
 		},
 		"has-ansi": {
 			"version": "2.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/has-ansi/-/has-ansi-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"requires": {
 				"ansi-regex": "^2.0.0"
@@ -3086,7 +5278,7 @@
 		},
 		"has-flag": {
 			"version": "3.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/has-flag/-/has-flag-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-symbol-support-x": {
@@ -3101,6 +5293,12 @@
 			"requires": {
 				"has-symbol-support-x": "^1.4.1"
 			}
+		},
+		"has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+			"dev": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -3167,7 +5365,7 @@
 		},
 		"he": {
 			"version": "1.1.1",
-			"resolved": "http://bbnpm.azurewebsites.net/he/-/he-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
 			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
 			"dev": true
 		},
@@ -3186,12 +5384,18 @@
 			}
 		},
 		"homedir-polyfill": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
 			"requires": {
 				"parse-passwd": "^1.0.0"
 			}
+		},
+		"hosted-git-info": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"dev": true
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
@@ -3211,14 +5415,71 @@
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
 			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
 		},
+		"http-proxy-agent": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"dev": true,
+			"requires": {
+				"agent-base": "4",
+				"debug": "3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
 		"http-signature": {
 			"version": "1.2.0",
-			"resolved": "http://bbnpm.azurewebsites.net/http-signature/-/http-signature-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
 				"sshpk": "^1.7.0"
+			}
+		},
+		"https-proxy-agent": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+			"dev": true,
+			"requires": {
+				"agent-base": "^4.1.0",
+				"debug": "^3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"humanize-ms": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+			"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+			"dev": true,
+			"requires": {
+				"ms": "^2.0.0"
 			}
 		},
 		"iconv-lite": {
@@ -3229,9 +5490,70 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
+		"iferr": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+			"dev": true
+		},
+		"ignore": {
+			"version": "3.3.10",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+			"dev": true
+		},
+		"ignore-walk": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+			"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+			"dev": true,
+			"requires": {
+				"minimatch": "^3.0.4"
+			}
+		},
+		"import-fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+			"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+			"dev": true,
+			"requires": {
+				"caller-path": "^2.0.0",
+				"resolve-from": "^3.0.0"
+			},
+			"dependencies": {
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
+				}
+			}
+		},
+		"import-local": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+			"dev": true,
+			"requires": {
+				"pkg-dir": "^2.0.0",
+				"resolve-cwd": "^2.0.0"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
+		},
+		"indent-string": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+			"dev": true
+		},
 		"inflight": {
 			"version": "1.0.6",
-			"resolved": "http://bbnpm.azurewebsites.net/inflight/-/inflight-1.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
 				"once": "^1.3.0",
@@ -3240,13 +5562,96 @@
 		},
 		"inherits": {
 			"version": "2.0.3",
-			"resolved": "http://bbnpm.azurewebsites.net/inherits/-/inherits-2.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
 			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+		},
+		"init-package-json": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
+			"integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.1",
+				"npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+				"promzard": "^0.3.0",
+				"read": "~1.0.1",
+				"read-package-json": "1 || 2",
+				"semver": "2.x || 3.x || 4 || 5",
+				"validate-npm-package-license": "^3.0.1",
+				"validate-npm-package-name": "^3.0.0"
+			}
+		},
+		"inquirer": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+			"integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^3.2.0",
+				"chalk": "^2.4.2",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^3.0.3",
+				"figures": "^2.0.0",
+				"lodash": "^4.17.11",
+				"mute-stream": "0.0.7",
+				"run-async": "^2.2.0",
+				"rxjs": "^6.4.0",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^5.0.0",
+				"through": "^2.3.6"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+					"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+					"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
 		},
 		"int64-buffer": {
 			"version": "0.1.10",
@@ -3263,12 +5668,12 @@
 		},
 		"interpret": {
 			"version": "1.1.0",
-			"resolved": "http://bbnpm.azurewebsites.net/interpret/-/interpret-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
 			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
 		},
 		"into-stream": {
 			"version": "3.1.0",
-			"resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
 			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
 			"requires": {
 				"from2": "^2.1.1",
@@ -3288,6 +5693,12 @@
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
 			"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
 		},
+		"ip": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+			"dev": true
+		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -3295,6 +5706,12 @@
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
@@ -3309,6 +5726,15 @@
 			"version": "1.1.6",
 			"resolved": "http://bbnpm.azurewebsites.net/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+		},
+		"is-ci": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+			"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+			"dev": true,
+			"requires": {
+				"ci-info": "^1.5.0"
+			}
 		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
@@ -3334,6 +5760,12 @@
 					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
+		},
+		"is-directory": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+			"dev": true
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
@@ -3370,7 +5802,7 @@
 		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-glob": {
@@ -3389,6 +5821,12 @@
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
+		},
+		"is-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"dev": true
 		},
 		"is-object": {
 			"version": "1.0.1",
@@ -3427,26 +5865,61 @@
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
 			"optional": true
 		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
+		},
 		"is-retry-allowed": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
 			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
 		},
+		"is-ssh": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
+			"integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+			"dev": true,
+			"requires": {
+				"protocols": "^1.1.0"
+			}
+		},
 		"is-stream": {
 			"version": "1.1.0",
-			"resolved": "http://bbnpm.azurewebsites.net/is-stream/-/is-stream-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-subset": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+			"integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+			"dev": true
+		},
+		"is-text-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+			"dev": true,
+			"requires": {
+				"text-extensions": "^1.0.0"
+			}
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"optional": true
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"isarray": {
 			"version": "0.0.1",
@@ -3455,7 +5928,7 @@
 		},
 		"isexe": {
 			"version": "2.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/isexe/-/isexe-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
@@ -3477,7 +5950,7 @@
 		},
 		"isstream": {
 			"version": "0.1.2",
-			"resolved": "http://bbnpm.azurewebsites.net/isstream/-/isstream-0.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"isurl": {
@@ -3491,7 +5964,7 @@
 		},
 		"js-tokens": {
 			"version": "3.0.2",
-			"resolved": "http://bbnpm.azurewebsites.net/js-tokens/-/js-tokens-3.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"js-yaml": {
@@ -3514,7 +5987,7 @@
 		},
 		"jsbn": {
 			"version": "0.1.1",
-			"resolved": "http://bbnpm.azurewebsites.net/jsbn/-/jsbn-0.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
 		"jschardet": {
@@ -3564,7 +6037,7 @@
 		},
 		"jsesc": {
 			"version": "1.3.0",
-			"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
 			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
 		},
 		"json-buffer": {
@@ -3580,9 +6053,15 @@
 				"jsonparse": "~1.2.0"
 			}
 		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
+		},
 		"json-schema": {
 			"version": "0.2.3",
-			"resolved": "http://bbnpm.azurewebsites.net/json-schema/-/json-schema-0.2.3.tgz",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
@@ -3592,17 +6071,17 @@
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
-			"resolved": "http://bbnpm.azurewebsites.net/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json5": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsonfile": {
 			"version": "4.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/jsonfile/-/jsonfile-4.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 			"requires": {
 				"graceful-fs": "^4.1.6"
@@ -3639,7 +6118,7 @@
 		},
 		"jsprim": {
 			"version": "1.4.1",
-			"resolved": "http://bbnpm.azurewebsites.net/jsprim/-/jsprim-1.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
 			"requires": {
 				"assert-plus": "1.0.0",
@@ -3706,7 +6185,7 @@
 		},
 		"lcov-parse": {
 			"version": "0.0.10",
-			"resolved": "http://bbnpm.azurewebsites.net/lcov-parse/-/lcov-parse-0.0.10.tgz",
+			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
 			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
 			"dev": true
 		},
@@ -3715,13 +6194,113 @@
 			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
 			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
 		},
+		"lerna": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/lerna/-/lerna-3.13.1.tgz",
+			"integrity": "sha512-7kSz8LLozVsoUNTJzJzy+b8TnV9YdviR2Ee2PwGZSlVw3T1Rn7kOAPZjEi+3IWnOPC96zMPHVmjCmzQ4uubalw==",
+			"dev": true,
+			"requires": {
+				"@lerna/add": "3.13.1",
+				"@lerna/bootstrap": "3.13.1",
+				"@lerna/changed": "3.13.1",
+				"@lerna/clean": "3.13.1",
+				"@lerna/cli": "3.13.0",
+				"@lerna/create": "3.13.1",
+				"@lerna/diff": "3.13.1",
+				"@lerna/exec": "3.13.1",
+				"@lerna/import": "3.13.1",
+				"@lerna/init": "3.13.1",
+				"@lerna/link": "3.13.1",
+				"@lerna/list": "3.13.1",
+				"@lerna/publish": "3.13.1",
+				"@lerna/run": "3.13.1",
+				"@lerna/version": "3.13.1",
+				"import-local": "^1.0.0",
+				"npmlog": "^4.1.2"
+			}
+		},
 		"levn": {
 			"version": "0.3.0",
-			"resolved": "http://bbnpm.azurewebsites.net/levn/-/levn-0.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
+			}
+		},
+		"libnpmaccess": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.1.tgz",
+			"integrity": "sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==",
+			"dev": true,
+			"requires": {
+				"aproba": "^2.0.0",
+				"get-stream": "^4.0.0",
+				"npm-package-arg": "^6.1.0",
+				"npm-registry-fetch": "^3.8.0"
+			},
+			"dependencies": {
+				"aproba": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+					"dev": true
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
+			}
+		},
+		"libnpmpublish": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.1.tgz",
+			"integrity": "sha512-nefbvJd/wY38zdt+b9SHL6171vqBrMtZ56Gsgfd0duEKb/pB8rDT4/ObUQLrHz1tOfht1flt2zM+UGaemzAG5g==",
+			"dev": true,
+			"requires": {
+				"aproba": "^2.0.0",
+				"figgy-pudding": "^3.5.1",
+				"get-stream": "^4.0.0",
+				"lodash.clonedeep": "^4.5.0",
+				"normalize-package-data": "^2.4.0",
+				"npm-package-arg": "^6.1.0",
+				"npm-registry-fetch": "^3.8.0",
+				"semver": "^5.5.1",
+				"ssri": "^6.0.1"
+			},
+			"dependencies": {
+				"aproba": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+					"dev": true
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
+			}
+		},
+		"load-json-file": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"locate-path": {
@@ -3753,6 +6332,18 @@
 			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
 			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
 		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+			"dev": true
+		},
+		"lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+			"dev": true
+		},
 		"lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
@@ -3760,7 +6351,7 @@
 		},
 		"lodash.get": {
 			"version": "4.4.2",
-			"resolved": "http://bbnpm.azurewebsites.net/lodash.get/-/lodash.get-4.4.2.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
 		},
 		"lodash.includes": {
@@ -3833,10 +6424,35 @@
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
 			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
 		},
+		"lodash.set": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+			"dev": true
+		},
 		"lodash.sortby": {
 			"version": "4.7.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+		},
+		"lodash.template": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+			"dev": true,
+			"requires": {
+				"lodash._reinterpolate": "~3.0.0",
+				"lodash.templatesettings": "^4.0.0"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+			"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+			"dev": true,
+			"requires": {
+				"lodash._reinterpolate": "~3.0.0"
+			}
 		},
 		"lodash.toarray": {
 			"version": "3.0.2",
@@ -3858,6 +6474,12 @@
 			"resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
 			"integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
 		},
+		"lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+			"dev": true
+		},
 		"log-driver": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
@@ -3877,15 +6499,86 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
+		"loud-rejection": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+			"dev": true,
+			"requires": {
+				"currently-unhandled": "^0.4.1",
+				"signal-exit": "^3.0.0"
+			}
+		},
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
 			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 		},
+		"lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
+			"requires": {
+				"yallist": "^3.0.2"
+			}
+		},
+		"macos-release": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
+			"integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A==",
+			"dev": true
+		},
+		"make-dir": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+			"dev": true,
+			"requires": {
+				"pify": "^3.0.0"
+			}
+		},
 		"make-error": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
 			"integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+		},
+		"make-fetch-happen": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz",
+			"integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
+			"dev": true,
+			"requires": {
+				"agentkeepalive": "^3.4.1",
+				"cacache": "^11.0.1",
+				"http-cache-semantics": "^3.8.1",
+				"http-proxy-agent": "^2.1.0",
+				"https-proxy-agent": "^2.2.1",
+				"lru-cache": "^4.1.2",
+				"mississippi": "^3.0.0",
+				"node-fetch-npm": "^2.0.2",
+				"promise-retry": "^1.1.1",
+				"socks-proxy-agent": "^4.0.0",
+				"ssri": "^6.0.0"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"dev": true
+				}
+			}
 		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
@@ -3899,6 +6592,12 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
 			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+		},
+		"map-obj": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+			"dev": true
 		},
 		"map-visit": {
 			"version": "1.0.0",
@@ -3924,7 +6623,7 @@
 			"dependencies": {
 				"readable-stream": {
 					"version": "1.0.34",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -3935,7 +6634,7 @@
 				},
 				"string_decoder": {
 					"version": "0.10.31",
-					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
@@ -3948,7 +6647,7 @@
 		},
 		"md5.js": {
 			"version": "1.3.4",
-			"resolved": "http://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
 			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
 			"requires": {
 				"hash-base": "^3.0.0",
@@ -3964,6 +6663,37 @@
 				"mimic-fn": "^1.0.0",
 				"p-is-promise": "^1.1.0"
 			}
+		},
+		"meow": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+			"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+			"dev": true,
+			"requires": {
+				"camelcase-keys": "^4.0.0",
+				"decamelize-keys": "^1.0.0",
+				"loud-rejection": "^1.0.0",
+				"minimist": "^1.1.3",
+				"minimist-options": "^3.0.1",
+				"normalize-package-data": "^2.3.4",
+				"read-pkg-up": "^3.0.0",
+				"redent": "^2.0.0",
+				"trim-newlines": "^2.0.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
+		},
+		"merge2": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
+			"integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
+			"dev": true
 		},
 		"micromatch": {
 			"version": "2.3.11",
@@ -4011,7 +6741,7 @@
 		},
 		"minimatch": {
 			"version": "3.0.4",
-			"resolved": "http://bbnpm.azurewebsites.net/minimatch/-/minimatch-3.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
 				"brace-expansion": "^1.1.7"
@@ -4021,6 +6751,53 @@
 			"version": "0.0.8",
 			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"minimist-options": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+			"dev": true,
+			"requires": {
+				"arrify": "^1.0.1",
+				"is-plain-obj": "^1.1.0"
+			}
+		},
+		"minipass": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
+			}
+		},
+		"minizlib": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+			"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+			"dev": true,
+			"requires": {
+				"minipass": "^2.2.1"
+			}
+		},
+		"mississippi": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+			"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+			"dev": true,
+			"requires": {
+				"concat-stream": "^1.5.0",
+				"duplexify": "^3.4.2",
+				"end-of-stream": "^1.1.0",
+				"flush-write-stream": "^1.0.0",
+				"from2": "^2.1.0",
+				"parallel-transform": "^1.1.0",
+				"pump": "^3.0.0",
+				"pumpify": "^1.3.3",
+				"stream-each": "^1.1.0",
+				"through2": "^2.0.0"
+			}
 		},
 		"mixin-deep": {
 			"version": "1.3.1",
@@ -4043,7 +6820,7 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "http://bbnpm.azurewebsites.net/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"requires": {
 				"minimist": "0.0.8"
@@ -4108,14 +6885,34 @@
 				}
 			}
 		},
+		"modify-values": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+			"integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+			"dev": true
+		},
 		"moment": {
 			"version": "2.22.2",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
 			"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
 		},
+		"move-concurrently": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+			"dev": true,
+			"requires": {
+				"aproba": "^1.1.1",
+				"copy-concurrently": "^1.0.0",
+				"fs-write-stream-atomic": "^1.0.8",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4",
+				"run-queue": "^1.0.3"
+			}
+		},
 		"ms": {
 			"version": "2.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/ms/-/ms-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"ms-rest": {
@@ -4144,30 +6941,6 @@
 				"ms-rest": "^2.3.2",
 				"request": "^2.88.0",
 				"uuid": "^3.2.1"
-			}
-		},
-		"ms-rest-azure-js": {
-			"version": "1.0.176",
-			"resolved": "https://registry.npmjs.org/ms-rest-azure-js/-/ms-rest-azure-js-1.0.176.tgz",
-			"integrity": "sha512-qtEBpSf/1nJ0/m1jGLkHISRnpOeHUp5n4SvzZRdFeYnGF4SQx9v/fl8a8ZwEmyujmgbUwyLNM9qKpH5PmW7pZg==",
-			"requires": {
-				"ms-rest-js": "^1.0.443",
-				"tslib": "^1.9.2"
-			},
-			"dependencies": {
-				"ms-rest-js": {
-					"version": "1.0.465",
-					"resolved": "https://registry.npmjs.org/ms-rest-js/-/ms-rest-js-1.0.465.tgz",
-					"integrity": "sha512-MMSmxy6yd/EcxcKxdKy13SckcjBWSgcFkO2Ggibw0wQvZKr3DDaOGOaivElfdRkA+djacZLl4A912MNT5VhBPA==",
-					"requires": {
-						"axios": "^0.18.0",
-						"form-data": "^2.3.2",
-						"tough-cookie": "^2.4.3",
-						"tslib": "^1.9.2",
-						"uuid": "^3.2.1",
-						"xml2js": "^0.4.19"
-					}
-				}
 			}
 		},
 		"ms-rest-js": {
@@ -4199,10 +6972,23 @@
 				}
 			}
 		},
-		"mstranslator": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mstranslator/-/mstranslator-3.0.0.tgz",
-			"integrity": "sha1-ancOpFD/tMZfaNXmruBRuC3gXPM="
+		"multimatch": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+			"dev": true,
+			"requires": {
+				"array-differ": "^1.0.0",
+				"array-union": "^1.0.1",
+				"arrify": "^1.0.0",
+				"minimatch": "^3.0.0"
+			}
+		},
+		"mute-stream": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"nan": {
 			"version": "2.12.1",
@@ -4214,7 +7000,6 @@
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-			"optional": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -4232,20 +7017,17 @@
 				"arr-diff": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"optional": true
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 				},
 				"array-unique": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"optional": true
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-					"optional": true
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -4317,6 +7099,89 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
 			"integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
 		},
+		"node-fetch-npm": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+			"integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
+			"dev": true,
+			"requires": {
+				"encoding": "^0.1.11",
+				"json-parse-better-errors": "^1.0.0",
+				"safe-buffer": "^5.1.1"
+			}
+		},
+		"node-gyp": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+			"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+			"dev": true,
+			"requires": {
+				"fstream": "^1.0.0",
+				"glob": "^7.0.3",
+				"graceful-fs": "^4.1.2",
+				"mkdirp": "^0.5.0",
+				"nopt": "2 || 3",
+				"npmlog": "0 || 1 || 2 || 3 || 4",
+				"osenv": "0",
+				"request": "^2.87.0",
+				"rimraf": "2",
+				"semver": "~5.3.0",
+				"tar": "^2.0.0",
+				"which": "1"
+			},
+			"dependencies": {
+				"fstream": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"inherits": "~2.0.0",
+						"mkdirp": ">=0.5 0",
+						"rimraf": "2"
+					}
+				},
+				"semver": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"dev": true
+				}
+			}
+		},
+		"nopt": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+					"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				}
+			}
+		},
 		"normalize-path": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -4335,17 +7200,116 @@
 				"sort-keys": "^2.0.0"
 			}
 		},
+		"npm-bundled": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+			"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+			"dev": true
+		},
+		"npm-lifecycle": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-2.1.0.tgz",
+			"integrity": "sha512-QbBfLlGBKsktwBZLj6AviHC6Q9Y3R/AY4a2PYSIRhSKSS0/CxRyD/PfxEX6tPeOCXQgMSNdwGeECacstgptc+g==",
+			"dev": true,
+			"requires": {
+				"byline": "^5.0.0",
+				"graceful-fs": "^4.1.11",
+				"node-gyp": "^3.8.0",
+				"resolve-from": "^4.0.0",
+				"slide": "^1.1.6",
+				"uid-number": "0.0.6",
+				"umask": "^1.1.0",
+				"which": "^1.3.1"
+			}
+		},
+		"npm-package-arg": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
+			"integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "^2.6.0",
+				"osenv": "^0.1.5",
+				"semver": "^5.5.0",
+				"validate-npm-package-name": "^3.0.0"
+			}
+		},
+		"npm-packlist": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+			"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+			"dev": true,
+			"requires": {
+				"ignore-walk": "^3.0.1",
+				"npm-bundled": "^1.0.1"
+			}
+		},
+		"npm-pick-manifest": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz",
+			"integrity": "sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==",
+			"dev": true,
+			"requires": {
+				"figgy-pudding": "^3.5.1",
+				"npm-package-arg": "^6.0.0",
+				"semver": "^5.4.1"
+			}
+		},
+		"npm-registry-fetch": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.9.0.tgz",
+			"integrity": "sha512-srwmt8YhNajAoSAaDWndmZgx89lJwIZ1GWxOuckH4Coek4uHv5S+o/l9FLQe/awA+JwTnj4FJHldxhlXdZEBmw==",
+			"dev": true,
+			"requires": {
+				"JSONStream": "^1.3.4",
+				"bluebird": "^3.5.1",
+				"figgy-pudding": "^3.4.1",
+				"lru-cache": "^4.1.3",
+				"make-fetch-happen": "^4.0.1",
+				"npm-package-arg": "^6.1.0"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "4.1.5",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"dev": true
+				}
+			}
+		},
 		"npm-run-path": {
 			"version": "2.0.2",
-			"resolved": "http://bbnpm.azurewebsites.net/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"requires": {
 				"path-key": "^2.0.0"
 			}
 		},
+		"npmlog": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"dev": true,
+			"requires": {
+				"are-we-there-yet": "~1.1.2",
+				"console-control-strings": "~1.1.0",
+				"gauge": "~2.7.3",
+				"set-blocking": "~2.0.0"
+			}
+		},
 		"number-is-nan": {
 			"version": "1.0.1",
-			"resolved": "http://bbnpm.azurewebsites.net/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nwsapi": {
@@ -6726,17 +9690,32 @@
 				}
 			}
 		},
+		"octokit-pagination-methods": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+			"integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+			"dev": true
+		},
 		"once": {
 			"version": "1.4.0",
-			"resolved": "http://bbnpm.azurewebsites.net/once/-/once-1.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
 				"wrappy": "1"
 			}
 		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^1.0.0"
+			}
+		},
 		"optimist": {
 			"version": "0.6.1",
-			"resolved": "http://bbnpm.azurewebsites.net/optimist/-/optimist-0.6.1.tgz",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"requires": {
 				"minimist": "~0.0.1",
@@ -6745,7 +9724,7 @@
 		},
 		"optionator": {
 			"version": "0.8.2",
-			"resolved": "http://bbnpm.azurewebsites.net/optionator/-/optionator-0.8.2.tgz",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"requires": {
 				"deep-is": "~0.1.3",
@@ -6758,14 +9737,14 @@
 			"dependencies": {
 				"wordwrap": {
 					"version": "1.0.0",
-					"resolved": "http://bbnpm.azurewebsites.net/wordwrap/-/wordwrap-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
 					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 				}
 			}
 		},
 		"os-homedir": {
 			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
@@ -6778,10 +9757,30 @@
 				"mem": "^4.0.0"
 			}
 		},
+		"os-name": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz",
+			"integrity": "sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==",
+			"dev": true,
+			"requires": {
+				"macos-release": "^2.0.0",
+				"windows-release": "^3.1.0"
+			}
+		},
 		"os-tmpdir": {
 			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"osenv": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"dev": true,
+			"requires": {
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.0"
+			}
 		},
 		"output-file-sync": {
 			"version": "1.1.2",
@@ -6800,7 +9799,7 @@
 		},
 		"p-cancelable": {
 			"version": "0.4.1",
-			"resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
 			"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
 		},
 		"p-defer": {
@@ -6810,7 +9809,7 @@
 		},
 		"p-finally": {
 			"version": "1.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/p-finally/-/p-finally-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-is-promise": {
@@ -6834,6 +9833,33 @@
 				"p-limit": "^2.0.0"
 			}
 		},
+		"p-map": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+			"dev": true
+		},
+		"p-map-series": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-1.0.0.tgz",
+			"integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
+			"dev": true,
+			"requires": {
+				"p-reduce": "^1.0.0"
+			}
+		},
+		"p-pipe": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz",
+			"integrity": "sha1-SxoROZoRUgpneQ7loMHViB1r7+k=",
+			"dev": true
+		},
+		"p-reduce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+			"dev": true
+		},
 		"p-timeout": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
@@ -6847,6 +9873,15 @@
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
 			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
 		},
+		"p-waterfall": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-waterfall/-/p-waterfall-1.0.0.tgz",
+			"integrity": "sha1-ftlLPOszMngjU69qrhGqn8I1uwA=",
+			"dev": true,
+			"requires": {
+				"p-reduce": "^1.0.0"
+			}
+		},
 		"package-json": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/package-json/-/package-json-5.0.0.tgz",
@@ -6857,6 +9892,84 @@
 				"registry-url": "^3.1.0",
 				"semver": "^5.5.0"
 			}
+		},
+		"pacote": {
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.0.tgz",
+			"integrity": "sha512-aUplXozRbzhaJO48FaaeClmN+2Mwt741MC6M3bevIGZwdCaP7frXzbUOfOWa91FPHoLITzG0hYaKY363lxO3bg==",
+			"dev": true,
+			"requires": {
+				"bluebird": "^3.5.3",
+				"cacache": "^11.3.2",
+				"figgy-pudding": "^3.5.1",
+				"get-stream": "^4.1.0",
+				"glob": "^7.1.3",
+				"lru-cache": "^5.1.1",
+				"make-fetch-happen": "^4.0.1",
+				"minimatch": "^3.0.4",
+				"minipass": "^2.3.5",
+				"mississippi": "^3.0.0",
+				"mkdirp": "^0.5.1",
+				"normalize-package-data": "^2.4.0",
+				"npm-package-arg": "^6.1.0",
+				"npm-packlist": "^1.1.12",
+				"npm-pick-manifest": "^2.2.3",
+				"npm-registry-fetch": "^3.8.0",
+				"osenv": "^0.1.5",
+				"promise-inflight": "^1.0.1",
+				"promise-retry": "^1.1.1",
+				"protoduck": "^5.0.1",
+				"rimraf": "^2.6.2",
+				"safe-buffer": "^5.1.2",
+				"semver": "^5.6.0",
+				"ssri": "^6.0.1",
+				"tar": "^4.4.8",
+				"unique-filename": "^1.1.1",
+				"which": "^1.3.1"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"tar": {
+					"version": "4.4.8",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+					"dev": true,
+					"requires": {
+						"chownr": "^1.1.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.2"
+					}
+				}
+			}
+		},
+		"parallel-transform": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"dev": true,
+			"requires": {
+				"cyclist": "~0.2.2",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.1.5"
+			}
+		},
+		"parse-github-repo-url": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
+			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
+			"dev": true
 		},
 		"parse-glob": {
 			"version": "3.0.4",
@@ -6870,10 +9983,50 @@
 				"is-glob": "^2.0.0"
 			}
 		},
+		"parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"dev": true,
+			"requires": {
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
+			}
+		},
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+		},
+		"parse-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
+			"integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+			"dev": true,
+			"requires": {
+				"is-ssh": "^1.3.0",
+				"protocols": "^1.4.0"
+			}
+		},
+		"parse-url": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
+			"integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+			"dev": true,
+			"requires": {
+				"is-ssh": "^1.3.0",
+				"normalize-url": "^3.3.0",
+				"parse-path": "^4.0.0",
+				"protocols": "^1.4.0"
+			},
+			"dependencies": {
+				"normalize-url": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+					"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+					"dev": true
+				}
+			}
 		},
 		"parse5": {
 			"version": "4.0.0",
@@ -6885,19 +10038,25 @@
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
 			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
 		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+			"dev": true
+		},
 		"path-exists": {
 			"version": "3.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/path-exists/-/path-exists-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
 			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "http://bbnpm.azurewebsites.net/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "2.0.1",
-			"resolved": "http://bbnpm.azurewebsites.net/path-key/-/path-key-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
 			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-parse": {
@@ -6907,10 +10066,19 @@
 		},
 		"path-to-regexp": {
 			"version": "1.7.0",
-			"resolved": "http://bbnpm.azurewebsites.net/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
 			"requires": {
 				"isarray": "0.0.1"
+			}
+		},
+		"path-type": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+			"dev": true,
+			"requires": {
+				"pify": "^3.0.0"
 			}
 		},
 		"pathval": {
@@ -6920,13 +10088,82 @@
 		},
 		"performance-now": {
 			"version": "2.1.0",
-			"resolved": "http://bbnpm.azurewebsites.net/performance-now/-/performance-now-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
+			"requires": {
+				"pinkie": "^2.0.0"
+			}
+		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
+				}
+			}
 		},
 		"please-upgrade-node": {
 			"version": "3.1.1",
@@ -6944,12 +10181,11 @@
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-			"optional": true
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
-			"resolved": "http://bbnpm.azurewebsites.net/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
 		"prepend-http": {
@@ -6988,10 +10224,62 @@
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.2.tgz",
 			"integrity": "sha512-/OLz5F9beZUWwSHZDreXgap1XShX6W+DCHQCqwCF7uZ88s6uTlD2cR3JBE77SegCmNtb1Idst+NfmwcdU6KVhw=="
 		},
+		"promise-inflight": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+			"dev": true
+		},
+		"promise-retry": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+			"integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+			"dev": true,
+			"requires": {
+				"err-code": "^1.0.0",
+				"retry": "^0.10.0"
+			}
+		},
+		"promzard": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+			"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+			"dev": true,
+			"requires": {
+				"read": "1"
+			}
+		},
 		"propagate": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
 			"integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk="
+		},
+		"proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+			"dev": true
+		},
+		"protocols": {
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
+			"integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
+			"dev": true
+		},
+		"protoduck": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
+			"integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
+			"dev": true,
+			"requires": {
+				"genfun": "^5.0.0"
+			}
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"psl": {
 			"version": "1.1.29",
@@ -7011,7 +10299,7 @@
 			"dependencies": {
 				"readable-stream": {
 					"version": "1.0.34",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -7022,8 +10310,41 @@
 				},
 				"string_decoder": {
 					"version": "0.10.31",
-					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"pumpify": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+			"dev": true,
+			"requires": {
+				"duplexify": "^3.6.0",
+				"inherits": "^2.0.3",
+				"pump": "^2.0.0"
+			},
+			"dependencies": {
+				"pump": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
 				}
 			}
 		},
@@ -7032,6 +10353,12 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
+		"q": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+			"dev": true
+		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -7039,7 +10366,7 @@
 		},
 		"query-string": {
 			"version": "5.1.1",
-			"resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
 			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
 			"requires": {
 				"decode-uri-component": "^0.2.0",
@@ -7056,6 +10383,12 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
 			"integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
+		},
+		"quick-lru": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+			"dev": true
 		},
 		"randomatic": {
 			"version": "3.1.1",
@@ -7095,8 +10428,118 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
+			}
+		},
+		"read": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+			"dev": true,
+			"requires": {
+				"mute-stream": "~0.0.4"
+			}
+		},
+		"read-cmd-shim": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2"
+			}
+		},
+		"read-package-json": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
+			"integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.1",
+				"graceful-fs": "^4.1.2",
+				"json-parse-better-errors": "^1.0.1",
+				"normalize-package-data": "^2.0.0",
+				"slash": "^1.0.0"
+			}
+		},
+		"read-package-tree": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.2.tgz",
+			"integrity": "sha512-rW3XWUUkhdKmN2JKB4FL563YAgtINifso5KShykufR03nJ5loGFlkUMe1g/yxmqX073SoYYTsgXu7XdDinKZuA==",
+			"dev": true,
+			"requires": {
+				"debuglog": "^1.0.1",
+				"dezalgo": "^1.0.0",
+				"once": "^1.3.0",
+				"read-package-json": "^2.0.0",
+				"readdir-scoped-modules": "^1.0.0"
+			}
+		},
+		"read-pkg": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+			"dev": true,
+			"requires": {
+				"load-json-file": "^4.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^3.0.0"
+			}
+		},
+		"read-pkg-up": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.0.0",
+				"read-pkg": "^3.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
 				}
 			}
 		},
@@ -7111,7 +10554,7 @@
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
 				"core-util-is": "~1.0.0",
@@ -7128,6 +10571,18 @@
 					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				}
+			}
+		},
+		"readdir-scoped-modules": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+			"integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
+			"dev": true,
+			"requires": {
+				"debuglog": "^1.0.1",
+				"dezalgo": "^1.0.0",
+				"graceful-fs": "^4.1.2",
+				"once": "^1.3.0"
 			}
 		},
 		"readdirp": {
@@ -7417,10 +10872,20 @@
 		},
 		"rechoir": {
 			"version": "0.6.2",
-			"resolved": "http://bbnpm.azurewebsites.net/rechoir/-/rechoir-0.6.2.tgz",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
 				"resolve": "^1.1.6"
+			}
+		},
+		"redent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+			"dev": true,
+			"requires": {
+				"indent-string": "^3.0.0",
+				"strip-indent": "^2.0.0"
 			}
 		},
 		"regenerate": {
@@ -7503,7 +10968,7 @@
 			"dependencies": {
 				"jsesc": {
 					"version": "0.5.0",
-					"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
 			}
@@ -7603,7 +11068,7 @@
 		},
 		"request-promise-core": {
 			"version": "1.1.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"requires": {
 				"lodash": "^4.13.1"
@@ -7611,7 +11076,7 @@
 		},
 		"request-promise-native": {
 			"version": "1.0.5",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
 			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
 			"requires": {
 				"request-promise-core": "1.1.1",
@@ -7621,12 +11086,12 @@
 		},
 		"require-directory": {
 			"version": "2.1.1",
-			"resolved": "http://bbnpm.azurewebsites.net/require-directory/-/require-directory-2.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
 		"require-main-filename": {
 			"version": "1.0.1",
-			"resolved": "http://bbnpm.azurewebsites.net/require-main-filename/-/require-main-filename-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"requires-port": {
@@ -7642,6 +11107,29 @@
 				"path-parse": "^1.0.5"
 			}
 		},
+		"resolve-cwd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"dev": true,
+			"requires": {
+				"resolve-from": "^3.0.0"
+			},
+			"dependencies": {
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
+				}
+			}
+		},
+		"resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"dev": true
+		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -7655,10 +11143,26 @@
 				"lowercase-keys": "^1.0.0"
 			}
 		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
+			"requires": {
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+		},
+		"retry": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+			"dev": true
 		},
 		"rimraf": {
 			"version": "2.6.3",
@@ -7673,6 +11177,33 @@
 			"resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
 			"integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
 		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
+			"requires": {
+				"is-promise": "^2.1.0"
+			}
+		},
+		"run-queue": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+			"dev": true,
+			"requires": {
+				"aproba": "^1.1.1"
+			}
+		},
+		"rxjs": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+			"integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.9.0"
+			}
+		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -7680,7 +11211,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"requires": {
 				"ret": "~0.1.10"
@@ -7721,7 +11252,7 @@
 		},
 		"set-blocking": {
 			"version": "2.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/set-blocking/-/set-blocking-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-value": {
@@ -7752,7 +11283,7 @@
 		},
 		"shebang-command": {
 			"version": "1.2.0",
-			"resolved": "http://bbnpm.azurewebsites.net/shebang-command/-/shebang-command-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"requires": {
 				"shebang-regex": "^1.0.0"
@@ -7760,7 +11291,7 @@
 		},
 		"shebang-regex": {
 			"version": "1.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
 		"shelljs": {
@@ -7828,7 +11359,7 @@
 		},
 		"signal-exit": {
 			"version": "3.0.2",
-			"resolved": "http://bbnpm.azurewebsites.net/signal-exit/-/signal-exit-3.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"sinon": {
@@ -7872,7 +11403,7 @@
 			"dependencies": {
 				"readable-stream": {
 					"version": "1.0.34",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -7883,10 +11414,22 @@
 				},
 				"string_decoder": {
 					"version": "0.10.31",
-					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
+		},
+		"slide": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+			"dev": true
+		},
+		"smart-buffer": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
+			"integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
+			"dev": true
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -7925,7 +11468,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-			"optional": true,
 			"requires": {
 				"define-property": "^1.0.0",
 				"isobject": "^3.0.0",
@@ -7936,7 +11478,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"optional": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -7945,7 +11486,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -7954,7 +11494,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -7963,7 +11502,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"optional": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -7973,8 +11511,7 @@
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"optional": true
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				},
 				"kind-of": {
 					"version": "6.0.2",
@@ -7987,9 +11524,28 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-			"optional": true,
 			"requires": {
 				"kind-of": "^3.2.0"
+			}
+		},
+		"socks": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.2.3.tgz",
+			"integrity": "sha512-+2r83WaRT3PXYoO/1z+RDEBE7Z2f9YcdQnJ0K/ncXXbV5gJ6wYfNAebYFYiiUjM6E4JyXnPY8cimwyvFYHVUUA==",
+			"dev": true,
+			"requires": {
+				"ip": "^1.1.5",
+				"smart-buffer": "4.0.2"
+			}
+		},
+		"socks-proxy-agent": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.1.tgz",
+			"integrity": "sha512-Kezx6/VBguXOsEe5oU3lXYyKMi4+gva72TwJ7pQY5JfqUx2nMk7NXA6z/mpNqIlfQjWYVfeuNvQjexiTaTn6Nw==",
+			"dev": true,
+			"requires": {
+				"agent-base": "~4.2.0",
+				"socks": "~2.2.0"
 			}
 		},
 		"sort-keys": {
@@ -8038,12 +11594,62 @@
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
+		"spdx-correct": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"dev": true,
+			"requires": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"dev": true
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"dev": true,
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+			"integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+			"dev": true
+		},
+		"split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"requires": {
+				"through": "2"
+			}
+		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"requires": {
 				"extend-shallow": "^3.0.0"
+			}
+		},
+		"split2": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+			"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+			"dev": true,
+			"requires": {
+				"through2": "^2.0.2"
 			}
 		},
 		"sprintf-js": {
@@ -8065,6 +11671,15 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.0.2",
 				"tweetnacl": "~0.14.0"
+			}
+		},
+		"ssri": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+			"dev": true,
+			"requires": {
+				"figgy-pudding": "^3.5.1"
 			}
 		},
 		"stack-chain": {
@@ -8093,8 +11708,24 @@
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+		},
+		"stream-each": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+			"integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"stream-shift": "^1.0.0"
+			}
+		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+			"dev": true
 		},
 		"strict-uri-encode": {
 			"version": "1.1.0",
@@ -8103,7 +11734,7 @@
 		},
 		"string-width": {
 			"version": "2.1.1",
-			"resolved": "http://bbnpm.azurewebsites.net/string-width/-/string-width-2.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
@@ -8127,7 +11758,7 @@
 		},
 		"string_decoder": {
 			"version": "1.1.1",
-			"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
 				"safe-buffer": "~5.1.0"
@@ -8148,8 +11779,14 @@
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+		},
+		"strip-indent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
@@ -8164,6 +11801,25 @@
 				"escape-string-regexp": "^1.0.2"
 			}
 		},
+		"strong-log-transformer": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
+			"integrity": "sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==",
+			"dev": true,
+			"requires": {
+				"duplexer": "^0.1.1",
+				"minimist": "^1.2.0",
+				"through": "^2.3.4"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
+		},
 		"supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -8171,23 +11827,101 @@
 		},
 		"symbol-tree": {
 			"version": "3.2.2",
-			"resolved": "http://bbnpm.azurewebsites.net/symbol-tree/-/symbol-tree-3.2.2.tgz",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
 			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+		},
+		"tar": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+			"dev": true,
+			"requires": {
+				"block-stream": "*",
+				"fstream": "^1.0.2",
+				"inherits": "2"
+			},
+			"dependencies": {
+				"fstream": {
+					"version": "1.0.11",
+					"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"inherits": "~2.0.0",
+						"mkdirp": ">=0.5 0",
+						"rimraf": "2"
+					}
+				}
+			}
+		},
+		"temp-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+			"dev": true
+		},
+		"temp-write": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/temp-write/-/temp-write-3.4.0.tgz",
+			"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"is-stream": "^1.1.0",
+				"make-dir": "^1.0.0",
+				"pify": "^3.0.0",
+				"temp-dir": "^1.0.0",
+				"uuid": "^3.0.1"
+			}
 		},
 		"text-encoding": {
 			"version": "0.6.4",
-			"resolved": "http://bbnpm.azurewebsites.net/text-encoding/-/text-encoding-0.6.4.tgz",
+			"resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
 			"integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+		},
+		"text-extensions": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+			"integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+			"dev": true
 		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
+		"through2": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
+			},
+			"dependencies": {
+				"xtend": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+					"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+					"dev": true
+				}
+			}
+		},
 		"timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
 			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
+			"requires": {
+				"os-tmpdir": "~1.0.2"
+			}
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
@@ -8217,7 +11951,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-			"optional": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
@@ -8227,7 +11960,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"optional": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
@@ -8263,6 +11995,18 @@
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
 			"integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
 		},
+		"trim-newlines": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+			"dev": true
+		},
+		"trim-off-newlines": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+			"dev": true
+		},
 		"trim-repeated": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -8295,7 +12039,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"v8flags": {
@@ -8321,12 +12065,12 @@
 		},
 		"tslib": {
 			"version": "1.9.3",
-			"resolved": "http://bbnpm.azurewebsites.net/tslib/-/tslib-1.9.3.tgz",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
 			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
 		},
 		"tslint": {
 			"version": "5.11.0",
-			"resolved": "http://bbnpm.azurewebsites.net/tslint/-/tslint-5.11.0.tgz",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
 			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
 			"dev": true,
 			"requires": {
@@ -8355,7 +12099,7 @@
 			"dependencies": {
 				"tsutils": {
 					"version": "2.28.0",
-					"resolved": "http://bbnpm.azurewebsites.net/tsutils/-/tsutils-2.28.0.tgz",
+					"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.28.0.tgz",
 					"integrity": "sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==",
 					"dev": true,
 					"requires": {
@@ -8366,7 +12110,7 @@
 		},
 		"tsutils": {
 			"version": "2.29.0",
-			"resolved": "http://bbnpm.azurewebsites.net/tsutils/-/tsutils-2.29.0.tgz",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
 			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
 			"dev": true,
 			"requires": {
@@ -8380,7 +12124,7 @@
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
-			"resolved": "http://bbnpm.azurewebsites.net/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
 				"safe-buffer": "^5.0.1"
@@ -8396,12 +12140,12 @@
 		},
 		"tweetnacl": {
 			"version": "0.14.5",
-			"resolved": "http://bbnpm.azurewebsites.net/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"type-check": {
 			"version": "0.3.2",
-			"resolved": "http://bbnpm.azurewebsites.net/type-check/-/type-check-0.3.2.tgz",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"requires": {
 				"prelude-ls": "~1.1.2"
@@ -8409,8 +12153,14 @@
 		},
 		"type-detect": {
 			"version": "4.0.8",
-			"resolved": "http://bbnpm.azurewebsites.net/type-detect/-/type-detect-4.0.8.tgz",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
 		},
 		"typedoc": {
 			"version": "0.12.0",
@@ -8445,7 +12195,7 @@
 		},
 		"typedoc-default-themes": {
 			"version": "0.5.0",
-			"resolved": "http://bbnpm.azurewebsites.net/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
+			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
 			"integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
 		},
 		"typedoc-plugin-external-module-name": {
@@ -8490,6 +12240,18 @@
 				}
 			}
 		},
+		"uid-number": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+			"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+			"dev": true
+		},
+		"umask": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+			"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+			"dev": true
+		},
 		"underscore": {
 			"version": "1.8.3",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
@@ -8525,6 +12287,33 @@
 						"to-object-path": "^0.3.0"
 					}
 				}
+			}
+		},
+		"unique-filename": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+			"dev": true,
+			"requires": {
+				"unique-slug": "^2.0.0"
+			}
+		},
+		"unique-slug": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
+			"integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+			"dev": true,
+			"requires": {
+				"imurmurhash": "^0.1.4"
+			}
+		},
+		"universal-user-agent": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.3.tgz",
+			"integrity": "sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==",
+			"dev": true,
+			"requires": {
+				"os-name": "^3.0.0"
 			}
 		},
 		"universalify": {
@@ -8593,7 +12382,7 @@
 			"dependencies": {
 				"readable-stream": {
 					"version": "1.0.34",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -8604,7 +12393,7 @@
 				},
 				"string_decoder": {
 					"version": "0.10.31",
-					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
@@ -8655,6 +12444,12 @@
 				"prepend-http": "^2.0.0"
 			}
 		},
+		"url-template": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+			"integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+			"dev": true
+		},
 		"url-to-options": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
@@ -8692,7 +12487,7 @@
 		},
 		"uuid": {
 			"version": "3.3.2",
-			"resolved": "http://bbnpm.azurewebsites.net/uuid/-/uuid-3.3.2.tgz",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"v8flags": {
@@ -8703,14 +12498,33 @@
 				"user-home": "^1.1.1"
 			}
 		},
+		"validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"validate-npm-package-name": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+			"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+			"dev": true,
+			"requires": {
+				"builtins": "^1.0.3"
+			}
+		},
 		"validator": {
 			"version": "9.4.1",
-			"resolved": "http://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
 			"integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
 		},
 		"verror": {
 			"version": "1.10.0",
-			"resolved": "http://bbnpm.azurewebsites.net/verror/-/verror-1.10.0.tgz",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
 				"assert-plus": "^1.0.0",
@@ -8724,6 +12538,15 @@
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"requires": {
 				"browser-process-hrtime": "^0.1.2"
+			}
+		},
+		"wcwidth": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+			"dev": true,
+			"requires": {
+				"defaults": "^1.0.3"
 			}
 		},
 		"webidl-conversions": {
@@ -8764,8 +12587,17 @@
 		},
 		"which-module": {
 			"version": "2.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/which-module/-/which-module-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+		},
+		"wide-align": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.2 || 2"
+			}
 		},
 		"window-size": {
 			"version": "1.1.1",
@@ -8835,14 +12667,23 @@
 				}
 			}
 		},
+		"windows-release": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz",
+			"integrity": "sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==",
+			"dev": true,
+			"requires": {
+				"execa": "^0.10.0"
+			}
+		},
 		"wordwrap": {
 			"version": "0.0.3",
-			"resolved": "http://bbnpm.azurewebsites.net/wordwrap/-/wordwrap-0.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
 			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://bbnpm.azurewebsites.net/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
 				"string-width": "^1.0.1",
@@ -8851,7 +12692,7 @@
 			"dependencies": {
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "http://bbnpm.azurewebsites.net/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
 						"number-is-nan": "^1.0.0"
@@ -8859,7 +12700,7 @@
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "http://bbnpm.azurewebsites.net/string-width/-/string-width-1.0.2.tgz",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
 						"code-point-at": "^1.0.0",
@@ -8871,8 +12712,51 @@
 		},
 		"wrappy": {
 			"version": "1.0.2",
-			"resolved": "http://bbnpm.azurewebsites.net/wrappy/-/wrappy-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write-file-atomic": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+			"integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"write-json-file": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
+			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
+			"dev": true,
+			"requires": {
+				"detect-indent": "^5.0.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"pify": "^3.0.0",
+				"sort-keys": "^2.0.0",
+				"write-file-atomic": "^2.0.0"
+			},
+			"dependencies": {
+				"detect-indent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+					"dev": true
+				}
+			}
+		},
+		"write-pkg": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.2.0.tgz",
+			"integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
+			"dev": true,
+			"requires": {
+				"sort-keys": "^2.0.0",
+				"write-json-file": "^2.2.0"
+			}
 		},
 		"ws": {
 			"version": "5.2.2",
@@ -8920,6 +12804,12 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+		},
+		"yallist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+			"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+			"dev": true
 		},
 		"yargs": {
 			"version": "12.0.5",


### PR DESCRIPTION
Fixes #786 

## Description
Replace async-file package with fs-extra.

These packages provide the same functionality with slightly different syntax.

Removing dependence on async-file reduces the packages we need to worry about.

## Specific Changes

* replaced dependence in package file
* replaced calls to .delete with .remove
* replaced calls to .exists with .pathExists

## Testing

Run existing tests