### PR TITLE
[4.3] Update the LUIS SDK to point at v1.2.2 of Luis Runtime SDK

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -24,7 +24,7 @@
     "@types/html-entities": "^1.2.16",
     "@types/node": "^10.12.18",
     "@types/request-promise-native": "^1.0.10",
-    "azure-cognitiveservices-luis-runtime": "1.2.0",
+    "azure-cognitiveservices-luis-runtime": "1.2.2",
     "botbuilder-core": "~4.1.6",
     "html-entities": "^1.2.1",
     "moment": "^2.20.1",


### PR DESCRIPTION
Updates the Luis Runtime SDK to point at v1.2.2.
There's no functional difference, but the npm package install won't emit a misleading message for Bot Framework users (about deprecation).