### PR TITLE
[4.3 cherry-pick]: Bump to latest luis SDK package

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -24,7 +24,7 @@
     "@types/html-entities": "^1.2.16",
     "@types/node": "^10.12.18",
     "@types/request-promise-native": "^1.0.10",
-    "azure-cognitiveservices-luis-runtime": "1.2.0",
+    "azure-cognitiveservices-luis-runtime": "1.2.2",
     "botbuilder-core": "~4.1.6",
     "html-entities": "^1.2.1",
     "moment": "^2.20.1",


### PR DESCRIPTION
## Description
Cherry pick bump of LUIS runtime version to remove deprecation message

## Specific Changes
  - bump azure-cognitiveservices-luis-runtime to 1.2.2