### PR TITLE
Fixes syntax error in catch block

### DIFF
--- a/libraries/botbuilder-rules/src/botDebugger.ts
+++ b/libraries/botbuilder-rules/src/botDebugger.ts
@@ -255,7 +255,7 @@ export class BotDebugger extends BotAdapterSet {
 				const result = await BotDebugger.connectToEmulator(context);
 				memory = {id: result};
 				await this.updateMemory(context.activity.conversation.id, memory);
-			} catch {
+			} catch (e) {
 			}
 		}
 		return !!memory.id;

--- a/libraries/botbuilder-rules/src/input/numberSlot.ts
+++ b/libraries/botbuilder-rules/src/input/numberSlot.ts
@@ -41,7 +41,7 @@ export class NumberSlot extends InputSlot<number> {
             if (typeof result.value == 'string') {
                 try {
                     result.value = parseFloat(result.value);
-                } catch {
+                } catch (e) {
                     return undefined;
                 }
             }


### PR DESCRIPTION
## Description
Fixes syntax error in catch statements. I was getting this error previously:
```
/mnt/c/Users/krrames/Projects/botbuilder-js/libraries/botbuilder-rules/lib/botDebugger.js:216
            catch {
                  ^

SyntaxError: Unexpected token {
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:616:28)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/mnt/c/Users/krrames/Projects/botbuilder-js/libraries/botbuilder-rules/lib/index.js:20:10)
```

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Added Exception parameter `e` to catch statements