### PR TITLE
Upgrade LUIS SDK to latest typescript version

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -24,7 +24,7 @@
     "@types/html-entities": "^1.2.16",
     "@types/node": "^10.12.18",
     "@types/request-promise-native": "^1.0.10",
-    "azure-cognitiveservices-luis-runtime": "1.2.2",
+    "@azure/cognitiveservices-luis-runtime": "2.0.0",
     "botbuilder-core": "~4.1.6",
     "html-entities": "^1.2.1",
     "moment": "^2.20.1",


### PR DESCRIPTION
The LUIS SDK is generated by the Azure team, and the underlying generated Autorest-based SDK is moving to a new typescript-generated back-end (the Javascript version is going to be deprecated).

This moves us to the new typescript SDK.