### PR TITLE
Restore the deleted script "test:travis" as "test:coveralls"

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "build": "lerna run build",
         "clean": "lerna run clean",
         "test": "lerna run build && nyc mocha \"libraries/bot*/tests/*.test.js\"",
+        "test:coveralls": "lerna run build && nyc mocha \"libraries/bot*/tests/*.test.js\" && nyc report --reporter=text-lcov | coveralls",
         "build-docs": "lerna run build-docs",
         "eslint": "./node_modules/.bin/eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts",
         "eslint-fix": "./node_modules/.bin/eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts --fix",


### PR DESCRIPTION
This lets us run coveralls in the BotBuilder-JS-master-CI build.

Script "test" would no longer be run in the build, as "test:coveralls" covers it.