### PR TITLE
[DO NOT MERGE] Update @azure/ms-rest-js version to support proxy settings

### DIFF
--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -19,7 +19,7 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "dependencies": {
-    "@azure/ms-rest-js": "1.2.6",
+    "@azure/ms-rest-js": "1.8.1",
     "@types/jsonwebtoken": "7.2.8",
     "@types/node": "^10.12.18",
     "base64url": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     },
     "dependencies": {
         "ms-rest-azure": "^2.5.9",
-        "ms-rest-js": "^1.0.1",
         "read-text-file": "^1.1.0",
         "replace-in-file": "^3.4.2",
         "sinon": "^6.3.4",


### PR DESCRIPTION
Fixes #717 

## Specific Changes
- Remove unused dependency from root package.json
    - The [ms-rest-js](https://www.npmjs.com/package/ms-rest-js) dependency is deprecated.
- Update dependency from botframework-connector library
    - [@azure/ms-rest-js](https://www.npmjs.com/package/@azure/ms-rest-js) lastets version 1.8.1

## Testing

1. Local HTTP proxy with [AnyProxy](http://anyproxy.io/en/) application
		Ran echo-bot with HTTP environment variable. 
**Results:**
HTTP proxy server locally => PASS
![image](https://user-images.githubusercontent.com/37461749/56152911-57d23e80-5f8b-11e9-9e93-6d64850c638b.png)


The test ran succefully 
![image](https://user-images.githubusercontent.com/37461749/56144948-b68ebc80-5f79-11e9-868a-5d25f47f02bf.png)