### PR TITLE
Support ordinal.relative entity in LUIS

### DIFF
--- a/libraries/botbuilder-ai/src/luisRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizer.ts
@@ -545,6 +545,15 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
             switch (entity.type) {
                 case 'builtin.number':
                 case 'builtin.ordinal': return Number(res.value);
+                case "builtin.ordinal.relative":
+                    {
+                        let offset: any = Number(res.offset);
+                        let relativeTo: any = res.relativeTo;
+                        return {
+                            offset,
+                            relativeTo
+                        };
+                    }
                 case 'builtin.percentage':
                     {
                         let svalue: string = res.value;
@@ -569,11 +578,16 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
                         return obj;
                     }
                 default:
-                    return Object.keys(entity.resolution).length > 1 ?
-                        entity.resolution :
-                        entity.resolution.value ?
-                            entity.resolution.value :
-                            entity.resolution.values;
+                    {
+                        if (Object.keys(entity.resolution).length > 1)
+                        {
+                            return entity.resolution;
+                        }
+
+                        return entity.resolution.value ||
+                            entity.resolution.values ||
+                            entity.resolution;
+                    }
             }
         }
     }

--- a/libraries/botbuilder-ai/tests/TestData/LuisRecognizer/Composite1.json
+++ b/libraries/botbuilder-ai/tests/TestData/LuisRecognizer/Composite1.json
@@ -1,5 +1,5 @@
 {
-  "text": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5:30am and 4 acres and 4 pico meters and chrimc@hotmail.com and $4 and $4.25 and also 32 and 210.4 and first and 10% and 10.5% and 425-555-1234 and 3 degrees and -27.5 degrees c",
+  "text": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5:30am and 4 acres and 4 pico meters and chrimc@hotmail.com and $4 and $4.25 and also 32 and 210.4 and first and 10% and 10.5% and 425-555-1234 and 3 degrees and -27.5 degrees c and last",
   "intents": {
     "EntityTests": {
       "score": 0.9783022
@@ -37,9 +37,9 @@
       "Composite1": [
         {
           "startIndex": 0,
-          "endIndex": 262,
+          "endIndex": 271,
           "score": 0.7279488,
-          "text": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5 : 30am and 4 acres and 4 pico meters and chrimc @ hotmail . com and $ 4 and $ 4 . 25 and also 32 and 210 . 4 and first and 10 % and 10 . 5 % and 425 - 555 - 1234 and 3 degrees and - 27 . 5 degrees c",
+          "text": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5 : 30am and 4 acres and 4 pico meters and chrimc @ hotmail . com and $ 4 and $ 4 . 25 and also 32 and 210 . 4 and first and 10 % and 10 . 5 % and 425 - 555 - 1234 and 3 degrees and - 27 . 5 degrees c and last",
           "type": "Composite1"
         }
       ]
@@ -292,6 +292,14 @@
               "text": "-27.5 degrees c",
               "type": "builtin.temperature"
             }
+          ],
+          "ordinal_relative": [
+            {
+              "startIndex": 267,
+              "endIndex": 271,
+              "text": "last",
+              "type": "builtin.ordinal.relative"
+            }
           ]
         },
         "age": [
@@ -400,6 +408,12 @@
             "number": -27.5,
             "units": "C"
           }
+        ],
+        "ordinal_relative": [
+          {
+            "offset": 1,
+            "relativeTo": "end"
+          }
         ]
       }
     ]
@@ -409,7 +423,7 @@
     "score": 0.5
   },
   "luisResult": {
-    "query": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5:30am and 4 acres and 4 pico meters and chrimc@hotmail.com and $4 and $4.25 and also 32 and 210.4 and first and 10% and 10.5% and 425-555-1234 and 3 degrees and -27.5 degrees c",
+    "query": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5:30am and 4 acres and 4 pico meters and chrimc@hotmail.com and $4 and $4.25 and also 32 and 210.4 and first and 10% and 10.5% and 425-555-1234 and 3 degrees and -27.5 degrees c and last",
     "topScoringIntent": {
       "intent": "EntityTests",
       "score": 0.9783022
@@ -458,10 +472,10 @@
     ],
     "entities": [
       {
-        "entity": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5 : 30am and 4 acres and 4 pico meters and chrimc @ hotmail . com and $ 4 and $ 4 . 25 and also 32 and 210 . 4 and first and 10 % and 10 . 5 % and 425 - 555 - 1234 and 3 degrees and - 27 . 5 degrees c",
+        "entity": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5 : 30am and 4 acres and 4 pico meters and chrimc @ hotmail . com and $ 4 and $ 4 . 25 and also 32 and 210 . 4 and first and 10 % and 10 . 5 % and 425 - 555 - 1234 and 3 degrees and - 27 . 5 degrees c and last",
         "type": "Composite1",
         "startIndex": 0,
-        "endIndex": 261,
+        "endIndex": 270,
         "score": 0.7279488
       },
       {
@@ -839,12 +853,22 @@
           "unit": "C",
           "value": "-27.5"
         }
+      },
+      {
+        "entity": "last",
+        "type": "builtin.ordinal.relative",
+        "startIndex": 267,
+        "endIndex": 270,
+        "resolution": {
+          "offset": "1",
+          "relativeTo": "end"
+        }
       }
     ],
     "compositeEntities": [
       {
         "parentType": "Composite1",
-        "value": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5 : 30am and 4 acres and 4 pico meters and chrimc @ hotmail . com and $ 4 and $ 4 . 25 and also 32 and 210 . 4 and first and 10 % and 10 . 5 % and 425 - 555 - 1234 and 3 degrees and - 27 . 5 degrees c",
+        "value": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5 : 30am and 4 acres and 4 pico meters and chrimc @ hotmail . com and $ 4 and $ 4 . 25 and also 32 and 210 . 4 and first and 10 % and 10 . 5 % and 425 - 555 - 1234 and 3 degrees and - 27 . 5 degrees c and last",
         "children": [
           {
             "type": "builtin.age",
@@ -985,6 +1009,10 @@
           {
             "type": "builtin.temperature",
             "value": "-27.5 degrees c"
+          },
+          {
+            "type": "builtin.ordinal.relative",
+            "value": "last"
           }
         ]
       }

--- a/libraries/botbuilder-ai/tests/TestData/LuisRecognizer/UnknownResolution.json
+++ b/libraries/botbuilder-ai/tests/TestData/LuisRecognizer/UnknownResolution.json
@@ -1,0 +1,43 @@
+﻿{
+  "text": "unknown",
+  "intents": {
+    "None": {
+      "score": 0.8575135
+    }
+  },
+  "entities": {
+    "$instance": {
+      "something_unknown": [
+        {
+          "startIndex": 0,
+          "endIndex": 7,
+          "text": "unknown",
+          "type": "builtin.something.unknown"
+        }
+      ]
+    },
+    "something_unknown": [
+      {
+        "unknown": "unknown"
+      }
+    ]
+  },
+  "luisResult": {
+    "query": "unknown",
+    "topScoringIntent": {
+      "intent": "None",
+      "score": 0.8575135
+    },
+    "entities": [
+      {
+        "entity": "unknown",
+        "type": "builtin.something.unknown",
+        "startIndex": 0,
+        "endIndex": 6,
+        "resolution": {
+          "unknown": "unknown"
+        }
+      }
+    ]
+  }
+}

--- a/libraries/botbuilder-ai/tests/luisRecognizer.test.js
+++ b/libraries/botbuilder-ai/tests/luisRecognizer.test.js
@@ -857,6 +857,7 @@ describe('LuisRecognizer', function () {
         });
     });
 
+    it('should parse unknown resolution', done => TestJson("UnknownResolution.json", res => done()));
 });
 
 class telemetryOverrideRecognizer extends LuisRecognizer {


### PR DESCRIPTION
## Description
This adds support for the "ordinal.relative" entity in LUIS and allows handling entities that don't have the "value" or "values" property in the resolution.

## Specific Changes
  - Support ordinal.relative
  - Support any resolution that doesn't have the "value"/"values" property in the resolution.