### PR TITLE
Update @azure/ms-rest-js to 1.8.4 (no node upgrade)

### DIFF
--- a/libraries/botbuilder-ai/package-lock.json
+++ b/libraries/botbuilder-ai/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@azure/ms-rest-js": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.8.2.tgz",
-			"integrity": "sha512-xpXLTUztG/oYcyieN0GiS9l33nFTYFm/xetaHef+wbEKevEhEfKzp7Q94nwovNwjhteNSRL2+PjY1uYOQlv3yQ==",
+			"version": "1.8.4",
+			"resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.8.4.tgz",
+			"integrity": "sha512-eoyRARiaf+U90T2Bs2uJ2Zqqk/cLvQujOw42Y9ZB2eRJZoGjJd7Xjh4oKuhnuVGwy8lvMM/Ffj7I77E/CJ9drg==",
 			"requires": {
 				"@types/tunnel": "0.0.0",
 				"axios": "^0.18.0",

--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -28,7 +28,7 @@
     "botbuilder-core": "~4.1.6",
     "html-entities": "^1.2.1",
     "moment": "^2.20.1",
-    "@azure/ms-rest-js": "~1.8.2",
+    "@azure/ms-rest-js": "~1.8.4",
     "request": "^2.87.0",
     "request-promise-native": "1.0.5",
     "url-parse": "^1.4.4"


### PR DESCRIPTION
Fixes #916

## Description
Upgrade to ms-rest-js reference to 1.8.4 to match `cognitiveservices-luis-runtime` version.

