### PR TITLE
change a boolean expr in evaluator/switchcasebody

### DIFF
--- a/libraries/botbuilder-lg/src/evaluator.ts
+++ b/libraries/botbuilder-lg/src/evaluator.ts
@@ -224,7 +224,7 @@ export class Evaluator extends AbstractParseTreeVisitor<string> implements LGFil
                 continue; //skip the first node which is a switch statement
             }
 
-            if (idx === length - 1 && caseNode.switchCaseStat().DEFAULT()){
+            if (idx === length - 1 && caseNode.switchCaseStat().DEFAULT() !== undefined){
                 const defaultBody: lp.NormalTemplateBodyContext = caseNode.normalTemplateBody();
                 if (defaultBody !== undefined){
                     return this.visit(defaultBody);


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - change caseNode.switchCaseStat().DEFAULT()  to caseNode.switchCaseStat().DEFAULT() !== undefine.
makes code more readable.
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->