### PR TITLE
[Expression] Obsolete special format

### DIFF
--- a/libraries/botbuilder-expression-parser/src/expressionEngine.ts
+++ b/libraries/botbuilder-expression-parser/src/expressionEngine.ts
@@ -52,7 +52,7 @@ export class ExpressionEngine implements IExpressionParser {
         public visitFuncInvokeExp(context: ep.FuncInvokeExpContext): Expression {
             const parameters: Expression[] = this.ProcessArgsList(context.argsList());
 
-            // if context.primaryExpression() is idAtom --> normal function
+            // Current only IdAtom is supported as function name
             if (context.primaryExpression() instanceof ep.IdAtomContext) {
                 const idAtom: ep.IdAtomContext = <ep.IdAtomContext>(context.primaryExpression());
                 const functionName: string = idAtom.text;
@@ -60,17 +60,7 @@ export class ExpressionEngine implements IExpressionParser {
                 return this.MakeExpression(functionName, ...parameters);
             }
 
-            //if context.primaryExpression() is memberaccessExp --> lamda function
-            if (context.primaryExpression() instanceof ep.MemberAccessExpContext) {
-                const memberAccessExp: ep.MemberAccessExpContext = <ep.MemberAccessExpContext>(context.primaryExpression());
-                const instance: Expression = this.visit(memberAccessExp.primaryExpression());
-                const functionName: string = memberAccessExp.IDENTIFIER().text;
-                parameters.splice(0, 0, instance);
-
-                return this.MakeExpression(functionName, ...parameters);
-            }
-
-            throw Error('This format is wrong.');
+            throw Error(`This format is wrong in expression ${context.text}.`);
         }
 
         public visitIdAtom(context: ep.IdAtomContext): Expression {

--- a/libraries/botbuilder-expression-parser/tests/badExpression.test.js
+++ b/libraries/botbuilder-expression-parser/tests/badExpression.test.js
@@ -18,6 +18,7 @@ const badExpressions =
   "a.func()", // no such function
   "(1.foreach)()",// error func
   "('str'.foreach)()",// error func
+  "'hello'.length()",// not support currently
 
   // Operators test
   "'1' + 2", // params should be number

--- a/libraries/botbuilder-expression-parser/tests/expression.test.js
+++ b/libraries/botbuilder-expression-parser/tests/expression.test.js
@@ -109,10 +109,10 @@ const dataSource = [
   ["addOrdinal(11 + 13)", "24th"],
   ["addOrdinal(-1)", "-1"],//original string value
   ["count(guid())", 36],
-  ["guid().indexOf('-')", 8],
+  ["indexOf(guid(), '-')", 8],
   ["indexOf(guid(), '-')", 8],
   ["indexOf(hello, '-')", -1],
-  ["guid().lastIndexOf('-')", 23],
+  ["lastIndexOf(guid(), '-')", 23],
   ["lastIndexOf(guid(), '-')", 23],
   ["lastIndexOf(hello, '-')", -1],
 


### PR DESCRIPTION
Previously Expression support such format: 'hello'.length(), which is same as length('hello'), but in the future, this kind of Expression will be deprecated.