### PR TITLE
dotnet issue 1860 activity.text can be null

### DIFF
--- a/libraries/botbuilder/src/inspectionMiddleware.ts
+++ b/libraries/botbuilder/src/inspectionMiddleware.ts
@@ -186,7 +186,7 @@ export class InspectionMiddleware extends InterceptionMiddleware {
 
     public async processCommand(turnContext: TurnContext): Promise<any> {
 
-        if (turnContext.activity.type == ActivityTypes.Message) {
+        if (turnContext.activity.type == ActivityTypes.Message && turnContext.activity.text !== undefined) {
 
             var command = turnContext.activity.text.trim().split(' ');
             if (command.length > 1 && command[0] === InspectionMiddleware.command) {


### PR DESCRIPTION
The activity, even if it a message activity, can have null text. For example if it just contains an attachment.

This brings the Node repo inline with the C# implementation.