### PR TITLE
fix import in inspectionMiddleware.ts

### DIFF
--- a/libraries/botbuilder/src/inspectionMiddleware.ts
+++ b/libraries/botbuilder/src/inspectionMiddleware.ts
@@ -5,9 +5,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Activity, ActivityTypes, ConversationReference } from 'botframework-schema';
 import { MicrosoftAppCredentials, ConnectorClient } from 'botframework-connector';
-import { Middleware, TurnContext, BotState, StatePropertyAccessor, UserState, ConversationState, Storage } from 'botbuilder-core';
+import { Activity, ActivityTypes, BotState, ConversationReference, ConversationState, Middleware, StatePropertyAccessor, Storage, TurnContext, UserState } from 'botbuilder-core';
 
 /** @private */
 class TraceActivity {
@@ -396,4 +395,4 @@ export class InspectionState extends BotState {
     protected getStorageKey(turnContext: TurnContext) {
         return 'InspectionState';
     }
-} 
+}


### PR DESCRIPTION

## Description
Stops importing directly from botframework-schema in botbuilder, which does not have a direct dependency on this library.

Instead import from botbuilder-core, which exposes botframework-schema

This makes the InspectionMiddleware class usable outside of the repo/project.
