### PR TITLE
Add ability to pass LUIS prediction options into Recognizer.recognize method

### DIFF
--- a/libraries/botbuilder-ai/src/luisRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizer.ts
@@ -270,6 +270,7 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
      * @param context Context for the current turn of conversation with the use.
      * @param telemetryProperties Additional properties to be logged to telemetry with the LuisResult event.
      * @param telemetryMetrics Additional metrics to be logged to telemetry with the LuisResult event.
+     * @param options (Optional) options object used to control predictions. Should conform to the [LuisPrectionOptions](#luispredictionoptions) definition.
      */
     public recognize(context: TurnContext, telemetryProperties?: { [key: string]: string }, telemetryMetrics?: { [key: string]: number }, options?: LuisPredictionOptions): Promise<RecognizerResult> {
         const cached: any = context.turnState.get(this.cacheKey);

--- a/libraries/botbuilder-ai/src/luisRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizer.ts
@@ -271,8 +271,9 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
      * @param telemetryProperties Additional properties to be logged to telemetry with the LuisResult event.
      * @param telemetryMetrics Additional metrics to be logged to telemetry with the LuisResult event.
      */
-    public recognize(context: TurnContext, telemetryProperties?: { [key: string]: string }, telemetryMetrics?: { [key: string]: number }): Promise<RecognizerResult> {
+    public recognize(context: TurnContext, telemetryProperties?: { [key: string]: string }, telemetryMetrics?: { [key: string]: number }, options?: LuisPredictionOptions): Promise<RecognizerResult> {
         const cached: any = context.turnState.get(this.cacheKey);
+        const luisPredictionOptions = options ? this.setLuisPredictionOptions(this.options, options) : this.options;
         if (!cached) {
             const utterance: string = context.activity.text || '';
             let recognizerPromise: Promise<RecognizerResult>;
@@ -288,12 +289,12 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
                 recognizerPromise = this.luisClient.prediction.resolve(
                     this.application.applicationId, utterance,
                     {
-                        verbose: this.options.includeAllIntents,
+                        verbose: luisPredictionOptions.includeAllIntents,
                         customHeaders: {
                             'Ocp-Apim-Subscription-Key': this.application.endpointKey,
                             'User-Agent': this.getUserAgent()
                         },
-                        ...this.options
+                        ...luisPredictionOptions
                     })
                     // Map results
                     .then((luisResult: LuisModels.LuisResult) => ({
@@ -303,7 +304,7 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
                         entities: this.getEntitiesAndMetadata(
                             luisResult.entities,
                             luisResult.compositeEntities,
-                            this.options.includeInstanceData === undefined || this.options.includeInstanceData
+                            luisPredictionOptions.includeInstanceData === undefined || luisPredictionOptions.includeInstanceData
                         ),
                         sentiment: this.getSentiment(luisResult),
                         luisResult: (this.includeApiResults ? luisResult : null)
@@ -707,6 +708,13 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
         }
 
         return result;
+    }
+
+    /**
+     * Merges the default options set by the Recognizer contructor with the 'user' options passed into the 'recognize' method
+    */
+    private setLuisPredictionOptions(defaultOptions: LuisPredictionOptions, userOptions: LuisPredictionOptions): any {
+      return Object.assign(defaultOptions, userOptions);
     }
 
     /**

--- a/libraries/botbuilder-ai/tests/luisRecognizer.test.js
+++ b/libraries/botbuilder-ai/tests/luisRecognizer.test.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const fs = require('fs-extra');
 const nock = require('nock');
+const sinon = require('sinon');
 const { TestAdapter, TurnContext } = require('botbuilder-core');
 const { LuisRecognizer } = require('../');
 const luisAppId = '38330cad-f768-4619-96f9-69ea333e594b';
@@ -867,6 +868,35 @@ describe('LuisRecognizer', function () {
             assert(res.entities.$instance.Name[0].endIndex === 15);
             assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
         });
+    });
+
+    it('should accept LuisPredictionOptions passed into recognizer "recognize" method', done => {
+        const luisPredictionDefaultOptions = {
+            includeAllIntents: true,
+            includeInstanceData: true
+        };
+        const luisPredictionUserOptions = {
+            includeAllIntents: false,
+            includeInstanceData: false
+        };
+        const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, luisPredictionDefaultOptions, true);
+        const mergedOptions = luisPredictionUserOptions ? recognizer.setLuisPredictionOptions(recognizer.options, luisPredictionUserOptions) : recognizer.options;
+        assert(mergedOptions.includeAllIntents === false);
+        assert(mergedOptions.includeInstanceData === false);
+        throttle(done);
+    });
+
+    it('should use default Luis prediction options if no user options passed in', done => {
+        const luisPredictionDefaultOptions = {
+            includeAllIntents: true,
+            includeInstanceData: true
+        };
+        const luisPredictionUserOptions = null;
+        const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, luisPredictionDefaultOptions, true);
+        const mergedOptions = luisPredictionUserOptions ? recognizer.setLuisPredictionOptions(recognizer.options, luisPredictionUserOptions) : recognizer.options;
+        assert(mergedOptions.includeAllIntents === true);
+        assert(mergedOptions.includeInstanceData === true);
+        throttle(done);
     });
 
 });

--- a/libraries/botbuilder-ai/tests/luisRecognizer.test.js
+++ b/libraries/botbuilder-ai/tests/luisRecognizer.test.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
 const fs = require('fs-extra');
 const nock = require('nock');
-const sinon = require('sinon');
 const { TestAdapter, TurnContext } = require('botbuilder-core');
 const { LuisRecognizer } = require('../');
 const luisAppId = '38330cad-f768-4619-96f9-69ea333e594b';


### PR DESCRIPTION
Fixes #964 

## Description
Add ability for Recognizer.recognize method to accept user-defined luis prediction options and use the properties present in that particular request, defaulting to the options set by the class constructor otherwise.

## Specific Changes
1) botbuilder-js\libraries\botbuilder-ai\src\luisRecognizer.ts
  -- Added additional parameter to 'recognize' method to accept user-defined luis prediction options.
  -- Added private method 'setLuisPredictionOptions' to merge the user-defined and default options objects (and to make it testable).

## Testing
Tests added to:
libraries/botbuilder-ai/tests/luisRecognizer.test.js