### PR TITLE
upgrade filenamify to ^4.1.0 in botbuilder

### DIFF
--- a/libraries/botbuilder/package-lock.json
+++ b/libraries/botbuilder/package-lock.json
@@ -15,14 +15,6 @@
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
       "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
     },
-    "@types/filenamify": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/filenamify/-/filenamify-2.0.2.tgz",
-      "integrity": "sha512-/sO8rlEFYLZGjoDCIy1BmSdo+xNQbtJIgyrElZrzALolPUhBHvY/vQVGKSw4RSkREtuAv3eb6M7mDXvhpFxYbw==",
-      "requires": {
-        "filenamify": "*"
-      }
-    },
     "@types/form-data": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
@@ -103,12 +95,6 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
-    },
-    "app-root-path": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.2.1.tgz",
-      "integrity": "sha512-91IFKeKk7FjfmezPKkwtaRvSpnUc4gDwPAjA1YZ9Gn0q0PPeW+vbeUsZuyDwjI7+QTHhcLen2v25fi/AmhvbJA==",
-      "dev": true
     },
     "arrify": {
       "version": "1.0.1",
@@ -367,20 +353,6 @@
         "mimic-response": "^1.0.0"
       }
     },
-    "codelyzer": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/codelyzer/-/codelyzer-4.5.0.tgz",
-      "integrity": "sha512-oO6vCkjqsVrEsmh58oNlnJkRXuA30hF8cdNAQV9DytEalDwyOFRvHMnlKFzmOStNerOmPGZU9GAHnBo4tGvtiQ==",
-      "dev": true,
-      "requires": {
-        "app-root-path": "^2.1.0",
-        "css-selector-tokenizer": "^0.7.0",
-        "cssauron": "^1.4.0",
-        "semver-dsl": "^1.0.1",
-        "source-map": "^0.5.7",
-        "sprintf-js": "^1.1.1"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -427,32 +399,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "css-selector-tokenizer": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
-      "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
-      "dev": true,
-      "requires": {
-        "cssesc": "^0.1.0",
-        "fastparse": "^1.1.1",
-        "regexpu-core": "^1.0.0"
-      }
-    },
-    "cssauron": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/cssauron/-/cssauron-1.4.0.tgz",
-      "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
-      "dev": true,
-      "requires": {
-        "through": "X.X.X"
-      }
-    },
-    "cssesc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-      "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
-      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -581,24 +527,18 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
-    "fastparse": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
-      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
-      "dev": true
-    },
     "filename-reserved-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
       "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
     },
     "filenamify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
-      "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.1.0.tgz",
+      "integrity": "sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==",
       "requires": {
         "filename-reserved-regex": "^2.0.0",
-        "strip-outer": "^1.0.0",
+        "strip-outer": "^1.0.1",
         "trim-repeated": "^1.0.0"
       }
     },
@@ -955,12 +895,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==",
-      "dev": true
-    },
-    "jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "dev": true
     },
     "json-buffer": {
@@ -4146,23 +4080,6 @@
         }
       }
     },
-    "regenerate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-      "dev": true
-    },
-    "regexpu-core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-      "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-      "dev": true,
-      "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
-      }
-    },
     "registry-auth-token": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
@@ -4180,21 +4097,6 @@
       "dev": true,
       "requires": {
         "rc": "^1.0.1"
-      }
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
-    },
-    "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
-      "requires": {
-        "jsesc": "~0.5.0"
       }
     },
     "request": {
@@ -4284,11 +4186,6 @@
       "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
       "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
     },
-    "rsa-pem-from-mod-exp": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
-      "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -4316,15 +4213,6 @@
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
-    "semver-dsl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/semver-dsl/-/semver-dsl-1.0.1.tgz",
-      "integrity": "sha1-02eN5VVeimH2Ke7QJTZq5fJzQKA=",
-      "dev": true,
-      "requires": {
-        "semver": "^5.3.0"
-      }
-    },
     "sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -4333,12 +4221,6 @@
       "requires": {
         "is-plain-obj": "^1.0.0"
       }
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
     },
     "source-map-support": {
       "version": "0.5.12",
@@ -4357,12 +4239,6 @@
           "dev": true
         }
       }
-    },
-    "sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -4448,12 +4324,6 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
     },
     "timed-out": {
       "version": "4.0.1",

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -20,18 +20,16 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "dependencies": {
-    "@types/filenamify": "^2.0.1",
     "@types/node": "^10.12.18",
     "botbuilder-core": "~4.1.6",
     "botframework-connector": "~4.1.6",
-    "filenamify": "^2.0.0",
+    "filenamify": "^4.1.0",
     "fs-extra": "^7.0.1"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.47",
     "assert": "^1.4.1",
     "chatdown": "^1.0.2",
-    "codelyzer": "^4.1.0",
     "mocha": "^5.2.0",
     "nock": "^10.0.3",
     "nyc": "^11.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,20 @@
 				"xml2js": "^0.4.19"
 			},
 			"dependencies": {
+				"axios": {
+					"version": "0.19.0",
+					"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+					"integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+					"requires": {
+						"follow-redirects": "1.5.10",
+						"is-buffer": "^2.0.2"
+					}
+				},
+				"is-buffer": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+					"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+				},
 				"tunnel": {
 					"version": "0.0.6",
 					"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -1119,8 +1133,24 @@
 		},
 		"@types/events": {
 			"version": "1.2.0",
-			"resolved": "http://bbnpm.azurewebsites.net/@types%2fevents/-/events-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
 			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
+		},
+		"@types/filenamify": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/filenamify/-/filenamify-2.0.2.tgz",
+			"integrity": "sha512-/sO8rlEFYLZGjoDCIy1BmSdo+xNQbtJIgyrElZrzALolPUhBHvY/vQVGKSw4RSkREtuAv3eb6M7mDXvhpFxYbw==",
+			"requires": {
+				"filenamify": "*"
+			}
+		},
+		"@types/form-data": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+			"integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/fs-extra": {
 			"version": "5.1.0",
@@ -1555,9 +1585,8 @@
 		},
 		"arrify": {
 			"version": "1.0.1",
-			"resolved": "http://bbnpm.azurewebsites.net/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-			"dev": true
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
 		},
 		"asap": {
 			"version": "2.0.6",
@@ -1659,22 +1688,6 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-		},
-		"axios": {
-			"version": "0.18.0",
-			"resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-			"integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
-			"requires": {
-				"follow-redirects": "1.5.10",
-				"is-buffer": "^2.0.2"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-					"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
-				}
-			}
 		},
 		"azure-storage": {
 			"version": "2.10.2",
@@ -2424,6 +2437,18 @@
 				"botframework-connector": "^4.4.0",
 				"filenamify": "^2.0.0",
 				"fs-extra": "^7.0.1"
+			},
+			"dependencies": {
+				"filenamify": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
+					"integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
+					"requires": {
+						"filename-reserved-regex": "^2.0.0",
+						"strip-outer": "^1.0.0",
+						"trim-repeated": "^1.0.0"
+					}
+				}
 			}
 		},
 		"botbuilder-ai": {
@@ -2585,7 +2610,7 @@
 		"browser-stdout": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+			"integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA="
 		},
 		"browserify-mime": {
 			"version": "1.2.9",
@@ -2604,7 +2629,7 @@
 		},
 		"buffer-equal-constant-time": {
 			"version": "1.0.1",
-			"resolved": "http://bbnpm.azurewebsites.net/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
 			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
 		},
 		"buffer-from": {
@@ -3459,9 +3484,16 @@
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
-			"resolved": "http://bbnpm.azurewebsites.net/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-			"dev": true
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+		},
+		"decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"requires": {
+				"mimic-response": "^1.0.0"
+			}
 		},
 		"dedent": {
 			"version": "0.7.0",
@@ -3488,7 +3520,7 @@
 		},
 		"deep-is": {
 			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"resolved": "http://bbnpm.azurewebsites.net/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
 		"deepmerge": {
@@ -3671,9 +3703,9 @@
 			}
 		},
 		"dotenv": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
-			"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+			"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
 		},
 		"dtrace-provider": {
 			"version": "0.8.7",
@@ -3686,7 +3718,7 @@
 		},
 		"duplexer": {
 			"version": "0.1.1",
-			"resolved": "http://bbnpm.azurewebsites.net/duplexer/-/duplexer-0.1.1.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 		},
 		"duplexer3": {
@@ -3716,7 +3748,7 @@
 		},
 		"ecdsa-sig-formatter": {
 			"version": "1.0.10",
-			"resolved": "http://bbnpm.azurewebsites.net/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
 			"integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
 			"requires": {
 				"safe-buffer": "^5.0.1"
@@ -3984,7 +4016,7 @@
 		},
 		"esrecurse": {
 			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+			"resolved": "http://bbnpm.azurewebsites.net/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"requires": {
 				"estraverse": "^4.1.0"
@@ -3992,7 +4024,7 @@
 		},
 		"estraverse": {
 			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"resolved": "http://bbnpm.azurewebsites.net/estraverse/-/estraverse-4.2.0.tgz",
 			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
 		},
 		"esutils": {
@@ -4047,7 +4079,7 @@
 		},
 		"extend": {
 			"version": "3.0.2",
-			"resolved": "http://bbnpm.azurewebsites.net/extend/-/extend-3.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
 		"extend-shallow": {
@@ -4405,7 +4437,7 @@
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"resolved": "http://bbnpm.azurewebsites.net/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"fastparse": {
@@ -4446,12 +4478,12 @@
 			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
 		},
 		"filenamify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
-			"integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.1.0.tgz",
+			"integrity": "sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==",
 			"requires": {
 				"filename-reserved-regex": "^2.0.0",
-				"strip-outer": "^1.0.0",
+				"strip-outer": "^1.0.1",
 				"trim-repeated": "^1.0.0"
 			}
 		},
@@ -4592,7 +4624,7 @@
 		},
 		"from2": {
 			"version": "2.3.0",
-			"resolved": "http://bbnpm.azurewebsites.net/from2/-/from2-2.3.0.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 			"requires": {
 				"inherits": "^2.0.1",
@@ -6048,7 +6080,7 @@
 		},
 		"is-buffer": {
 			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
 		},
 		"is-callable": {
@@ -6168,9 +6200,8 @@
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
-			"resolved": "http://bbnpm.azurewebsites.net/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -6396,9 +6427,32 @@
 		},
 		"jsonparse": {
 			"version": "1.2.0",
-			"resolved": "http://bbnpm.azurewebsites.net/jsonparse/-/jsonparse-1.2.0.tgz",
-			"integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70=",
-			"dev": true
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jsonparse/-/jsonparse-1.2.0.tgz",
+			"integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
+		},
+		"jsonwebtoken": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
+			"integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
+			"requires": {
+				"jws": "^3.1.4",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.0.0",
+				"xtend": "^4.0.1"
+			},
+			"dependencies": {
+				"xtend": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+					"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+				}
+			}
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -6469,7 +6523,7 @@
 		},
 		"lcov-parse": {
 			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+			"resolved": "http://bbnpm.azurewebsites.net/lcov-parse/-/lcov-parse-0.0.10.tgz",
 			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM="
 		},
 		"lerna": {
@@ -6498,7 +6552,7 @@
 		},
 		"levn": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"resolved": "http://bbnpm.azurewebsites.net/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"requires": {
 				"prelude-ls": "~1.1.2",
@@ -6704,7 +6758,7 @@
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
-			"resolved": "http://bbnpm.azurewebsites.net/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
 		"lodash.template": {
@@ -6757,8 +6811,15 @@
 		"log-driver": {
 			"version": "1.2.7",
 			"resolved": "http://bbnpm.azurewebsites.net/log-driver/-/log-driver-1.2.7.tgz",
-			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-			"dev": true
+			"integrity": "sha1-Y7lQIfBwL+36LJuwok53l9cYcdg="
+		},
+		"log-symbols": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"requires": {
+				"chalk": "^2.0.1"
+			}
 		},
 		"lolex": {
 			"version": "4.1.0",
@@ -7328,7 +7389,7 @@
 		},
 		"moment": {
 			"version": "2.22.2",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/moment/-/moment-2.22.2.tgz",
 			"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
 		},
 		"move-concurrently": {
@@ -7762,27 +7823,10 @@
 			"resolved": "http://bbnpm.azurewebsites.net/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
-		"nwsapi": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-			"integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ=="
-		},
-		"oauth-sign": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "http://bbnpm.azurewebsites.net/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
-		},
-		"object-copy": {
-			"version": "0.1.0",
-			"resolved": "http://bbnpm.azurewebsites.net/object-copy/-/object-copy-0.1.0.tgz",
-			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-			"dev": true,
+		"nyc": {
+			"version": "11.9.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
+			"integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
 			"requires": {
 				"archy": "^1.0.0",
 				"arrify": "^1.0.1",
@@ -7815,8 +7859,7 @@
 			"dependencies": {
 				"align-text": {
 					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-					"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"kind-of": "^3.0.2",
@@ -7826,76 +7869,62 @@
 				},
 				"amdefine": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-					"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+					"bundled": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+					"bundled": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+					"bundled": true
 				},
 				"append-transform": {
 					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-					"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+					"bundled": true,
 					"requires": {
 						"default-require-extensions": "^1.0.0"
 					}
 				},
 				"archy": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-					"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+					"bundled": true
 				},
 				"arr-diff": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+					"bundled": true
 				},
 				"arr-flatten": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-					"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+					"bundled": true
 				},
 				"arr-union": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-					"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+					"bundled": true
 				},
 				"array-unique": {
 					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+					"bundled": true
 				},
 				"arrify": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+					"bundled": true
 				},
 				"assign-symbols": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-					"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+					"bundled": true
 				},
 				"async": {
 					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+					"bundled": true
 				},
 				"atob": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-					"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+					"bundled": true
 				},
 				"babel-code-frame": {
 					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-					"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+					"bundled": true,
 					"requires": {
 						"chalk": "^1.1.3",
 						"esutils": "^2.0.2",
@@ -7904,8 +7933,7 @@
 				},
 				"babel-generator": {
 					"version": "6.26.1",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-					"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+					"bundled": true,
 					"requires": {
 						"babel-messages": "^6.23.0",
 						"babel-runtime": "^6.26.0",
@@ -7916,191 +7944,17 @@
 						"source-map": "^0.5.7",
 						"trim-right": "^1.0.1"
 					}
-				}
-			}
-		},
-		"parallel-transform": {
-			"version": "1.1.0",
-			"resolved": "http://bbnpm.azurewebsites.net/parallel-transform/-/parallel-transform-1.1.0.tgz",
-			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-			"dev": true,
-			"requires": {
-				"cyclist": "~0.2.2",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.1.5"
-			}
-		},
-		"parent-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
-			"integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
-			"dev": true,
-			"requires": {
-				"callsites": "^3.0.0"
-			},
-			"dependencies": {
-				"callsites": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-					"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
-					"dev": true
-				}
-			}
-		},
-		"parse-github-repo-url": {
-			"version": "1.4.1",
-			"resolved": "http://bbnpm.azurewebsites.net/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
-			"dev": true
-		},
-		"parse-json": {
-			"version": "4.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-			"dev": true,
-			"requires": {
-				"error-ex": "^1.3.1",
-				"json-parse-better-errors": "^1.0.1"
-			}
-		},
-		"parse-path": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
-			"integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
-			"dev": true,
-			"requires": {
-				"is-ssh": "^1.3.0",
-				"protocols": "^1.4.0"
-			}
-		},
-		"parse-url": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
-			"integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
-			"dev": true,
-			"requires": {
-				"is-ssh": "^1.3.0",
-				"normalize-url": "^3.3.0",
-				"parse-path": "^4.0.0",
-				"protocols": "^1.4.0"
-			},
-			"dependencies": {
-				"normalize-url": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-					"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
-					"dev": true
-				}
-			}
-		},
-		"parse5": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
-		},
-		"pascalcase": {
-			"version": "0.1.1",
-			"resolved": "http://bbnpm.azurewebsites.net/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-			"dev": true
-		},
-		"path-dirname": {
-			"version": "1.0.2",
-			"resolved": "http://bbnpm.azurewebsites.net/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-			"dev": true
-		},
-		"path-exists": {
-			"version": "3.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "http://bbnpm.azurewebsites.net/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
-		"path-is-inside": {
-			"version": "1.0.2",
-			"resolved": "http://bbnpm.azurewebsites.net/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-			"dev": true
-		},
-		"path-key": {
-			"version": "2.0.1",
-			"resolved": "http://bbnpm.azurewebsites.net/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-		},
-		"path-to-regexp": {
-			"version": "1.7.0",
-			"resolved": "http://bbnpm.azurewebsites.net/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-			"requires": {
-				"isarray": "0.0.1"
-			}
-		},
-		"path-type": {
-			"version": "3.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/path-type/-/path-type-3.0.0.tgz",
-			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-			"dev": true,
-			"requires": {
-				"pify": "^3.0.0"
-			}
-		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "http://bbnpm.azurewebsites.net/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-		},
-		"pify": {
-			"version": "3.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-			"dev": true
-		},
-		"pinkie": {
-			"version": "2.0.4",
-			"resolved": "http://bbnpm.azurewebsites.net/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-			"dev": true
-		},
-		"pinkie-promise": {
-			"version": "2.0.1",
-			"resolved": "http://bbnpm.azurewebsites.net/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"dev": true,
-			"requires": {
-				"pinkie": "^2.0.0"
-			}
-		},
-		"pkg-dir": {
-			"version": "2.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/pkg-dir/-/pkg-dir-2.0.0.tgz",
-			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-			"dev": true,
-			"requires": {
-				"find-up": "^2.1.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
+				},
+				"babel-messages": {
+					"version": "6.23.0",
+					"bundled": true,
 					"requires": {
 						"babel-runtime": "^6.22.0"
 					}
 				},
 				"babel-runtime": {
 					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-					"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+					"bundled": true,
 					"requires": {
 						"core-js": "^2.4.0",
 						"regenerator-runtime": "^0.11.0"
@@ -8108,8 +7962,7 @@
 				},
 				"babel-template": {
 					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-					"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+					"bundled": true,
 					"requires": {
 						"babel-runtime": "^6.26.0",
 						"babel-traverse": "^6.26.0",
@@ -8120,8 +7973,7 @@
 				},
 				"babel-traverse": {
 					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-					"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+					"bundled": true,
 					"requires": {
 						"babel-code-frame": "^6.26.0",
 						"babel-messages": "^6.23.0",
@@ -8136,8 +7988,7 @@
 				},
 				"babel-types": {
 					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-					"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+					"bundled": true,
 					"requires": {
 						"babel-runtime": "^6.26.0",
 						"esutils": "^2.0.2",
@@ -8147,18 +7998,15 @@
 				},
 				"babylon": {
 					"version": "6.18.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-					"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+					"bundled": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+					"bundled": true
 				},
 				"base": {
 					"version": "0.11.2",
-					"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-					"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+					"bundled": true,
 					"requires": {
 						"cache-base": "^1.0.1",
 						"class-utils": "^0.3.5",
@@ -8171,32 +8019,28 @@
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"bundled": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"bundled": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"bundled": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"bundled": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -8205,20 +8049,17 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+							"bundled": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+							"bundled": true
 						}
 					}
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"bundled": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -8226,8 +8067,7 @@
 				},
 				"braces": {
 					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"bundled": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
 						"array-unique": "^0.3.2",
@@ -8243,8 +8083,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"bundled": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -8253,13 +8092,11 @@
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+					"bundled": true
 				},
 				"cache-base": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-					"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+					"bundled": true,
 					"requires": {
 						"collection-visit": "^1.0.0",
 						"component-emitter": "^1.2.1",
@@ -8274,15 +8111,13 @@
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+							"bundled": true
 						}
 					}
 				},
 				"caching-transform": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-					"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+					"bundled": true,
 					"requires": {
 						"md5-hex": "^1.2.0",
 						"mkdirp": "^0.5.1",
@@ -8291,14 +8126,12 @@
 				},
 				"camelcase": {
 					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+					"bundled": true,
 					"optional": true
 				},
 				"center-align": {
 					"version": "0.1.3",
-					"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-					"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"align-text": "^0.1.3",
@@ -8307,8 +8140,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"bundled": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
 						"escape-string-regexp": "^1.0.2",
@@ -8319,8 +8151,7 @@
 				},
 				"class-utils": {
 					"version": "0.3.6",
-					"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-					"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+					"bundled": true,
 					"requires": {
 						"arr-union": "^3.1.0",
 						"define-property": "^0.2.5",
@@ -8330,23 +8161,20 @@
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"bundled": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+							"bundled": true
 						}
 					}
 				},
 				"cliui": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"center-align": "^0.1.1",
@@ -8356,21 +8184,18 @@
 					"dependencies": {
 						"wordwrap": {
 							"version": "0.0.2",
-							"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-							"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+							"bundled": true,
 							"optional": true
 						}
 					}
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+					"bundled": true
 				},
 				"collection-visit": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-					"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+					"bundled": true,
 					"requires": {
 						"map-visit": "^1.0.0",
 						"object-visit": "^1.0.0"
@@ -8378,38 +8203,31 @@
 				},
 				"commondir": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-					"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+					"bundled": true
 				},
 				"component-emitter": {
 					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+					"bundled": true
 				},
 				"convert-source-map": {
 					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-					"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+					"bundled": true
 				},
 				"copy-descriptor": {
 					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-					"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+					"bundled": true
 				},
 				"core-js": {
 					"version": "2.5.6",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
-					"integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
+					"bundled": true
 				},
 				"cross-spawn": {
 					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-					"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+					"bundled": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
 						"which": "^1.2.9"
@@ -8417,39 +8235,33 @@
 				},
 				"debug": {
 					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"bundled": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"debug-log": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-					"integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8="
+					"bundled": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+					"bundled": true
 				},
 				"decode-uri-component": {
 					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-					"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+					"bundled": true
 				},
 				"default-require-extensions": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-					"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+					"bundled": true,
 					"requires": {
 						"strip-bom": "^2.0.0"
 					}
 				},
 				"define-property": {
 					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-					"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+					"bundled": true,
 					"requires": {
 						"is-descriptor": "^1.0.2",
 						"isobject": "^3.0.1"
@@ -8457,24 +8269,21 @@
 					"dependencies": {
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"bundled": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"bundled": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"bundled": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -8483,46 +8292,39 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+							"bundled": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+							"bundled": true
 						}
 					}
 				},
 				"detect-indent": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-					"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+					"bundled": true,
 					"requires": {
 						"repeating": "^2.0.0"
 					}
 				},
 				"error-ex": {
 					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-					"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+					"bundled": true,
 					"requires": {
 						"is-arrayish": "^0.2.1"
 					}
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"bundled": true
 				},
 				"esutils": {
 					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+					"bundled": true
 				},
 				"execa": {
 					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"bundled": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
 						"get-stream": "^3.0.0",
@@ -8535,8 +8337,7 @@
 					"dependencies": {
 						"cross-spawn": {
 							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-							"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+							"bundled": true,
 							"requires": {
 								"lru-cache": "^4.0.1",
 								"shebang-command": "^1.2.0",
@@ -8547,8 +8348,7 @@
 				},
 				"expand-brackets": {
 					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"bundled": true,
 					"requires": {
 						"debug": "^2.3.3",
 						"define-property": "^0.2.5",
@@ -8561,16 +8361,14 @@
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"bundled": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"bundled": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -8579,8 +8377,7 @@
 				},
 				"extend-shallow": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+					"bundled": true,
 					"requires": {
 						"assign-symbols": "^1.0.0",
 						"is-extendable": "^1.0.1"
@@ -8588,8 +8385,7 @@
 					"dependencies": {
 						"is-extendable": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"bundled": true,
 							"requires": {
 								"is-plain-object": "^2.0.4"
 							}
@@ -8598,8 +8394,7 @@
 				},
 				"extglob": {
 					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"bundled": true,
 					"requires": {
 						"array-unique": "^0.3.2",
 						"define-property": "^1.0.0",
@@ -8613,40 +8408,35 @@
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"bundled": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"bundled": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"bundled": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"bundled": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"bundled": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -8655,15 +8445,13 @@
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+							"bundled": true
 						}
 					}
 				},
 				"fill-range": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"bundled": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-number": "^3.0.0",
@@ -8673,8 +8461,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"bundled": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -8683,8 +8470,7 @@
 				},
 				"find-cache-dir": {
 					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-					"integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+					"bundled": true,
 					"requires": {
 						"commondir": "^1.0.1",
 						"mkdirp": "^0.5.1",
@@ -8693,21 +8479,18 @@
 				},
 				"find-up": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"bundled": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
 				},
 				"for-in": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-					"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+					"bundled": true
 				},
 				"foreground-child": {
 					"version": "1.5.6",
-					"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-					"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+					"bundled": true,
 					"requires": {
 						"cross-spawn": "^4",
 						"signal-exit": "^3.0.0"
@@ -8715,36 +8498,30 @@
 				},
 				"fragment-cache": {
 					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-					"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+					"bundled": true,
 					"requires": {
 						"map-cache": "^0.2.2"
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+					"bundled": true
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+					"bundled": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+					"bundled": true
 				},
 				"get-value": {
 					"version": "2.0.6",
-					"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-					"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+					"bundled": true
 				},
 				"glob": {
 					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"bundled": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -8756,18 +8533,15 @@
 				},
 				"globals": {
 					"version": "9.18.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+					"bundled": true
 				},
 				"graceful-fs": {
 					"version": "4.1.11",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+					"bundled": true
 				},
 				"handlebars": {
 					"version": "4.0.11",
-					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-					"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+					"bundled": true,
 					"requires": {
 						"async": "^1.4.0",
 						"optimist": "^0.6.1",
@@ -8777,8 +8551,7 @@
 					"dependencies": {
 						"source-map": {
 							"version": "0.4.4",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-							"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+							"bundled": true,
 							"requires": {
 								"amdefine": ">=0.0.4"
 							}
@@ -8787,21 +8560,18 @@
 				},
 				"has-ansi": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-					"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+					"bundled": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
 				"has-flag": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+					"bundled": true
 				},
 				"has-value": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-					"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+					"bundled": true,
 					"requires": {
 						"get-value": "^2.0.6",
 						"has-values": "^1.0.0",
@@ -8810,15 +8580,13 @@
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+							"bundled": true
 						}
 					}
 				},
 				"has-values": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-					"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+					"bundled": true,
 					"requires": {
 						"is-number": "^3.0.0",
 						"kind-of": "^4.0.0"
@@ -8826,16 +8594,14 @@
 					"dependencies": {
 						"is-number": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-							"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+							"bundled": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"bundled": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -8844,8 +8610,7 @@
 						},
 						"kind-of": {
 							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+							"bundled": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -8854,18 +8619,15 @@
 				},
 				"hosted-git-info": {
 					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-					"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+					"bundled": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+					"bundled": true
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"bundled": true,
 					"requires": {
 						"once": "^1.3.0",
 						"wrappy": "1"
@@ -8873,60 +8635,51 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+					"bundled": true
 				},
 				"invariant": {
 					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-					"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+					"bundled": true,
 					"requires": {
 						"loose-envify": "^1.0.0"
 					}
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+					"bundled": true
 				},
 				"is-accessor-descriptor": {
 					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+					"bundled": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
 				},
 				"is-arrayish": {
 					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+					"bundled": true
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+					"bundled": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+					"bundled": true,
 					"requires": {
 						"builtin-modules": "^1.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+					"bundled": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
 				},
 				"is-descriptor": {
 					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+					"bundled": true,
 					"requires": {
 						"is-accessor-descriptor": "^0.1.6",
 						"is-data-descriptor": "^0.1.4",
@@ -8935,114 +8688,96 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+							"bundled": true
 						}
 					}
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+					"bundled": true
 				},
 				"is-finite": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-					"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+					"bundled": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+					"bundled": true
 				},
 				"is-number": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"bundled": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
 				},
 				"is-odd": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-					"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+					"bundled": true,
 					"requires": {
 						"is-number": "^4.0.0"
 					},
 					"dependencies": {
 						"is-number": {
 							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-							"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+							"bundled": true
 						}
 					}
 				},
 				"is-plain-object": {
 					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"bundled": true,
 					"requires": {
 						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+							"bundled": true
 						}
 					}
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+					"bundled": true
 				},
 				"is-utf8": {
 					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-					"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+					"bundled": true
 				},
 				"is-windows": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-					"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+					"bundled": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+					"bundled": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+					"bundled": true
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+					"bundled": true
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
-					"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A=="
+					"bundled": true
 				},
 				"istanbul-lib-hook": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
-					"integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+					"bundled": true,
 					"requires": {
 						"append-transform": "^0.4.0"
 					}
 				},
 				"istanbul-lib-instrument": {
 					"version": "1.10.1",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
-					"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+					"bundled": true,
 					"requires": {
 						"babel-generator": "^6.18.0",
 						"babel-template": "^6.16.0",
@@ -9055,8 +8790,7 @@
 				},
 				"istanbul-lib-report": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
-					"integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
+					"bundled": true,
 					"requires": {
 						"istanbul-lib-coverage": "^1.1.2",
 						"mkdirp": "^0.5.1",
@@ -9066,8 +8800,7 @@
 					"dependencies": {
 						"supports-color": {
 							"version": "3.2.3",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"bundled": true,
 							"requires": {
 								"has-flag": "^1.0.0"
 							}
@@ -9076,8 +8809,7 @@
 				},
 				"istanbul-lib-source-maps": {
 					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
-					"integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
+					"bundled": true,
 					"requires": {
 						"debug": "^3.1.0",
 						"istanbul-lib-coverage": "^1.1.2",
@@ -9088,8 +8820,7 @@
 					"dependencies": {
 						"debug": {
 							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-							"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+							"bundled": true,
 							"requires": {
 								"ms": "2.0.0"
 							}
@@ -9098,48 +8829,41 @@
 				},
 				"istanbul-reports": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.4.0.tgz",
-					"integrity": "sha512-OPzVo1fPZ2H+owr8q/LYKLD+vquv9Pj4F+dj808MdHbuQLD7S4ACRjcX+0Tne5Vxt2lxXvdZaL7v+FOOAV281w==",
+					"bundled": true,
 					"requires": {
 						"handlebars": "^4.0.3"
 					}
 				},
 				"js-tokens": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+					"bundled": true
 				},
 				"jsesc": {
 					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+					"bundled": true
 				},
 				"kind-of": {
 					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"bundled": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
 				},
 				"lazy-cache": {
 					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-					"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+					"bundled": true,
 					"optional": true
 				},
 				"lcid": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+					"bundled": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
 					}
 				},
 				"load-json-file": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"bundled": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"parse-json": "^2.2.0",
@@ -9150,8 +8874,7 @@
 				},
 				"locate-path": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"bundled": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -9159,34 +8882,29 @@
 					"dependencies": {
 						"path-exists": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+							"bundled": true
 						}
 					}
 				},
 				"lodash": {
 					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+					"bundled": true
 				},
 				"longest": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-					"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+					"bundled": true,
 					"optional": true
 				},
 				"loose-envify": {
 					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-					"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+					"bundled": true,
 					"requires": {
 						"js-tokens": "^3.0.0"
 					}
 				},
 				"lru-cache": {
 					"version": "4.1.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+					"bundled": true,
 					"requires": {
 						"pseudomap": "^1.0.2",
 						"yallist": "^2.1.2"
@@ -9194,57 +8912,49 @@
 				},
 				"map-cache": {
 					"version": "0.2.2",
-					"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-					"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+					"bundled": true
 				},
 				"map-visit": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-					"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+					"bundled": true,
 					"requires": {
 						"object-visit": "^1.0.0"
 					}
 				},
 				"md5-hex": {
 					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+					"bundled": true,
 					"requires": {
 						"md5-o-matic": "^0.1.1"
 					}
 				},
 				"md5-o-matic": {
 					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-					"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
+					"bundled": true
 				},
 				"mem": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+					"bundled": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
 					}
 				},
 				"merge-source-map": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-					"integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+					"bundled": true,
 					"requires": {
 						"source-map": "^0.6.1"
 					},
 					"dependencies": {
 						"source-map": {
 							"version": "0.6.1",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+							"bundled": true
 						}
 					}
 				},
 				"micromatch": {
 					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"bundled": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -9263,33 +8973,28 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+							"bundled": true
 						}
 					}
 				},
 				"mimic-fn": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+					"bundled": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"bundled": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"bundled": true
 				},
 				"mixin-deep": {
 					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-					"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+					"bundled": true,
 					"requires": {
 						"for-in": "^1.0.2",
 						"is-extendable": "^1.0.1"
@@ -9297,8 +9002,7 @@
 					"dependencies": {
 						"is-extendable": {
 							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+							"bundled": true,
 							"requires": {
 								"is-plain-object": "^2.0.4"
 							}
@@ -9307,21 +9011,18 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"bundled": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+					"bundled": true
 				},
 				"nanomatch": {
 					"version": "1.2.9",
-					"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-					"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+					"bundled": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
 						"array-unique": "^0.3.2",
@@ -9339,25 +9040,21 @@
 					"dependencies": {
 						"arr-diff": {
 							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-							"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+							"bundled": true
 						},
 						"array-unique": {
 							"version": "0.3.2",
-							"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-							"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+							"bundled": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+							"bundled": true
 						}
 					}
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-					"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+					"bundled": true,
 					"requires": {
 						"hosted-git-info": "^2.1.4",
 						"is-builtin-module": "^1.0.0",
@@ -9367,26 +9064,22 @@
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+					"bundled": true,
 					"requires": {
 						"path-key": "^2.0.0"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+					"bundled": true
 				},
 				"object-copy": {
 					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-					"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+					"bundled": true,
 					"requires": {
 						"copy-descriptor": "^0.1.0",
 						"define-property": "^0.2.5",
@@ -9395,8 +9088,7 @@
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"bundled": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -9405,46 +9097,40 @@
 				},
 				"object-visit": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-					"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+					"bundled": true,
 					"requires": {
 						"isobject": "^3.0.0"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+							"bundled": true
 						}
 					}
 				},
 				"object.pick": {
 					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-					"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+					"bundled": true,
 					"requires": {
 						"isobject": "^3.0.1"
 					},
 					"dependencies": {
 						"isobject": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+							"bundled": true
 						}
 					}
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"bundled": true,
 					"requires": {
 						"wrappy": "1"
 					}
 				},
 				"optimist": {
 					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+					"bundled": true,
 					"requires": {
 						"minimist": "~0.0.1",
 						"wordwrap": "~0.0.2"
@@ -9452,13 +9138,11 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+					"bundled": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"bundled": true,
 					"requires": {
 						"execa": "^0.7.0",
 						"lcid": "^1.0.0",
@@ -9467,70 +9151,59 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+					"bundled": true
 				},
 				"p-limit": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-					"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+					"bundled": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
 				},
 				"p-locate": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"bundled": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
 				},
 				"p-try": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+					"bundled": true
 				},
 				"parse-json": {
 					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"bundled": true,
 					"requires": {
 						"error-ex": "^1.2.0"
 					}
 				},
 				"pascalcase": {
 					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-					"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+					"bundled": true
 				},
 				"path-exists": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"bundled": true,
 					"requires": {
 						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+					"bundled": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+					"bundled": true
 				},
 				"path-parse": {
 					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-					"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+					"bundled": true
 				},
 				"path-type": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"bundled": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"pify": "^2.0.0",
@@ -9539,34 +9212,29 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+					"bundled": true
 				},
 				"pinkie": {
 					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+					"bundled": true
 				},
 				"pinkie-promise": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+					"bundled": true,
 					"requires": {
 						"pinkie": "^2.0.0"
 					}
 				},
 				"pkg-dir": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+					"bundled": true,
 					"requires": {
 						"find-up": "^1.0.0"
 					},
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+							"bundled": true,
 							"requires": {
 								"path-exists": "^2.0.0",
 								"pinkie-promise": "^2.0.0"
@@ -9576,18 +9244,15 @@
 				},
 				"posix-character-classes": {
 					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-					"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+					"bundled": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+					"bundled": true
 				},
 				"read-pkg": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"bundled": true,
 					"requires": {
 						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
@@ -9596,8 +9261,7 @@
 				},
 				"read-pkg-up": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"bundled": true,
 					"requires": {
 						"find-up": "^1.0.0",
 						"read-pkg": "^1.0.0"
@@ -9605,8 +9269,7 @@
 					"dependencies": {
 						"find-up": {
 							"version": "1.1.2",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+							"bundled": true,
 							"requires": {
 								"path-exists": "^2.0.0",
 								"pinkie-promise": "^2.0.0"
@@ -9616,13 +9279,11 @@
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+					"bundled": true
 				},
 				"regex-not": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-					"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+					"bundled": true,
 					"requires": {
 						"extend-shallow": "^3.0.2",
 						"safe-regex": "^1.1.0"
@@ -9630,51 +9291,42 @@
 				},
 				"repeat-element": {
 					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-					"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+					"bundled": true
 				},
 				"repeat-string": {
 					"version": "1.6.1",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-					"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+					"bundled": true
 				},
 				"repeating": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-					"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+					"bundled": true,
 					"requires": {
 						"is-finite": "^1.0.0"
 					}
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+					"bundled": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+					"bundled": true
 				},
 				"resolve-from": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+					"bundled": true
 				},
 				"resolve-url": {
 					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-					"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+					"bundled": true
 				},
 				"ret": {
 					"version": "0.1.15",
-					"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-					"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+					"bundled": true
 				},
 				"right-align": {
 					"version": "0.1.3",
-					"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-					"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"align-text": "^0.1.1"
@@ -9682,34 +9334,29 @@
 				},
 				"rimraf": {
 					"version": "2.6.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+					"bundled": true,
 					"requires": {
 						"glob": "^7.0.5"
 					}
 				},
 				"safe-regex": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-					"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+					"bundled": true,
 					"requires": {
 						"ret": "~0.1.10"
 					}
 				},
 				"semver": {
 					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+					"bundled": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+					"bundled": true
 				},
 				"set-value": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-					"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+					"bundled": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-extendable": "^0.1.1",
@@ -9719,8 +9366,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"bundled": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -9729,31 +9375,26 @@
 				},
 				"shebang-command": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"bundled": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
 					}
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+					"bundled": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+					"bundled": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-					"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+					"bundled": true
 				},
 				"snapdragon": {
 					"version": "0.8.2",
-					"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-					"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+					"bundled": true,
 					"requires": {
 						"base": "^0.11.1",
 						"debug": "^2.2.0",
@@ -9767,16 +9408,14 @@
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"bundled": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"bundled": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
@@ -9785,8 +9424,7 @@
 				},
 				"snapdragon-node": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-					"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+					"bundled": true,
 					"requires": {
 						"define-property": "^1.0.0",
 						"isobject": "^3.0.0",
@@ -9795,32 +9433,28 @@
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"bundled": true,
 							"requires": {
 								"is-descriptor": "^1.0.0"
 							}
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"bundled": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"bundled": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"bundled": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -9829,33 +9463,28 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+							"bundled": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+							"bundled": true
 						}
 					}
 				},
 				"snapdragon-util": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-					"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+					"bundled": true,
 					"requires": {
 						"kind-of": "^3.2.0"
 					}
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+					"bundled": true
 				},
 				"source-map-resolve": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-					"integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+					"bundled": true,
 					"requires": {
 						"atob": "^2.0.0",
 						"decode-uri-component": "^0.2.0",
@@ -9866,13 +9495,11 @@
 				},
 				"source-map-url": {
 					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-					"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+					"bundled": true
 				},
 				"spawn-wrap": {
 					"version": "1.4.2",
-					"resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
-					"integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+					"bundled": true,
 					"requires": {
 						"foreground-child": "^1.5.6",
 						"mkdirp": "^0.5.0",
@@ -9884,8 +9511,7 @@
 				},
 				"spdx-correct": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-					"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+					"bundled": true,
 					"requires": {
 						"spdx-expression-parse": "^3.0.0",
 						"spdx-license-ids": "^3.0.0"
@@ -9893,13 +9519,11 @@
 				},
 				"spdx-exceptions": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-					"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+					"bundled": true
 				},
 				"spdx-expression-parse": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+					"bundled": true,
 					"requires": {
 						"spdx-exceptions": "^2.1.0",
 						"spdx-license-ids": "^3.0.0"
@@ -9907,21 +9531,18 @@
 				},
 				"spdx-license-ids": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-					"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+					"bundled": true
 				},
 				"split-string": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-					"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+					"bundled": true,
 					"requires": {
 						"extend-shallow": "^3.0.0"
 					}
 				},
 				"static-extend": {
 					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-					"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+					"bundled": true,
 					"requires": {
 						"define-property": "^0.2.5",
 						"object-copy": "^0.1.0"
@@ -9929,8 +9550,7 @@
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"bundled": true,
 							"requires": {
 								"is-descriptor": "^0.1.0"
 							}
@@ -9939,8 +9559,7 @@
 				},
 				"string-width": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"bundled": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -9948,13 +9567,11 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+							"bundled": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"bundled": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -9963,34 +9580,29 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"bundled": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-bom": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"bundled": true,
 					"requires": {
 						"is-utf8": "^0.2.0"
 					}
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+					"bundled": true
 				},
 				"supports-color": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+					"bundled": true
 				},
 				"test-exclude": {
 					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
-					"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+					"bundled": true,
 					"requires": {
 						"arrify": "^1.0.1",
 						"micromatch": "^3.1.8",
@@ -10001,18 +9613,15 @@
 					"dependencies": {
 						"arr-diff": {
 							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-							"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+							"bundled": true
 						},
 						"array-unique": {
 							"version": "0.3.2",
-							"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-							"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+							"bundled": true
 						},
 						"braces": {
 							"version": "2.3.2",
-							"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-							"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+							"bundled": true,
 							"requires": {
 								"arr-flatten": "^1.1.0",
 								"array-unique": "^0.3.2",
@@ -10028,8 +9637,7 @@
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
-									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+									"bundled": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -10038,8 +9646,7 @@
 						},
 						"expand-brackets": {
 							"version": "2.1.4",
-							"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-							"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+							"bundled": true,
 							"requires": {
 								"debug": "^2.3.3",
 								"define-property": "^0.2.5",
@@ -10052,32 +9659,28 @@
 							"dependencies": {
 								"define-property": {
 									"version": "0.2.5",
-									"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-									"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+									"bundled": true,
 									"requires": {
 										"is-descriptor": "^0.1.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
-									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+									"bundled": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
 								},
 								"is-accessor-descriptor": {
 									"version": "0.1.6",
-									"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-									"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+									"bundled": true,
 									"requires": {
 										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
 											"version": "3.2.2",
-											"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-											"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+											"bundled": true,
 											"requires": {
 												"is-buffer": "^1.1.5"
 											}
@@ -10086,16 +9689,14 @@
 								},
 								"is-data-descriptor": {
 									"version": "0.1.4",
-									"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-									"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+									"bundled": true,
 									"requires": {
 										"kind-of": "^3.0.2"
 									},
 									"dependencies": {
 										"kind-of": {
 											"version": "3.2.2",
-											"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-											"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+											"bundled": true,
 											"requires": {
 												"is-buffer": "^1.1.5"
 											}
@@ -10104,8 +9705,7 @@
 								},
 								"is-descriptor": {
 									"version": "0.1.6",
-									"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-									"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+									"bundled": true,
 									"requires": {
 										"is-accessor-descriptor": "^0.1.6",
 										"is-data-descriptor": "^0.1.4",
@@ -10114,15 +9714,13 @@
 								},
 								"kind-of": {
 									"version": "5.1.0",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-									"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+									"bundled": true
 								}
 							}
 						},
 						"extglob": {
 							"version": "2.0.4",
-							"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-							"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+							"bundled": true,
 							"requires": {
 								"array-unique": "^0.3.2",
 								"define-property": "^1.0.0",
@@ -10136,16 +9734,14 @@
 							"dependencies": {
 								"define-property": {
 									"version": "1.0.0",
-									"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-									"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+									"bundled": true,
 									"requires": {
 										"is-descriptor": "^1.0.0"
 									}
 								},
 								"extend-shallow": {
 									"version": "2.0.1",
-									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+									"bundled": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -10154,8 +9750,7 @@
 						},
 						"fill-range": {
 							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-							"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+							"bundled": true,
 							"requires": {
 								"extend-shallow": "^2.0.1",
 								"is-number": "^3.0.0",
@@ -10165,8 +9760,7 @@
 							"dependencies": {
 								"extend-shallow": {
 									"version": "2.0.1",
-									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+									"bundled": true,
 									"requires": {
 										"is-extendable": "^0.1.0"
 									}
@@ -10175,24 +9769,21 @@
 						},
 						"is-accessor-descriptor": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-							"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+							"bundled": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
 						},
 						"is-data-descriptor": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-							"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+							"bundled": true,
 							"requires": {
 								"kind-of": "^6.0.0"
 							}
 						},
 						"is-descriptor": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-							"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+							"bundled": true,
 							"requires": {
 								"is-accessor-descriptor": "^1.0.0",
 								"is-data-descriptor": "^1.0.0",
@@ -10201,16 +9792,14 @@
 						},
 						"is-number": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-							"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+							"bundled": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							},
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"bundled": true,
 									"requires": {
 										"is-buffer": "^1.1.5"
 									}
@@ -10219,18 +9808,15 @@
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+							"bundled": true
 						},
 						"kind-of": {
 							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+							"bundled": true
 						},
 						"micromatch": {
 							"version": "3.1.10",
-							"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-							"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+							"bundled": true,
 							"requires": {
 								"arr-diff": "^4.0.0",
 								"array-unique": "^0.3.2",
@@ -10251,21 +9837,18 @@
 				},
 				"to-fast-properties": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+					"bundled": true
 				},
 				"to-object-path": {
 					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-					"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+					"bundled": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					}
 				},
 				"to-regex": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-					"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+					"bundled": true,
 					"requires": {
 						"define-property": "^2.0.2",
 						"extend-shallow": "^3.0.2",
@@ -10275,8 +9858,7 @@
 				},
 				"to-regex-range": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"bundled": true,
 					"requires": {
 						"is-number": "^3.0.0",
 						"repeat-string": "^1.6.1"
@@ -10284,8 +9866,7 @@
 					"dependencies": {
 						"is-number": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-							"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+							"bundled": true,
 							"requires": {
 								"kind-of": "^3.0.2"
 							}
@@ -10294,13 +9875,11 @@
 				},
 				"trim-right": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-					"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+					"bundled": true
 				},
 				"uglify-js": {
 					"version": "2.8.29",
-					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+					"bundled": true,
 					"optional": true,
 					"requires": {
 						"source-map": "~0.5.1",
@@ -10310,8 +9889,7 @@
 					"dependencies": {
 						"yargs": {
 							"version": "3.10.0",
-							"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-							"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+							"bundled": true,
 							"optional": true,
 							"requires": {
 								"camelcase": "^1.0.2",
@@ -10324,14 +9902,12 @@
 				},
 				"uglify-to-browserify": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-					"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+					"bundled": true,
 					"optional": true
 				},
 				"union-value": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-					"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+					"bundled": true,
 					"requires": {
 						"arr-union": "^3.1.0",
 						"get-value": "^2.0.6",
@@ -10341,16 +9917,14 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"bundled": true,
 							"requires": {
 								"is-extendable": "^0.1.0"
 							}
 						},
 						"set-value": {
 							"version": "0.4.3",
-							"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-							"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+							"bundled": true,
 							"requires": {
 								"extend-shallow": "^2.0.1",
 								"is-extendable": "^0.1.1",
@@ -10362,8 +9936,7 @@
 				},
 				"unset-value": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-					"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+					"bundled": true,
 					"requires": {
 						"has-value": "^0.3.1",
 						"isobject": "^3.0.0"
@@ -10371,8 +9944,7 @@
 					"dependencies": {
 						"has-value": {
 							"version": "0.3.1",
-							"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-							"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+							"bundled": true,
 							"requires": {
 								"get-value": "^2.0.3",
 								"has-values": "^0.1.4",
@@ -10381,8 +9953,7 @@
 							"dependencies": {
 								"isobject": {
 									"version": "2.1.0",
-									"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-									"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+									"bundled": true,
 									"requires": {
 										"isarray": "1.0.0"
 									}
@@ -10391,40 +9962,34 @@
 						},
 						"has-values": {
 							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-							"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+							"bundled": true
 						},
 						"isobject": {
 							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-							"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+							"bundled": true
 						}
 					}
 				},
 				"urix": {
 					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-					"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+					"bundled": true
 				},
 				"use": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-					"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+					"bundled": true,
 					"requires": {
 						"kind-of": "^6.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
 							"version": "6.0.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-							"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+							"bundled": true
 						}
 					}
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-					"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+					"bundled": true,
 					"requires": {
 						"spdx-correct": "^3.0.0",
 						"spdx-expression-parse": "^3.0.0"
@@ -10432,32 +9997,27 @@
 				},
 				"which": {
 					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-					"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+					"bundled": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+					"bundled": true
 				},
 				"window-size": {
 					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-					"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+					"bundled": true,
 					"optional": true
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+					"bundled": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"bundled": true,
 					"requires": {
 						"string-width": "^1.0.1",
 						"strip-ansi": "^3.0.1"
@@ -10465,16 +10025,14 @@
 					"dependencies": {
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+							"bundled": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"bundled": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -10485,13 +10043,11 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+					"bundled": true
 				},
 				"write-file-atomic": {
 					"version": "1.3.4",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+					"bundled": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
@@ -10500,18 +10056,15 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+					"bundled": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+					"bundled": true
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+					"bundled": true,
 					"requires": {
 						"cliui": "^4.0.0",
 						"decamelize": "^1.1.1",
@@ -10529,18 +10082,15 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+							"bundled": true
 						},
 						"camelcase": {
 							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+							"bundled": true
 						},
 						"cliui": {
 							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-							"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+							"bundled": true,
 							"requires": {
 								"string-width": "^2.1.1",
 								"strip-ansi": "^4.0.0",
@@ -10549,16 +10099,14 @@
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"bundled": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
 						},
 						"yargs-parser": {
 							"version": "9.0.2",
-							"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-							"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+							"bundled": true,
 							"requires": {
 								"camelcase": "^4.1.0"
 							}
@@ -10567,16 +10115,14 @@
 				},
 				"yargs-parser": {
 					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+					"bundled": true,
 					"requires": {
 						"camelcase": "^4.1.0"
 					},
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+							"bundled": true
 						}
 					}
 				}
@@ -10722,7 +10268,7 @@
 		},
 		"optionator": {
 			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"resolved": "http://bbnpm.azurewebsites.net/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"requires": {
 				"deep-is": "~0.1.3",
@@ -10735,7 +10281,7 @@
 			"dependencies": {
 				"wordwrap": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"resolved": "http://bbnpm.azurewebsites.net/wordwrap/-/wordwrap-1.0.0.tgz",
 					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 				}
 			}
@@ -11047,7 +10593,7 @@
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+			"resolved": "http://bbnpm.azurewebsites.net/path-is-inside/-/path-is-inside-1.0.2.tgz",
 			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 		},
 		"path-key": {
@@ -11062,7 +10608,7 @@
 		},
 		"path-to-regexp": {
 			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+			"resolved": "http://bbnpm.azurewebsites.net/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
 			"requires": {
 				"isarray": "0.0.1"
@@ -11175,7 +10721,7 @@
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"resolved": "http://bbnpm.azurewebsites.net/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
 		"prepend-http": {
@@ -11266,7 +10812,7 @@
 		},
 		"psl": {
 			"version": "1.1.29",
-			"resolved": "http://bbnpm.azurewebsites.net/psl/-/psl-1.1.29.tgz",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
 			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
 		},
 		"pullstream": {
@@ -11538,10 +11084,65 @@
 				"util-deprecate": "~1.0.1"
 			},
 			"dependencies": {
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": "http://bbnpm.azurewebsites.net/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
 				}
 			}
 		},
@@ -11763,35 +11364,9 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
 					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-					"dev": true
-				}
-			}
-		},
-		"read-text-file": {
-			"version": "1.1.0",
-			"resolved": "http://bbnpm.azurewebsites.net/read-text-file/-/read-text-file-1.1.0.tgz",
-			"integrity": "sha1-0MPxh2iCj5EH1huws2jue5D3GJM=",
-			"requires": {
-				"iconv-lite": "^0.4.17",
-				"jschardet": "^1.4.2"
-			}
-		},
-		"readable-stream": {
-			"version": "2.3.6",
-			"resolved": "http://bbnpm.azurewebsites.net/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-			"dev": true,
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			},
-			"dependencies": {
-				"isarray": {
+					"optional": true
+				},
+				"is-data-descriptor": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
@@ -11868,7 +11443,7 @@
 		},
 		"rechoir": {
 			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"resolved": "http://bbnpm.azurewebsites.net/rechoir/-/rechoir-0.6.2.tgz",
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"requires": {
 				"resolve": "^1.1.6"
@@ -12181,7 +11756,7 @@
 		},
 		"request-promise-core": {
 			"version": "1.1.1",
-			"resolved": "http://bbnpm.azurewebsites.net/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/request-promise-core/-/request-promise-core-1.1.1.tgz",
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"requires": {
 				"lodash": "^4.13.1"
@@ -12189,7 +11764,7 @@
 		},
 		"request-promise-native": {
 			"version": "1.0.5",
-			"resolved": "http://bbnpm.azurewebsites.net/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/request-promise-native/-/request-promise-native-1.0.5.tgz",
 			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
 			"requires": {
 				"request-promise-core": "1.1.1",
@@ -12784,7 +12359,7 @@
 		},
 		"sort-keys": {
 			"version": "2.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/sort-keys/-/sort-keys-2.0.0.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/sort-keys/-/sort-keys-2.0.0.tgz",
 			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 			"requires": {
 				"is-plain-obj": "^1.0.0"
@@ -13005,7 +12580,7 @@
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
-			"resolved": "http://bbnpm.azurewebsites.net/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
 		},
 		"stream-each": {
@@ -13074,9 +12649,8 @@
 		},
 		"strip-bom": {
 			"version": "3.0.0",
-			"resolved": "http://bbnpm.azurewebsites.net/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-			"dev": true
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 		},
 		"strip-eof": {
 			"version": "1.0.0",
@@ -13090,9 +12664,16 @@
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
-			"resolved": "http://bbnpm.azurewebsites.net/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+		},
+		"strip-outer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+			"requires": {
+				"escape-string-regexp": "^1.0.2"
+			}
 		},
 		"strong-log-transformer": {
 			"version": "2.1.0",
@@ -13268,7 +12849,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "http://bbnpm.azurewebsites.net/through/-/through-2.3.8.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
@@ -13483,10 +13064,9 @@
 			}
 		},
 		"tslint-microsoft-contrib": {
-			"version": "5.2.1",
-			"resolved": "http://bbnpm.azurewebsites.net/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.2.1.tgz",
-			"integrity": "sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==",
-			"dev": true,
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.2.0.tgz",
+			"integrity": "sha512-6tfi/2tHqV/3CL77pULBcK+foty11Rr0idRDxKnteTaKm6gWF9qmaCNU17HVssOuwlYNyOmd9Jsmjd+1t3a3qw==",
 			"requires": {
 				"tsutils": "^2.27.2 <2.29.0"
 			},
@@ -13529,7 +13109,7 @@
 		},
 		"type-check": {
 			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"resolved": "http://bbnpm.azurewebsites.net/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"requires": {
 				"prelude-ls": "~1.1.2"
@@ -13578,7 +13158,7 @@
 		},
 		"typedoc-default-themes": {
 			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
+			"resolved": "http://bbnpm.azurewebsites.net/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
 			"integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
 		},
 		"typedoc-plugin-external-module-name": {
@@ -13632,7 +13212,7 @@
 		},
 		"underscore": {
 			"version": "1.8.3",
-			"resolved": "http://bbnpm.azurewebsites.net/underscore/-/underscore-1.8.3.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/underscore/-/underscore-1.8.3.tgz",
 			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
 		},
 		"union-value": {
@@ -13856,9 +13436,8 @@
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
-			"resolved": "http://bbnpm.azurewebsites.net/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"uuid": {
 			"version": "3.3.2",
@@ -14128,12 +13707,12 @@
 		},
 		"xmlbuilder": {
 			"version": "9.0.7",
-			"resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
 			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 		},
 		"xmldom": {
 			"version": "0.1.27",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+			"resolved": "http://bbnpm.azurewebsites.net/xmldom/-/xmldom-0.1.27.tgz",
 			"integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
 		},
 		"xpath.js": {


### PR DESCRIPTION
## Description
Removes the NPM warning about filenamify already including types (added in [3.0.0](https://github.com/sindresorhus/filenamify/releases/tag/v3.0.0))

The breaking change from 2.0.0 to 3.0.0 is that Node.js 6 and up is required for 3.0.0. 

Breaking change from 3.0.0 to 4.0.0 is that Node.js 8 is required for 4.0.0.



## Specific Changes
  - Bump `"filenamify"` dependency from `^2.0.0` to `^4.1.0` in `"botbuilder"`.
  - Remove `"@types/filenamify"` dependency from `"botbuilder"`


## Testing
Successfully rebuilt library and re-ran tests locally