### PR TITLE
[LG WIP] new analyzer

### DIFF
--- a/libraries/botbuilder-lg/src/analyzer.ts
+++ b/libraries/botbuilder-lg/src/analyzer.ts
@@ -19,16 +19,16 @@ import { LGTemplate } from './lgTemplate';
 
 export class AnalyzerResult {
     public Variables: string[];
-    public TemplateRefNames: string[];
+    public TemplateReferences: string[];
 
     public constructor(variables: string[] = [], templateRefNames: string[] = []) {
         this.Variables = Array.from(new Set(variables));
-        this.TemplateRefNames = Array.from(new Set(templateRefNames));
+        this.TemplateReferences = Array.from(new Set(templateRefNames));
     }
 
     public union(outputItem: AnalyzerResult): this {
         this.Variables = Array.from(new Set(this.Variables.concat(outputItem.Variables)));
-        this.TemplateRefNames = Array.from(new Set(this.TemplateRefNames.concat(outputItem.TemplateRefNames)));
+        this.TemplateReferences = Array.from(new Set(this.TemplateReferences.concat(outputItem.TemplateReferences)));
 
         return this;
     }
@@ -173,7 +173,7 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
                 result.union(this.AnalyzeTemplate((exp.Children[0] as Constant).Value));
             } else {
                 // only get template ref names
-                const templaterefNames: string[] = this.AnalyzeTemplate((exp.Children[0] as Constant).Value).TemplateRefNames;
+                const templaterefNames: string[] = this.AnalyzeTemplate((exp.Children[0] as Constant).Value).TemplateReferences;
                 result.union(new AnalyzerResult([], templaterefNames));
 
                 // analyzer other children
@@ -236,7 +236,7 @@ export class Analyzer extends AbstractParseTreeVisitor<AnalyzerResult> implement
             if (this.TemplateMap[exp].Parameters === undefined || this.TemplateMap[exp].Parameters.length === 0) {
                 result.union(this.AnalyzeTemplate(exp));
             } else {
-                result.union(new AnalyzerResult([], this.AnalyzeTemplate(exp).TemplateRefNames));
+                result.union(new AnalyzerResult([], this.AnalyzeTemplate(exp).TemplateReferences));
             }
         }
 

--- a/libraries/botbuilder-lg/src/mslgTool.ts
+++ b/libraries/botbuilder-lg/src/mslgTool.ts
@@ -54,7 +54,7 @@ export class MSLGTool {
     public GetTemplateVariables(templateName: string): string[] {
         const analyzer: Analyzer = new Analyzer(this.Templates);
 
-        return analyzer.AnalyzeTemplate(templateName);
+        return analyzer.AnalyzeTemplate(templateName).Variables;
     }
 
     public ExpandTemplate(templateName: string, scope: any, methodBinder?: IGetMethod): string[] {

--- a/libraries/botbuilder-lg/src/templateEngine.ts
+++ b/libraries/botbuilder-lg/src/templateEngine.ts
@@ -7,7 +7,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import { Analyzer } from './analyzer';
+import { Analyzer, AnalyzerOutputItem } from './analyzer';
 import { Diagnostic, DiagnosticSeverity } from './diagnostic';
 import { Evaluator } from './evaluator';
 import { IGetMethod } from './getMethodExtensions';
@@ -75,7 +75,7 @@ export class TemplateEngine {
         return evalutor.EvaluateTemplate(templateName, scope);
     }
 
-    public analyzeTemplate(templateName: string): string[] {
+    public analyzeTemplate(templateName: string): AnalyzerOutputItem {
         const analyzer: Analyzer = new Analyzer(this.templates);
 
         return analyzer.AnalyzeTemplate(templateName);

--- a/libraries/botbuilder-lg/src/templateEngine.ts
+++ b/libraries/botbuilder-lg/src/templateEngine.ts
@@ -7,7 +7,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import { Analyzer, AnalyzerOutputItem } from './analyzer';
+import { Analyzer, AnalyzerResult } from './analyzer';
 import { Diagnostic, DiagnosticSeverity } from './diagnostic';
 import { Evaluator } from './evaluator';
 import { IGetMethod } from './getMethodExtensions';
@@ -75,7 +75,7 @@ export class TemplateEngine {
         return evalutor.EvaluateTemplate(templateName, scope);
     }
 
-    public analyzeTemplate(templateName: string): AnalyzerOutputItem {
+    public analyzeTemplate(templateName: string): AnalyzerResult {
         const analyzer: Analyzer = new Analyzer(this.templates);
 
         return analyzer.AnalyzeTemplate(templateName);

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -203,28 +203,41 @@ describe('LG', function () {
     });
 
     it('TestAnalyzer', function () {
-        var engine = new TemplateEngine().addFile(GetExampleFilePath("Analyzer.lg"));
-        var evaled1 = engine.analyzeTemplate("orderReadOut");
-        var evaled1Options = ["orderType", "userName", "base", "topping", "bread", "meat"];
-        console.log(evaled1[0]);
-        assert.strictEqual(evaled1.length, evaled1Options.length);
-        evaled1Options.forEach(element => assert.strictEqual(evaled1.includes(element), true));
-
-        var evaled2 = engine.analyzeTemplate("sandwichOrderConfirmation");
-        var evaled2Options = ["bread", "meat"];
-        assert.strictEqual(evaled2.length, evaled2Options.length);
-        evaled2Options.forEach(element => assert.strictEqual(evaled2.includes(element), true));
-
-        var evaled3 = engine.analyzeTemplate("template1");
-        // TODO: input.property should really be: customer.property but analyzer needs to be 
-        var evaled3Options = ["alarms", "customer", "tasks[0]", "age", "city"];
-        assert.strictEqual(evaled3.length, evaled3Options.length);
-        evaled3Options.forEach(element => assert.strictEqual(evaled3.includes(element), true));
-
-        var evaled4 = engine.analyzeTemplate('coffee-to-go-order')
-        var evaled4Options = ['coffee', 'userName', 'size', 'price']
-        assert.strictEqual(evaled4.length, evaled4Options.length);
-        evaled4Options.forEach(element => assert.strictEqual(evaled4.includes(element), true));
+        var testData = [
+            {
+                name:'orderReadOut',
+                variableOptions:["orderType", "userName", "base", "topping", "bread", "meat"],
+                templateRefOptions:["wPhrase", "pizzaOrderConfirmation", "sandwichOrderConfirmation"]
+            },
+            {
+                name:'sandwichOrderConfirmation',
+                variableOptions:["bread", "meat"],
+                templateRefOptions:[]
+            },
+            {
+                name:'template1',
+                 // TODO: input.property should really be: customer.property but analyzer needs to be 
+                variableOptions:["alarms", "customer", "tasks[0]", "age", "city"],
+                templateRefOptions:["template2", "template3", "template4", "template5","template6"]
+            },
+            {
+                name:'coffee-to-go-order',
+                variableOptions:['coffee', 'userName', 'size', 'price'],
+                templateRefOptions:["wPhrase", "LatteOrderConfirmation", "MochaOrderConfirmation","CuppuccinoOrderConfirmation"]
+            },
+        ]
+        for (const testItem of testData) {
+            var engine = TemplateEngine.fromFiles(GetExampleFilePath("Analyzer.lg"));
+            var evaled1 = engine.analyzeTemplate(testItem.name);
+            var variableEvaled = evaled1.Variables;
+            var variableEvaledOptions = testItem.variableOptions;
+            assert.strictEqual(variableEvaled.length, variableEvaledOptions.length);
+            variableEvaledOptions.forEach(element => assert.strictEqual(variableEvaled.includes(element), true));
+            var templateEvaled = evaled1.TemplateRefNames;
+            var templateEvaledOptions = testItem.templateRefOptions;
+            assert.strictEqual(templateEvaled.length, templateEvaledOptions.length);
+            templateEvaledOptions.forEach(element => assert.strictEqual(templateEvaled.includes(element), true));
+        }
     });
 
     it('TestlgTemplateFunction', function () {
@@ -241,9 +254,10 @@ describe('LG', function () {
     it('TestAnalyzelgTemplateFunction', function () {
         var engine = new TemplateEngine().addFile(GetExampleFilePath("lgTemplate.lg"));
         var evaled = engine.analyzeTemplate('TemplateD');
+        var variableEvaled = evaled.Variables;
         var options = ['b'];
-        assert.strictEqual(evaled.length, options.length);
-        options.forEach(e => assert.strictEqual(evaled.includes(e), true));
+        assert.strictEqual(variableEvaled.length, options.length);
+        options.forEach(e => assert.strictEqual(variableEvaled.includes(e), true));
     });
 
     it('TestExceptionCatch', function () {

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -227,7 +227,7 @@ describe('LG', function () {
             },
         ]
         for (const testItem of testData) {
-            var engine = TemplateEngine.fromFiles(GetExampleFilePath("Analyzer.lg"));
+            var engine = new TemplateEngine().addFile(GetExampleFilePath("Analyzer.lg"));
             var evaled1 = engine.analyzeTemplate(testItem.name);
             var variableEvaled = evaled1.Variables;
             var variableEvaledOptions = testItem.variableOptions;

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -233,7 +233,7 @@ describe('LG', function () {
             var variableEvaledOptions = testItem.variableOptions;
             assert.strictEqual(variableEvaled.length, variableEvaledOptions.length);
             variableEvaledOptions.forEach(element => assert.strictEqual(variableEvaled.includes(element), true));
-            var templateEvaled = evaled1.TemplateRefNames;
+            var templateEvaled = evaled1.TemplateReferences;
             var templateEvaledOptions = testItem.templateRefOptions;
             assert.strictEqual(templateEvaled.length, templateEvaledOptions.length);
             templateEvaledOptions.forEach(element => assert.strictEqual(templateEvaled.includes(element), true));


### PR DESCRIPTION
origin issue: https://github.com/microsoft/botbuilder-dotnet/issues/2093

Originally `analyzeTemplate(templateName: string)` would return a list of variables. 
From now , this function will reture a structure dat, including a list of variables and list of templateref names.

