### PR TITLE
add credentials to inspection middleware for test bot

### DIFF
--- a/libraries/testbot/.env
+++ b/libraries/testbot/.env
@@ -1,0 +1,2 @@
+MicrosoftAppId=
+MicrosoftAppPassword=

--- a/libraries/testbot/index.js
+++ b/libraries/testbot/index.js
@@ -2,9 +2,14 @@
 // Licensed under the MIT License.
 
 const restify = require('restify');
+const path = require('path');
 
 const { BotFrameworkAdapter, MemoryStorage, UserState, ConversationState, InspectionState, InspectionMiddleware } = require('botbuilder');
+const { MicrosoftAppCredentials } = require('botframework-connector');
 const { MyBot } = require('./bots/myBot')
+
+const ENV_FILE = path.join(__dirname, '.env');
+require('dotenv').config({ path: ENV_FILE });
 
 const adapter = new BotFrameworkAdapter({
     appId: process.env.MicrosoftAppId,
@@ -17,7 +22,7 @@ var inspectionState = new InspectionState(memoryStorage);
 var userState = new UserState(memoryStorage);
 var conversationState = new ConversationState(memoryStorage);
 
-adapter.use(new InspectionMiddleware(inspectionState, userState, conversationState));
+adapter.use(new InspectionMiddleware(inspectionState, userState, conversationState, new MicrosoftAppCredentials(process.env.MicrosoftAppId, process.env.MicrosoftAppPassword)));
 
 adapter.onTurnError = async (context, error) => {
     console.error(`\n [onTurnError]: ${ error }`);

--- a/libraries/testbot/package-lock.json
+++ b/libraries/testbot/package-lock.json
@@ -300,6 +300,11 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
+    "dotenv": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+    },
     "dtrace-provider": {
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",

--- a/libraries/testbot/package.json
+++ b/libraries/testbot/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "botbuilder": "^4.1.6",
-    "restify": "^8.3.0"
+    "restify": "^8.3.0",
+    "dotenv": "^6.1.0"
   }
 }


### PR DESCRIPTION
Inspection middleware will not function properly unless MicrosoftAppCredentials are provided.  Modified TestBot to provide this during construction.