### PR TITLE
DialogTestClient updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ root = true
 
 # Tab indentation
 [*]
-indent_style = tab
+indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # ![Bot Framework SDK v4 for JavaScript](./docs/media/BotFrameworkJavaScript_header.png)
 
-### [Click here to find out what's new](https://github.com/Microsoft/botframework/blob/master/whats-new.md#whats-new)
+### [Click here to find out what's new with Bot Framework](https://github.com/Microsoft/botframework/blob/master/whats-new.md#whats-new)
 
 # Bot Framework SDK v4 for JavaScript
 

--- a/libraries/botbuilder-testing/README.md
+++ b/libraries/botbuilder-testing/README.md
@@ -18,7 +18,7 @@ Use the DialogTestClient to drive unit tests of your dialogs.
 
 To create a test client:
 ```javascript
-let client = new DialogTestClient(dialog_to_test, dialog_options, OptionalMiddlewares);
+const client = new DialogTestClient('test', dialog_to_test, dialog_options, OptionalMiddlewares);
 ```
 
 To "send messages" through the dialog:
@@ -28,7 +28,7 @@ let reply = await client.sendActivity('test');
 
 To check for additional messages:
 ```javascript
-reply = await client.getNextReply();
+reply = client.getNextReply();
 ```
 
 Here is a sample unit test using assert:
@@ -37,21 +37,21 @@ Here is a sample unit test using assert:
 const { DialogTestClient, DialogTestLogger } = require('botbuilder-testing');
 const assert = require('assert');
 
-let my_dialog = new SomeDialog();
-let options = { ... dialog options ... };
+const my_dialog = new SomeDialog();
+const options = { ... dialog options ... };
 
 // set up a test client with a logger middleware that logs messages in and out
-let client = new DialogTestClient(my_dialog, options, [new DialogTestLogger()]);
+const client = new DialogTestClient('test', my_dialog, options, [new DialogTestLogger()]);
 
 // send a test message, catch the reply
 let reply = await client.sendActivity('hello');
-assert(reply.text == 'hello yourself', 'first message was wrong');
+assert.strictEqual(reply.text, 'hello yourself', 'first message was wrong');
 // expecting 2 messages in a row?
-reply = await client.getNextReply();
-assert(reply.text == 'second message', 'second message as wrong');
+reply = client.getNextReply();
+assert.strictEqual(reply.tex, 'second message', 'second message as wrong');
 
 // test end state
-assert(client.dialogTurnResult.status == 'empty', 'dialog is not empty');
+assert.strictEqual(client.dialogTurnResult.status, 'empty', 'dialog is not empty');
 ```
 
 [Additional examples are available here](tests/)
@@ -63,6 +63,5 @@ By default, the transcript will be logged with the `mocha-logger` package. You m
 your own logger:
 
 ```javascript
-let testlogger = new DialogTestLogger(console);
+const testlogger = new DialogTestLogger(console);
 ```
-

--- a/libraries/botbuilder-testing/README.md
+++ b/libraries/botbuilder-testing/README.md
@@ -48,7 +48,7 @@ let reply = await client.sendActivity('hello');
 assert.strictEqual(reply.text, 'hello yourself', 'first message was wrong');
 // expecting 2 messages in a row?
 reply = client.getNextReply();
-assert.strictEqual(reply.tex, 'second message', 'second message as wrong');
+assert.strictEqual(reply.text, 'second message', 'second message as wrong');
 
 // test end state
 assert.strictEqual(client.dialogTurnResult.status, 'empty', 'dialog is not empty');

--- a/libraries/botbuilder-testing/tests/dialogTestClient.test.js
+++ b/libraries/botbuilder-testing/tests/dialogTestClient.test.js
@@ -11,15 +11,14 @@ const assert = require('assert');
 describe('DialogTestClient', function() {
 
     it('should create a DialogTestClient', async function() {
-        let client = new DialogTestClient();
+        let client = new DialogTestClient('test', null);
         assert(client instanceof DialogTestClient, 'Created an invalid object');
     });
 
     it('should create a DialogTestClient with a custom channelId', async function() {
-        let client = new DialogTestClient(null, null, null, null, null, {channelId: 'custom'});
+        let client = new DialogTestClient('custom', null);
         assert(client._testAdapter.template.channelId == 'custom', 'Created with wrong channel id');
     });
-
 
     it('should process a single turn waterfall dialog', async function() {
 
@@ -30,15 +29,12 @@ describe('DialogTestClient', function() {
             }
         ]);
 
-        let client = new DialogTestClient(dialog, null, null, null, null, {channelId: 'custom'});
+        let client = new DialogTestClient('test', dialog);
         let reply = await client.sendActivity('hello');
         assert(reply.text == 'hello', 'dialog responded with incorrect message');
-        assert(reply.channelId == 'custom', 'custom channel id didnt get set');
+        assert(reply.channelId == 'test', 'test channel id didnt get set');
         assert(client.dialogTurnResult.status == DialogTurnStatus.complete, 'dialog did not end properly');
-
     });
-
-
 
     it('should process a 2 turn waterfall dialog', async function() {
 
@@ -54,17 +50,16 @@ describe('DialogTestClient', function() {
             },
         ]);
 
-        let client = new DialogTestClient(dialog, null, [new DialogTestLogger()], null, null, {channelId: 'custom'});
+        let client = new DialogTestClient('test', dialog, null, [new DialogTestLogger()], null, null);
         let reply = await client.sendActivity('hello');
         assert(reply.text == 'hello', 'dialog responded with incorrect message');
         // get typing
-        reply = await client.getNextReply();
+        reply = client.getNextReply();
         assert(reply.type == 'typing', 'dialog responded with incorrect message');
-        reply = await client.getNextReply();
+        reply = client.getNextReply();
         assert(reply.text == 'hello 2', 'dialog responded with incorrect 2nd message');
         assert(client.dialogTurnResult.status == DialogTurnStatus.complete, 'dialog did not end properly');
     });
-
 
     it('should process a component dialog', async function() {
 
@@ -81,7 +76,7 @@ describe('DialogTestClient', function() {
                         return step.next();
                     },
                 ]);
-        
+
                 this.addDialog(dialog);
                 this.addDialog(new TextPrompt('textPrompt'));
             }
@@ -89,7 +84,7 @@ describe('DialogTestClient', function() {
             async run(turnContext, accessor) {
                 const dialogSet = new DialogSet(accessor);
                 dialogSet.add(this);
-        
+
                 const dialogContext = await dialogSet.createContext(turnContext);
                 const results = await dialogContext.continueDialog();
                 if (results.status === DialogTurnStatus.empty) {
@@ -98,15 +93,12 @@ describe('DialogTestClient', function() {
             }
         }
 
-
         let component = new MainDialog('component');
-
-        let client = new DialogTestClient(component,null, [new DialogTestLogger()]);
+        let client = new DialogTestClient('test', component, null, [new DialogTestLogger()]);
         let reply = await client.sendActivity('hello');
         assert(reply.text == 'Tell me something','dialog responded with incorrect message');
         reply = await client.sendActivity('foo');
         assert(reply.text == 'you said: foo', 'dialog responded with incorrect 2nd message');
         assert(client.dialogTurnResult.status == DialogTurnStatus.complete, 'dialog did not end properly');
     });
-
 });


### PR DESCRIPTION
* Removed callback from constructor (we don't want to expose that one for now).
* Removed adapterOptions from constructor.
* Refactored constructor to take a channeldId or a TestAdapter (required).
* Added optional conversationState parameter to constructor
* Added conversationUpdate property to allow devs to manipulate state during tests.

Updated Readme to match current changes
Updated tests to pass.
Updated .editorconfig to enforce spaces instead of tabs