### PR TITLE
QnAMakerService correctly builds hostname URL & throws error w/o URL

### DIFF
--- a/libraries/botframework-config/src/models/qnaMakerService.ts
+++ b/libraries/botframework-config/src/models/qnaMakerService.ts
@@ -39,8 +39,14 @@ export class QnaMakerService extends ConnectedService implements IQnAService {
      */
     constructor(source: IQnAService = {} as IQnAService) {
         super(source, ServiceTypes.QnA);
+        
+        if (!source.hostname) {
+            throw TypeError('QnAMakerService requires source parameter to have a hostname.')
+        }
 
-        this.hostname = new URL('/qnamaker', this.hostname).href;
+        if (!this.hostname.endsWith('/qnamaker')) {
+            this.hostname = new URL('/qnamaker', this.hostname).href;
+        }
     }
 
     // encrypt keys in service

--- a/libraries/botframework-config/tests/service.test.js
+++ b/libraries/botframework-config/tests/service.test.js
@@ -29,5 +29,22 @@ describe("Service Tests", () => {
         });
         assert.equal(qna.hostname, "https://myservice.azurewebsites.net/qnamaker");
     });
+
+    it("QnAMaker correctly does not add suffix when already hostname endind with \/qnamaker", () => {
+        let qnaWithQnamakerHostname = new bf.QnaMakerService({
+            hostname: "https://MyServiceThatDoesntNeedAppending.azurewebsites.net/qnamaker"
+        });
+        assert.equal(qnaWithQnamakerHostname.hostname, "https://MyServiceThatDoesntNeedAppending.azurewebsites.net/qnamaker");
+    });
+
+    it("QnAMaker should throw error without hostname", () => {
+        function createQnaWithoutHostname() {
+            new bf.QnaMakerService({});
+        }
+
+        let noHostnameError = new TypeError('QnAMakerService requires source parameter to have a hostname.')
+
+        assert.throws(() => createQnaWithoutHostname(), noHostnameError)
+    });
 });
 


### PR DESCRIPTION
Fixes #939 

## Description
* Issue 1: URL built for hostname would _always_ append "`/qnamaker`" to `QnAMakerService.hostname`, even when the `hostname` already had `/qnamaker` in the hostname string
  * **QnAMakerService will now only append `/qnamaker` to hostname, if it does not end in `/qnamaker` already**
  * Ex 1: `https://myservice.azurewebsites.net` => `https://myservice.azurewebsites.net/qnamaker`
  * Ex 2: `https://MyServiceThatDoesntNeedAppending.azurewebsites.net/qnamaker` remains the same

* Issue 2: previously if `QnAMakerService`'s first parameter receives a `source` that does not have a `hostname`, in the URL class's logic, it would throw invalid URL error when constructing URL + base to create `QnAMakerService.hostname`
  * As per Steven's advice, **QnAMakerService now throws an error, clearly stating that the hostname is required in the source to construct the QnAMakerService properly**
  * this is because nothing actually can be done w/regards to QnAMaker unless you have a hostname