### PR TITLE
Lock exact versions across dependencies

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -24,7 +24,7 @@
     "@azure/ms-rest-js": "1.8.13",
     "@microsoft/recognizers-text-date-time": "1.1.2",
     "@types/node": "^10.12.18",
-    "botbuilder-core": "~4.1.6",
+    "botbuilder-core": "4.1.6",
     "moment": "^2.20.1",
     "node-fetch": "^2.3.0",
     "url-parse": "^1.4.4"

--- a/libraries/botbuilder-applicationinsights/package.json
+++ b/libraries/botbuilder-applicationinsights/package.json
@@ -24,7 +24,7 @@
     "appinsights-usage": "1.0.2",
     "applicationinsights": "1.2.0",
     "applicationinsights-js": "1.0.20",
-    "botbuilder-core": "^4.1.6",
+    "botbuilder-core": "4.1.6",
     "cls-hooked": "^4.2.2"
   },
   "devDependencies": {

--- a/libraries/botbuilder-azure/package.json
+++ b/libraries/botbuilder-azure/package.json
@@ -24,7 +24,7 @@
     "@types/documentdb": "^1.10.5",
     "@types/node": "^10.12.18",
     "azure-storage": "2.10.2",
-    "botbuilder": "~4.1.6",
+    "botbuilder": "4.1.6",
     "documentdb": "1.14.5",
     "flat": "^4.0.0",
     "semaphore": "^1.1.0"

--- a/libraries/botbuilder-core/package.json
+++ b/libraries/botbuilder-core/package.json
@@ -21,7 +21,7 @@
   "typings": "./lib/index.d.ts",
   "dependencies": {
     "assert": "^1.4.1",
-    "botframework-schema": "~4.1.6"
+    "botframework-schema": "4.1.6"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.47",

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -25,7 +25,7 @@
     "@microsoft/recognizers-text-number": "1.1.2",
     "@microsoft/recognizers-text-suite": "1.1.2",
     "@types/node": "^10.12.18",
-    "botbuilder-core": "~4.1.6"
+    "botbuilder-core": "4.1.6"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.47",

--- a/libraries/botbuilder-testing/package.json
+++ b/libraries/botbuilder-testing/package.json
@@ -20,8 +20,8 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "dependencies": {
-    "botbuilder-core": "~4.1.6",
-    "botbuilder-dialogs": "~4.1.6",
+    "botbuilder-core": "4.1.6",
+    "botbuilder-dialogs": "4.1.6",
     "mocha-logger": "^1.0.6"
   },
   "devDependencies": {

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -21,8 +21,8 @@
   "typings": "./lib/index.d.ts",
   "dependencies": {
     "@types/node": "^10.12.18",
-    "botbuilder-core": "~4.1.6",
-    "botframework-connector": "~4.1.6",
+    "botbuilder-core": "4.1.6",
+    "botframework-connector": "4.1.6",
     "filenamify": "^4.1.0",
     "fs-extra": "^7.0.1"
   },

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -23,7 +23,7 @@
     "@types/jsonwebtoken": "7.2.8",
     "@types/node": "^10.12.18",
     "base64url": "^3.0.0",
-    "botframework-schema": "~4.1.6",
+    "botframework-schema": "4.1.6",
     "form-data": "^2.3.3",
     "jsonwebtoken": "8.0.1",
     "nock": "^10.0.3",

--- a/libraries/testbot/package.json
+++ b/libraries/testbot/package.json
@@ -10,10 +10,10 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "botbuilder": "^4.1.6",
-    "botbuilder-ai": "^4.1.6",
-    "botbuilder-dialogs": "^4.1.6",
-    "botbuilder-testing": "^4.1.6",
+    "botbuilder": "4.1.6",
+    "botbuilder-ai": "4.1.6",
+    "botbuilder-dialogs": "4.1.6",
+    "botbuilder-testing": "4.1.6",
     "@microsoft/recognizers-text-data-types-timex-expression": "^1.1.4",
     "dotenv": "^6.1.0",
     "restify": "^8.3.0"


### PR DESCRIPTION
The dependencies across our packages previously had "^" dependencies. 
```
dependencies": {
    "botbuilder-core": "^4.5.0-RC1",
    "botframework-connector": "^4.5.0-RC1",
  },
```

This PR makes these *exact* dependencies, as we always version the set of BotBuilder packages together. 
```
dependencies": {
    "botbuilder-core": "4.5.0-RC1",
    "botframework-connector": "4.5.0-RC1",
  },
```

The *actual* version number (4.4.0, 4.5.0, 4.5.1, etc) is stamped by the Build System. 