### PR TITLE
Version fix: "botbuilder-testing": "4.5.0" from invalid version 4.1.6

### DIFF
--- a/libraries/testbot/package.json
+++ b/libraries/testbot/package.json
@@ -13,7 +13,7 @@
     "botbuilder": "4.1.6",
     "botbuilder-ai": "4.1.6",
     "botbuilder-dialogs": "4.1.6",
-    "botbuilder-testing": "4.1.6",
+    "botbuilder-testing": "4.5.0",
     "@microsoft/recognizers-text-data-types-timex-expression": "^1.1.4",
     "dotenv": "^6.1.0",
     "restify": "^8.3.0"


### PR DESCRIPTION
Version 4.1.6 does not exist. 
This is a regression from PR "Lock exact versions across dependencies"  https://github.com/microsoft/botbuilder-js/pull/1040 which broke the Run-JS-Functional-Tests-Linux build.

This fix should immediately fix the build. However, there are a lot of other dependencies specifying an exact version match of 4.1.6 instead of 4.5.0, which forces the code to run on 8-month-old packages.

I guess that means we will have to get good at rolling all dependencies every time new package versions are released. (I recall there is a tool to do this.)
