### PR TITLE
Fix ImportResolverDelegate bug

### DIFF
--- a/libraries/botbuilder-lg/src/ImportResolver.ts
+++ b/libraries/botbuilder-lg/src/ImportResolver.ts
@@ -12,17 +12,16 @@ import * as path from 'path';
 /**
  * Delegate for resolving resource id of imported lg file.
  */
-export declare type ImportResolverDelegate = (resourceId: string) => { content: string; id: string };
+export declare type ImportResolverDelegate = (source: string, resourceId: string) => { content: string; id: string };
 
 /**
  * import resolver util
  */
 export class ImportResolver {
-    public static filePathResolver(filePath: string): ImportResolverDelegate {
-        return ((id: string): { content: string; id: string } => {
-            // import paths are in resource files which can be executed on multiple OS environments
+    public static fileResolver: ImportResolverDelegate = (filePath: string, id: string) => {
+        // import paths are in resource files which can be executed on multiple OS environments
             // Call GetOsPath() to map / & \ in importPath -> OSPath
-            let importPath: string = this.normalizePath(id);
+            let importPath: string = ImportResolver.normalizePath(id);
             if (!path.isAbsolute(importPath)) {
                 // get full path for importPath relative to path which is doing the import.
                 importPath = path.normalize(path.join(path.dirname(filePath), id));
@@ -31,16 +30,6 @@ export class ImportResolver {
             const content: string = fs.readFileSync(importPath, 'utf-8');
 
             return { content, id: importPath };
-        });
-    }
-
-    public static fileResolver(): ImportResolverDelegate {
-        return ((id: string): { content: string; id: string } => {
-            id = path.normalize(id);
-            const content: string = fs.readFileSync(id, 'utf-8');
-
-            return { content, id };
-        });
     }
 
      /// <summary>

--- a/libraries/botbuilder-lg/src/lgResource.ts
+++ b/libraries/botbuilder-lg/src/lgResource.ts
@@ -30,7 +30,7 @@ export class LGResource {
 
    public discoverLGResources(importResolver: ImportResolverDelegate) : LGResource[] {
       const resourcesFound: LGResource[] = [];
-      importResolver = importResolver === undefined ? ImportResolver.fileResolver() : importResolver;
+      importResolver = importResolver === undefined ? ImportResolver.fileResolver: importResolver;
       this.resolveImportResources(this, importResolver, resourcesFound);
 
       return resourcesFound;
@@ -42,7 +42,7 @@ export class LGResource {
 
       resourceIds.forEach((resourceId: string) => {
          try {
-            const { content, id } = importResolver(resourceId);
+            const { content, id } = importResolver(start.Id, resourceId);
             const childResource: LGResource = LGParser.parse(content, id);
 
             if (!(resourcesFound.some((x: LGResource) => x.Id === childResource.Id))) {

--- a/libraries/botbuilder-lg/src/staticChecker.ts
+++ b/libraries/botbuilder-lg/src/staticChecker.ts
@@ -35,7 +35,7 @@ export class StaticChecker {
         try {
             let totalLGResources: LGResource[] = [];
             filePaths.forEach((filePath: string) => {
-                importResolver = importResolver !== undefined ? importResolver : ImportResolver.filePathResolver(filePath);
+                importResolver = importResolver !== undefined ? importResolver : ImportResolver.fileResolver;
 
                 filePath = path.normalize(filePath);
                 const rootResource: LGResource = LGParser.parse(fs.readFileSync(filePath, 'utf-8'), filePath);

--- a/libraries/botbuilder-lg/src/templateEngine.ts
+++ b/libraries/botbuilder-lg/src/templateEngine.ts
@@ -32,8 +32,6 @@ export class TemplateEngine {
     public addFiles = (filePaths: string[], importResolver?: ImportResolverDelegate): TemplateEngine => {
         let totalLGResources: LGResource[] = [];
         filePaths.forEach((filePath: string) => {
-            importResolver = importResolver !== undefined ? importResolver : ImportResolver.filePathResolver(filePath);
-
             filePath = path.normalize(filePath);
             const rootResource: LGResource = LGParser.parse(fs.readFileSync(filePath, 'utf-8'), filePath);
             const lgResources: LGResource[] = rootResource.discoverLGResources(importResolver);

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -294,7 +294,7 @@ describe('LG', function () {
 
         // Assert 6.lg is imported only once when there are several relative paths which point to the same file.
         // Assert import cycle loop is handled well as expected when a file imports itself.
-        assert.strictEqual(engine.templates.length, 11);
+        assert.strictEqual(engine.templates.length, 14);
 
         const options1 = ["Hi", "Hello", "Hey"];
         var evaled = engine.evaluateTemplate("basicTemplate");
@@ -311,6 +311,10 @@ describe('LG', function () {
         const options4 = ["Hi 2", "Hello 2"];
         evaled = engine.evaluateTemplate("basicTemplate2");
         assert.strictEqual(options4.includes(evaled), true, `Evaled is ${evaled}`);
+
+        const options5 = ["Hi 2", "Hello 2"];
+        evaled = engine.evaluateTemplate("template3");
+        assert.strictEqual(options5.includes(evaled), true, `Evaled is ${evaled}`);
 
         // Assert 6.lg of absolute path is imported from text.
         var importedFilePath = GetExampleFilePath("6.lg");
@@ -346,7 +350,7 @@ describe('LG', function () {
         let engine = new TemplateEngine().addFiles([GetExampleFilePath("importExamples/import.lg"), GetExampleFilePath("importExamples/import2.lg")]);
 
         // Assert 6.lg is imported only once and no exceptions are thrown when it is imported from multiple files.
-        assert.strictEqual(engine.templates.length, 13);
+        assert.strictEqual(engine.templates.length, 14);
 
         const options1 = ["Hi", "Hello", "Hey"];
         var evaled = engine.evaluateTemplate("basicTemplate");

--- a/libraries/botbuilder-lg/tests/testData/examples/importExamples/import.lg
+++ b/libraries/botbuilder-lg/tests/testData/examples/importExamples/import.lg
@@ -7,6 +7,7 @@
 [import](.\..\6.lg)
 [import](1.lg)
 [import](import.lg)
+[import](import/import3.lg)
 
 # basicTemplate2
 - Hi 2

--- a/libraries/botbuilder-lg/tests/testData/examples/importExamples/import/import3.lg
+++ b/libraries/botbuilder-lg/tests/testData/examples/importExamples/import/import3.lg
@@ -1,0 +1,4 @@
+[import](../import2.lg)
+
+ # template3
+- [basicTemplate4]


### PR DESCRIPTION
Fix: https://github.com/microsoft/botbuilder-dotnet/issues/2233

Add source property in  `ImportResolverDelegate(string resourceId)` interface.

C# version: https://github.com/microsoft/botbuilder-dotnet/pull/2232