### PR TITLE
Revert dependency version change

### DIFF
--- a/libraries/testbot/package.json
+++ b/libraries/testbot/package.json
@@ -13,7 +13,7 @@
     "botbuilder": "4.1.6",
     "botbuilder-ai": "4.1.6",
     "botbuilder-dialogs": "4.1.6",
-    "botbuilder-testing": "4.5.0",
+    "botbuilder-testing": "4.1.6",
     "@microsoft/recognizers-text-data-types-timex-expression": "^1.1.4",
     "dotenv": "^6.1.0",
     "restify": "^8.3.0"


### PR DESCRIPTION
This reverts PR https://github.com/microsoft/botbuilder-js/pull/1052 which turned out not to fix the build break in Run-JS-Functional-Tests-Linux #70275. 