### PR TITLE
[DO NOT MERGE] Remove spread operators from cardFactory.ts

### DIFF
--- a/libraries/botbuilder-core/src/cardFactory.ts
+++ b/libraries/botbuilder-core/src/cardFactory.ts
@@ -245,7 +245,7 @@ export class CardFactory {
             images = text;
             text = undefined;
         }
-        const card: Partial<ThumbnailCard> = { ...other };
+        const card: Partial<ThumbnailCard> = Object.assign({}, other);
         if (title) { card.title = title; }
         if (text) { card.text = text; }
         if (images) { card.images = CardFactory.images(images); }
@@ -334,7 +334,7 @@ function mediaCard(contentType: string,
     media: (MediaUrl | string)[],
     buttons?: (CardAction | string)[],
     other?: any): Attachment {
-    const card: VideoCard = { ...other };
+    const card: VideoCard = Object.assign({}, other);
     if (title) { card.title = title; }
     card.media = CardFactory.media(media);
     if (buttons) { card.buttons = CardFactory.actions(buttons); }


### PR DESCRIPTION
Fixes https://github.com/microsoft/BotBuilder-Samples/issues/1618
This bug was verified on Edge ver. 44.18362.1.0

## Description
Edge does not support the spread operator, so I the replaced instances causing error with `Object.assign({}, varname)` in `cardFactory.ts, which is what the error in the above issue specifies.

However, this doesn't remove the spread operator from the entire repo. Is this something that we want removed everywhere? The spread operator is used quite frequently throughout the project. A quick search of `...` in all `.ts` files produces 79 other 

## Specific Changes
  - `cardFactory.ts` no longer uses spread operator in `mediaCard` and `signinCard`
  - This has **not** removed the spread operator from the rest of the project

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
I did not add new tests.