### PR TITLE
[Expression] Change accessProperty to case insensitive

### DIFF
--- a/libraries/botbuilder-expression-parser/tests/badExpression.test.js
+++ b/libraries/botbuilder-expression-parser/tests/badExpression.test.js
@@ -330,6 +330,7 @@ const badExpressions =
 
   // Memory access test
   "getProperty(bag, 1)",// second param should be string
+  "bag[1]",// first param should be string
   "Accessor(1)",// first param should be string
   "Accessor(bag, 1)", // second should be object
   "one[0]",  // one is not list

--- a/libraries/botbuilder-expression-parser/tests/expression.test.js
+++ b/libraries/botbuilder-expression-parser/tests/expression.test.js
@@ -386,6 +386,7 @@ const dataSource = [
 
   // Memory access tests
   ["getProperty(bag, concat('na','me'))", "mybag"],
+  ["getProperty(bag, 'Name')", "mybag"],
   ["items[2]", "two", ["items[2]"]],
   ["bag.list[bag.index - 2]", "blue", ["bag.list", "bag.index"]],
   ["items[nestedItems[1].x]", "two", ["items", "nestedItems[1].x"]],

--- a/libraries/botbuilder-expression-parser/tests/expression.test.js
+++ b/libraries/botbuilder-expression-parser/tests/expression.test.js
@@ -387,11 +387,14 @@ const dataSource = [
   // Memory access tests
   ["getProperty(bag, concat('na','me'))", "mybag"],
   ["getProperty(bag, 'Name')", "mybag"],
+  ["getProperty(bag.set, 'FOUR')", 4.0],
   ["items[2]", "two", ["items[2]"]],
   ["bag.list[bag.index - 2]", "blue", ["bag.list", "bag.index"]],
   ["items[nestedItems[1].x]", "two", ["items", "nestedItems[1].x"]],
   ["bag['name']", "mybag"],
   ["bag[substring(concat('na','me','more'), 0, length('name'))]", "mybag"],
+  ["bag['NAME']", "mybag"],
+  ["bag.set[concat('Fo', 'UR')]", 4.0],
   ["getProperty(undefined, 'p')", undefined],
   ["(getProperty(undefined, 'p'))[1]", undefined],
 

--- a/libraries/botbuilder-expression/src/extensions.ts
+++ b/libraries/botbuilder-expression/src/extensions.ts
@@ -118,10 +118,21 @@ export class Extensions {
         // tslint:disable-next-line: prefer-const
         let error: string;
         // todo, Is there a better way to access value, or any case is not listed below?
-        if (instance instanceof Map && <Map<string, any>>instance.get(property) !== undefined) {
-            value = <Map<string, any>>instance.get(property);
+        if (instance instanceof Map && <Map<string, any>>instance !== undefined) {
+            const instanceMap: Map<string, any> = <Map<string, any>>instance;
+            if (instanceMap.has(property)) {
+                value = instanceMap.get(property);
+            } else {
+                const prop: string = Array.from(instanceMap.keys()).find((k: string) => k.toLowerCase() === property.toLowerCase());
+                if (prop !== undefined) {
+                    value = instanceMap.get(prop);
+                }
+            }
         } else {
-            value = instance[property];
+            const prop: string = Object.keys(instance).find((k: string) => k.toLowerCase() === property.toLowerCase());
+            if (prop !== undefined) {
+                value = instance[prop];
+            }
         }
 
         return { value, error };


### PR DESCRIPTION
Before the change, the accessProperty function is case sensitive. After the change, the accessProperty function is case insensitive, which means getProperty(A, 'name') equals to getProperty(A, 'name'). This change is to alige with the C# version which is a key issue there.