### PR TITLE
Add botbuilder-dialogs-adaptive to script set-dependency-versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-docs": "lerna run build-docs",
     "eslint": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts",
     "eslint-fix": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts --fix",
-    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ^${Version} botbuilder botbuilder-choices botbuilder-dialogs botbuilder-core botbuilder-prompts botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ^${Version} botbuilder botbuilder-ai botbuilder-dialogs botbuilder-testing",
+    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ^${Version} botbuilder botbuilder-choices botbuilder-dialogs botbuilder-dialogs-adaptive botbuilder-core botbuilder-prompts botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ^${Version} botbuilder botbuilder-ai botbuilder-dialogs botbuilder-testing",
     "update-versions": "lerna run set-version && npm run set-dependency-versions"
   },
   "dependencies": {


### PR DESCRIPTION
This adds the dependency botbuilder-dialogs-adaptive to the set-dependency-versions script.

Should fix the bad dependency reference that is breaking build BotBuilder-JS-4.future-daily.