### PR TITLE
Reverts changes PR #1002

### DIFF
--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -89,14 +89,10 @@ export class ComponentDialog<O extends object = {}> extends Dialog<O> {
 
         // Check for end of inner dialog
         if (turnResult.status !== DialogTurnStatus.waiting) {
-            if (turnResult.status === DialogTurnStatus.cancelled) {
-                await this.endComponent(outerDC, turnResult.result);
-                const cancelledTurnResult: DialogTurnResult = { status: DialogTurnStatus.cancelled, result: turnResult.result }
-                return cancelledTurnResult;
-            }
             // Return result to calling dialog
             return await this.endComponent(outerDC, turnResult.result);
-        } 
+        }
+
         // Just signal end of turn
         return Dialog.EndOfTurn;
     }
@@ -110,17 +106,12 @@ export class ComponentDialog<O extends object = {}> extends Dialog<O> {
 
         // Check for end of inner dialog
         if (turnResult.status !== DialogTurnStatus.waiting) {
-            if (turnResult.status === DialogTurnStatus.cancelled) {
-                await this.endComponent(outerDC, turnResult.result);
-                const cancelledTurnResult: DialogTurnResult = { status: DialogTurnStatus.cancelled, result: turnResult.result }
-                return cancelledTurnResult;
-            }
             // Return result to calling dialog
             return await this.endComponent(outerDC, turnResult.result);
-        } else {
-            // Just signal end of turn
-            return Dialog.EndOfTurn;
         }
+
+        // Just signal end of turn
+        return Dialog.EndOfTurn;
     }
 
     public async resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult> {
@@ -261,5 +252,4 @@ export class ComponentDialog<O extends object = {}> extends Dialog<O> {
     public get telemetryClient(): BotTelemetryClient {
         return this._telemetryClient;
     }
-
 }

--- a/libraries/testbot/tests/dialogs/cancelAndHelpDialog.test.js
+++ b/libraries/testbot/tests/dialogs/cancelAndHelpDialog.test.js
@@ -48,7 +48,7 @@ describe('CancelAndHelpDialog', () => {
 
                 reply = await client.sendActivity(testData);
                 assert.strictEqual(reply.text, 'Cancelling...');
-                assert.strictEqual(client.dialogTurnResult.status, 'cancelled');
+                assert.strictEqual(client.dialogTurnResult.status, 'complete');
             });
         });
     });

--- a/libraries/testbot/tests/dialogs/testData/bookingDialogTestCases.js
+++ b/libraries/testbot/tests/dialogs/testData/bookingDialogTestCases.js
@@ -110,7 +110,7 @@ module.exports = [
             ['hi', 'To what city would you like to travel?'],
             ['cancel', 'Cancelling...']
         ],
-        expectedStatus: 'cancelled',
+        expectedStatus: 'complete',
         expectedResult: undefined,
     },
     {
@@ -121,7 +121,7 @@ module.exports = [
             ['Seattle','From what city will you be travelling?'],
             ['cancel', 'Cancelling...']
         ],
-        expectedStatus: 'cancelled',
+        expectedStatus: 'complete',
         expectedResult: undefined,
     },
     {
@@ -133,7 +133,7 @@ module.exports = [
             ['New York', 'On what date would you like to travel?'],
             ['cancel', 'Cancelling...']
         ],
-        expectedStatus: 'cancelled',
+        expectedStatus: 'complete',
         expectedResult: undefined,
     },
     {
@@ -146,7 +146,7 @@ module.exports = [
             ['tomorrow', `Please confirm, I have you traveling to: Seattle from: New York on: ${ tomorrow }. Is this correct? (1) Yes or (2) No`],
             ['cancel', 'Cancelling...']
         ],
-        expectedStatus: 'cancelled',
+        expectedStatus: 'complete',
         expectedResult: undefined,
     }
 ]


### PR DESCRIPTION
Reverted changes in https://github.com/microsoft/botbuilder-js/pull/1002 to componentDialog and updated TestBotTests.

It is not possible in the current implementation to return cancelled status from a componentDialog