### PR TITLE
[DO NOT MERGE] Fixed removeMention regex for IE

### DIFF
--- a/libraries/botbuilder-core/src/turnContext.ts
+++ b/libraries/botbuilder-core/src/turnContext.ts
@@ -114,7 +114,7 @@ export class TurnContext {
         var mentions = TurnContext.getMentions(activity);
         for (var i=0; i<mentions.length; i++) {
             if (mentions[i].mentioned.id === id) {
-                var mentionNameMatch = mentions[i].text.match(/(?<=<at.*>)(.*?)(?=<\/at>)/i);
+                var mentionNameMatch = mentions[i].text.match(/<at.*>(.*?)<\/at>/i);
                 if (mentionNameMatch.length > 0) {
                     activity.text = activity.text.replace(mentionNameMatch[0], '');
                     activity.text = activity.text.replace(/<at><\/at>/g, '');


### PR DESCRIPTION
Fixes #1075 	

## Description

IE doesn't support negative/positive lookaheads/lookbehinds in RegExp, so this removes it.

## Specific Changes

RegExp changed from:

```js
/(?<=<at.*>)(.*?)(?=<\/at>)/i
```

To:

```
/<at.*>(.*?)<\/at>/i
```

This also removes two of the capture groups, which is fine, because we only need one.

## Testing

Tests already existed:

![image](https://user-images.githubusercontent.com/40401643/61410704-9e407d80-a899-11e9-9b8a-4307ea0bd80b.png)
