### PR TITLE
TemplateEngine.addText should require fullPath as id when using default fileResolver

### DIFF
--- a/libraries/botbuilder-lg/src/ImportResolver.ts
+++ b/libraries/botbuilder-lg/src/ImportResolver.ts
@@ -42,7 +42,7 @@ export class ImportResolver {
     /// </remarks>
     /// <param name="ambigiousPath">authoredPath.</param>
     /// <returns>path expressed as OS path.</returns>
-    private static normalizePath(ambigiousPath: string): string {
+    public static normalizePath(ambigiousPath: string): string {
         if (process.platform === 'win32') {
              // map linux/mac sep -> windows
             return ambigiousPath.replace('/', '\\');

--- a/libraries/botbuilder-lg/src/templateEngine.ts
+++ b/libraries/botbuilder-lg/src/templateEngine.ts
@@ -147,7 +147,7 @@ export class TemplateEngine {
         if (importResolver === undefined) {
             const importPath: string = ImportResolver.normalizePath(id);
             if (!path.isAbsolute(importPath)) {
-                throw new Error('[Error] ImportResolver can not be empty when using AddText unless id is full path string');
+                throw new Error('[Error] id must be full path when importResolver is empty');
             }
         }
     }

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -145,7 +145,7 @@ describe('LG', function () {
     });
 
     it('TestBasicInlineTemplate', function () {
-        var emptyEngine = new TemplateEngine().addText("", "test", undefined);
+        var emptyEngine = new TemplateEngine();
         assert.strictEqual(emptyEngine.evaluate("Hi"), "Hi", emptyEngine.evaluate("Hi"));
         assert.strictEqual(emptyEngine.evaluate("Hi", ""), "Hi", emptyEngine.evaluate("Hi", ""));
 
@@ -316,23 +316,8 @@ describe('LG', function () {
         evaled = engine.evaluateTemplate("template3");
         assert.strictEqual(options5.includes(evaled), true, `Evaled is ${evaled}`);
 
-        // Assert 6.lg of absolute path is imported from text.
-        var importedFilePath = GetExampleFilePath("6.lg");
-        engine = new TemplateEngine().addText(`# basicTemplate\r\n- Hi\r\n- Hello\r\n[import](${importedFilePath})`, 'test', undefined);
-
-        assert.strictEqual(engine.templates.length, 8);
-
-        evaled = engine.evaluateTemplate("basicTemplate");
-        assert.strictEqual(options1.includes(evaled), true, `Evaled is ${evaled}`);
-
-        evaled = engine.evaluateTemplate("welcome");
-        assert.strictEqual(options2.includes(evaled), true, `Evaled is ${evaled}`);
-
-        evaled = engine.evaluateTemplate("welcome", { userName: "DL" });
-        assert.strictEqual(options3.includes(evaled), true, `Evaled is ${evaled}`);
-
         // Assert 6.lg of relative path is imported from text.
-        engine = new TemplateEngine().addText(`# basicTemplate\r\n- Hi\r\n- Hello\r\n[import](./tests/testData/examples/6.lg)`, 'test', undefined);
+        engine = new TemplateEngine().addText(`# basicTemplate\r\n- Hi\r\n- Hello\r\n[import](./6.lg)`, GetExampleFilePath("xx.lg"));
 
         assert.strictEqual(engine.templates.length, 8);
 

--- a/libraries/botbuilder-lg/tests/templateEngineThrowException.test.js
+++ b/libraries/botbuilder-lg/tests/templateEngineThrowException.test.js
@@ -127,4 +127,8 @@ describe('LGExceptionTest', function () {
             }    
         }
     });
+
+    it('AddTextWithWrongId', function() {
+        assert.throws(() => { new TemplateEngine().addText("# t \n - hi", "a.lg"); }, Error);
+    });
 });


### PR DESCRIPTION
fix: https://github.com/microsoft/botbuilder-dotnet/issues/2249