### PR TITLE
Prevent Common LUIS Endpoint User Error

### DIFF
--- a/libraries/botbuilder-ai/src/luisRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizer.ts
@@ -180,7 +180,7 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
             const { applicationId, endpoint, endpointKey } = application;
             this.application = {
                 applicationId: applicationId,
-                endpoint: endpoint,
+                endpoint: this.getValidEndpoint(endpoint),
                 endpointKey: endpointKey
             };
         }
@@ -750,5 +750,17 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
         if (!this.application.endpointKey) {
             throw new Error(`Invalid \`endpointKey\` value detected: ${this.application.endpointKey}\nPlease make sure your endpointKey is a valid LUIS Endpoint Key, e.g. "048ec46dc58e495482b0c447cfdbd291".`);
         }
+    }
+
+    /**
+     * Allows users to pass in either Machine Name (LUIS region or custom <name>.api...) or the full URL
+     * 
+     * @param endpoint https://<region/custom>.api.cognitive.microsoft.com
+     */
+    private getValidEndpoint(endpoint: string): string|null {
+        if (!endpoint) return null;
+
+        const machineName = endpoint.match(/(?:https?:\/\/)?([A-Z]*)(?:.*)?/i)[1];
+        return `https://${ machineName }.api.cognitive.microsoft.com`;
     }
 }

--- a/libraries/botbuilder-ai/tests/luisRecognizer.test.js
+++ b/libraries/botbuilder-ai/tests/luisRecognizer.test.js
@@ -520,7 +520,7 @@ describe('LuisRecognizer', function () {
         });
     });
 
-    it('should successfully construct with valid endpoint.', () => {
+    it('should successfully construct with valid endpoint when given the full application', () => {
         // Note this is NOT a real LUIS application ID nor a real LUIS subscription-key.
         // These are GUIDs edited to look right to the parsing and validation code.
         const mockedEndpoint = 'https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=';
@@ -530,6 +530,38 @@ describe('LuisRecognizer', function () {
         assert(recognizer.application.applicationId === 'b31aeaf3-3511-495b-a07f-571fc873214b');
         assert(recognizer.application.endpointKey === '048ec46dc58e495482b0c447cfdbd291');
         assert(recognizer.application.endpoint === 'https://westus.api.cognitive.microsoft.com');
+    });
+
+    it('should successfully construct with valid endpoint when given endpoint parameters', () => {
+        // Note this is NOT a real LUIS application ID nor a real LUIS subscription-key.
+        // These are GUIDs edited to look right to the parsing and validation code.
+        const appId = 'b31aeaf3-3511-495b-a07f-571fc873214b';
+        const endpointKey = '048ec46dc58e495482b0c447cfdbd291';
+        const regionEndpoint = 'westus';
+        const partialEndpoint = 'https://westus.api.cognitive.microsoft.com';
+        const customEndpoint = 'custom';
+        const mockedEndpoint = 'https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=';
+
+        const regionRecognizer = new LuisRecognizer({applicationId: appId, endpointKey: endpointKey, endpoint: regionEndpoint});
+        const partialRecognizer = new LuisRecognizer({applicationId: appId, endpointKey: endpointKey, endpoint: partialEndpoint});
+        const customRecognizer = new LuisRecognizer({applicationId: appId, endpointKey: endpointKey, endpoint: customEndpoint});
+        const mockedRecognizer = new LuisRecognizer(mockedEndpoint);
+
+        assert(regionRecognizer.application.applicationId === appId);
+        assert(regionRecognizer.application.endpointKey === endpointKey);
+        assert(regionRecognizer.application.endpoint === 'https://westus.api.cognitive.microsoft.com');
+
+        assert(partialRecognizer.application.applicationId === appId);
+        assert(partialRecognizer.application.endpointKey === endpointKey);
+        assert(partialRecognizer.application.endpoint === 'https://westus.api.cognitive.microsoft.com');
+
+        assert(customRecognizer.application.applicationId === appId);
+        assert(customRecognizer.application.endpointKey === endpointKey);
+        assert(customRecognizer.application.endpoint === 'https://custom.api.cognitive.microsoft.com');
+
+        assert(mockedRecognizer.application.applicationId === appId);
+        assert(mockedRecognizer.application.endpointKey === endpointKey);
+        assert(mockedRecognizer.application.endpoint === 'https://westus.api.cognitive.microsoft.com');
     });
 
     it('should throw an error when parsing application endpoint with no subscription-key.', () => {


### PR DESCRIPTION
Prevents: 

https://github.com/microsoft/BotBuilder-Samples/issues/1659
https://stackoverflow.com/questions/57105966/botbuilder-nlp-with-dispatch-error-no-such-host-is-known

I know I've seen this in past issues, as well. I also hit this occasionally, myself.

## Description

When constructing `LuisRecognizer`, user needs to supply an Endpoint. It isn't *super* clear whether the format is supposed to be any of the following:

* `https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/...`
* `westus`
* `westus.api.cognitive.microsoft.com`

This problem occurs mostly in the NLP samples because:

1. `.env` calls for `LuisAPIHostName=`
2. And it builds the Recognizer with `endpoint: https://${ process.env.LuisAPIHostName }.api.cognitive.microsoft.com`

**The samples aren't consistent with this, either**

[**C# CoreBot**](https://github.com/microsoft/BotBuilder-Samples/blob/master/samples/csharp_dotnetcore/13.core-bot/FlightBookingRecognizer.cs#L24)

```csharp
$"https://" + configuration["LuisAPIHostName"]);
```

[**C# NLP**](https://github.com/microsoft/BotBuilder-Samples/blob/master/samples/csharp_dotnetcore/14.nlp-with-dispatch/BotServices.cs#L20)

```csharp
$"https://{configuration["LuisAPIHostName"]}.api.cognitive.microsoft.com"),
```

So, the user MUST supply only `westus` and everything else results in an unclear error (depending on what they supply).

## Specific Changes

Uses regex to allow for any of the above formats.

## Alternatives Considered

The actual `LuisRecognizer` hints what is supposed to be supplied:

```js
export interface LuisApplication {
    [...]
    /**
     *  (Optional) LUIS endpoint with a default of https://westus.api.cognitive.microsoft.com
     */
    endpoint?: string;
    [...]
}
```

Instead of this PR, we could maybe make the sample more descriptive (maybe call it `LuisRegion` instead of `LuisAPIHostName` - **this might actually be best**), do a validation check on the environment variables, or change it to use the whole endpoint URL.

@v-kydela mentioned this might break LUIS hosted on custom domains. So, maybe this isn't as good of a solution as changing the `.env` variable name.

**Let me know if we like this idea and I'll write up the C# version**

## Testing

See tests in file changes.

Testing just LuisRecognizer.tests.js:

![image](https://user-images.githubusercontent.com/40401643/61551215-6c4e2900-aa09-11e9-8625-1069e9fabcfb.png)
