### PR TITLE
Changed library versions to "4.0.0-local"

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -2,7 +2,7 @@
   "name": "botbuilder-ai",
   "author": "Microsoft Corp.",
   "description": "Cognitive services extensions for Microsoft BotBuilder.",
-  "version": "4.1.6",
+  "version": "4.0.0-local",
   "license": "MIT",
   "keywords": [
     "botbuilder",
@@ -24,7 +24,7 @@
     "@azure/ms-rest-js": "1.8.13",
     "@microsoft/recognizers-text-date-time": "1.1.2",
     "@types/node": "^10.12.18",
-    "botbuilder-core": "4.1.6",
+    "botbuilder-core": "4.0.0-local",
     "moment": "^2.20.1",
     "node-fetch": "^2.3.0",
     "url-parse": "^1.4.4"

--- a/libraries/botbuilder-applicationinsights/package.json
+++ b/libraries/botbuilder-applicationinsights/package.json
@@ -2,7 +2,7 @@
   "name": "botbuilder-applicationinsights",
   "author": "Microsoft Corp.",
   "description": "Application Insights extensions for Microsoft BotBuilder.",
-  "version": "4.1.6",
+  "version": "4.0.0-local",
   "license": "MIT",
   "keywords": [
     "botbuilder",
@@ -24,7 +24,7 @@
     "appinsights-usage": "1.0.2",
     "applicationinsights": "1.2.0",
     "applicationinsights-js": "1.0.20",
-    "botbuilder-core": "4.1.6",
+    "botbuilder-core": "4.0.0-local",
     "cls-hooked": "^4.2.2"
   },
   "devDependencies": {

--- a/libraries/botbuilder-azure/package.json
+++ b/libraries/botbuilder-azure/package.json
@@ -2,7 +2,7 @@
   "name": "botbuilder-azure",
   "author": "Microsoft Corp.",
   "description": "Azure extensions for Microsoft BotBuilder.",
-  "version": "4.1.6",
+  "version": "4.0.0-local",
   "license": "MIT",
   "keywords": [
     "botbuilder",
@@ -24,7 +24,7 @@
     "@types/documentdb": "^1.10.5",
     "@types/node": "^10.12.18",
     "azure-storage": "2.10.2",
-    "botbuilder": "4.1.6",
+    "botbuilder": "4.0.0-local",
     "documentdb": "1.14.5",
     "flat": "^4.0.0",
     "semaphore": "^1.1.0"

--- a/libraries/botbuilder-core/package.json
+++ b/libraries/botbuilder-core/package.json
@@ -2,7 +2,7 @@
   "name": "botbuilder-core",
   "author": "Microsoft Corp.",
   "description": "Core components for Microsoft Bot Builder. Components in this library can run either in a browser or on the server.",
-  "version": "4.1.6",
+  "version": "4.0.0-local",
   "license": "MIT",
   "keywords": [
     "botbuilder",
@@ -21,7 +21,7 @@
   "typings": "./lib/index.d.ts",
   "dependencies": {
     "assert": "^1.4.1",
-    "botframework-schema": "4.1.6"
+    "botframework-schema": "4.0.0-local"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.47",

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -2,7 +2,7 @@
   "name": "botbuilder-dialogs",
   "author": "Microsoft Corp.",
   "description": "A dialog stack based conversation manager for Microsoft BotBuilder.",
-  "version": "4.1.6",
+  "version": "4.0.0-local",
   "license": "MIT",
   "keywords": [
     "botbuilder",
@@ -25,7 +25,7 @@
     "@microsoft/recognizers-text-number": "1.1.2",
     "@microsoft/recognizers-text-suite": "1.1.2",
     "@types/node": "^10.12.18",
-    "botbuilder-core": "4.1.6"
+    "botbuilder-core": "4.0.0-local"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.47",

--- a/libraries/botbuilder-testing/package.json
+++ b/libraries/botbuilder-testing/package.json
@@ -2,7 +2,7 @@
   "name": "botbuilder-testing",
   "author": "Microsoft Corp.",
   "description": "Helpers for testing Bot Framework bots",
-  "version": "4.1.6",
+  "version": "4.0.0-local",
   "license": "MIT",
   "keywords": [
     "botbuilder",
@@ -20,8 +20,8 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "dependencies": {
-    "botbuilder-core": "4.1.6",
-    "botbuilder-dialogs": "4.1.6",
+    "botbuilder-core": "4.0.0-local",
+    "botbuilder-dialogs": "4.0.0-local",
     "mocha-logger": "^1.0.6"
   },
   "devDependencies": {

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -2,7 +2,7 @@
   "name": "botbuilder",
   "author": "Microsoft Corp.",
   "description": "Bot Builder is a framework for building rich bots on virtually any platform.",
-  "version": "4.1.6",
+  "version": "4.0.0-local",
   "license": "MIT",
   "keywords": [
     "botbuilder",
@@ -21,8 +21,8 @@
   "typings": "./lib/index.d.ts",
   "dependencies": {
     "@types/node": "^10.12.18",
-    "botbuilder-core": "4.1.6",
-    "botframework-connector": "4.1.6",
+    "botbuilder-core": "4.0.0-local",
+    "botframework-connector": "4.0.0-local",
     "filenamify": "^4.1.0",
     "fs-extra": "^7.0.1"
   },

--- a/libraries/botframework-config/package.json
+++ b/libraries/botframework-config/package.json
@@ -2,7 +2,7 @@
   "name": "botframework-config",
   "author": "Microsoft Corp.",
   "description": "library for working with Bot Framework .bot configuration files",
-  "version": "4.1.6",
+  "version": "4.0.0-local",
   "license": "MIT",
   "keywords": [
     "bots",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -2,7 +2,7 @@
   "name": "botframework-connector",
   "author": "Microsoft Corp.",
   "description": "Bot Connector is autorest generated connector client.",
-  "version": "4.1.6",
+  "version": "4.0.0-local",
   "license": "MIT",
   "keywords": [
     "botconnector",
@@ -23,7 +23,7 @@
     "@types/jsonwebtoken": "7.2.8",
     "@types/node": "^10.12.18",
     "base64url": "^3.0.0",
-    "botframework-schema": "4.1.6",
+    "botframework-schema": "4.0.0-local",
     "form-data": "^2.3.3",
     "jsonwebtoken": "8.0.1",
     "nock": "^10.0.3",

--- a/libraries/botframework-schema/package.json
+++ b/libraries/botframework-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-schema",
-  "version": "4.1.6",
+  "version": "4.0.0-local",
   "description": "Activity schema for the Microsoft Bot Framework.",
   "keywords": [
     "botconnector",

--- a/libraries/functional-tests/functionaltestbot/package.json
+++ b/libraries/functional-tests/functionaltestbot/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "botbuilder": "^4.1.6",
+    "botbuilder": "^4.0.0-local",
     "restify": "^8.3.0",
     "dotenv": "^6.1.0"
   }

--- a/libraries/functional-tests/functionaltestbot/package.json
+++ b/libraries/functional-tests/functionaltestbot/package.json
@@ -9,7 +9,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "botbuilder": "^4.0.0-local",
+    "botbuilder": "4.0.0-local",
+    "botframework-connector": "4.0.0-local",
     "restify": "^8.3.0",
     "dotenv": "^6.1.0"
   }

--- a/libraries/functional-tests/functionaltestbot/package.json
+++ b/libraries/functional-tests/functionaltestbot/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "botbuilder": "4.0.0-local",
+    "botbuilder": "^4.1.6",
     "restify": "^8.3.0",
     "dotenv": "^6.1.0"
   }

--- a/libraries/functional-tests/functionaltestbot/package.json
+++ b/libraries/functional-tests/functionaltestbot/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "botbuilder": "^4.1.6",
+    "botbuilder": "4.0.0-local",
     "restify": "^8.3.0",
     "dotenv": "^6.1.0"
   }

--- a/libraries/testbot/package.json
+++ b/libraries/testbot/package.json
@@ -10,10 +10,10 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "botbuilder": "4.1.6",
-    "botbuilder-ai": "4.1.6",
-    "botbuilder-dialogs": "4.1.6",
-    "botbuilder-testing": "4.1.6",
+    "botbuilder": "4.0.0-local",
+    "botbuilder-ai": "4.0.0-local",
+    "botbuilder-dialogs": "4.0.0-local",
+    "botbuilder-testing": "4.0.0-local",
     "@microsoft/recognizers-text-data-types-timex-expression": "^1.1.4",
     "dotenv": "^6.1.0",
     "restify": "^8.3.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-docs": "lerna run build-docs",
     "eslint": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts",
     "eslint-fix": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts --fix",
-    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ^${Version} botbuilder botbuilder-choices botbuilder-dialogs botbuilder-core botbuilder-prompts botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ^${Version} botbuilder botbuilder-ai botbuilder-dialogs botbuilder-testing",
+    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ${Version} botbuilder botbuilder-ai botbuilder-azure botbuilder-core botbuilder-dialogs botbuilder-testing botframework-config botframework-connector botframework-schema && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ${Version} botbuilder botbuilder-ai botbuilder-azure botbuilder-core botbuilder-dialogs botbuilder-testing botframework-config botframework-connector botframework-schema",
     "update-versions": "lerna run set-version && npm run set-dependency-versions"
   },
   "dependencies": {

--- a/tools/util/updateDependenciesInPackageJsons.js
+++ b/tools/util/updateDependenciesInPackageJsons.js
@@ -14,7 +14,7 @@ console.log(dependencies);
 
 // Update versions for specified dependencies in package.json file
 function updateDependencies(filePath) {
-    var fs = require('fs')
+    var fs = require('fs');
     fs.readFile(filePath, 'utf8', function (err, data) {
         if (err) {
             return console.log(err);
@@ -22,7 +22,7 @@ function updateDependencies(filePath) {
 
         var result = '';
         dependencies.forEach(function (dependency) {
-            var findString = new RegExp('("dependencies":)(.+?)("' + dependency + '":\\s*")([^\/"]+)', "gms")
+            var findString = new RegExp('("dependencies":)(.+?)("' + dependency + '":\\s*")([^\/"]+)', "gms");
             console.log('findString =');
             console.log(findString);
             var replaceString = '$1$2$3' + newVersion;

--- a/tools/util/updateDependenciesInPackageJsons.js
+++ b/tools/util/updateDependenciesInPackageJsons.js
@@ -23,8 +23,14 @@ function updateDependencies(filePath) {
         var result = '';
         dependencies.forEach(function (dependency) {
             var findString = new RegExp('("dependencies":)(.+?)("' + dependency + '":\\s*")([^\/"]+)', "gms")
+            console.log('findString =');
+            console.log(findString);
             var replaceString = '$1$2$3' + newVersion;
+            console.log('replaceString =');
+            console.log(replaceString);
             result = data.replace(findString, replaceString);
+            console.log('result =');
+            console.log(result);
             data = result;
         });
 

--- a/tools/util/updateDependenciesInPackageJsons.js
+++ b/tools/util/updateDependenciesInPackageJsons.js
@@ -23,14 +23,8 @@ function updateDependencies(filePath) {
         var result = '';
         dependencies.forEach(function (dependency) {
             var findString = new RegExp('("dependencies":)(.+?)("' + dependency + '":\\s*")([^\/"]+)', "gms");
-            console.log('findString =');
-            console.log(findString);
             var replaceString = '$1$2$3' + newVersion;
-            console.log('replaceString =');
-            console.log(replaceString);
             result = data.replace(findString, replaceString);
-            console.log('result =');
-            console.log(result);
             data = result;
         });
 

--- a/transcripts/package.json
+++ b/transcripts/package.json
@@ -10,9 +10,9 @@
     "dependencies": {
         "@types/node": "^10.12.18",
         "@types/restify": "^7.2.1",
-        "botbuilder": "^4.2.1",
-        "botbuilder-ai": "^4.2.1",
-        "botbuilder-dialogs": "^4.2.1"
+        "botbuilder": "4.0.0-local",
+        "botbuilder-ai": "4.0.0-local",
+        "botbuilder-dialogs": "4.0.0-local"
     },
     "devDependencies": {
         "mocha": "^5.2.0",


### PR DESCRIPTION
Implements #1084. 

Summary of changes:

- Updated packages.json files to set the versions of the modules to 4.0.0-local.
- Updated packages.json to reference 4.0.0-local (strict)
- Updated workspace packages.json "set-dependency-versions" to apply strict version dependencies rather than ^ versions to ensure we use the packages that are part of the build.
- Also, "set-dependency-versions" had references to packages that don't exist (like botbuilder-choices) and was missing other packages (like botbuilder-ai), I removed the packages that don't exist and added the missing ones.

Manually test daily and functional test builds (windows and linux) against the branch and they all passed.