### PR TITLE
added (e) to catch statements to work with older version of node.js

### DIFF
--- a/libraries/botbuilder-expression/src/builtInFunction.ts
+++ b/libraries/botbuilder-expression/src/builtInFunction.ts
@@ -346,7 +346,7 @@ export class BuiltInFunctions {
             if (Number.isNaN(parsedData.getTime())) {
                 error = `${value} is not a valid datetime string.`;
             }
-        } catch {
+        } catch (e) {
             error = `${value} is not a valid datetime string.`;
         }
 
@@ -367,7 +367,7 @@ export class BuiltInFunctions {
             } else if (parsedData.toISOString() !== value) {
                 error = `${value} is not a ISO format datetime string.`;
             }
-        } catch {
+        } catch (e) {
             error = `${value} is not a valid datetime string.`;
         }
 
@@ -747,14 +747,14 @@ export class BuiltInFunctions {
         let xPathResult: any;
         try {
             xmlDoc = parser.parseFromString(xmlStr);
-        } catch {
+        } catch (e) {
             error = `${xmlStr} is not valid xml`;
         }
 
         if (error === undefined) {
             try {
                 xPathResult = xpathEval.select(xpath, xmlDoc);
-            } catch {
+            } catch (e) {
                 error = `${xpath} is not an valid expression`;
             }
         }
@@ -1281,7 +1281,7 @@ export class BuiltInFunctions {
         try {
             const jsonObj: any = typeof contentToConvert === 'string' ? JSON.parse(contentToConvert) : contentToConvert;
             result = new Builder().buildObject(jsonObj);
-        } catch {
+        } catch (e) {
             error = 'Invalid json';
         }
 
@@ -1353,7 +1353,7 @@ export class BuiltInFunctions {
         let error: string;
         try {
             result = timedata.format(format);
-        } catch {
+        } catch (e) {
             error = `${format} is not a valid timestamp format`;
         }
 
@@ -1372,7 +1372,7 @@ export class BuiltInFunctions {
         if (error === undefined) {
             try {
                 result = timezone.tz(timeStamp, timeZone).format(format);
-            } catch {
+            } catch (e) {
                 error = `${format} is not a valid timestamp format`;
             }
         }
@@ -1406,14 +1406,14 @@ export class BuiltInFunctions {
                 try {
                     const sourceTime: moment.Moment = timezone.tz(timeStamp, timeZone);
                     formattedSourceTime = sourceTime.format();
-                    } catch {
+                    } catch (e) {
                     error = `${timeStamp} with ${timeZone} is not a valid timestamp with specified timeZone:`;
                 }
 
                 if (error === undefined) {
                     try {
                         result = timezone.tz(formattedSourceTime, 'Etc/UTC').format(format);
-                    } catch {
+                    } catch (e) {
                         error = `${format} is not a valid timestamp format`;
                     }
                 }
@@ -1481,7 +1481,7 @@ export class BuiltInFunctions {
         let error: string;
         try {
             result = new URL(uri);
-        } catch {
+        } catch (e) {
             error = `Invalid URI: ${uri}`;
         }
 
@@ -1496,7 +1496,7 @@ export class BuiltInFunctions {
         if (error === undefined) {
             try {
                 result = parsed.hostname;
-            } catch {
+            } catch (e) {
                 error = 'invalid operation, input uri should be an absolute URI';
             }
         }
@@ -1513,7 +1513,7 @@ export class BuiltInFunctions {
             try {
                 const uriObj: URL = new URL(uri);
                 result = uriObj.pathname;
-            } catch {
+            } catch (e) {
                 error = 'invalid operation, input uri should be an absolute URI';
             }
         }
@@ -1529,7 +1529,7 @@ export class BuiltInFunctions {
         if (error === undefined) {
             try {
                 result = parsed.pathname + parsed.search;
-            } catch {
+            } catch (e) {
                 error = 'invalid operation, input uri should be an absolute URI';
             }
         }
@@ -1545,7 +1545,7 @@ export class BuiltInFunctions {
         if (error === undefined) {
             try {
                 result = parsed.port;
-            } catch {
+            } catch (e) {
                 error = 'invalid operation, input uri should be an absolute URI';
             }
         }
@@ -1561,7 +1561,7 @@ export class BuiltInFunctions {
         if (error === undefined) {
             try {
                 result = parsed.search;
-            } catch {
+            } catch (e) {
                 error = 'invalid operation, input uri should be an absolute URI';
             }
         }
@@ -1577,7 +1577,7 @@ export class BuiltInFunctions {
         if (error === undefined) {
             try {
                 result = parsed.protocol.replace(':', '');
-            } catch {
+            } catch (e) {
                 error = 'invalid operation, input uri should be an absolute URI';
             }
         }


### PR DESCRIPTION
It looks like we are using newer node.js syntax stile for catching errors.

On 8.11 you are not allowed to catch without (e)
this doesn't work
'''
  }
    some code 
  }  
   catch { 
  }
'''

@donglixp  we need to add test that include older versions of node.js

version 8 is still in LTS until April 2020.

## Testing
I ran no testing.