### PR TITLE
 Fix Linux functional test bot not working

### DIFF
--- a/libraries/functional-tests/functionaltestbot/package.json
+++ b/libraries/functional-tests/functionaltestbot/package.json
@@ -9,8 +9,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "botbuilder": "4.0.0-local",
-    "botframework-connector": "4.0.0-local",
+    "botbuilder": "file:./botbuilder",
+    "botframework-connector": "file:./botframework-connector",
     "restify": "^8.3.0",
     "dotenv": "^6.1.0"
   }


### PR DESCRIPTION
## Description
After changing the local libraries to `4.0.0-local` the Functional Tests for Linux started to fail.
This PR replaces local dependency of functional test bot with relative path in the `package.json` file.

## Specific Changes
To fix the functional tests, it is necessary to configure the functional test bot dependencies to use relative path and also include the transpiled libraries in the Git Deployment.

In order to include the transpiled libraries in the Git Deployment, the task `Use Node 10x` and `npm install` must be moved before the `Git Bot Deployment` task, and also add a `npm run build` as shown below:
![image](https://user-images.githubusercontent.com/39467613/62052304-9d89de80-b1eb-11e9-91e7-7f4956262e55.png)

To bundle the libraries along with the bot on the Linux pipelines, the following lines must be included to the `Git Bot Deployment` task:
```cmd
set S=$(System.DefaultWorkingDirectory)\libraries
set D=$(System.DefaultWorkingDirectory)\libraries\functional-tests\functionaltestbot

robocopy %S%\botbuilder %D%\botbuilder /S /XF .gitignore /XD src tests /NFL /NDL
robocopy %S%\botbuilder-core %D%\botbuilder-core /S /XF .gitignore /XD src tests /NFL /NDL
robocopy %S%\botframework-connector %D%\botframework-connector /S /XF .gitignore /XD src tests /NFL /NDL
robocopy %S%\botframework-schema %D%\botframework-schema /S /XF .gitignore /XD src tests /NFL /NDL
```
- `/S` Copies the sub folders
- `/XF .gitignore` Excludes the `.gitignore` file, as otherwise the libraries won't be included in the Git Deploy
- `/XD src tests` Excludes the `src` and `tests` folders to avoid cluttering the commit
- `/NFL` Doesn't log the File List to avoid cluttering the pipelines log
- `/NDL` Doesn't log the Directory List to avoid cluttering the pipelines log

Each `robocopy` copies a library needed by the Functional Testbot to the `functionaltestbot` directory to be included in the commit of git deploy.

These lines must be added at the start of the CMD script, as shown below:
![image](https://user-images.githubusercontent.com/39467613/61981578-71464600-afd0-11e9-8038-2f2c01accfe6.png)
