### PR TITLE
[LG] Fix lg reference parameter issue

### DIFF
--- a/libraries/botbuilder-lg/src/evaluator.ts
+++ b/libraries/botbuilder-lg/src/evaluator.ts
@@ -258,7 +258,16 @@ export class Evaluator extends AbstractParseTreeVisitor<string> implements LGFil
     private EvalTemplateRef(exp: string) : string {
         exp = exp.replace(/(^\[*)/g, '')
                 .replace(/(\]*$)/g, '');
-        exp = exp.indexOf('(') < 0 ? exp.concat('()') : exp;
+
+        if (exp.indexOf('(') < 0) {
+            if (exp in this.TemplateMap) {
+                exp = exp.concat('(')
+                        .concat(this.TemplateMap[exp].Parameters.join())
+                        .concat(')');
+            } else {
+                exp = exp.concat('()');
+            }
+        }
 
         return this.EvalExpression(exp);
     }

--- a/libraries/botbuilder-lg/src/expander.ts
+++ b/libraries/botbuilder-lg/src/expander.ts
@@ -245,8 +245,17 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGFi
 
     private EvalTemplateRef(exp: string) : string[] {
         exp = exp.replace(/(^\[*)/g, '')
-                .replace(/(\]*$)/g, '');
-        exp = exp.indexOf('(') < 0 ? exp.concat('()') : exp;
+            .replace(/(\]*$)/g, '');
+            
+        if (exp.indexOf('(') < 0) {
+            if (exp in this.TemplateMap) {
+                exp = exp.concat('(')
+                    .concat(this.TemplateMap[exp].Parameters.join())
+                    .concat(')');
+            } else {
+                exp = exp.concat('()');
+            }
+        }
 
         return this.EvalExpression(exp);
     }

--- a/libraries/botbuilder-lg/src/staticChecker.ts
+++ b/libraries/botbuilder-lg/src/staticChecker.ts
@@ -433,7 +433,16 @@ class StaticCheckerInner extends AbstractParseTreeVisitor<Diagnostic[]> implemen
                 .replace(/(\]*$)/g, '')
                 .trim();
 
-        const expression: string = exp.indexOf('(') < 0 ? exp.concat('()') : exp;
+        let expression: string = exp;
+        if (exp.indexOf('(') < 0) {
+            if (exp in this.TemplateMap) {
+                expression = exp.concat('(')
+                    .concat(this.TemplateMap[exp].Parameters.join())
+                    .concat(')');
+            } else {
+                expression = exp.concat('()');
+            }
+        }
 
         try {
             new ExpressionEngine(new GetMethodExtensions(new Evaluator(this.Templates, undefined)).GetMethodX).parse(expression);

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -192,8 +192,14 @@ describe('LG', function () {
     it('TestTemplateRef', function () {
         var engine = new TemplateEngine().addFile(GetExampleFilePath("TemplateRef.lg"));
         var scope = { time: "morning", name: "Dong Lei" };
-        var evaled = engine.evaluateTemplate("Hello", scope);
-        assert.strictEqual(evaled, "Good morning Dong Lei", `Evaled is ${evaled}`);
+        var evaled1 = engine.evaluateTemplate("Hello", scope);
+        assert.strictEqual(evaled1, "Good morning Dong Lei", `Evaled is ${evaled1}`);
+
+        var evaled2 = engine.evaluateTemplate("Hello2", scope);
+        assert.strictEqual(evaled2, "Good morning Dong Lei", `Evaled is ${evaled2}`);
+
+        var evaled3 = engine.evaluateTemplate("Hello3", scope);
+        assert.strictEqual(evaled3, "Good morning Dong Lei", `Evaled is ${evaled3}`);
     });
 
     it('TestEscapeCharacter', function () {

--- a/libraries/botbuilder-lg/tests/testData/examples/TemplateRef.lg
+++ b/libraries/botbuilder-lg/tests/testData/examples/TemplateRef.lg
@@ -1,6 +1,12 @@
 # Hello
 - [Welcome(time)] {name}
 
+# Hello2
+- [Welcome] {name}
+
+ # Hello3
+- {Welcome(time)} {name}
+
 # Welcome(time)
 - IF: {time == 'morning'}
  - Good morning

--- a/libraries/botbuilder-lg/tests/testData/exceptionExamples/TemplateParamsNotMatchArgsNum.lg
+++ b/libraries/botbuilder-lg/tests/testData/exceptionExamples/TemplateParamsNotMatchArgsNum.lg
@@ -1,10 +1,16 @@
+# templateRef(arg1, arg2)
+- hi 
+
 # template
-- [templateRef('p1','p2')]
+- [templateRef('p1','p2','p3')]
 
- # templateRef(arg)
-- hi
-
- # template2
+# template2
 - ```
-   @{templateRef()}
- ``` 
+   @{templateRef('p1')}
+ ```
+
+# template3
+- {templateRef()}
+
+# template4
+- [templateRef()]


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-dotnet/issues/2344

We have a validation function in static checker period which is validating whether the parameters number from template definition is same with the number from the actual template call function. This PR is to make the validation always pass if the actual parameter number is zero. This is by design that no parameters mean parameters are inherited from caller's the scope.