### PR TITLE
Add Resource Response Id to cloned activities when logging

### DIFF
--- a/libraries/botbuilder-core/src/transcriptLogger.ts
+++ b/libraries/botbuilder-core/src/transcriptLogger.ts
@@ -50,17 +50,12 @@ export class TranscriptLoggerMiddleware implements Middleware {
             // run full pipeline
             const responses: ResourceResponse[] = await next2();
 
-            let responseIndex = 0;
-            activities.forEach((a: Partial<Activity>) => {
-                let clonedActivity: Activity = this.cloneActivity(a);
-                if (responses) {
-                    // if there is no id on the activity, add the id returned from the service
-                    if (responseIndex < responses.length) {
-                        if (!clonedActivity.id) {
-                            clonedActivity.id = responses[responseIndex].id;
-                        }
+            activities.map((a: Partial<Activity>, index: number) => {
+                const clonedActivity = this.cloneActivity(a);
+                if (index < responses.length) {
+                    if (!clonedActivity.id) {
+                        clonedActivity.id = responses[index].id;
                     }
-                    responseIndex++;
                 }
                 this.logActivity(transcript, clonedActivity);
             });

--- a/libraries/botbuilder-core/tests/transcriptMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/transcriptMiddleware.test.js
@@ -198,15 +198,15 @@ describe(`TranscriptLoggerMiddleware`, function () {
     });
 
     it(`should add resource response id to activity when activity id is empty`, function (done) {
-        var conversationId = null;
-        var transcriptStore = new MemoryTranscriptStore();
-        var adapter = new TestAdapter(async (context) => {
+        let conversationId = null;
+        const transcriptStore = new MemoryTranscriptStore();
+        const adapter = new TestAdapter(async (context) => {
             conversationId = context.activity.conversation.id;
 
             await context.sendActivity(`echo:${context.activity.text}`);
         }).use(new TranscriptLoggerMiddleware(transcriptStore));
 
-        var fooActivity = {
+        const fooActivity = {
             type: ActivityTypes.Message,
             id: 'testFooId',
             text: 'foo'
@@ -232,7 +232,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
 
                     assert.equal(pagedResult.items[2].text, 'bar');
                     // Received activities also auto-add the incremental from the test adapter
-                    assert.equal(pagedResult.items[2].id, 1);
+                    assert.equal(pagedResult.items[2].id, '1');
 
                     assert.equal(pagedResult.items[3].text, 'echo:bar');
                     assert.equal(pagedResult.items[3].id, '2');

--- a/libraries/botbuilder-core/tests/transcriptMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/transcriptMiddleware.test.js
@@ -196,6 +196,54 @@ describe(`TranscriptLoggerMiddleware`, function () {
             adapter.send('test');
         });
     });
+
+    it(`should add resource response id to activity when activity id is empty`, function (done) {
+        var conversationId = null;
+        var transcriptStore = new MemoryTranscriptStore();
+        var adapter = new TestAdapter(async (context) => {
+            conversationId = context.activity.conversation.id;
+
+            await context.sendActivity(`echo:${context.activity.text}`);
+        }).use(new TranscriptLoggerMiddleware(transcriptStore));
+
+        var fooActivity = {
+            type: ActivityTypes.Message,
+            id: 'testFooId',
+            text: 'foo'
+        };
+
+        adapter
+            .send(fooActivity)
+            // sent activities do not contain the id returned from the service, so it should be undefined here
+            .assertReply(activity => assert.equal(activity.id, undefined) && assert.equal(activity.text, 'echo:foo')) 
+            .send('bar')
+            .assertReply(activity => assert.equal(activity.id, undefined) && assert.equal(activity.text, 'echo:bar'))
+            .then(() => {
+                transcriptStore.getTranscriptActivities('test', conversationId).then(pagedResult => {
+                    assert.equal(pagedResult.items.length, 4);
+                    assert.equal(pagedResult.items[0].text, 'foo');
+                    // Transcript activities should have the id present on the activity when received
+                    assert.equal(pagedResult.items[0].id, 'testFooId');
+
+                    assert.equal(pagedResult.items[1].text, 'echo:foo');
+                    // Sent Activities in the transcript store should have the Id returned from Resource Response 
+                    // (the test adapter increments a number and uses this for the id)
+                    assert.equal(pagedResult.items[1].id, '0');
+
+                    assert.equal(pagedResult.items[2].text, 'bar');
+                    // Received activities also auto-add the incremental from the test adapter
+                    assert.equal(pagedResult.items[2].id, 1);
+
+                    assert.equal(pagedResult.items[3].text, 'echo:bar');
+                    assert.equal(pagedResult.items[3].id, '2');
+                    pagedResult.items.forEach(a => {
+                        assert(a.timestamp);
+                    })
+                    done();
+                });
+            });
+    });
+
 });
 
 


### PR DESCRIPTION
Fixes #1101

## Description
When sending an activity, a resource response id is returned from the service.  This PR adds that id to the activity being logged (if one is not present).

## Testing
Added a unit test, and tested manually with a local bot.