### PR TITLE
make on and handle in ActivityHandler protected for subclassing

### DIFF
--- a/libraries/botbuilder-core/src/activityHandler.ts
+++ b/libraries/botbuilder-core/src/activityHandler.ts
@@ -276,11 +276,11 @@ export class ActivityHandler {
     }
 
     /**
-     * Private method used to bind handlers to events by name
+     * Used to bind handlers to events by name
      * @param type string
      * @param handler BotHandler
      */
-    private on(type: string, handler: BotHandler) {
+    protected on(type: string, handler: BotHandler) {
         if (!this.handlers[type]) {
             this.handlers[type] = [handler];
         } else {
@@ -290,11 +290,11 @@ export class ActivityHandler {
     }
 
     /**
-     * Private method used to fire events and execute any bound handlers
+     * Used to fire events and execute any bound handlers
      * @param type string
      * @param handler BotHandler
      */
-    private async handle(context: TurnContext, type: string,  onNext: () => Promise<void>): Promise<any> {
+    protected async handle(context: TurnContext, type: string,  onNext: () => Promise<void>): Promise<any> {
         let returnValue: any = null;
 
         async function runHandler(index: number): Promise<void> {


### PR DESCRIPTION
## Description
Attempting to create an TeamsActivityHandler by extending the ActivityHandler was not possible, because of the inability to add a new handler since `ActivityHandler.on` is private. Additionally, creating `TeamsActivityHandler.run` was not possible because `ActivityHandler.handle` is private.

This PR makes those two methods protected, which allows for developers to meaningfully extend the ActivityHandler.

## Specific Changes
  - Make `ActivityHandler.on` and `ActivityHandler.handle` protected methods instead of private.

FYI @johnataylor, @EricDahlvang, @Virtual-Josh 