### PR TITLE
4.5 cherry-pick ActivityHandler updates and TranscriptLoggerMiddleware bug fix

### DIFF
--- a/libraries/botbuilder-core/src/activityHandler.ts
+++ b/libraries/botbuilder-core/src/activityHandler.ts
@@ -276,11 +276,11 @@ export class ActivityHandler {
     }
 
     /**
-     * Private method used to bind handlers to events by name
+     * Used to bind handlers to events by name
      * @param type string
      * @param handler BotHandler
      */
-    private on(type: string, handler: BotHandler) {
+    protected on(type: string, handler: BotHandler) {
         if (!this.handlers[type]) {
             this.handlers[type] = [handler];
         } else {
@@ -290,11 +290,11 @@ export class ActivityHandler {
     }
 
     /**
-     * Private method used to fire events and execute any bound handlers
+     * Used to fire events and execute any bound handlers
      * @param type string
      * @param handler BotHandler
      */
-    private async handle(context: TurnContext, type: string,  onNext: () => Promise<void>): Promise<any> {
+    protected async handle(context: TurnContext, type: string,  onNext: () => Promise<void>): Promise<any> {
         let returnValue: any = null;
 
         async function runHandler(index: number): Promise<void> {

--- a/libraries/botbuilder-core/src/transcriptLogger.ts
+++ b/libraries/botbuilder-core/src/transcriptLogger.ts
@@ -49,7 +49,16 @@ export class TranscriptLoggerMiddleware implements Middleware {
         context.onSendActivities(async (ctx: TurnContext, activities: Partial<Activity>[], next2: () => Promise<ResourceResponse[]>) => {
             // run full pipeline
             const responses: ResourceResponse[] = await next2();
-            activities.forEach((a: ResourceResponse) => this.logActivity(transcript, this.cloneActivity(a)));
+
+            activities.map((a: Partial<Activity>, index: number) => {
+                const clonedActivity = this.cloneActivity(a);
+                if (index < responses.length) {
+                    if (!clonedActivity.id) {
+                        clonedActivity.id = responses[index].id;
+                    }
+                }
+                this.logActivity(transcript, clonedActivity);
+            });
 
             return responses;
         });
@@ -138,13 +147,13 @@ export class TranscriptLoggerMiddleware implements Middleware {
      * Error logging helper function.
      * @param err Error or object to console.error out.
      */
-    private transcriptLoggerErrorHandler(err: Error|any): void {
+    private transcriptLoggerErrorHandler(err: Error | any): void {
         // tslint:disable:no-console
         if (err instanceof Error) {
-            console.error(`TranscriptLoggerMiddleware logActivity failed: "${ err.message }"`);
+            console.error(`TranscriptLoggerMiddleware logActivity failed: "${err.message}"`);
             console.error(err.stack);
         } else {
-            console.error(`TranscriptLoggerMiddleware logActivity failed: "${ JSON.stringify(err) }"`);
+            console.error(`TranscriptLoggerMiddleware logActivity failed: "${JSON.stringify(err)}"`);
         }
         // tslint:enable:no-console
     }

--- a/libraries/botbuilder-core/tests/transcriptMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/transcriptMiddleware.test.js
@@ -196,6 +196,54 @@ describe(`TranscriptLoggerMiddleware`, function () {
             adapter.send('test');
         });
     });
+
+    it(`should add resource response id to activity when activity id is empty`, function (done) {
+        let conversationId = null;
+        const transcriptStore = new MemoryTranscriptStore();
+        const adapter = new TestAdapter(async (context) => {
+            conversationId = context.activity.conversation.id;
+
+            await context.sendActivity(`echo:${context.activity.text}`);
+        }).use(new TranscriptLoggerMiddleware(transcriptStore));
+
+        const fooActivity = {
+            type: ActivityTypes.Message,
+            id: 'testFooId',
+            text: 'foo'
+        };
+
+        adapter
+            .send(fooActivity)
+            // sent activities do not contain the id returned from the service, so it should be undefined here
+            .assertReply(activity => assert.equal(activity.id, undefined) && assert.equal(activity.text, 'echo:foo')) 
+            .send('bar')
+            .assertReply(activity => assert.equal(activity.id, undefined) && assert.equal(activity.text, 'echo:bar'))
+            .then(() => {
+                transcriptStore.getTranscriptActivities('test', conversationId).then(pagedResult => {
+                    assert.equal(pagedResult.items.length, 4);
+                    assert.equal(pagedResult.items[0].text, 'foo');
+                    // Transcript activities should have the id present on the activity when received
+                    assert.equal(pagedResult.items[0].id, 'testFooId');
+
+                    assert.equal(pagedResult.items[1].text, 'echo:foo');
+                    // Sent Activities in the transcript store should have the Id returned from Resource Response 
+                    // (the test adapter increments a number and uses this for the id)
+                    assert.equal(pagedResult.items[1].id, '0');
+
+                    assert.equal(pagedResult.items[2].text, 'bar');
+                    // Received activities also auto-add the incremental from the test adapter
+                    assert.equal(pagedResult.items[2].id, '1');
+
+                    assert.equal(pagedResult.items[3].text, 'echo:bar');
+                    assert.equal(pagedResult.items[3].id, '2');
+                    pagedResult.items.forEach(a => {
+                        assert(a.timestamp);
+                    })
+                    done();
+                });
+            });
+    });
+
 });
 
 


### PR DESCRIPTION
## Description
cherry-picks #1117 and #1114 into the `4.5` branch for a patch release

These PRs are also for the ongoing Teams work. 

## Specific Changes
  - `ActivityHandler.on()` and `ActivityHandler.handle()` are now `protected` instead of `private` which allows for meaningful subclassing of the ActivityHandler in JS.
  - TranscriptLoggerMiddleware logs cloned activities with the actual `activity.id` returned from the service (via `ResourceResponse`)
    - This helps address the issue that prompted microsoft/BotBuilder-Samples#1713

