### PR TITLE
Use Recognizers Cultures in Choice & Confirm Prompt

### DIFF
--- a/libraries/botbuilder-ai/src/luisRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizer.ts
@@ -142,7 +142,7 @@ export interface LuisRecognizerTelemetryClient {
  *
  * @remarks
  * This class is used to recognize intents and extract entities from incoming messages.
- * See this class in action [in this sample application](https://github.com/Microsoft/BotBuilder-Samples/tree/master/samples/javascript_nodejs/12.nlp-with-luis).
+ * See this class in action [in this sample application](https://github.com/microsoft/BotBuilder-Samples/tree/master/samples/javascript_nodejs/14.nlp-with-dispatch).
  *
  * This component can be used within your bots logic by calling [recognize()](#recognize).
  */

--- a/libraries/botbuilder-dialogs/src/prompts/choicePrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/choicePrompt.ts
@@ -71,7 +71,7 @@ export class ChoicePrompt extends Prompt<FoundChoice> {
 
     protected async onPrompt(context: TurnContext, state: any, options: PromptOptions, isRetry: boolean): Promise<void> {
         // Determine locale
-        let locale: string = context.activity.locale || this.defaultLocale;
+        let locale: string = Culture.mapToNearestLanguage(context.activity.locale || this.defaultLocale);
         if (!locale || !ChoicePrompt.defaultChoiceOptions.hasOwnProperty(locale)) {
             locale = 'en-us';
         }

--- a/libraries/botbuilder-dialogs/src/prompts/choicePrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/choicePrompt.ts
@@ -8,6 +8,7 @@
 import { Activity, TurnContext } from 'botbuilder-core';
 import { ChoiceFactory, ChoiceFactoryOptions, FindChoicesOptions, FoundChoice, recognizeChoices } from '../choices';
 import { ListStyle, Prompt, PromptOptions, PromptRecognizerResult, PromptValidator } from './prompt';
+import { Culture } from '@microsoft/recognizers-text';
 
 /**
  * Prompts a user to select from a list of choices.
@@ -22,14 +23,14 @@ export class ChoicePrompt extends Prompt<FoundChoice> {
      * Default options for rendering the choices to the user based on locale.
      */
     private static defaultChoiceOptions: { [locale: string]: ChoiceFactoryOptions } = {
-        'es-es': { inlineSeparator: ', ', inlineOr: ' o ', inlineOrMore: ', o ', includeNumbers: true },
-        'nl-nl': { inlineSeparator: ', ', inlineOr: ' of ', inlineOrMore: ', of ', includeNumbers: true },
-        'en-us': { inlineSeparator: ', ', inlineOr: ' or ', inlineOrMore: ', or ', includeNumbers: true },
-        'fr-fr': { inlineSeparator: ', ', inlineOr: ' ou ', inlineOrMore: ', ou ', includeNumbers: true },
-        'de-de': { inlineSeparator: ', ', inlineOr: ' oder ', inlineOrMore: ', oder ', includeNumbers: true },
-        'ja-jp': { inlineSeparator: '、 ', inlineOr: ' または ', inlineOrMore: '、 または ', includeNumbers: true },
-        'pt-br': { inlineSeparator: ', ', inlineOr: ' ou ', inlineOrMore: ', ou ', includeNumbers: true },
-        'zh-cn': { inlineSeparator: '， ', inlineOr: ' 要么 ', inlineOrMore: '， 要么 ', includeNumbers: true }
+        [Culture.Spanish]: { inlineSeparator: ', ', inlineOr: ' o ', inlineOrMore: ', o ', includeNumbers: true },
+        [Culture.Dutch]: { inlineSeparator: ', ', inlineOr: ' of ', inlineOrMore: ', of ', includeNumbers: true },
+        [Culture.English]: { inlineSeparator: ', ', inlineOr: ' or ', inlineOrMore: ', or ', includeNumbers: true },
+        [Culture.French]: { inlineSeparator: ', ', inlineOr: ' ou ', inlineOrMore: ', ou ', includeNumbers: true },
+        [Culture.German]: { inlineSeparator: ', ', inlineOr: ' oder ', inlineOrMore: ', oder ', includeNumbers: true },
+        [Culture.Japanese]: { inlineSeparator: '、 ', inlineOr: ' または ', inlineOrMore: '、 または ', includeNumbers: true },
+        [Culture.Portuguese]: { inlineSeparator: ', ', inlineOr: ' ou ', inlineOrMore: ', ou ', includeNumbers: true },
+        [Culture.Chinese]: { inlineSeparator: '， ', inlineOr: ' 要么 ', inlineOrMore: '， 要么 ', includeNumbers: true }
     };
 
     /**

--- a/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
@@ -9,6 +9,7 @@ import * as Recognizers from '@microsoft/recognizers-text-choice';
 import { Activity, TurnContext } from 'botbuilder-core';
 import { Choice, ChoiceFactoryOptions, recognizeChoices } from '../choices';
 import { ListStyle, Prompt, PromptOptions, PromptRecognizerResult, PromptValidator } from './prompt';
+import { Culture } from '@microsoft/recognizers-text';
 
 /**
  * Prompts a user to confirm something with a "yes" or "no" response.
@@ -24,28 +25,28 @@ export class ConfirmPrompt extends Prompt<boolean> {
      * @deprecated since version 4.3
      */
     private static defaultConfirmChoices: { [locale: string]: (string | Choice)[] } = {
-        'es-es': ['Sí', 'No'],
-        'nl-nl': ['Ja', 'Nee'],
-        'en-us': ['Yes', 'No'],
-        'fr-fr': ['Oui', 'Non'],
-        'de-de': ['Ja', 'Nein'],
-        'ja-jp': ['はい', 'いいえ'],
-        'pt-br': ['Sim', 'Não'],
-        'zh-cn': ['是的', '不']
+        [Culture.Spanish]: ['Sí', 'No'],
+        [Culture.Dutch]: ['Ja', 'Nee'],
+        [Culture.English]: ['Yes', 'No'],
+        [Culture.French]: ['Oui', 'Non'],
+        [Culture.German]: ['Ja', 'Nein'],
+        [Culture.Japanese]: ['はい', 'いいえ'],
+        [Culture.Portuguese]: ['Sim', 'Não'],
+        [Culture.Chinese]: ['是的', '不']
     };
 
     /**
      * Default options for rendering the choices to the user based on locale.
      */
     private static defaultChoiceOptions: { [locale: string]: { choices: (string|Choice)[]; options: ChoiceFactoryOptions }} = {
-        'es-es': { choices: ['Sí', 'No'], options: { inlineSeparator: ', ', inlineOr: ' o ', inlineOrMore: ', o ', includeNumbers: true }},
-        'nl-nl': { choices: ['Ja', 'Nee'], options: { inlineSeparator: ', ', inlineOr: ' of ', inlineOrMore: ', of ', includeNumbers: true }},
-        'en-us': { choices: ['Yes', 'No'], options: { inlineSeparator: ', ', inlineOr: ' or ', inlineOrMore: ', or ', includeNumbers: true }},
-        'fr-fr': { choices: ['Oui', 'Non'], options: { inlineSeparator: ', ', inlineOr: ' ou ', inlineOrMore: ', ou ', includeNumbers: true }},
-        'de-de': { choices: ['Ja', 'Nein'], options: { inlineSeparator: ', ', inlineOr: ' oder ', inlineOrMore: ', oder ', includeNumbers: true }},
-        'ja-jp': { choices: ['はい', 'いいえ'], options: { inlineSeparator: '、 ', inlineOr: ' または ', inlineOrMore: '、 または ', includeNumbers: true }},
-        'pt-br': { choices: ['Sim', 'Não'], options: { inlineSeparator: ', ', inlineOr: ' ou ', inlineOrMore: ', ou ', includeNumbers: true }},
-        'zh-cn': { choices: ['是的', '不'], options: { inlineSeparator: '， ', inlineOr: ' 要么 ', inlineOrMore: '， 要么 ', includeNumbers: true }}
+        [Culture.Spanish]: { choices: ['Sí', 'No'], options: { inlineSeparator: ', ', inlineOr: ' o ', inlineOrMore: ', o ', includeNumbers: true }},
+        [Culture.Dutch]: { choices: ['Ja', 'Nee'], options: { inlineSeparator: ', ', inlineOr: ' of ', inlineOrMore: ', of ', includeNumbers: true }},
+        [Culture.English]: { choices: ['Yes', 'No'], options: { inlineSeparator: ', ', inlineOr: ' or ', inlineOrMore: ', or ', includeNumbers: true }},
+        [Culture.French]: { choices: ['Oui', 'Non'], options: { inlineSeparator: ', ', inlineOr: ' ou ', inlineOrMore: ', ou ', includeNumbers: true }},
+        [Culture.German]: { choices: ['Ja', 'Nein'], options: { inlineSeparator: ', ', inlineOr: ' oder ', inlineOrMore: ', oder ', includeNumbers: true }},
+        [Culture.Japanese]: { choices: ['はい', 'いいえ'], options: { inlineSeparator: '、 ', inlineOr: ' または ', inlineOrMore: '、 または ', includeNumbers: true }},
+        [Culture.Portuguese]: { choices: ['Sim', 'Não'], options: { inlineSeparator: ', ', inlineOr: ' ou ', inlineOrMore: ', ou ', includeNumbers: true }},
+        [Culture.Chinese]: { choices: ['是的', '不'], options: { inlineSeparator: '， ', inlineOr: ' 要么 ', inlineOrMore: '， 要么 ', includeNumbers: true }}
     };
     /**
      * The prompts default locale that should be recognized.

--- a/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
@@ -130,7 +130,7 @@ export class ConfirmPrompt extends Prompt<boolean> {
     }
 
     private determineCulture(activity: Activity): string {
-        let culture: string = activity.locale || this.defaultLocale;
+        let culture: string = Culture.mapToNearestLanguage(activity.locale || this.defaultLocale);
         if (!culture || !ConfirmPrompt.defaultChoiceOptions.hasOwnProperty(culture)) {
             culture = 'en-us';
         }

--- a/libraries/botbuilder-dialogs/tests/choicePrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/choicePrompt.test.js
@@ -298,6 +298,91 @@ describe('ChoicePrompt', function () {
             .assertReply('red');
     });
 
+    it('should recognize locale variations of correct locales', async function () {
+        const locales = [
+            'es-es',
+            'nl-nl',
+            'en-us',
+            'fr-fr',
+            'de-de',
+            'ja-jp',
+            'pt-br',
+            'zh-cn'
+        ];
+        // es-ES
+        const capEnding = (locale) => {
+            return `${ locale.split('-')[0] }-${ locale.split('-')[1].toUpperCase() }`;
+        };
+        // es-Es
+        const titleEnding = (locale) => {
+            locale[3] = locale.charAt(3).toUpperCase();
+            return locale;
+        };
+        // ES
+        const capTwoLetter = (locale) => {
+            return locale.split('-')[0].toUpperCase();
+        };
+        // es
+        const lowerTwoLetter = (locale) => {
+            return locale.split('-')[0].toLowerCase();
+        };
+
+        // This creates an object of the correct locale along with its test locales
+        const localeTests = locales.reduce((obj, locale) => {
+            obj[locale] = [
+                locale,
+                capEnding(locale),
+                titleEnding(locale),
+                capTwoLetter(locale),
+                lowerTwoLetter(locale)
+            ];
+            return obj;
+        }, {});
+
+        // Test each valid locale
+        await Promise.all(Object.keys(localeTests).map(async (validLocale) => {
+            // Hold the correct answer from when a valid locale is used
+            let expectedAnswer;
+            // Test each of the test locales
+            await Promise.all(localeTests[validLocale].map(async (testLocale) => {
+                const adapter = new TestAdapter(async (turnContext) => {
+                    const dc = await dialogs.createContext(turnContext);
+        
+                    const results = await dc.continueDialog();
+                    if (results.status === DialogTurnStatus.empty) {
+                        await dc.prompt('prompt', { prompt: 'Please choose a color.', choices: stringChoices });
+                    } else if (results.status === DialogTurnStatus.complete) {
+                        const selectedChoice = results.result;
+                        await turnContext.sendActivity(selectedChoice.value);
+                    }
+                    await convoState.saveChanges(turnContext);
+                });
+                const convoState = new ConversationState(new MemoryStorage());
+        
+                const dialogState = convoState.createProperty('dialogState');
+                const dialogs = new DialogSet(dialogState);
+                const choicePrompt = new ChoicePrompt('prompt', async (prompt) => {
+                    assert(prompt);
+                    if (!prompt.recognized.succeeded) {
+                        await prompt.context.sendActivity('bad input.');
+                    }
+                    return prompt.recognized.succeeded;
+                }, 'es-es');
+                dialogs.add(choicePrompt);
+        
+                await adapter.send({ text: 'Hello', type: ActivityTypes.Message, locale: testLocale })
+                    .assertReply((activity) => {
+                        // if the valid locale is tested, save the answer because then we can test to see
+                        //    if the test locales produce the same answer
+                        if (validLocale === testLocale) {
+                            expectedAnswer = activity.text;
+                        }
+                        assert.strictEqual(activity.text, expectedAnswer);
+                    });
+            }));
+        }));       
+    });
+
     it('should not render choices and not blow up if choices aren\'t passed in', async function () {
         const adapter = new TestAdapter(async (turnContext) => {
             const dc = await dialogs.createContext(turnContext);

--- a/package.json
+++ b/package.json
@@ -31,8 +31,6 @@
     "read-text-file": "^1.1.0",
     "replace-in-file": "^4.1.0",
     "sinon": "^7.3.2",
-    "tslint": "^5.18.0",
-    "tslint-microsoft-contrib": "^6.2.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-external-module-name": "^2.1.0",
     "typedoc-plugin-markdown": "^2.0.6",


### PR DESCRIPTION
## Description

Currently, Confirm and Choice Prompts use an object with all-lowercase keys for localization:

```js
{
    'es-es': { inlineSeparator: ', ', inlineOr: ' o ', inlineOrMore: ', o ', includeNumbers: true },
    [...]
};
```

The locale used for the prompt is determined with something like this:

```js
ChoicePrompt.defaultChoiceOptions[locale]
```

If the `locale` is not all-lowercase, it defaults to `en-us`. This can be problematic because:

1. [`activity.locale` uses ISO 3166](https://github.com/microsoft/botbuilder-js/blob/5b8b7efef63d31dc32fe99050aa15e42378e832d/libraries/botframework-schema/src/activityInterfaces.ts#L115), which I believe [is normally recognized as all-caps](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
2. [WebChat sends the capitalized country-code version](https://github.com/microsoft/BotFramework-WebChat/blob/a10096a5d769240da04d9c3fd4a57bcb384cbed4/packages/embed/src/locale.js#L26)

So, if an activity comes in with `locale: "fr-FR"` instead of `locale: "fr-fr"`, they're going to get an `en-us` prompt. Tested to confirm.

This allows for locales like:

* `fr-fr`
* `fr-FR`
* `FR`
* `fr`

to all get mapped to the appropriate `fr-fr`

Thanks to @stevkan for the assist!

## Specific Changes

I could have just done `.toLowerCase()` in each prompt, but instead, kept it more in line with [the DotNet versions](https://github.com/microsoft/botbuilder-dotnet/blob/master/libraries/Microsoft.Bot.Builder.Dialogs/Prompts/ConfirmPrompt.cs) (*Note: [`recognizers-text` essentially calls `toLowerCase()` as well](https://github.com/microsoft/Recognizers-Text/blob/master/JavaScript/packages/recognizers-text/src/culture.ts#L41)*):

**C#**

```csharp
{ Spanish, (new Choice("Sí"), new Choice("No"), new ChoiceFactoryOptions(", ", " o ", ", o ", true)) },
```

by using:

**Node**

```js
import { Culture } from '@microsoft/recognizers-text';
[...]
[Culture.Spanish]: { choices: ['Sí', 'No'], options: { inlineSeparator: ', ', inlineOr: ' o ', inlineOrMore: ', o ', includeNumbers: true }},
```

## Testing

Current tests [DO test for locale](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder-dialogs/tests/confirmPrompt.test.js#L245) and all current tests pass:

![image](https://user-images.githubusercontent.com/40401643/63808132-1c9a3180-c8d4-11e9-9e5c-952179a8a76c.png)
