### PR TITLE
Fix break in build BotBuilder-JS-master-CI

### DIFF
--- a/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
+++ b/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
@@ -335,7 +335,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
         ).withFilter(new azure.LinearRetryPolicyFilter(5, 500));
 
         // The perfect use case for a Proxy
-        return new Proxy({}, {
+        return new Proxy(<BlobServiceAsync>{}, {
             get(target: azure.services.blob.blobservice.BlobService, p: PropertyKey): Promise<any> {
 				const prop = p.toString().endsWith('Async') ? p.toString().replace('Async', '') :p;
                 return target[p] || (target[p] = denodeify(blobService, blobService[prop]));


### PR DESCRIPTION
Add type assertion BlobServiceAsync.

The error: src/azureBlobTranscriptStore.ts(338,26): error TS2345: Argument of type '{}' is not assignable to parameter of type 'BlobService'.

The broken build: https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=77050&view=results

The broken commit: https://github.com/microsoft/botbuilder-js/commit/91453777fabe865be81717f9a244ac9c92324c85

