### PR TITLE
Updated credentials passed into InspectionMiddleware

### DIFF
--- a/libraries/functional-tests/functionaltestbot/index.js
+++ b/libraries/functional-tests/functionaltestbot/index.js
@@ -5,7 +5,6 @@ const restify = require('restify');
 const path = require('path');
 
 const { BotFrameworkAdapter, MemoryStorage, UserState, ConversationState, InspectionState, InspectionMiddleware } = require('botbuilder');
-const { MicrosoftAppCredentials } = require('botframework-connector');
 const { MyBot } = require('./bots/myBot')
 
 const ENV_FILE = path.join(__dirname, '.env');
@@ -22,7 +21,7 @@ var inspectionState = new InspectionState(memoryStorage);
 var userState = new UserState(memoryStorage);
 var conversationState = new ConversationState(memoryStorage);
 
-adapter.use(new InspectionMiddleware(inspectionState, userState, conversationState, new MicrosoftAppCredentials(process.env.MicrosoftAppId, process.env.MicrosoftAppPassword)));
+adapter.use(new InspectionMiddleware(inspectionState, userState, conversationState, { appId: process.env.MicrosoftAppId, appPassword: process.env.MicrosoftAppPassword }));
 
 adapter.onTurnError = async (context, error) => {
     console.error(`\n [onTurnError]: ${ error }`);


### PR DESCRIPTION
Fixes #1115, "Docs: InspectionMiddleware example code has a bug"

## Description
Updates how credentials are passed into InspectionMiddleware when added to the adapter. Also, removed unnecessary BotFramework-Connector dependency, following change.

## Specific Changes
  - Changed:
`adapter.use(new InspectionMiddleware(inspectionState, userState, conversationState, new MicrosoftAppCredentials(process.env.MicrosoftAppId, process.env.MicrosoftAppPassword)));`  
to
`adapter.use(new InspectionMiddleware(inspectionState, userState, conversationState, { appId: process.env.MicrosoftAppId, appPassword: process.env.MicrosoftAppPassword }));`
  - Removed:
 `const { MicrosoftAppCredentials } = require('botframework-connector');`