### PR TITLE
Fix 1 test

### DIFF
--- a/libraries/botbuilder-dialogs/tests/dialogContext.test.js
+++ b/libraries/botbuilder-dialogs/tests/dialogContext.test.js
@@ -8,8 +8,8 @@ const continueMessage = { text: `continue`, type: 'message' };
 class BindingTestDialog extends Dialog {
     constructor(dialogId, inputBinding, outputBinding) {
         super(dialogId);
-        this.inputBindings['value'] = inputBinding;
-        this.outputBinding = outputBinding; 
+        this.inputProperties['value'] = inputBinding;
+        this.outputProperty = outputBinding; 
     }
 
     async beginDialog(dc, options) {


### PR DESCRIPTION
For build BotBuilder-JS-4.future-daily.
Fix dialogContext.test.js, DialogContext, "should bind input & output state to a dialog."
     TypeError: Cannot set property 'value' of undefined.