### PR TITLE
Choice prompt fixes 1175

### DIFF
--- a/libraries/botbuilder-dialogs/src/choices/choiceFactory.ts
+++ b/libraries/botbuilder-dialogs/src/choices/choiceFactory.ts
@@ -135,8 +135,8 @@ export class ChoiceFactory {
         }
     }
 
-    public static heroCard(choices: Choice[] = [], text = '', speak = ''): Activity {
-        const buttons: CardAction[] = choices.map(choice => ({
+    public static heroCard(choices: (string | Choice)[] = [], text = '', speak = ''): Activity {
+        const buttons: CardAction[] = ChoiceFactory.toChoices(choices).map(choice => ({
             title: choice.value,
             type: ActionTypes.ImBack,
             value: choice.value

--- a/libraries/botbuilder-dialogs/src/prompts/prompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/prompt.ts
@@ -335,7 +335,11 @@ export abstract class Prompt<T> extends Dialog {
             }
 
             if (msg.attachments) {
-                prompt.attachments = msg.attachments;
+                if (prompt.attachments) {
+                  prompt.attachments = prompt.attachments.concat(msg.attachments);
+                } else {
+                  prompt.attachments = msg.attachments;
+                }
             }
 
             return prompt;


### PR DESCRIPTION
This PR contains 2 separate foxes for choicePrompt:

1) Related to https://github.com/microsoft/botbuilder-js/issues/1175
    - When a choicePrompt is sent with 'heroCard' styling and has an attacment, the attachment is not being sent. This fix ensures that both the hero card and attachment are sent back from the bot.

2) Discovered while testing the first fix - when choices are specified as an array of strings, they do not render in the hero card. The fix is to convert the string array to a Choice[] array in the ChoiceFactory class.