### PR TITLE
Fix the content type on the wire to be consistent with the C# implemetation.

### DIFF
--- a/libraries/botframework-streaming-extensions/src/HttpContentStream.ts
+++ b/libraries/botframework-streaming-extensions/src/HttpContentStream.ts
@@ -12,12 +12,12 @@ import { IHttpContentHeaders } from './Interfaces/IHttpContentHeaders';
 export class HttpContentStream {
     public readonly id: string;
     public readonly content: HttpContent;
-    public description: { id: string; contentType: string; length: number; };
+    public description: { id: string; type: string; length: number; };
 
     public constructor(content: HttpContent) {
         this.id = generateGuid();
         this.content = content;
-        this.description = {id: this.id, contentType: (this.content.headers) ? this.content.headers.contentType : "unknown", length: (this.content.headers) ? this.content.headers.contentLength : 0};
+        this.description = {id: this.id, type: (this.content.headers) ? this.content.headers.type : "unknown", length: (this.content.headers) ? this.content.headers.contentLength : 0};
     }
 }
 

--- a/libraries/botframework-streaming-extensions/src/Interfaces/IHttpContentHeaders.ts
+++ b/libraries/botframework-streaming-extensions/src/Interfaces/IHttpContentHeaders.ts
@@ -7,6 +7,6 @@
  */
 
 export interface IHttpContentHeaders {
-    contentType?: string;
+    type?: string;
     contentLength?: number;
 }

--- a/libraries/botframework-streaming-extensions/src/StreamingRequest.ts
+++ b/libraries/botframework-streaming-extensions/src/StreamingRequest.ts
@@ -63,7 +63,7 @@ export class StreamingRequest {
             let stream = new SubscribableStream();
             stream.write(body, 'utf8');
             this.addStream(new HttpContent({
-                contentType: 'application/json; charset=utf-8',
+                type: 'application/json; charset=utf-8',
                 contentLength: stream.length
             },
             stream));

--- a/libraries/botframework-streaming-extensions/src/StreamingResponse.ts
+++ b/libraries/botframework-streaming-extensions/src/StreamingResponse.ts
@@ -44,7 +44,7 @@ export class StreamingResponse {
         let stream = new SubscribableStream();
         stream.write(JSON.stringify(body), 'utf8');
         this.addStream(new HttpContent({
-            contentType: 'application/json; charset=utf-8',
+            type: 'application/json; charset=utf-8',
             contentLength: stream.length
         }, stream));
     }


### PR DESCRIPTION
The C# implementation expects the content-type to be called "type".