### PR TITLE
Remove await when starting up a named pipe server.

### DIFF
--- a/libraries/botframework-streaming-extensions/src/NamedPipe/NamedPipeServer.ts
+++ b/libraries/botframework-streaming-extensions/src/NamedPipe/NamedPipeServer.ts
@@ -75,7 +75,11 @@ export class NamedPipeServer implements IStreamingTransportServer {
             });
         });
 
-        await Promise.all([incoming, outgoing]);
+        // These promises will only resolve when the underlying connection has terminated.
+        // Anything awaiting on them will be blocked for the duration of the session,
+        // which is useful when detecting premature terminations, but requires an unawaited
+        // promise during the process of establishing the connection.
+        Promise.all([incoming, outgoing]);
 
         const { PipePath, ServerIncomingPath, ServerOutgoingPath } = NamedPipeTransport
         const incomingPipeName = PipePath + this._baseName + ServerIncomingPath;


### PR DESCRIPTION
## Description
This PR removes a single word in code and adds a 43 word comment explaining why.

