### PR TITLE
Named pipe server should listen before connect can complete

### DIFF
--- a/libraries/botframework-streaming-extensions/src/NamedPipe/NamedPipeServer.ts
+++ b/libraries/botframework-streaming-extensions/src/NamedPipe/NamedPipeServer.ts
@@ -75,14 +75,14 @@ export class NamedPipeServer implements IStreamingTransportServer {
             });
         });
 
-        await Promise.all([incoming, outgoing]);
-
         const { PipePath, ServerIncomingPath, ServerOutgoingPath } = NamedPipeTransport;
         const incomingPipeName = PipePath + this._baseName + ServerIncomingPath;
         const outgoingPipeName = PipePath + this._baseName + ServerOutgoingPath;
 
         this._incomingServer.listen(incomingPipeName);
         this._outgoingServer.listen(outgoingPipeName);
+
+        await Promise.all([incoming, outgoing]);
 
         return 'connected';
     }


### PR DESCRIPTION
Fixes #1259.

## Description

Named pipe server should listen before connect can complete.

## Specific Changes

- Moving `await` after `listen`, otherwise, it will cause starvation

## Testing

<!-- If you are adding a new feature to a library, you must include tests for your new code. -->