### PR TITLE
Fix typedoc vulnerability

### DIFF
--- a/libraries/botbuilder-core/package.json
+++ b/libraries/botbuilder-core/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "test": "tsc && nyc mocha tests/",
     "build": "tsc",
-    "build-docs": "typedoc --theme markdown --entryPoint botbuilder --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\botbuilder .\\lib\\index.d.ts ..\\botbuilder-core\\lib\\index.d.ts ..\\botbuilder-core-extensions\\lib\\index.d.ts ..\\botframework-schema\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK\" --readme none",
+    "build-docs": "typedoc --theme markdown --entryPoint botbuilder --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\botbuilder .\\lib\\index.d.ts ..\\botbuilder-core\\lib\\index.d.ts ..\\botframework-schema\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK\" --readme none",
     "clean": "erase /q /s .\\lib",
     "set-version": "npm version --allow-same-version ${Version}"
   },

--- a/libraries/botbuilder-testing/package.json
+++ b/libraries/botbuilder-testing/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "test": "tsc && nyc mocha tests/",
     "build": "tsc",
-    "build-docs": "typedoc --theme markdown --entryPoint botbuilder --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\botbuilder .\\lib\\index.d.ts ..\\botbuilder-core\\lib\\index.d.ts ..\\botbuilder-core-extensions\\lib\\index.d.ts ..\\botframework-schema\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK\" --readme none",
+    "build-docs": "typedoc --theme markdown --entryPoint botbuilder --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\botbuilder .\\lib\\index.d.ts ..\\botbuilder-core\\lib\\index.d.ts ..\\botframework-schema\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK\" --readme none",
     "clean": "erase /q /s .\\lib",
     "set-version": "npm version --allow-same-version ${Version}"
   },

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "test": "tsc && nyc mocha tests/",
     "build": "tsc",
-    "build-docs": "typedoc --theme markdown --entryPoint botbuilder --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\botbuilder .\\lib\\index.d.ts ..\\botbuilder-core\\lib\\index.d.ts ..\\botbuilder-core-extensions\\lib\\index.d.ts ..\\botframework-schema\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK\" --readme none",
+    "build-docs": "typedoc --theme markdown --entryPoint botbuilder --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\botbuilder .\\lib\\index.d.ts ..\\botbuilder-core\\lib\\index.d.ts ..\\botframework-schema\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK\" --readme none",
     "clean": "erase /q /s .\\lib",
     "set-version": "npm version --allow-same-version ${Version}"
   },

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "read-text-file": "^1.1.0",
     "replace-in-file": "^4.1.0",
     "sinon": "^7.3.2",
-    "typedoc": "^0.14.2",
+    "typedoc": "^0.15.0",
     "typedoc-plugin-external-module-name": "^2.1.0",
-    "typedoc-plugin-markdown": "^2.0.6",
+    "typedoc-plugin-markdown": "^2.2.10",
     "typescript": "^3.5.2",
     "watershed": "^0.4.0"
   },


### PR DESCRIPTION
## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
The lerna-build process found two vulnerabilities related to the `typedoc` package. Those vulnerabilities were fixed.
In addition, references to the old `botbuilder-core-extensions` package were deleted.

### Before
![image](https://user-images.githubusercontent.com/12394167/66485260-e3caac00-ea7e-11e9-92a5-4af94e1c93c4.png)

### After
![image](https://user-images.githubusercontent.com/12394167/66485266-e927f680-ea7e-11e9-8550-ab89313a4cec.png)


## Specific Changes
<!-- Please list the changes in a concise manner. -->
  - `typedoc@^0.14.2` ==> `typedoc@^0.15.0`
  - `typedoc-plugin-markdown@^2.0.6` ==> `typedoc-plugin-markdown@^2.2.10`
  - `botbuilder-core-extensions` docs deleted from `botbuilder-core`, `botbuilder-testing`, and `botbuilder` packages.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
Running `npm run build-docs` after changes
![image](https://user-images.githubusercontent.com/12394167/66485282-f349f500-ea7e-11e9-8382-62ec71130e18.png)
