### PR TITLE
Relax the rules for what counts as a well formed GUID.

### DIFF
--- a/libraries/botframework-streaming-extensions/src/Payloads/HeaderSerializer.ts
+++ b/libraries/botframework-streaming-extensions/src/Payloads/HeaderSerializer.ts
@@ -59,7 +59,7 @@ export class HeaderSerializer {
             throw Error('Header Type is missing or malformed.');
         }
 
-        if (!header.id || !header.id.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i) || header.id.length !==  this.IdLength) {
+        if (!header.id || !header.id.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i) || header.id.length !==  this.IdLength) {
             throw Error('Header ID is missing or malformed.');
         }
 

--- a/libraries/botframework-streaming-extensions/tests/HeaderSerializer.test.js
+++ b/libraries/botframework-streaming-extensions/tests/HeaderSerializer.test.js
@@ -116,4 +116,15 @@ describe('HeaderSerializer', () => {
             .throws('Header ID is missing or malformed.');
     });
 
+    it('accepts nil GUIDs as valid header IDs', () => {
+        let buffer = Buffer.alloc(Number(PayloadConstants.PayloadConstants.MaxHeaderLength));
+        buffer.write('A.000168.00000000-0000-0000-0000-000000000000.1\n');
+
+        let result = HeaderSerializer.HeaderSerializer.deserialize(buffer);
+        
+        expect(result.id)
+            .to
+            .deep
+            .equal('00000000-0000-0000-0000-000000000000');
+    });
 });


### PR DESCRIPTION
The previous regex pattern used to determine if a header's identifier GUID was well formed enforced the timestamp based UUID rules as laid out in RFC 4122. The dotnet standard library used in C# bots only requires a GUID to match the 8-4-4-4-12 pattern to be valid, making them less restrictive. 

This change relaxes the regex matching to match any GUID following the 8-4-4-4-12 pattern for parity with the C# library. 