### PR TITLE
move nock to devDependency

### DIFF
--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -26,7 +26,6 @@
     "botframework-schema": "4.1.6",
     "form-data": "^2.3.3",
     "jsonwebtoken": "8.0.1",
-    "nock": "^10.0.3",
     "node-fetch": "^2.2.1",
     "rsa-pem-from-mod-exp": "^0.8.4"
   },
@@ -35,6 +34,7 @@
     "codelyzer": "^4.1.0",
     "dotenv": "^5.0.1",
     "mocha": "^5.2.0",
+    "nock": "^10.0.3",
     "nyc": "^11.4.1",
     "should": "^13.2.3",
     "source-map-support": "^0.5.3",


### PR DESCRIPTION
## Description
Leaking a testing lib in dependencies. Moved to devDependency.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - moved `nock` to `devDependencies` in botframework-connector

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
N/A - This does not add or change functionality. No new test coverage is needed.