### PR TITLE
normalize azure blob timestamp properties to be iso1806 format

### DIFF
--- a/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
+++ b/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
@@ -79,7 +79,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
             {
                 fromid: activity.from.id,
                 recipientid: activity.recipient.id,
-                timestamp: activity.timestamp.getTime().toString()
+                timestamp: activity.timestamp.toJSON()
             }
         );
 
@@ -205,8 +205,8 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
     ): Promise<azure.BlobService.BlobResult[]> {
     	const listBlobResult = await this.client.listBlobsSegmentedWithPrefixAsync(container, prefix, token, { include: 'metadata' });
         listBlobResult.entries.some(blob => {
-            const timestamp: number = parseInt(blob.metadata.timestamp, 10);
-            if (timestamp >= startDate.getTime()) {
+            const timestamp: Date = new Date(blob.metadata.timestamp);
+            if (timestamp >= startDate) {
                 if (continuationToken) {
                     if (blob.name === continuationToken) {
                         continuationToken = null;

--- a/libraries/botbuilder-azure/tests/TestData/expectedCalls.json
+++ b/libraries/botbuilder-azure/tests/TestData/expectedCalls.json
@@ -72,7 +72,7 @@
 			"createBlockBlobFromTextAsync": [
 				"test-transcript",
 				"test/logActivityTest/8d66eb2e84b8000-1.json",
-				"{\"type\":\"message\",\"timestamp\":{},\"id\":1,\"text\":\"testMessage\",\"channelId\":\"test\",\"from\":{\"id\":\"User1\"},\"conversation\":{\"id\":\"logActivityTest\"},\"recipient\":{\"id\":\"Bot1\",\"name\":\"2\"},\"serviceUrl\":\"http://foo.com/api/messages\"}",
+				"{\"type\":\"message\",\"timestamp\":\"2018-12-31T00:00:00.000Z\",\"id\":1,\"text\":\"testMessage\",\"channelId\":\"test\",\"from\":{\"id\":\"User1\"},\"conversation\":{\"id\":\"logActivityTest\"},\"recipient\":{\"id\":\"Bot1\",\"name\":\"2\"},\"serviceUrl\":\"http://foo.com/api/messages\"}",
 				null
 			]
 		},
@@ -83,7 +83,7 @@
 				{
 					"fromid": "User1",
 					"recipientid": "Bot1",
-					"timestamp": "1546214400000"
+					"timestamp": "2018-12-31T00:00:00.000Z"
 				}
 			]
 		},

--- a/libraries/botbuilder-azure/tests/azureBlobTranscriptStore.test.js
+++ b/libraries/botbuilder-azure/tests/azureBlobTranscriptStore.test.js
@@ -198,7 +198,6 @@ describe('The AzureBlobTranscriptStore', () => {
 	it('should log an activity', async () => {
 		const date = new Date(1546214400000);
 		const activity = createActivity('logActivityTest', date);
-console.log(date.toJSON());
 		await storage.logActivity(activity);
 		const { mockFunctionCalls } = mockService;
 		const { logActivity } = expectedCalls;

--- a/libraries/botbuilder-azure/tests/azureBlobTranscriptStore.test.js
+++ b/libraries/botbuilder-azure/tests/azureBlobTranscriptStore.test.js
@@ -196,9 +196,9 @@ describe('The AzureBlobTranscriptStore', () => {
 	});
 
 	it('should log an activity', async () => {
-		const date = {getTime: () => 1546214400000};
+		const date = new Date(1546214400000);
 		const activity = createActivity('logActivityTest', date);
-
+console.log(date.toJSON());
 		await storage.logActivity(activity);
 		const { mockFunctionCalls } = mockService;
 		const { logActivity } = expectedCalls;


### PR DESCRIPTION

fix for  https://github.com/microsoft/botbuilder-dotnet/issues/2120

## Description
js code was storing as number of seconds since 1970, and C# was using iso 1806

## Specific Changes
changed to use Date().toJSON() which is iso 1806

## Testing
updated tests