### PR TITLE
[Teams] Update onTeamsMessagingExtensionFetchTask() & add tests for TeamsActivityHandler

### DIFF
--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -188,7 +188,7 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * 
+     * Receives invoke activities with Activity name of 'composeExtension/onCardButtonClicked'
      * @param context 
      * @param cardData 
      */

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -311,7 +311,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param action
      */
-    protected async onTeamsMessagingExtensionFetchTask(context: TurnContext, query: MessagingExtensionQuery): Promise<MessagingExtensionActionResponse> {
+    protected async onTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         throw new Error('NotImplemented');
     }
 

--- a/libraries/botbuilder/tests/teams/actionBasedMessagingExtension-fetchTask/src/actionBasedMessagingExtensionFetchBot.ts
+++ b/libraries/botbuilder/tests/teams/actionBasedMessagingExtension-fetchTask/src/actionBasedMessagingExtensionFetchBot.ts
@@ -34,7 +34,7 @@ export class ActionBasedMessagingExtensionFetchTaskBot extends TeamsActivityHand
         });
     }
 
-    protected async onTeamsMessagingExtensionFetchTask(context, query): Promise<MessagingExtensionActionResponse> {
+    protected async onTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const response = AdaptiveCardHelper.createTaskModuleAdaptiveCardResponse();
         return response;
     }

--- a/libraries/botbuilder/tests/teams/actionBasedMessagingExtension/src/actionBasedMessagingExtensionBot.ts
+++ b/libraries/botbuilder/tests/teams/actionBasedMessagingExtension/src/actionBasedMessagingExtensionBot.ts
@@ -10,7 +10,8 @@ import {
     TaskModuleContinueResponse,
     TaskModuleMessageResponse,
     TaskModuleResponseBase,
-    TeamsActivityHandler
+    TeamsActivityHandler,
+    TurnContext
 } from 'botbuilder';
 
 export class ActionBasedMessagingExtensionBot extends TeamsActivityHandler {
@@ -81,13 +82,13 @@ export class ActionBasedMessagingExtensionBot extends TeamsActivityHandler {
 
     // This method fires when an user uses an Action-based Messaging Extension from the Teams Client.
     // It should send back the tab or task module for the user to interact with.
-    protected async onTeamsMessagingExtensionFetchTask(context, query): Promise<MessagingExtensionActionResponse> {
+    protected async onTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         return {
             task: this.taskModuleResponse(query, false)
         };
     }
 
-    protected async onTeamsBotMessagePreviewSend(context, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async onTeamsBotMessagePreviewSend(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         let body: MessagingExtensionActionResponse;
         const card = this.getCardFromPreviewMessage(action);
         if (!card) {

--- a/libraries/botbuilder/tests/teams/messagingExtensionAuth/src/messagingExtensionAuthBot.ts
+++ b/libraries/botbuilder/tests/teams/messagingExtensionAuth/src/messagingExtensionAuthBot.ts
@@ -69,7 +69,7 @@ export class MessagingExtensionAuthBot extends TeamsActivityHandler {
         });
     }
 
-    protected async onTeamsMessagingExtensionFetchTask(context: TurnContext, query: MessagingExtensionQuery): Promise<MessagingExtensionActionResponse> {
+    protected async onTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const adapter: IUserTokenProvider = context.adapter as BotFrameworkAdapter;
         const userToken = await adapter.getUserToken(context, this.connectionName);
         if (!userToken)

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -146,10 +146,89 @@ describe('TeamsActivityHandler', () => {
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'decline' });
             adapter.send(fileConsentActivity)
                 .assertReply(activity => {
-                    assert(activity.type === 'invokeResponse', `incorrect activity type "${ activity.type }", expected "invokeResponse"`);
-                    assert(activity.value.status === 501, `incorrect status code "${ activity.value.status }", expected "501"`);
-                    assert(!activity.value.body,
-                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
+                    assert.strictEqual(activity.type, 'invokeResponse');
+                    assert.strictEqual(activity.value.status, 501);
+                    assert.strictEqual(activity.value.body, undefined);
+                });
+        });
+
+        it('onTeamsO365ConnectorCardAction is not overridden', async () => {
+            const bot = new TeamsActivityHandler();
+    
+            const adapter = new TestAdapter(async context => {
+                await bot.run(context);
+            });
+    
+            const teamsO365ConnectorCardActionActivity = createInvokeActivity('actionableMessage/executeAction');
+            adapter.send(teamsO365ConnectorCardActionActivity)
+                .assertReply(activity => {
+                    assert.strictEqual(activity.type, 'invokeResponse');
+                    assert.strictEqual(activity.value.status, 501);
+                    assert.strictEqual(activity.value.body, undefined);
+                });
+        });
+
+        it('onTeamsSigninVerifyState is not overridden', async () => {
+            const bot = new TeamsActivityHandler();
+    
+            const adapter = new TestAdapter(async context => {
+                await bot.run(context);
+            });
+    
+            const signinVerifyStateActivity = createInvokeActivity('signin/verifyState');
+            adapter.send(signinVerifyStateActivity)
+                .assertReply(activity => {
+                    assert.strictEqual(activity.type, 'invokeResponse');
+                    assert.strictEqual(activity.value.status, 501);
+                    assert.strictEqual(activity.value.body, undefined);
+                });
+        });
+
+        it('onTeamsMessagingExtensionCardButtonClicked is not overridden', async () => {
+            const bot = new TeamsActivityHandler();
+    
+            const adapter = new TestAdapter(async context => {
+                await bot.run(context);
+            });
+    
+            const cardButtonClickedActivity = createInvokeActivity('composeExtension/onCardButtonClicked');
+            adapter.send(cardButtonClickedActivity)
+                .assertReply(activity => {
+                    assert.strictEqual(activity.type, 'invokeResponse');
+                    assert.strictEqual(activity.value.status, 501);
+                    assert.strictEqual(activity.value.body, undefined);
+                });
+        });
+
+        it('onTeamsTaskModuleFetch is not overridden', async () => {
+            const bot = new TeamsActivityHandler();
+    
+            const adapter = new TestAdapter(async context => {
+                await bot.run(context);
+            });
+    
+            const taskFetchActivity = createInvokeActivity('task/fetch');
+            adapter.send(taskFetchActivity)
+                .assertReply(activity => {
+                    assert.strictEqual(activity.type, 'invokeResponse');
+                    assert.strictEqual(activity.value.status, 501);
+                    assert.strictEqual(activity.value.body, undefined);
+                });
+        });
+
+        it('onTeamsTaskModuleSubmit is not overridden', async () => {
+            const bot = new TeamsActivityHandler();
+    
+            const adapter = new TestAdapter(async context => {
+                await bot.run(context);
+            });
+    
+            const taskSubmitActivity = createInvokeActivity('task/submit');
+            adapter.send(taskSubmitActivity)
+                .assertReply(activity => {
+                    assert.strictEqual(activity.type, 'invokeResponse');
+                    assert.strictEqual(activity.value.status, 501);
+                    assert.strictEqual(activity.value.body, undefined);
                 });
         });
     });
@@ -633,132 +712,5 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                 });
         });
-    });
-
-    xit('should handle "AcceptFileConsent" activities', async () => {
-        const bot = new TeamsActivityHandler();
-        bot.onAcceptFileConsent(async (context, value, next) => {
-            assert(context, 'context not passed to handler');
-            assert(value, 'value not passed in');
-            assert(value === context.activity.value);
-            assert(next, 'next handler not passed in');
-            await context.sendActivity('fileconsent received');
-            await next();
-            return { status: 200 };
-        });
-
-        const adapter = new TestAdapter(async context => {
-            await bot.run(context);
-        });
-
-        const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'accept' });
-
-        adapter.send(fileConsentActivity)
-            .assertReply('fileconsent received')
-            .assertReply(activity => {
-                // Verify that bot sends out an invokeResponse via the TurnContext.
-                assert(activity.value, 'activity value does not exist');
-                assert(activity.value.status === 200, `incorrect status code "${activity.value.status}", expected "200"`);
-                assert(activity.type === 'invokeResponse', `incorrect activity type "${activity.type}", expected "invokeResponse"`);
-            });
-    });
-
-    xit('should throw an error if onAcceptFileConsent handler does not return InvokeResponse', done => {
-        const bot = new TeamsActivityHandler();
-        bot.onAcceptFileConsent(async (context, value, next) => {
-            assert(context, 'context not passed to handler');
-            assert(value, 'value not passed in');
-            assert(value === context.activity.value);
-            assert(next, 'next handler not passed in');
-            await context.sendActivity('fileconsent received');
-            await next();
-        });
-
-        const adapter = new TestAdapter(async context => {
-            await bot.run(context);
-        });
-
-        adapter.onTurnError = async (context, error) => {
-            assert(error.message === 'TeamsActivityHandler.teamsInvokeWrapper(): InvokeResponse not returned from "onAcceptFileConsent" handler.', `unexpected error thrown: ${error.message}`);
-            done();
-        }
-
-        const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'accept' });
-
-        adapter.send(fileConsentActivity)
-            .assertReply('fileconsent received');
-    });
-
-    xit('should handle "DeclineFileConsent" activities', async () => {
-        const bot = new TeamsActivityHandler();
-        bot.onDeclineFileConsent(async (context, value, next) => {
-            assert(context, 'context not passed to handler');
-            assert(value, 'value not passed in');
-            assert(value === context.activity.value);
-            assert(next, 'next handler not passed in');
-            await context.sendActivity('fileconsent not received');
-            await next();
-            return { status: 200 };
-        });
-
-        const adapter = new TestAdapter(async context => {
-            await bot.run(context);
-        });
-
-        const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'decline' });
-
-        adapter.send(fileConsentActivity)
-            .assertReply('fileconsent not received')
-            .assertReply(activity => {
-                assert(activity.value, 'activity value does not exist');
-                assert(activity.value.status === 200, `incorrect status code "${activity.value.status}", expected "200"`);
-                assert(activity.type === 'invokeResponse', `incorrect activity type "${activity.type}", expected "invokeResponse"`);
-            });
-    });
-
-    xit('should throw an error if onDeclineFileConsent handler does not return InvokeResponse', done => {
-        const bot = new TeamsActivityHandler();
-        bot.onDeclineFileConsent(async (context, value, next) => {
-            assert(context, 'context not passed to handler');
-            assert(value, 'value not passed in');
-            assert(value === context.activity.value);
-            assert(next, 'next handler not passed in');
-            await context.sendActivity('fileconsent received');
-            await next();
-        });
-
-        const adapter = new TestAdapter(async context => {
-            await bot.run(context);
-        });
-
-        adapter.onTurnError = async (context, error) => {
-            assert(error.message === 'TeamsActivityHandler.teamsInvokeWrapper(): InvokeResponse not returned from "onDeclineFileConsent" handler.', `unexpected error thrown: ${error.message}`);
-            done();
-        }
-
-        const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'decline' });
-
-        adapter.send(fileConsentActivity)
-            .assertReply('fileconsent received');
-    });
-
-    xit('should handle "TaskModuleFetch" activities', async () => {
-        throw new Error("Not Implemented");
-    });
-
-    xit('should throw an error if onTaskModuleFetch handler does not return InvokeResponse', done => {
-        throw new Error("Not Implemented");
-    });
-
-    xit('should handle "TaskModuleSubmit" activities', async () => {
-        throw new Error("Not Implemented");
-    });
-
-    xit('should handle "MessagingExtensionQuery" activities', async () => {
-        throw new Error("Not Implemented");
-    });
-
-    xit('should handle "365CardActions"', async () => {
-        throw new Error("Not Implemented");
     });
 });

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -224,6 +224,39 @@ describe('TeamsActivityHandler', () => {
         });
     });
 
+    describe('should send a BadRequest status code when', () => {
+        it('onTeamsFileConsent() receives an unexpected action value', () => {
+            const bot = new TeamsActivityHandler();            
+            const adapter = new TestAdapter(async context => {
+                await bot.run(context);
+            });
+            const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'test' });
+
+            adapter.send(fileConsentActivity)
+                .assertReply(activity => {
+                    assert.strictEqual(activity.type, 'invokeResponse');
+                    assert.strictEqual(activity.value.status, 400);
+                    assert.strictEqual(activity.value.body, undefined);
+                });
+
+        });
+
+        it('onTeamsMessagingExtensionSubmitActionDispatch() receives an unexpected botMessagePreviewAction value', () => {
+            const bot = new TeamsActivityHandler();            
+            const adapter = new TestAdapter(async context => {
+                await bot.run(context);
+            });
+            const fileConsentActivity = createInvokeActivity('composeExtension/submitAction', { botMessagePreviewAction: 'test' });
+
+            adapter.send(fileConsentActivity)
+                .assertReply(activity => {
+                    assert.strictEqual(activity.type, 'invokeResponse');
+                    assert.strictEqual(activity.value.status, 400);
+                    assert.strictEqual(activity.value.body, undefined);
+                });
+        });
+    });
+
     describe('should dispatch through a registered', () => {
         let fileConsentAcceptCalled = false;
         let fileConsentDeclineCalled = false;


### PR DESCRIPTION
## Description
  - Update signature `onTeamsMessagingExtensionFetchTask()`
  - Add more Tests for TeamsActivityHandler

## Specific Changes
  - Change `onTeamsMessagingExtensionFetchTask()` signature **(Hackathon Feedback)**

From:

`protected async onTeamsMessagingExtensionFetchTask(context: TurnContext, query: MessagingExtensionQuery): Promise<MessagingExtensionActionResponse> {`

to:

`protected async onTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {`

  - Update scenarios with new signature for onTeamsMessagingExtensionFetchTask
  - Add Teams-specific ConversationUpdate tests for TeamsActivityHandler
  - Add final BadRequest tests for TeamsActivityHandler
  - Add more NotImplemented tests for TeamsActivityHandler

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->