### PR TITLE
[Teams] Rename onTeams*-Invoke methods to handleTeams*, add TeamsInfo.getTeamMembers

### DIFF
--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -58,51 +58,51 @@ export class TeamsActivityHandler extends ActivityHandler {
     protected async onInvokeActivity(context: TurnContext): Promise<InvokeResponse> {
         try {
             if (!context.activity.name && context.activity.channelId === 'msteams') {
-                return await this.onTeamsCardActionInvoke(context);
+                return await this.handleTeamsCardActionInvoke(context);
             } else {
                 switch (context.activity.name) {
                     case 'signin/verifyState':
-                        await this.onTeamsSigninVerifyState(context, context.activity.value);
+                        await this.handleTeamsSigninVerifyState(context, context.activity.value);
                         return TeamsActivityHandler.createInvokeResponse();
 
                     case 'fileConsent/invoke':
-                        return TeamsActivityHandler.createInvokeResponse(await this.onTeamsFileConsent(context, context.activity.value));
+                        return TeamsActivityHandler.createInvokeResponse(await this.handleTeamsFileConsent(context, context.activity.value));
 
                     case 'actionableMessage/executeAction':
-                        await this.onTeamsO365ConnectorCardAction(context, context.activity.value);
+                        await this.handleTeamsO365ConnectorCardAction(context, context.activity.value);
                         return TeamsActivityHandler.createInvokeResponse();
 
                     case 'composeExtension/queryLink':
-                        return TeamsActivityHandler.createInvokeResponse(await this.onTeamsAppBasedLinkQuery(context, context.activity.value));
+                        return TeamsActivityHandler.createInvokeResponse(await this.handleTeamsAppBasedLinkQuery(context, context.activity.value));
 
                     case 'composeExtension/query':
-                        return TeamsActivityHandler.createInvokeResponse(await this.onTeamsMessagingExtensionQuery(context, context.activity.value));
+                        return TeamsActivityHandler.createInvokeResponse(await this.handleTeamsMessagingExtensionQuery(context, context.activity.value));
 
                     case 'composeExtension/selectItem':
-                        return TeamsActivityHandler.createInvokeResponse(await this.onTeamsMessagingExtensionSelectItem(context, context.activity.value));
+                        return TeamsActivityHandler.createInvokeResponse(await this.handleTeamsMessagingExtensionSelectItem(context, context.activity.value));
 
                     case 'composeExtension/submitAction':
-                        return TeamsActivityHandler.createInvokeResponse(await this.onTeamsMessagingExtensionSubmitActionDispatch(context, context.activity.value));
+                        return TeamsActivityHandler.createInvokeResponse(await this.handleTeamsMessagingExtensionSubmitActionDispatch(context, context.activity.value));
 
                     case 'composeExtension/fetchTask':
-                        return TeamsActivityHandler.createInvokeResponse(await this.onTeamsMessagingExtensionFetchTask(context, context.activity.value));
+                        return TeamsActivityHandler.createInvokeResponse(await this.handleTeamsMessagingExtensionFetchTask(context, context.activity.value));
 
                     case 'composeExtension/querySettingUrl':
-                        return TeamsActivityHandler.createInvokeResponse(await this.onTeamsMessagingExtensionConfigurationQuerySettingUrl(context, context.activity.value));
+                        return TeamsActivityHandler.createInvokeResponse(await this.handleTeamsMessagingExtensionConfigurationQuerySettingUrl(context, context.activity.value));
 
                     case 'composeExtension/setting':
-                        await this.onTeamsMessagingExtensionConfigurationSetting(context, context.activity.value);
+                        await this.handleTeamsMessagingExtensionConfigurationSetting(context, context.activity.value);
                         return TeamsActivityHandler.createInvokeResponse();
 
                     case 'composeExtension/onCardButtonClicked':
-                        await this.onTeamsMessagingExtensionCardButtonClicked(context, context.activity.value);
+                        await this.handleTeamsMessagingExtensionCardButtonClicked(context, context.activity.value);
                         return TeamsActivityHandler.createInvokeResponse();
 
                     case 'task/fetch':
-                        return TeamsActivityHandler.createInvokeResponse(await this.onTeamsTaskModuleFetch(context, context.activity.value));
+                        return TeamsActivityHandler.createInvokeResponse(await this.handleTeamsTaskModuleFetch(context, context.activity.value));
 
                     case 'task/submit':
-                        return TeamsActivityHandler.createInvokeResponse(await this.onTeamsTaskModuleSubmit(context, context.activity.value));
+                        return TeamsActivityHandler.createInvokeResponse(await this.handleTeamsTaskModuleSubmit(context, context.activity.value));
 
                     default:
                         throw new Error('NotImplemented');
@@ -122,28 +122,24 @@ export class TeamsActivityHandler extends ActivityHandler {
      * 
      * @param context 
      */
-    protected async onTeamsCardActionInvoke(context: TurnContext): Promise<InvokeResponse> {
+    protected async handleTeamsCardActionInvoke(context: TurnContext): Promise<InvokeResponse> {
         throw new Error('NotImplemented');
     }
 
     /**
      * Receives invoke activities with Activity name of 'fileConsent/invoke'. Handlers registered here run before
-     * `onTeamsFileConsentAccept` and `onTeamsFileConsentDecline`.
-     * Developers are not passed a pointer to the next `onTeamsFileConsent` handler because the _wrapper_ around
-     * the handler will call `onDialogs` handlers after delegating to `onTeamsFileConsentAccept` or `onTeamsFileConsentDecline`.
-     * @remarks
-     * It is important that only ONE onTeamsFileConsent handler is registered, otherwise the handlers for
-     * onTeamsFileConsentAccept and onTeamsFileConsentDecline will run more than once.
-     * This method wraps the given handler and sends an InvokeResponse on behalf of the user.
+     * `handleTeamsFileConsentAccept` and `handleTeamsFileConsentDecline`.
+     * Developers are not passed a pointer to the next `handleTeamsFileConsent` handler because the _wrapper_ around
+     * the handler will call `onDialogs` handlers after delegating to `handleTeamsFileConsentAccept` or `handleTeamsFileConsentDecline`.
      * @param context
      * @param fileConsentCardResponse
      */
-    protected async onTeamsFileConsent(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
+    protected async handleTeamsFileConsent(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
         switch (fileConsentCardResponse.action) {
             case 'accept':
-                return await this.onTeamsFileConsentAccept(context, fileConsentCardResponse);
+                return await this.handleTeamsFileConsentAccept(context, fileConsentCardResponse);
             case 'decline':
-                return await this.onTeamsFileConsentDecline(context, fileConsentCardResponse);
+                return await this.handleTeamsFileConsentDecline(context, fileConsentCardResponse);
             default:
                 throw new Error('BadRequest');
         }
@@ -156,7 +152,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param fileConsentCardResponse
      */
-    protected async onTeamsFileConsentAccept(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
+    protected async handleTeamsFileConsentAccept(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
         throw new Error('NotImplemented');
     }
 
@@ -167,14 +163,14 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param fileConsentCardResponse
      */
-    protected async onTeamsFileConsentDecline(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
+    protected async handleTeamsFileConsentDecline(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
         throw new Error('NotImplemented');
     }
 
     /**
      * Receives invoke activities with Activity name of 'actionableMessage/executeAction'
      */
-    protected async onTeamsO365ConnectorCardAction(context: TurnContext, query: O365ConnectorCardActionQuery): Promise<void> {
+    protected async handleTeamsO365ConnectorCardAction(context: TurnContext, query: O365ConnectorCardActionQuery): Promise<void> {
         throw new Error('NotImplemented');
     }
 
@@ -183,7 +179,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param action
      */
-    protected async onTeamsSigninVerifyState(context: TurnContext, query: SigninStateVerificationQuery): Promise<void> {
+    protected async handleTeamsSigninVerifyState(context: TurnContext, query: SigninStateVerificationQuery): Promise<void> {
         throw new Error('NotImplemented');
     }
 
@@ -192,7 +188,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context 
      * @param cardData 
      */
-    protected async onTeamsMessagingExtensionCardButtonClicked(context: TurnContext, cardData: any): Promise<void> {
+    protected async handleTeamsMessagingExtensionCardButtonClicked(context: TurnContext, cardData: any): Promise<void> {
         throw new Error('NotImplemented');
     }
 
@@ -201,7 +197,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param taskModuleRequest
      */
-    protected async onTeamsTaskModuleFetch(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
+    protected async handleTeamsTaskModuleFetch(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
         throw new Error('NotImplemented');
     }
 
@@ -210,7 +206,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param taskModuleRequest
      */
-    protected async onTeamsTaskModuleSubmit(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
+    protected async handleTeamsTaskModuleSubmit(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
         throw new Error('NotImplemented');
     }
 
@@ -221,7 +217,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param query
      */
-    protected async onTeamsAppBasedLinkQuery(context: TurnContext, query: AppBasedLinkQuery): Promise<MessagingExtensionResponse> {
+    protected async handleTeamsAppBasedLinkQuery(context: TurnContext, query: AppBasedLinkQuery): Promise<MessagingExtensionResponse> {
         throw new Error('NotImplemented');
     }
 
@@ -232,7 +228,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param action
      */
-    protected async onTeamsMessagingExtensionQuery(context: TurnContext, query: MessagingExtensionQuery): Promise<MessagingExtensionResponse> {
+    protected async handleTeamsMessagingExtensionQuery(context: TurnContext, query: MessagingExtensionQuery): Promise<MessagingExtensionResponse> {
         throw new Error('NotImplemented');
     }
 
@@ -243,31 +239,31 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param action
      */
-    protected async onTeamsMessagingExtensionSelectItem(context: TurnContext, query: any): Promise<MessagingExtensionResponse> {
+    protected async handleTeamsMessagingExtensionSelectItem(context: TurnContext, query: any): Promise<MessagingExtensionResponse> {
         throw new Error('NotImplemented');
     }
 
     /**
-     * Receives invoke activities with the name 'composeExtension/submitAction' and is called before the next appropriate handler is called.
+     * Receives invoke activities with the name 'composeExtension/submitAction' and dispatches to botMessagePreview-flows as applicable.
      * @remarks
-     * A handler registered through this method does not dispatch to the next handler (either `onTeamsMessagingExtensionSubmitAction`, `onTeamsBotMessagePreviewEdit`, or `onTeamsBotMessagePreviewSend`).
+     * A handler registered through this method does not dispatch to the next handler (either `handleTeamsMessagingExtensionSubmitAction`, `handleTeamsMessagingExtensionBotMessagePreviewEdit`, or `handleTeamsMessagingExtensionBotMessagePreviewSend`).
      * This method exists for developers to optionally add more logic before the TeamsActivityHandler routes the activity to one of the
      * previously mentioned handlers.
      * @param context
      * @param action
      */
-    protected async onTeamsMessagingExtensionSubmitActionDispatch(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionSubmitActionDispatch(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         if (action.botMessagePreviewAction) {
             switch (action.botMessagePreviewAction) {
                 case 'edit':
-                    return await this.onTeamsMessagingExtensionBotMessagePreviewEdit(context, action);
+                    return await this.handleTeamsMessagingExtensionBotMessagePreviewEdit(context, action);
                 case 'send':
-                    return await this.onTeamsMessagingExtensionBotMessagePreviewSend(context, action);
+                    return await this.handleTeamsMessagingExtensionBotMessagePreviewSend(context, action);
                 default:
                     throw new Error('BadRequest');
             }
         } else {
-            return await this.onTeamsMessagingExtensionSubmitAction(context, action);
+            return await this.handleTeamsMessagingExtensionSubmitAction(context, action);
         }
     }
 
@@ -278,7 +274,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param action
      */
-    protected async onTeamsMessagingExtensionSubmitAction(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionSubmitAction(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         throw new Error('NotImplemented');
     }
 
@@ -290,7 +286,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param action
      */
-    protected async onTeamsMessagingExtensionBotMessagePreviewEdit(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionBotMessagePreviewEdit(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         throw new Error('NotImplemented');
     }
 
@@ -302,7 +298,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param action
      */
-    protected async onTeamsMessagingExtensionBotMessagePreviewSend(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionBotMessagePreviewSend(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         throw new Error('NotImplemented');
     }
 
@@ -311,7 +307,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param action
      */
-    protected async onTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         throw new Error('NotImplemented');
     }
 
@@ -320,7 +316,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param query
      */
-    protected async onTeamsMessagingExtensionConfigurationQuerySettingUrl(context: TurnContext, query: MessagingExtensionQuery): Promise<MessagingExtensionResponse> {
+    protected async handleTeamsMessagingExtensionConfigurationQuerySettingUrl(context: TurnContext, query: MessagingExtensionQuery): Promise<MessagingExtensionResponse> {
         throw new Error('NotImplemented');
     }
 
@@ -329,7 +325,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context
      * @param query
      */
-    protected onTeamsMessagingExtensionConfigurationSetting(context: TurnContext, settings: any): Promise<void> {
+    protected handleTeamsMessagingExtensionConfigurationSetting(context: TurnContext, settings: any): Promise<void> {
         throw new Error('NotImplemented');
     }
 

--- a/libraries/botbuilder/tests/teams/actionBasedMessagingExtension-fetchTask/src/actionBasedMessagingExtensionFetchBot.ts
+++ b/libraries/botbuilder/tests/teams/actionBasedMessagingExtension-fetchTask/src/actionBasedMessagingExtensionFetchBot.ts
@@ -34,19 +34,19 @@ export class ActionBasedMessagingExtensionFetchTaskBot extends TeamsActivityHand
         });
     }
 
-    protected async onTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const response = AdaptiveCardHelper.createTaskModuleAdaptiveCardResponse();
         return response;
     }
 
-    protected async onTeamsMessagingExtensionSubmitAction(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionSubmitAction(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const submittedData = action.data as SubmitExampleData;
         const adaptiveCard = AdaptiveCardHelper.toAdaptiveCardAttachment(submittedData);
         const response = CardResponseHelpers.toMessagingExtensionBotMessagePreviewResponse(adaptiveCard);
         return response;
     }
 
-    protected async onTeamsMessagingExtensionBotMessagePreviewEdit(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionBotMessagePreviewEdit(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const submitData = AdaptiveCardHelper.toSubmitExampleData(action);
         const response = AdaptiveCardHelper.createTaskModuleAdaptiveCardResponse(
                                                     submitData.Question,
@@ -57,7 +57,7 @@ export class ActionBasedMessagingExtensionFetchTaskBot extends TeamsActivityHand
         return response;
     }
 
-    protected async onTeamsMessagingExtensionBotMessagePreviewSend(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionBotMessagePreviewSend(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const submitData: SubmitExampleData = AdaptiveCardHelper.toSubmitExampleData(action);
         const adaptiveCard: Attachment = AdaptiveCardHelper.toAdaptiveCardAttachment(submitData);
 
@@ -79,8 +79,8 @@ export class ActionBasedMessagingExtensionFetchTaskBot extends TeamsActivityHand
         return response;
     }
 
-    protected async onTeamsMessagingExtensionCardButtonClicked(context: TurnContext, obj) {
-        const reply = MessageFactory.text('onTeamsMessagingExtensionCardButtonClicked Value: ' + JSON.stringify(context.activity.value));
+    protected async handleTeamsMessagingExtensionCardButtonClicked(context: TurnContext, obj) {
+        const reply = MessageFactory.text('handleTeamsMessagingExtensionCardButtonClicked Value: ' + JSON.stringify(context.activity.value));
         await context.sendActivity(reply);
     }
 }

--- a/libraries/botbuilder/tests/teams/actionBasedMessagingExtension/src/actionBasedMessagingExtensionBot.ts
+++ b/libraries/botbuilder/tests/teams/actionBasedMessagingExtension/src/actionBasedMessagingExtensionBot.ts
@@ -38,7 +38,7 @@ export class ActionBasedMessagingExtensionBot extends TeamsActivityHandler {
         });
     }
 
-    protected async onTeamsMessagingExtensionSubmitAction(context, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionSubmitAction(context, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const data = action.data;
         let body: MessagingExtensionActionResponse;
         if (data && data.done) {
@@ -82,13 +82,13 @@ export class ActionBasedMessagingExtensionBot extends TeamsActivityHandler {
 
     // This method fires when an user uses an Action-based Messaging Extension from the Teams Client.
     // It should send back the tab or task module for the user to interact with.
-    protected async onTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         return {
-            task: this.taskModuleResponse(query, false)
+            task: this.taskModuleResponse(action, false)
         };
     }
 
-    protected async onTeamsBotMessagePreviewSend(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionBotMessagePreviewSend(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         let body: MessagingExtensionActionResponse;
         const card = this.getCardFromPreviewMessage(action);
         if (!card) {
@@ -106,7 +106,7 @@ export class ActionBasedMessagingExtensionBot extends TeamsActivityHandler {
         return body;
     }
 
-    protected async onTeamsBotMessagePreviewEdit(context, value: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionBotMessagePreviewEdit(context, value: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const card = this.getCardFromPreviewMessage(value);
         let body: MessagingExtensionActionResponse;
         if (!card) {

--- a/libraries/botbuilder/tests/teams/adaptiveCards/src/adaptiveCardsBot.ts
+++ b/libraries/botbuilder/tests/teams/adaptiveCards/src/adaptiveCardsBot.ts
@@ -67,8 +67,8 @@ export class AdaptiveCardsBot extends TeamsActivityHandler {
         });
     }
 
-    protected async onTeamsTaskModuleFetch(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
-        await context.sendActivity(MessageFactory.text(`OnTeamsTaskModuleFetchAsync TaskModuleRequest: ${JSON.stringify(taskModuleRequest)}`));
+    protected async handleTeamsTaskModuleFetch(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
+        await context.sendActivity(MessageFactory.text(`handleTeamsTaskModuleFetchAsync TaskModuleRequest: ${JSON.stringify(taskModuleRequest)}`));
 
         /**
          * The following line disables the lint rules for the Adaptive Card so that users can
@@ -110,8 +110,8 @@ export class AdaptiveCardsBot extends TeamsActivityHandler {
         } as TaskModuleResponse;
     }
 
-    protected async onTeamsTaskModuleSubmit(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
-        await context.sendActivity(MessageFactory.text(`OnTeamsTaskModuleSubmit value: ${JSON.stringify(taskModuleRequest)}`));
+    protected async handleTeamsTaskModuleSubmit(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
+        await context.sendActivity(MessageFactory.text(`handleTeamsTaskModuleSubmit value: ${JSON.stringify(taskModuleRequest)}`));
 
         return { 
                 task: { 
@@ -121,8 +121,8 @@ export class AdaptiveCardsBot extends TeamsActivityHandler {
         } as TaskModuleResponse;
     }
 
-    protected async onTeamsCardActionInvoke(context: TurnContext): Promise<InvokeResponse> {
-        await context.sendActivity(MessageFactory.text(`OnTeamsCardActionInvoke value: ${JSON.stringify(context.activity.value)}`));
+    protected async handleTeamsCardActionInvoke(context: TurnContext): Promise<InvokeResponse> {
+        await context.sendActivity(MessageFactory.text(`handleTeamsCardActionInvoke value: ${JSON.stringify(context.activity.value)}`));
         return { status: 200 } as InvokeResponse;
     }
 

--- a/libraries/botbuilder/tests/teams/fileUpload/src/fileUploadBot.ts
+++ b/libraries/botbuilder/tests/teams/fileUpload/src/fileUploadBot.ts
@@ -41,7 +41,7 @@ export class FileUploadBot extends TeamsActivityHandler {
         });
     }
 
-    protected async onTeamsFileConsentAccept(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
+    protected async handleTeamsFileConsentAccept(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
         try {
             await this.sendFile(fileConsentCardResponse);
             await this.fileUploadCompleted(context, fileConsentCardResponse);
@@ -51,7 +51,7 @@ export class FileUploadBot extends TeamsActivityHandler {
         }
     }
 
-    protected async onTeamsFileConsentDecline(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
+    protected async handleTeamsFileConsentDecline(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void> {
         let reply = this.createReply(context.activity);
         reply.textFormat = "xml";
         reply.text = `Declined. We won't upload file <b>${fileConsentCardResponse.context["filename"]}</b>.`;

--- a/libraries/botbuilder/tests/teams/link-unfurling/src/linkUnfurling.ts
+++ b/libraries/botbuilder/tests/teams/link-unfurling/src/linkUnfurling.ts
@@ -27,7 +27,7 @@ export class LinkUnfurlingBot extends TeamsActivityHandler {
     // https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/messaging-extensions/search-extensions#receive-requests-from-links-inserted-into-the-compose-message-box
     // By specifying domains under the messageHandlers section in the manifest, the bot can receive
     // events when a user enters in a domain in the compose box.   
-    protected async onTeamsAppBasedLinkQuery(context: TurnContext, query: AppBasedLinkQuery): Promise<MessagingExtensionResponse> {
+    protected async handleTeamsAppBasedLinkQuery(context: TurnContext, query: AppBasedLinkQuery): Promise<MessagingExtensionResponse> {
         const attachment = CardFactory.thumbnailCard('Thumbnail Card', query.url, ["https://raw.githubusercontent.com/microsoft/botframework-sdk/master/icon.png"]);
 
         const result: MessagingExtensionResult = {

--- a/libraries/botbuilder/tests/teams/messagingExtensionAuth/src/messagingExtensionAuthBot.ts
+++ b/libraries/botbuilder/tests/teams/messagingExtensionAuth/src/messagingExtensionAuthBot.ts
@@ -69,7 +69,7 @@ export class MessagingExtensionAuthBot extends TeamsActivityHandler {
         });
     }
 
-    protected async onTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionFetchTask(context: TurnContext, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         const adapter: IUserTokenProvider = context.adapter as BotFrameworkAdapter;
         const userToken = await adapter.getUserToken(context, this.connectionName);
         if (!userToken)
@@ -107,7 +107,7 @@ export class MessagingExtensionAuthBot extends TeamsActivityHandler {
         return response;
     }
 
-    protected async onTeamsTaskModuleFetch(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
+    protected async handleTeamsTaskModuleFetch(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
         var data = context.activity.value;
         if (data && data.state)
         {
@@ -127,12 +127,12 @@ export class MessagingExtensionAuthBot extends TeamsActivityHandler {
         }
         else
         {
-            await context.sendActivity("OnTeamsTaskModuleFetchAsync called without 'state' in Activity.Value");
+            await context.sendActivity("handleTeamsTaskModuleFetchAsync called without 'state' in Activity.Value");
             return null;
         }
     }
 
-    protected async onTeamsMessagingExtensionSubmitAction(context, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
+    protected async handleTeamsMessagingExtensionSubmitAction(context, action: MessagingExtensionAction): Promise<MessagingExtensionActionResponse> {
         if (action.data != null && action.data.key && action.data.key == "signout")
         {
             // User clicked the Sign Out button from a Task Module

--- a/libraries/botbuilder/tests/teams/messagingExtensionConfig/src/messagingExtensionConfigBot.ts
+++ b/libraries/botbuilder/tests/teams/messagingExtensionConfig/src/messagingExtensionConfigBot.ts
@@ -38,7 +38,7 @@ export class MessagingExtensionConfigBot  extends TeamsActivityHandler {
         });
     }
 
-    protected async onTeamsMessagingExtensionConfigurationQuerySettingUrl(context: TurnContext, query: MessagingExtensionQuery){
+    protected async handleTeamsMessagingExtensionConfigurationQuerySettingUrl(context: TurnContext, query: MessagingExtensionQuery){
         return <MessagingExtensionActionResponse>
         {
             composeExtension: <MessagingExtensionResult> {
@@ -55,7 +55,7 @@ export class MessagingExtensionConfigBot  extends TeamsActivityHandler {
         }
     }
 
-    protected async onTeamsMessagingExtensionConfigurationSetting(context: TurnContext, settings){
+    protected async handleTeamsMessagingExtensionConfigurationSetting(context: TurnContext, settings){
         // This event is fired when the settings page is submitted
         await context.sendActivity(`onTeamsMessagingExtensionSettings event fired with ${ JSON.stringify(settings) }`);
     }

--- a/libraries/botbuilder/tests/teams/office365Card/src/office365CardsBot.ts
+++ b/libraries/botbuilder/tests/teams/office365Card/src/office365CardsBot.ts
@@ -46,7 +46,7 @@ export class Office365CardsBot extends TeamsActivityHandler {
         });
     }
 
-    protected async onTeamsO365ConnectorCardAction(context: TurnContext, query: O365ConnectorCardActionQuery): Promise<void> {
+    protected async handleTeamsO365ConnectorCardAction(context: TurnContext, query: O365ConnectorCardActionQuery): Promise<void> {
         await context.sendActivity(MessageFactory.text(`O365ConnectorCardActionQuery event value: ${JSON.stringify(query)}`));
     }
 

--- a/libraries/botbuilder/tests/teams/roster/src/rosterBot.ts
+++ b/libraries/botbuilder/tests/teams/roster/src/rosterBot.ts
@@ -68,7 +68,7 @@ export class RosterBot extends TeamsActivityHandler {
     }
     
     private async showChannels(context: TurnContext): Promise<void> { 
-        let channels = await TeamsInfo.getChannels(context);
+        let channels = await TeamsInfo.getTeamChannels(context);
         await context.sendActivity(MessageFactory.text(`Total of ${channels.length} channels are currently in team`));
         let messages = channels.map(function(channel) {
             return `${channel.id} --> ${channel.name ? channel.name : 'General'}`;

--- a/libraries/botbuilder/tests/teams/searchBasedMessagingExtension/src/teamsSearchExtensionBot.ts
+++ b/libraries/botbuilder/tests/teams/searchBasedMessagingExtension/src/teamsSearchExtensionBot.ts
@@ -50,7 +50,7 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
         });
     }
 
-    protected async onTeamsMessagingExtensionQuery(context: TurnContext, query: MessagingExtensionQuery): Promise<MessagingExtensionResponse>{
+    protected async handleTeamsMessagingExtensionQuery(context: TurnContext, query: MessagingExtensionQuery): Promise<MessagingExtensionResponse>{
         const accessor = this.userState.createProperty<{ useHeroCard: boolean }>(RICH_CARD_PROPERTY);
         const config = await accessor.get(context, { useHeroCard: true });
 
@@ -98,7 +98,7 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
         return composeExtensionResponse;
     }
     
-    protected async onTeamsAppBasedLinkQuery(context: TurnContext, query: AppBasedLinkQuery): Promise<MessagingExtensionResponse>{
+    protected async handleTeamsAppBasedLinkQuery(context: TurnContext, query: AppBasedLinkQuery): Promise<MessagingExtensionResponse>{
         const accessor = this.userState.createProperty<{ useHeroCard: boolean }>(RICH_CARD_PROPERTY);
         const config = await accessor.get(context, { useHeroCard: true });
 
@@ -140,7 +140,7 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
         return composeExtensionResponse;
     }
 
-    protected async onTeamsMessagingExtensionConfigurationQuerySettingUrl(context: TurnContext, query: MessagingExtensionQuery){
+    protected async handleTeamsMessagingExtensionConfigurationQuerySettingUrl(context: TurnContext, query: MessagingExtensionQuery){
         return <MessagingExtensionActionResponse>
         {
             composeExtension: <MessagingExtensionResult> {
@@ -158,7 +158,7 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
         }
     }
 
-    protected async onTeamsMessagingExtensionConfigurationSetting(context: TurnContext, settings: MessagingExtensionQuery){
+    protected async handleTeamsMessagingExtensionConfigurationSetting(context: TurnContext, settings: MessagingExtensionQuery){
         // This event is fired when the settings page is submitted
         const accessor = this.userState.createProperty<{ useHeroCard: boolean }>(RICH_CARD_PROPERTY);
         const config = await accessor.get(context, { useHeroCard: true });

--- a/libraries/botbuilder/tests/teams/taskModule/src/taskModuleBot.ts
+++ b/libraries/botbuilder/tests/teams/taskModule/src/taskModuleBot.ts
@@ -29,8 +29,8 @@ export class TaskModuleBot  extends TeamsActivityHandler {
         });
     }
 
-    protected async onTeamsTaskModuleFetch(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
-        var reply = MessageFactory.text("OnTeamsTaskModuleFetchAsync TaskModuleRequest" + JSON.stringify(taskModuleRequest));
+    protected async handleTeamsTaskModuleFetch(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
+        var reply = MessageFactory.text("handleTeamsTaskModuleFetchAsync TaskModuleRequest" + JSON.stringify(taskModuleRequest));
         await context.sendActivity(reply);
 
         return {
@@ -46,8 +46,8 @@ export class TaskModuleBot  extends TeamsActivityHandler {
         } as TaskModuleResponse;
     }
     
-    protected async onTeamsTaskModuleSubmit(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
-        var reply = MessageFactory.text("OnTeamsTaskModuleFetchAsync Value: " + JSON.stringify(taskModuleRequest));
+    protected async handleTeamsTaskModuleSubmit(context: TurnContext, taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse> {
+        var reply = MessageFactory.text("handleTeamsTaskModuleFetchAsync Value: " + JSON.stringify(taskModuleRequest));
         await context.sendActivity(reply);
 
         return {

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -98,7 +98,7 @@ describe('TeamsActivityHandler', () => {
     });
 
     describe('should send a NotImplemented status code if', () => {
-        it('onTeamsMessagingExtensionSubmitAction is not overridden', async () => {
+        it('handleTeamsMessagingExtensionSubmitAction is not overridden', async () => {
             const bot = new TeamsActivityHandler();
     
             const adapter = new TestAdapter(async context => {
@@ -149,7 +149,7 @@ describe('TeamsActivityHandler', () => {
                 });
         });
 
-        it('onTeamsFileConsentAccept is not overridden', async () => {
+        it('handleTeamsFileConsentAccept is not overridden', async () => {
             const bot = new TeamsActivityHandler();
     
             const adapter = new TestAdapter(async context => {
@@ -166,7 +166,7 @@ describe('TeamsActivityHandler', () => {
                 });
         });
 
-        it('onTeamsFileConsentDecline is not overridden', async () => {
+        it('handleTeamsFileConsentDecline is not overridden', async () => {
             const bot = new TeamsActivityHandler();
     
             const adapter = new TestAdapter(async context => {
@@ -182,7 +182,7 @@ describe('TeamsActivityHandler', () => {
                 });
         });
 
-        it('onTeamsO365ConnectorCardAction is not overridden', async () => {
+        it('handleTeamsO365ConnectorCardAction is not overridden', async () => {
             const bot = new TeamsActivityHandler();
     
             const adapter = new TestAdapter(async context => {
@@ -198,7 +198,7 @@ describe('TeamsActivityHandler', () => {
                 });
         });
 
-        it('onTeamsSigninVerifyState is not overridden', async () => {
+        it('handleTeamsSigninVerifyState is not overridden', async () => {
             const bot = new TeamsActivityHandler();
     
             const adapter = new TestAdapter(async context => {
@@ -214,7 +214,7 @@ describe('TeamsActivityHandler', () => {
                 });
         });
 
-        it('onTeamsMessagingExtensionCardButtonClicked is not overridden', async () => {
+        it('handleTeamsMessagingExtensionCardButtonClicked is not overridden', async () => {
             const bot = new TeamsActivityHandler();
     
             const adapter = new TestAdapter(async context => {
@@ -230,7 +230,7 @@ describe('TeamsActivityHandler', () => {
                 });
         });
 
-        it('onTeamsTaskModuleFetch is not overridden', async () => {
+        it('handleTeamsTaskModuleFetch is not overridden', async () => {
             const bot = new TeamsActivityHandler();
     
             const adapter = new TestAdapter(async context => {
@@ -246,7 +246,7 @@ describe('TeamsActivityHandler', () => {
                 });
         });
 
-        it('onTeamsTaskModuleSubmit is not overridden', async () => {
+        it('handleTeamsTaskModuleSubmit is not overridden', async () => {
             const bot = new TeamsActivityHandler();
     
             const adapter = new TestAdapter(async context => {
@@ -265,18 +265,18 @@ describe('TeamsActivityHandler', () => {
 
     describe('should send an OK status code', () => {
         class OKFileConsent extends TeamsActivityHandler {
-            async onTeamsFileConsentAccept(context, fileConsentCardResponse) {
+            async handleTeamsFileConsentAccept(context, fileConsentCardResponse) {
                 assert(context, 'context not found');
                 assert(fileConsentCardResponse, 'fileConsentCardResponse not found');
             }
 
-            async onTeamsFileConsentDecline(context, fileConsentCardResponse) {
+            async handleTeamsFileConsentDecline(context, fileConsentCardResponse) {
                 assert(context, 'context not found');
                 assert(fileConsentCardResponse, 'fileConsentCardResponse not found');
             }
         }
 
-        it('when a "fileConsent/invoke" activity is handled by onTeamsFileConsentAccept', async () => {
+        it('when a "fileConsent/invoke" activity is handled by handleTeamsFileConsentAccept', async () => {
             const bot = new OKFileConsent();
     
             const adapter = new TestAdapter(async context => {
@@ -293,7 +293,7 @@ describe('TeamsActivityHandler', () => {
                 });
         });
 
-        it('when a "fileConsent/invoke" activity is handled by onTeamsFileConsentDecline', async () => {
+        it('when a "fileConsent/invoke" activity is handled by handleTeamsFileConsentDecline', async () => {
             const bot = new OKFileConsent();
 
             const adapter = new TestAdapter(async context => {
@@ -310,9 +310,9 @@ describe('TeamsActivityHandler', () => {
                 });
         });
 
-        it('when a "fileConsent/invoke" activity handled by onTeamsFileConsent', async () => {
+        it('when a "fileConsent/invoke" activity handled by handleTeamsFileConsent', async () => {
             class FileConsent extends TeamsActivityHandler {
-                async onTeamsFileConsent(context, fileConsentCardResponse) {
+                async handleTeamsFileConsent(context, fileConsentCardResponse) {
                     assert(context, 'context not found');
                     assert(fileConsentCardResponse, 'fileConsentCardResponse not found');
                 }
@@ -343,20 +343,20 @@ describe('TeamsActivityHandler', () => {
                     this.submitReturn = { task: { type: 'message', value: 'test' } };
                 }
 
-                async onTeamsTaskModuleFetch(context, taskModuleRequest) {
+                async handleTeamsTaskModuleFetch(context, taskModuleRequest) {
                     assert(context, 'context not found');
                     assert(taskModuleRequest, 'taskModuleRequest not found');
                     return this.fetchReturn;
                 }
 
-                async onTeamsTaskModuleSubmit(context, taskModuleRequest) {
+                async handleTeamsTaskModuleSubmit(context, taskModuleRequest) {
                     assert(context, 'context not found');
                     assert(taskModuleRequest, 'taskModuleRequest not found');
                     return this.submitReturn;
                 }
             }
 
-            it('an overriden onTeamsTaskModuleFetch()', done => {
+            it('an overriden handleTeamsTaskModuleFetch()', done => {
                 const bot = new TaskHandler();
 
                 const adapter = new TestAdapter(async context => {
@@ -375,7 +375,7 @@ describe('TeamsActivityHandler', () => {
                     .catch(err => done(err));
             });
 
-            it('an overriden onTeamsTaskModuleSubmit()', done => {
+            it('an overriden handleTeamsTaskModuleSubmit()', done => {
                 const bot = new TaskHandler();
 
                 const adapter = new TestAdapter(async context => {
@@ -397,7 +397,7 @@ describe('TeamsActivityHandler', () => {
     });
 
     describe('should send a BadRequest status code when', () => {
-        it('onTeamsFileConsent() receives an unexpected action value', () => {
+        it('handleTeamsFileConsent() receives an unexpected action value', () => {
             const bot = new TeamsActivityHandler();            
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
@@ -412,7 +412,7 @@ describe('TeamsActivityHandler', () => {
                 });
         });
 
-        it('onTeamsMessagingExtensionSubmitActionDispatch() receives an unexpected botMessagePreviewAction value', () => {
+        it('handleTeamsMessagingExtensionSubmitActionDispatch() receives an unexpected botMessagePreviewAction value', () => {
             const bot = new TeamsActivityHandler();            
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
@@ -434,24 +434,24 @@ describe('TeamsActivityHandler', () => {
         let fileConsentCalled = false;
 
         class FileConsentBot extends TeamsActivityHandler {
-            async onTeamsFileConsent(context, fileConsentCardResponse) {
+            async handleTeamsFileConsent(context, fileConsentCardResponse) {
                 assert(context, 'context not found');
                 assert(fileConsentCardResponse, 'fileConsentCardResponse not found');
                 fileConsentCalled = true;
-                await super.onTeamsFileConsent(context, fileConsentCardResponse);
+                await super.handleTeamsFileConsent(context, fileConsentCardResponse);
             }
 
-            async onTeamsFileConsentAccept(context, fileConsentCardResponse) {
+            async handleTeamsFileConsentAccept(context, fileConsentCardResponse) {
                 assert(context, 'context not found');
                 assert(fileConsentCardResponse, 'fileConsentCardResponse not found');
-                assert(fileConsentCalled, 'onTeamsFileConsent handler was not called before onTeamsFileConsentAccept handler');
+                assert(fileConsentCalled, 'handleTeamsFileConsent handler was not called before handleTeamsFileConsentAccept handler');
                 fileConsentAcceptCalled = true;
             }
 
-            async onTeamsFileConsentDecline(context, fileConsentCardResponse) {
+            async handleTeamsFileConsentDecline(context, fileConsentCardResponse) {
                 assert(context, 'context not found');
                 assert(fileConsentCardResponse, 'fileConsentCardResponse not found');
-                assert(fileConsentCalled, 'onTeamsFileConsent handler was not called before onTeamsFileConsentDecline handler');
+                assert(fileConsentCalled, 'handleTeamsFileConsent handler was not called before handleTeamsFileConsentDecline handler');
                 fileConsentDeclineCalled = true;
             }            
         }
@@ -468,7 +468,7 @@ describe('TeamsActivityHandler', () => {
             fileConsentCalled = false;
         });
 
-        it('onTeamsFileConsent handler before an onTeamsFileConsentAccept handler', async () => {
+        it('handleTeamsFileConsent handler before an handleTeamsFileConsentAccept handler', async () => {
             const bot = new FileConsentBot();
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
@@ -482,12 +482,12 @@ describe('TeamsActivityHandler', () => {
                     assert(!activity.value.body,
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(activity.value.body)}`);
                 }).then(() => {
-                    assert(fileConsentCalled, 'onTeamsFileConsent handler not called');
-                    assert(fileConsentAcceptCalled, 'onTeamsFileConsentAccept handler not called');
+                    assert(fileConsentCalled, 'handleTeamsFileConsent handler not called');
+                    assert(fileConsentAcceptCalled, 'handleTeamsFileConsentAccept handler not called');
                 });
         });
 
-        it('onTeamsFileConsent handler before an onTeamsFileConsentDecline handler', async () => {
+        it('handleTeamsFileConsent handler before an handleTeamsFileConsentDecline handler', async () => {
             const bot = new FileConsentBot();
             const adapter = new TestAdapter(async context => {
                 await bot.run(context);
@@ -501,8 +501,8 @@ describe('TeamsActivityHandler', () => {
                     assert(!activity.value.body,
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(activity.value.body)}`);
                 }).then(() => {
-                    assert(fileConsentCalled, 'onTeamsFileConsent handler not called');
-                    assert(fileConsentDeclineCalled, 'onTeamsFileConsentDecline handler not called');
+                    assert(fileConsentCalled, 'handleTeamsFileConsent handler not called');
+                    assert(fileConsentDeclineCalled, 'handleTeamsFileConsentDecline handler not called');
     
                 });
         });
@@ -572,7 +572,7 @@ describe('TeamsActivityHandler', () => {
             adapter.send(activity)
                 .then(() => {
                     assert(onTeamsMemberAddedEvent, 'onTeamsMemberAddedEvent handler not called');
-                    assert(onConversationUpdateCalled, 'onTeamsFileConsentAccept handler not called');
+                    assert(onConversationUpdateCalled, 'handleTeamsFileConsentAccept handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
                 });
         });
@@ -619,7 +619,7 @@ describe('TeamsActivityHandler', () => {
             adapter.send(activity)
                 .then(() => {
                     assert(onTeamsMemberAddedEvent, 'onTeamsMemberAddedEvent handler not called');
-                    assert(onConversationUpdateCalled, 'onTeamsFileConsentAccept handler not called');
+                    assert(onConversationUpdateCalled, 'handleTeamsFileConsentAccept handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
                 });
         });


### PR DESCRIPTION
## Description
- Rename the JavaScript non-event events as necessary to “handleTeams…”
- Refactor TeamsInfo, add TeamsInfo.getTeamMembers()
   - TeamsInfo.getTeam*-methods optionally take a `teamId` parameter so users no longer need to mutate the `turnContext.activity.channelData.team` to get information for a specific team.

## Specific Changes
  - Rename onTeams*-Invoke methods to handleTeams*
  - Refactor TeamsInfo, add `TeamsInfo.getTeamMembers(context: TurnContext, teamId?: string)`
    - TeamsInfo.getMembers() now calls TeamsInfo.getTeamMembers() if a teamId is detected off of the turnContext.
  - TeamsInfo.getTeamDetails(), TeamsInfo.getTeamChannels() now optionally take a string in addition to the context parameter.

## Testing
- Added tests for TeamsInfo changes
- Renamed methods in teamsActivityHandler.test.js
- Rebuilt all scenarios in `botbuilder/tests/teams` and applied updates as necessary