### PR TITLE
[Streaming] Auth and browser compatibility fixes, linting, refactoring

### DIFF
--- a/libraries/botbuilder/tests/botFrameworkAdapter.test.js
+++ b/libraries/botbuilder/tests/botFrameworkAdapter.test.js
@@ -2,7 +2,6 @@ const assert = require('assert');
 const { TurnContext } = require('botbuilder-core');
 const connector = require('botframework-connector');
 const { BotFrameworkAdapter } = require('../');
-const os = require('os');
 
 const reference = {
     activityId: '1234',

--- a/libraries/botframework-streaming/src/webSocket/nodeWebSocket.ts
+++ b/libraries/botframework-streaming/src/webSocket/nodeWebSocket.ts
@@ -11,11 +11,10 @@ import { Socket } from 'net';
 import { Watershed } from 'watershed';
 import { ISocket } from '../interfaces/ISocket';
 
-const SHED = new Watershed();
-
 export class NodeWebSocket implements ISocket {
     private waterShedSocket: any;
     private connected: boolean;
+    protected watershedShed: Watershed;
 
     /**
      * Creates a new instance of the [NodeWebSocket](xref:botframework-streaming.NodeWebSocket) class.
@@ -25,6 +24,7 @@ export class NodeWebSocket implements ISocket {
     public constructor(waterShedSocket?) {
         this.waterShedSocket = waterShedSocket;
         this.connected = !!waterShedSocket;
+        this.watershedShed = new Watershed();
     }
 
     /**
@@ -34,7 +34,7 @@ export class NodeWebSocket implements ISocket {
      * @param head Buffer
      */
     public create(req: IncomingMessage, socket: Socket, head: Buffer): void {
-        this.waterShedSocket = SHED.accept(req, socket, head);
+        this.waterShedSocket = this.watershedShed.accept(req, socket, head);
         this.connected = true;
     }
 
@@ -62,7 +62,7 @@ export class NodeWebSocket implements ISocket {
      */
     public async connect(serverAddress, port = 8082): Promise<void> {
         // Following template from https://github.com/joyent/node-watershed#readme
-        const wskey = SHED.generateKey();
+        const wskey = this.watershedShed.generateKey();
         const options = {
             port: port,
             hostname: serverAddress,
@@ -75,7 +75,7 @@ export class NodeWebSocket implements ISocket {
         const req = request(options);
         req.end();
         req.on('upgrade', function(res, socket, head): void {
-            SHED.connect(res, socket, head, wskey);
+            this.watershedShed.connect(res, socket, head, wskey);
         });
 
         this.connected = true;


### PR DESCRIPTION
## Description

- Add the ServiceUrl value from the claims in `BotFrameworkAdapter.authenticateConnection()` to have the bot call getToken() to refresh (or cache) a token.
- Refactor some code in `BotFrameworkAdapter.processRequest()` (streaming entrypoint)
- Move `ws` and `Watershed` Server/"WaterShed" construction into the WsNodeWebSocket and NodeWebSocket methods so the botframework-streaming library is browser compat (thanks for the report @ckkashyap!)
- Linting