### PR TITLE
[Streaming] Create StreamingBotFrameworkAdapter with processUpgrade(req, socket, head)

### DIFF
--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -141,16 +141,6 @@ export interface BotFrameworkAdapterSettings {
      * Optional. The channel service option for this bot to validate connections from Azure or other channel locations.
      */
     channelService?: string;
-
-    /**
-     * Optional. The option to determine if this adapter accepts WebSocket connections
-     */
-    enableWebSockets?: boolean;
-
-    /**
-     * Optional. Used to pass in a NodeWebSocketFactoryBase instance. Allows bot to accept WebSocket connections.
-     */
-    webSocketFactory?: NodeWebSocketFactoryBase;
 }
 
 /**
@@ -178,18 +168,13 @@ const NODE_VERSION: any = process.version;
 
 // tslint:disable-next-line:no-var-requires no-require-imports
 const pjson: any = require('../package.json');
-const USER_AGENT: string = `Microsoft-BotFramework/3.1 BotBuilder/${ pjson.version } ` +
+export const USER_AGENT: string = `Microsoft-BotFramework/3.1 BotBuilder/${ pjson.version } ` +
     `(Node.js,Version=${ NODE_VERSION }; ${ TYPE } ${ RELEASE }; ${ ARCHITECTURE })`;
 const OAUTH_ENDPOINT = 'https://api.botframework.com';
 const US_GOV_OAUTH_ENDPOINT = 'https://api.botframework.azure.us';
 
 // This key is exported internally so that the TeamsActivityHandler will not overwrite any already set InvokeResponses.
 export const INVOKE_RESPONSE_KEY: symbol = Symbol('invokeResponse');
-const defaultPipeName = 'bfv4.pipes';
-const VERSION_PATH:string = '/api/version';
-const MESSAGES_PATH:string = '/api/messages';
-const GET:string = 'GET';
-const POST:string = 'POST';
 
 /**
  * A [BotAdapter](xref:botbuilder-core.BotAdapter) that can connect a bot to a service endpoint.
@@ -230,10 +215,7 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
     protected readonly credentialsProvider: SimpleCredentialProvider;
     protected readonly settings: BotFrameworkAdapterSettings;
 
-    private logic: (context: TurnContext) => Promise<void>;
-    private streamingServer: IStreamingTransportServer;
-    private isEmulatingOAuthCards: boolean;
-    private webSocketFactory: NodeWebSocketFactoryBase;
+    protected isEmulatingOAuthCards: boolean;
 
     /**
      * Creates a new instance of the [BotFrameworkAdapter](xref:botbuilder.BotFrameworkAdapter) class.
@@ -257,16 +239,6 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
         this.credentials = new MicrosoftAppCredentials(this.settings.appId, this.settings.appPassword || '', this.settings.channelAuthTenant);
         this.credentialsProvider = new SimpleCredentialProvider(this.credentials.appId, this.credentials.appPassword);
         this.isEmulatingOAuthCards = false;
-
-        // If the developer wants to use WebSockets, but didn't provide a WebSocketFactory,
-        // create a NodeWebSocketFactory.
-        if (this.settings.enableWebSockets && !this.settings.webSocketFactory) {
-            this.webSocketFactory = new NodeWebSocketFactory();
-        }
-
-        if (this.settings.webSocketFactory) {
-            this.webSocketFactory = this.settings.webSocketFactory;
-        }
 
         // If no channelService or openIdMetadata values were passed in the settings, check the process' Environment Variables for values.
         // These values may be set when a bot is provisioned on Azure and if so are required for the bot to properly work in Public Azure or a National Cloud.
@@ -759,10 +731,6 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
      * > without using the `await` keyword. Make sure all async functions use await!
      */
     public async processActivity(req: WebRequest, res: WebResponse, logic: (context: TurnContext) => Promise<any>): Promise<void> {
-        if (this.settings.enableWebSockets && req.method === GET && (req.headers.Upgrade || req.headers.upgrade)) {
-            return this.useWebSocket(req, res, logic);
-        }
-
         let body: any;
         let status: number;
         let processError: Error;
@@ -899,10 +867,7 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
                     if (!activity.serviceUrl) { throw new Error(`BotFrameworkAdapter.sendActivity(): missing serviceUrl.`); }
                     if (!activity.conversation || !activity.conversation.id) {
                         throw new Error(`BotFrameworkAdapter.sendActivity(): missing conversation id.`);
-                    }
-                    if (BotFrameworkAdapter.isFromStreamingConnection(activity as Activity)) {
-                        TokenResolver.checkForOAuthCards(this, context, activity as Activity);
-                    }
+                    } 
                     const client: ConnectorClient = this.createConnectorClient(activity.serviceUrl);
                     if (activity.type === 'trace' && activity.channelId !== 'emulator') {
                     // Just eat activity
@@ -962,102 +927,8 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
      * Override this in a derived class to create a mock connector client for unit testing.
      */
     public createConnectorClient(serviceUrl: string): ConnectorClient {
-
-        if (BotFrameworkAdapter.isStreamingServiceUrl(serviceUrl)) {
-
-            // Check if we have a streaming server. Otherwise, requesting a connector client
-            // for a non-existent streaming connection results in an error
-            if (!this.streamingServer) {
-                throw new Error(`Cannot create streaming connector client for serviceUrl ${serviceUrl} without a streaming connection. Call 'useWebSocket' or 'useNamedPipe' to start a streaming connection.`)
-            }
-
-            return new ConnectorClient(
-                this.credentials,
-                {
-                    baseUri: serviceUrl,
-                    userAgent: USER_AGENT,
-                    httpClient: new StreamingHttpClient(this.streamingServer)
-                });
-        }
-
         const client: ConnectorClient = new ConnectorClient(this.credentials, { baseUri: serviceUrl, userAgent: USER_AGENT} );
         return client;
-    }
-
-    /**
-     * Checks the validity of the request and attempts to map it the correct virtual endpoint,
-     * then generates and returns a response if appropriate.
-     * @param request A ReceiveRequest from the connected channel.
-     * @returns A response created by the BotAdapter to be sent to the client that originated the request.
-     */
-    public async processRequest(request: IReceiveRequest): Promise<StreamingResponse> {
-        let response = new StreamingResponse();
-
-        if (!request) {
-            response.statusCode = StatusCodes.BAD_REQUEST;
-            response.setBody(`No request provided.`);
-            return response;
-        }
-
-        if (!request.verb || !request.path) {
-            response.statusCode = StatusCodes.BAD_REQUEST;
-            response.setBody(`Request missing verb and/or path. Verb: ${ request.verb }. Path: ${ request.path }`);
-            return response;
-        } 
-
-        if (request.verb.toLocaleUpperCase() === GET && request.path.toLocaleLowerCase() === VERSION_PATH) {
-            response.statusCode = StatusCodes.OK;
-            response.setBody({UserAgent: USER_AGENT});
-
-            return response;
-        }
-
-        let body: Activity;
-        try {
-            body = await this.readRequestBodyAsString(request);
-
-        } catch (error) {
-            response.statusCode = StatusCodes.BAD_REQUEST;
-            response.setBody(`Unable to read request body. Error: ${ error }`);
-            return response;
-        }
-
-        if (request.verb.toLocaleUpperCase() !== POST) {
-            response.statusCode = StatusCodes.METHOD_NOT_ALLOWED;
-            response.setBody(`Method ${ request.verb.toLocaleUpperCase() } not allowed. Expected POST.`);
-            return response;
-        }
-
-        if (request.path.toLocaleLowerCase() !== MESSAGES_PATH) {
-            response.statusCode = StatusCodes.NOT_FOUND;
-            response.setBody(`Path ${ request.path.toLocaleLowerCase() } not not found. Expected ${ MESSAGES_PATH }}.`);
-            return response;
-        }
-
-        try {           
-            let context = new TurnContext(this, body);
-            await this.runMiddleware(context, this.logic);
-
-            if (body.type === ActivityTypes.Invoke) {
-                let invokeResponse: any = context.turnState.get(INVOKE_RESPONSE_KEY);
-
-                if (invokeResponse && invokeResponse.value) {
-                    const value: InvokeResponse = invokeResponse.value;
-                    response.statusCode = value.status;
-                    response.setBody(value.body);
-                } else {
-                    response.statusCode = StatusCodes.NOT_IMPLEMENTED;
-                }
-            } else {
-                response.statusCode = StatusCodes.OK;
-            }
-        } catch (error) {
-            response.statusCode = StatusCodes.INTERNAL_SERVER_ERROR;
-            response.setBody(error);
-            return response;
-        }
-
-        return response;
     }
 
     /**
@@ -1132,111 +1003,6 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
      */
     protected createContext(request: Partial<Activity>): TurnContext {
         return new TurnContext(this as any, request);
-    }
-
-    /**
-      * Determine if the Activity was sent via an Http/Https connection or Streaming
-      * This can be determined by looking at the ServiceUrl property:
-      *   (1) All channels that send messages via http/https are not streaming
-      *   (2) Channels that send messages via streaming have a ServiceUrl that does not begin with http/https.
-      * @param activity the activity.
-      */
-     private static isFromStreamingConnection(activity: Activity): boolean {
-        return activity && this.isStreamingServiceUrl(activity.serviceUrl);
-     }
-
-    /**
-      * Determine if the serviceUrl was sent via an Http/Https connection or Streaming
-      * This can be determined by looking at the ServiceUrl property:
-      *   (1) All channels that send messages via http/https are not streaming
-      *   (2) Channels that send messages via streaming have a ServiceUrl that does not begin with http/https.
-      * @param serviceUrl the serviceUrl provided in the resquest. 
-      */
-     private static isStreamingServiceUrl(serviceUrl: string): boolean {
-        return serviceUrl && !serviceUrl.toLowerCase().startsWith('http');
-     }
-
-    private async authenticateConnection(req: WebRequest, appId?: string, appPassword?: string, channelService?: string): Promise<boolean> {
-        if (!appId || !appPassword) {
-            // auth is disabled
-            return true;
-        }
-
-        let authHeader: string = req.headers.authorization || req.headers.Authorization || '';
-        let channelIdHeader: string = req.headers.channelid || req.headers.ChannelId || req.headers.ChannelID || '';
-        let credentials = new MicrosoftAppCredentials(appId, appPassword);
-        let credentialProvider = new SimpleCredentialProvider(credentials.appId, credentials.appPassword);
-        let claims = await JwtTokenValidation.validateAuthHeader(authHeader, credentialProvider, channelService, channelIdHeader);
-
-        return claims.isAuthenticated;
-    }
-
-    /**
-     * Connects the handler to a Named Pipe server and begins listening for incoming requests.
-     * @param pipeName The name of the named pipe to use when creating the server.
-     * @param logic The logic that will handle incoming requests.
-     */
-    private async useNamedPipe(pipeName: string = defaultPipeName, logic: (context: TurnContext) => Promise<any>): Promise<void>{
-        if (!logic) {
-            throw new Error('Bot logic needs to be provided to `useNamedPipe`');
-        }
-
-        this.logic = logic;
-
-        this.streamingServer = new NamedPipeServer(pipeName, this);
-        await this.streamingServer.start();
-    }
-
-    /**
-     * Process the initial request to establish a long lived connection via a streaming server.
-     * @param req The connection request.
-     * @param res The response sent on error or connection termination.
-     * @param logic The logic that will handle incoming requests.
-     */
-    private async useWebSocket(req: WebRequest, res: WebResponse, logic: (context: TurnContext) => Promise<any>): Promise<void> {   
-        if (!logic) {
-            throw new Error('Streaming logic needs to be provided to `useWebSocket`');
-        }
-
-        if (!this.webSocketFactory || !this.webSocketFactory.createWebSocket) {
-            throw new Error('BotFrameworkAdapter must have a WebSocketFactory in order to support streaming.');
-        }
-
-        this.logic = logic;
-
-        // Restify-specific check.
-        if (typeof((res as any).claimUpgrade) !== 'function') {
-            throw new Error("ClaimUpgrade is required for creating WebSocket connection.");
-        }
-
-        const authenticated = await this.authenticateConnection(req, this.settings.appId, this.settings.appPassword, this.settings.channelService);
-        if (!authenticated) {
-            res.status(StatusCodes.UNAUTHORIZED);
-            return Promise.resolve();
-        }
-        
-        const upgrade = (res as any).claimUpgrade();
-        const socket = this.webSocketFactory.createWebSocket(req as IncomingMessage, upgrade.socket, upgrade.head);
-
-        await this.startWebSocket(socket);
-    }
-
-    /**
-     * Connects the handler to a WebSocket server and begins listening for incoming requests.
-     * @param socket The socket to use when creating the server.
-     */
-    private async startWebSocket(socket: ISocket): Promise<void>{
-        this.streamingServer = new WebSocketServer(socket, this);
-        await this.streamingServer.start();
-    }
-
-    private async readRequestBodyAsString(request: IReceiveRequest): Promise<Activity> {            
-        try {
-            let contentStream =  request.streams[0];
-            return await contentStream.readAsJson<Activity>();
-        } catch (error) {
-            return Promise.reject(error);
-        }
     }
 }
 

--- a/libraries/botbuilder/src/index.ts
+++ b/libraries/botbuilder/src/index.ts
@@ -9,6 +9,7 @@
 export * from './botFrameworkAdapter';
 export * from './fileTranscriptStore';
 export * from './inspectionMiddleware';
+export * from './streamingBotFrameworkAdapter';
 export * from './teamsActivityHandler';
 export * from './teamsActivityHelpers';
 export * from './teamsInfo';

--- a/libraries/botbuilder/src/streamingBotFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/streamingBotFrameworkAdapter.ts
@@ -1,0 +1,386 @@
+/**
+ * @module botbuilder-ws
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    Activity,
+    ActivityTypes,
+    ResourceResponse,
+    TurnContext
+} from 'botbuilder-core';
+import {
+    ConnectorClient,
+    JwtTokenValidation,
+    MicrosoftAppCredentials,
+    SimpleCredentialProvider
+} from 'botframework-connector';
+import { IncomingMessage } from 'http';
+import { Socket } from 'net';
+import { TokenResolver } from './tokenResolver';
+import { BotFrameworkAdapter,
+    StatusCodes,
+    INVOKE_RESPONSE_KEY,
+    BotFrameworkAdapterSettings,
+    WebRequest,
+    USER_AGENT,
+    InvokeResponse,
+} from './botFrameworkAdapter';
+import {
+    IReceiveRequest,
+    ISocket,
+    IStreamingTransportServer,
+    NamedPipeServer,
+    NodeWebSocketFactoryBase,
+    StreamingResponse,
+    WebSocketServer,
+    WsNodeWebSocketFactory,
+} from 'botframework-streaming';
+import { StreamingHttpClient } from './streamingHttpClient';
+
+const defaultPipeName = 'bfv4.pipes';
+const VERSION_PATH:string = '/api/version';
+const MESSAGES_PATH:string = '/api/messages';
+const GET:string = 'GET';
+const POST:string = 'POST';
+
+export interface StreamingBotFrameworkAdapterSettings extends BotFrameworkAdapterSettings {
+    /**
+     * Optional. The option to determine if this adapter accepts WebSocket connections
+     */
+    enableWebSockets?: boolean;
+
+    /**
+     * Optional. Used to pass in a NodeWebSocketFactoryBase instance. Allows bot to accept WebSocket connections.
+     */
+    webSocketFactory?: NodeWebSocketFactoryBase;
+
+    /**
+     * Required.
+     */
+    logic: (context: TurnContext) => Promise<void>;
+}
+
+export class StreamingBotFrameworkAdapter extends BotFrameworkAdapter {
+    protected logic: (context: TurnContext) => Promise<void>;
+    protected streamingServer: IStreamingTransportServer;
+    protected webSocketFactory: any;
+
+    constructor(protected readonly settings: StreamingBotFrameworkAdapterSettings) {
+        super(settings);
+
+        // If the developer wants to use WebSockets, but didn't provide a WebSocketFactory,
+        // create a NodeWebSocketFactory.
+        if (this.settings.enableWebSockets && !this.settings.webSocketFactory) {
+            this.webSocketFactory = new WsNodeWebSocketFactory();
+        }
+
+        if (this.settings.webSocketFactory) {
+            this.webSocketFactory = this.settings.webSocketFactory;
+        }
+
+        if (!this.settings.logic) {
+            throw new Error('logic is a required setting for the StreamingBotFrameworkAdapter');
+        }
+        this.logic = this.settings.logic;
+    }
+
+    /**
+     * Setup a `ws` WebSocket connection on a Upgrade request from the service.
+     * @remarks
+     * This method should be used in an `'upgrade'`-listener off of the `http.Server`.
+     * ```ts
+     *  const adapter = new StreamingBotFrameworkAdapter();
+     * 
+     *  const server = require('http').createServer();
+     *  server.on('upgrade', (req, socket, head) => {
+     *      adapter.processUpgrade(req, socket, head);
+     *  }); 
+     * ```
+     * @param req 
+     * @param socket 
+     * @param head 
+     */
+    public async processUpgrade(req: IncomingMessage, socket: Socket, head: Buffer): Promise<void> {
+        if (!(req.headers.Upgrade || req.headers.upgrade)) {
+            throw new Error('StreamingBotFrameworkAdapter.procesUpgrade(): Appropriate "Upgrade" header not found');
+        }
+
+        // Direct Line Speech currently uses the 'GET' verb to initiate a WebSocket connection.
+        if (this.settings.enableWebSockets && req.method === GET) {
+            if (!this.logic) {
+                throw new Error('Streaming logic needs to be provided to `useWebSocket`');
+            }
+
+            if (!this.webSocketFactory || !this.webSocketFactory.createWebSocket) {
+                throw new Error('BotFrameworkAdapter must have a WebSocketFactory in order to support streaming.');
+            }
+
+            const authenticated = await this.authenticateConnection(req, this.settings.channelService);
+            if (!authenticated) {
+                const msg = this.createSocketResponse(StatusCodes.UNAUTHORIZED);
+                socket.end(msg, 'utf-8');
+                return;
+            }
+
+            const nodeWebSocket = await this.webSocketFactory.createWebSocket(req, socket, head);
+
+            // Connects the handler to a WebSocket server and begins listening for incoming requests.
+            this.streamingServer = new WebSocketServer(nodeWebSocket, this);
+            await this.streamingServer.start();
+        }
+    }
+
+    /**
+     * Creates a connector client.
+     * 
+     * @param serviceUrl The client's service URL.
+     * 
+     * @remarks
+     * Override this in a derived class to create a mock connector client for unit testing.
+     */
+    public createConnectorClient(serviceUrl: string): ConnectorClient {
+
+        if (StreamingBotFrameworkAdapter.isStreamingServiceUrl(serviceUrl)) {
+
+            // Check if we have a streaming server. Otherwise, requesting a connector client
+            // for a non-existent streaming connection results in an error
+            if (!this.streamingServer) {
+                throw new Error(`Cannot create streaming connector client for serviceUrl ${serviceUrl} without a streaming connection. Call 'useWebSocket' or 'useNamedPipe' to start a streaming connection.`)
+            }
+
+            return new ConnectorClient(
+                this.credentials,
+                {
+                    baseUri: serviceUrl,
+                    userAgent: USER_AGENT,
+                    httpClient: new StreamingHttpClient(this.streamingServer)
+                });
+        }
+
+        const client: ConnectorClient = new ConnectorClient(this.credentials, { baseUri: serviceUrl, userAgent: USER_AGENT} );
+        return client;
+    }
+
+    /**
+     * Checks the validity of the request and attempts to map it the correct virtual endpoint,
+     * then generates and returns a response if appropriate.
+     * @param request A ReceiveRequest from the connected channel.
+     * @returns A response created by the BotAdapter to be sent to the client that originated the request.
+     */
+    public async processRequest(request: IReceiveRequest): Promise<StreamingResponse> {
+        let response = new StreamingResponse();
+
+        if (!request) {
+            response.statusCode = StatusCodes.BAD_REQUEST;
+            response.setBody(`No request provided.`);
+            return response;
+        }
+
+        if (!request.verb || !request.path) {
+            response.statusCode = StatusCodes.BAD_REQUEST;
+            response.setBody(`Request missing verb and/or path. Verb: ${ request.verb }. Path: ${ request.path }`);
+            return response;
+        } 
+
+        if (request.verb.toLocaleUpperCase() === GET && request.path.toLocaleLowerCase() === VERSION_PATH) {
+            response.statusCode = StatusCodes.OK;
+            response.setBody({UserAgent: USER_AGENT});
+
+            return response;
+        }
+
+        let body: Activity;
+        try {
+            body = await this.readRequestBodyAsString(request);
+
+        } catch (error) {
+            response.statusCode = StatusCodes.BAD_REQUEST;
+            response.setBody(`Unable to read request body. Error: ${ error }`);
+            return response;
+        }
+
+        if (request.verb.toLocaleUpperCase() !== POST) {
+            response.statusCode = StatusCodes.METHOD_NOT_ALLOWED;
+            response.setBody(`Method ${ request.verb.toLocaleUpperCase() } not allowed. Expected POST.`);
+            return response;
+        }
+
+        if (request.path.toLocaleLowerCase() !== MESSAGES_PATH) {
+            response.statusCode = StatusCodes.NOT_FOUND;
+            response.setBody(`Path ${ request.path.toLocaleLowerCase() } not not found. Expected ${ MESSAGES_PATH }}.`);
+            return response;
+        }
+
+        try {           
+            let context = new TurnContext(this, body);
+            await this.runMiddleware(context, this.logic);
+
+            if (body.type === ActivityTypes.Invoke) {
+                let invokeResponse: any = context.turnState.get(INVOKE_RESPONSE_KEY);
+
+                if (invokeResponse && invokeResponse.value) {
+                    const value: InvokeResponse = invokeResponse.value;
+                    response.statusCode = value.status;
+                    response.setBody(value.body);
+                } else {
+                    response.statusCode = StatusCodes.NOT_IMPLEMENTED;
+                }
+            } else {
+                response.statusCode = StatusCodes.OK;
+            }
+        } catch (error) {
+            response.statusCode = StatusCodes.INTERNAL_SERVER_ERROR;
+            response.setBody(error);
+            return response;
+        }
+
+        return response;
+    }
+
+    /**
+     * Used to generate a response to send via the `net.Socket`.
+     * @param statusCode StatusCodes
+     */
+    private createSocketResponse(statusCode: StatusCodes): string {
+        switch (statusCode) {
+            case StatusCodes.UNAUTHORIZED:
+                return 'HTTP/1.1 401 Unauthorized';
+            
+            // Default is for 500 Internal Server Errors.
+            default:
+                return 'HTTP1/1.1 500 Internal Server Error';
+        }
+    }
+
+    private async readRequestBodyAsString(request: IReceiveRequest): Promise<Activity> {
+        try {
+            let contentStream =  request.streams[0];
+            return await contentStream.readAsJson<Activity>();
+        } catch (error) {
+            return Promise.reject(error);
+        }
+    }
+
+    /**
+     * An asynchronous method that sends a set of outgoing activities to a channel server.
+     * > [!NOTE] This method supports the framework and is not intended to be called directly for your code.
+     *
+     * @param context The context object for the turn.
+     * @param activities The activities to send.
+     * 
+     * @returns An array of [ResourceResponse](xref:)
+     * 
+     * @remarks
+     * The activities will be sent one after another in the order in which they're received. A
+     * response object will be returned for each sent activity. For `message` activities this will
+     * contain the ID of the delivered message.
+     *
+     * Use the turn context's [sendActivity](xref:botbuilder-core.TurnContext.sendActivity) or
+     * [sendActivities](xref:botbuilder-core.TurnContext.sendActivities) method, instead of directly
+     * calling this method. The [TurnContext](xref:botbuilder-core.TurnContext) ensures that outgoing
+     * activities are properly addressed and that all registered response event handlers are notified.
+     */
+    public async sendActivities(context: TurnContext, activities: Partial<Activity>[]): Promise<ResourceResponse[]> {
+        const responses: ResourceResponse[] = [];
+        for (let i = 0; i < activities.length; i++) {
+            const activity: Partial<Activity> = activities[i];
+            switch (activity.type) {
+                case 'delay':
+                    await delay(typeof activity.value === 'number' ? activity.value : 1000);
+                    responses.push({} as ResourceResponse);
+                    break;
+                case 'invokeResponse':
+                // Cache response to context object. This will be retrieved when turn completes.
+                    context.turnState.set(INVOKE_RESPONSE_KEY, activity);
+                    responses.push({} as ResourceResponse);
+                    break;
+                default:
+                    if (!activity.serviceUrl) { throw new Error(`BotFrameworkAdapter.sendActivity(): missing serviceUrl.`); }
+                    if (!activity.conversation || !activity.conversation.id) {
+                        throw new Error(`BotFrameworkAdapter.sendActivity(): missing conversation id.`);
+                    }
+                    if (StreamingBotFrameworkAdapter.isFromStreamingConnection(activity as Activity)) {
+                        TokenResolver.checkForOAuthCards(this, context, activity as Activity);
+                    }
+                    const client: ConnectorClient = this.createConnectorClient(activity.serviceUrl);
+                    if (activity.type === 'trace' && activity.channelId !== 'emulator') {
+                    // Just eat activity
+                        responses.push({} as ResourceResponse);
+                    } else if (activity.replyToId) {
+                        responses.push(await client.conversations.replyToActivity(
+                            activity.conversation.id,
+                            activity.replyToId,
+                            activity as Activity
+                        ));
+                    } else {
+                        responses.push(await client.conversations.sendToConversation(
+                            activity.conversation.id,
+                            activity as Activity
+                        ));
+                    }
+                    break;
+            }
+        }
+        return responses;
+    }
+
+    /**
+      * Determine if the Activity was sent via an Http/Https connection or Streaming
+      * This can be determined by looking at the ServiceUrl property:
+      *   (1) All channels that send messages via http/https are not streaming
+      *   (2) Channels that send messages via streaming have a ServiceUrl that does not begin with http/https.
+      * @param activity the activity.
+      */
+     protected static isFromStreamingConnection(activity: Activity): boolean {
+        return activity && this.isStreamingServiceUrl(activity.serviceUrl);
+     }
+
+    /**
+      * Determine if the serviceUrl was sent via an Http/Https connection or Streaming
+      * This can be determined by looking at the ServiceUrl property:
+      *   (1) All channels that send messages via http/https are not streaming
+      *   (2) Channels that send messages via streaming have a ServiceUrl that does not begin with http/https.
+      * @param serviceUrl the serviceUrl provided in the resquest. 
+      */
+     protected static isStreamingServiceUrl(serviceUrl: string): boolean {
+        return serviceUrl && !serviceUrl.toLowerCase().startsWith('http');
+     }
+
+     private async authenticateConnection(req: WebRequest, channelService?: string): Promise<boolean> {
+        if (!this.credentials.appId || !this.credentials.appPassword) {
+            // auth is disabled
+            return true;    
+        }
+
+        const authHeader: string = req.headers.authorization || req.headers.Authorization || '';
+        const channelIdHeader: string = req.headers.channelid || req.headers.ChannelId || req.headers.ChannelID || '';
+        const claims = await JwtTokenValidation.validateAuthHeader(authHeader, this.credentialsProvider, channelService, channelIdHeader);
+        return claims.isAuthenticated;
+    }
+
+    /**
+     * Connects the handler to a Named Pipe server and begins listening for incoming requests.
+     * @param pipeName The name of the named pipe to use when creating the server.
+     * @param logic The logic that will handle incoming requests.
+     */
+    private async useNamedPipe(pipeName: string = defaultPipeName, logic: (context: TurnContext) => Promise<any>): Promise<void>{
+        if (!logic) {
+            throw new Error('Bot logic needs to be provided to `useNamedPipe`');
+        }
+
+        this.logic = logic;
+
+        this.streamingServer = new NamedPipeServer(pipeName, this);
+        await this.streamingServer.start();
+    }
+}
+
+function delay(timeout: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, timeout);
+    });
+}


### PR DESCRIPTION
## Description
An exploration in a prototype StreamingBotFrameworkAdapter with a different entrance API via `processUpgrade(req: http.IncomingMessage, socket: net.Socket, head: Buffer): Promise<void>`.

The current way to use WebSockets in the BotFrameworkAdapter is that developers use `processActivity(req: HttpRequest, res: HttpResponse, logic: (TurnContext) => Promise<any>)`.

## Specific Changes
  - 
  -
  -

## Testing
Manually tested so far with Direct Line Speech.