### PR TITLE
Fix daily CI build after adding botframework-streaming to packages

### DIFF
--- a/libraries/botframework-streaming/package.json
+++ b/libraries/botframework-streaming/package.json
@@ -27,7 +27,7 @@
     "ws": "^7.1.2"
   },
   "engines": {
-    "node": ">12.3"
+    "node": ">10.14"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-docs": "lerna run build-docs",
     "eslint": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts",
     "eslint-fix": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts --fix",
-    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ^${Version} botbuilder botbuilder-choices botbuilder-dialogs botbuilder-core botbuilder-prompts botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ^${Version} botbuilder botbuilder-ai botbuilder-dialogs botbuilder-testing",
+    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ^${Version} botframework-streaming botbuilder botbuilder-choices botbuilder-dialogs botbuilder-core botbuilder-prompts botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ^${Version} botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-testing",
     "update-versions": "lerna run set-version && npm run set-dependency-versions"
   },
   "dependencies": {
@@ -34,8 +34,7 @@
     "typedoc": "^0.15.0",
     "typedoc-plugin-external-module-name": "^2.1.0",
     "typedoc-plugin-markdown": "^2.2.10",
-    "typescript": "^3.5.2",
-    "watershed": "^0.4.0"
+    "typescript": "^3.5.2"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION


## Specific Changes
  - Add botframework-streaming to the  npm scripts
  - Remove watershed dependency from the root of the repo

## Testing
Build successfully ran, results are here: https://botbuilder.myget.org/feed/botbuilder-v4-js-daily/package/npm/botbuilder/4.6.0-preview.84994