### PR TITLE
[QnAMaker] Active learning low score variation multiplier value (#1359)

### DIFF
--- a/libraries/botbuilder-ai/src/qnamaker-utils/activeLearningUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/activeLearningUtils.ts
@@ -12,10 +12,10 @@ import { QnAMakerResult } from '../qnamaker-interfaces/qnamakerResult';
 const MinimumScoreForLowScoreVariation = 20;
 
 // Previous Low Score Variation Multiplier
-const PreviousLowScoreVariationMultiplier = 1.4;
+const PreviousLowScoreVariationMultiplier = 0.7;
 
 // Max Low Score Variation Multiplier
-const MaxLowScoreVariationMultiplier = 2.0;
+const MaxLowScoreVariationMultiplier = 1.0;
 
 // Maximum Score For Low Score Variation
 const MaximumScoreForLowScoreVariation = 95.0;


### PR DESCRIPTION
Active learning low score variation multiplier value
- PreviousLowScoreVariationMultiplier to 0.7
- MaxLowScoreVariationMultiplier to 1.0

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - 
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->