### PR TITLE
[4.6, Engineering] Remove .js and .ts from .gitignore, change *.map to *.js.map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -308,6 +308,4 @@ __pycache__/
 package-lock.json
 
 *.tsbuildinfo
-*.map
-*.js
-*.ts
+*.js.map


### PR DESCRIPTION
## Description
Revert [changes](https://github.com/microsoft/botbuilder-js/pull/1351/commits/e92608c8e5eacc239101d76088db5f334dd3a0e3) to root `.gitignore` that prevent developers from moving or creating `.ts` and `.js` files and adding them to git.

This PR does **not** require a new RC for 4.6.