### PR TITLE
Fix @types/lru-cache missing in dependency

### DIFF
--- a/libraries/botframework-expressions/package.json
+++ b/libraries/botframework-expressions/package.json
@@ -15,6 +15,7 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "dependencies": {
+    "@types/lru-cache": "^5.1.0",
     "@microsoft/recognizers-text-data-types-timex-expression": "^1.1.4",
     "antlr4ts": "0.5.0-alpha.1",
     "jspath": "^0.4.0",


### PR DESCRIPTION
Fixes #1369 

## Description
Add lru-cache as dependency since it's been exposed in expression library. 

Otherwise we will hit 

```
node_modules/botframework-expressions/lib/commonRegex.d.ts:9:27 - error TS7016: Could not find a declaration file for module 'lru-cache'. 
'C:/Users/donglei/code/testg/node_modules/lru-cache/index.js' implicitly has an 'any' type.
  Try `npm install @types/lru-cache` if it exists or add a new declaration (.d.ts) file containing `declare module 'lru-cache';`

9 import * as LRUCache from 'lru-cache';
                            ~~~~~~~~~~~
```