### PR TITLE
[Engineering] Remove typescript devDependency from botframework-streaming

### DIFF
--- a/libraries/botframework-streaming/package.json
+++ b/libraries/botframework-streaming/package.json
@@ -39,11 +39,7 @@
     "sinon": "^7.4.1",
     "ts-node": "^4.1.0",
     "tslint": "^5.16.0",
-    "tslint-microsoft-contrib": "^5.2.1",
-    "typescript": "3.1.1"
-  },
-  "engines": {
-    "node": ">10.14"
+    "tslint-microsoft-contrib": "^5.2.1"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",


### PR DESCRIPTION

**Fixes:** 
![image](https://user-images.githubusercontent.com/14935595/68334680-fe00a580-008f-11ea-954f-4c2fdd5af85d.png)


## Description
Fixes build breaks in botframework-streaming caused by using devDependency of `typescript@3.1.1` and using Node.js 10.17.0.

Also removed `"engines"` from package.json, which should be used in applications, not libraries.

## Testing
Got a repro working on local machine, and [build 88744](https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=88744).