### PR TITLE
[4.6.1] Manually Cherry-pick #1392 & #1390 to 4.6 branch

### DIFF
--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -46,6 +46,7 @@ export class TeamsActivityHandler extends ActivityHandler {
                 if (invokeResponse && !context.turnState.get(INVOKE_RESPONSE_KEY)) {
                     await context.sendActivity({ value: invokeResponse, type: 'invokeResponse' });
                 }
+                await this.defaultNextEvent(context)();
                 break;
             default:
                 await super.onTurnActivity(context);

--- a/libraries/botframework-streaming/package.json
+++ b/libraries/botframework-streaming/package.json
@@ -39,11 +39,7 @@
     "sinon": "^7.4.1",
     "ts-node": "^4.1.0",
     "tslint": "^5.16.0",
-    "tslint-microsoft-contrib": "^5.2.1",
-    "typescript": "3.1.1"
-  },
-  "engines": {
-    "node": ">10.14"
+    "tslint-microsoft-contrib": "^5.2.1"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",


### PR DESCRIPTION
For 4.6.1

## Description
- Cherry-picks the `TeamsActivityHandler` not calling `defaultNextEvent` fix from #1390 
- Cherry-picks the `botframework-streaming` package.json fixes from #1392

## Testing
Local tests are passing, `botframework-streaming` is building locally