### PR TITLE
Choice prompt null locale fix [Cherry-pick against 4.6]

### DIFF
--- a/libraries/botbuilder-dialogs/src/prompts/promptCultureModels.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/promptCultureModels.ts
@@ -115,12 +115,35 @@ export class PromptCultureModels {
         noInLanguage: 'No',
     }
 
+    private static getSupportedCultureCodes(): string[] {
+        return this.getSupportedCultures().map((c): string => c.locale);
+    }
+
     /**
      * Use Recognizers-Text to normalize various potential Locale strings to a standard.
+     * @remarks This is mostly a copy/paste from https://github.com/microsoft/Recognizers-Text/blob/master/JavaScript/packages/recognizers-text/src/culture.ts#L39
+     *          This doesn't directly use Recognizers-Text's MapToNearestLanguage because if they add language support before we do, it will break our prompts.
      * @param cultureCode Represents locale. Examples: "en-US, en-us, EN".
      * @returns Normalized locale.
      */
-    public static mapToNearestLanguage = (cultureCode: string): string => Culture.mapToNearestLanguage(cultureCode);
+    public static mapToNearestLanguage(cultureCode: string): string {
+        if (cultureCode !== undefined) {
+            cultureCode = cultureCode.toLowerCase();
+            let supportedCultureCodes = this.getSupportedCultureCodes();
+    
+            if (supportedCultureCodes.indexOf(cultureCode) < 0) {
+                let culturePrefix = cultureCode.split('-')[0].trim();
+    
+                supportedCultureCodes.forEach(function(supportedCultureCode): void {
+                    if (supportedCultureCode.startsWith(culturePrefix)) {
+                        cultureCode = supportedCultureCode;
+                    }
+                });
+            }
+        }
+    
+        return cultureCode;
+    }
 
     public static getSupportedCultures = (): PromptCultureModel[] => 
         [

--- a/libraries/botbuilder-dialogs/tests/choicePrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/choicePrompt.test.js
@@ -1,5 +1,6 @@
 const { ActivityTypes, CardFactory, ConversationState, MemoryStorage, TestAdapter } = require('botbuilder-core');
 const { ChoicePrompt, ChoiceFactory, DialogSet, ListStyle, DialogTurnStatus } = require('../');
+const { PromptCultureModels } = require('../');
 const assert = require('assert');
 
 const answerMessage = { text: `red`, type: 'message' };
@@ -383,6 +384,50 @@ describe('ChoicePrompt', function () {
                     });
             }));
         }));      
+    });
+
+    it('should default to english locale', async function () {
+        const locales = [
+            null,
+            '',
+            'not-supported'
+        ];
+        await Promise.all(locales.map(async (testLocale) => {
+            const adapter = new TestAdapter(async (turnContext) => {
+                const dc = await dialogs.createContext(turnContext);
+    
+                const results = await dc.continueDialog();
+                if (results.status === DialogTurnStatus.empty) {
+                    await dc.prompt('prompt', { prompt: 'Please choose a color.', choices: stringChoices });
+                } else if (results.status === DialogTurnStatus.complete) {
+                    const selectedChoice = results.result;
+                    await turnContext.sendActivity(selectedChoice.value);
+                }
+                await convoState.saveChanges(turnContext);
+            });
+            const convoState = new ConversationState(new MemoryStorage());
+    
+            const dialogState = convoState.createProperty('dialogState');
+            const dialogs = new DialogSet(dialogState);
+            const choicePrompt = new ChoicePrompt('prompt', async (prompt) => {
+                assert(prompt);
+                if (!prompt.recognized.succeeded) {
+                    await prompt.context.sendActivity('bad input.');
+                }
+                return prompt.recognized.succeeded;
+            }, null);
+            dialogs.add(choicePrompt);
+    
+            await adapter.send({ text: 'Hello', type: ActivityTypes.Message, locale: testLocale })
+                .assertReply((activity) => {
+                    const expectedChoices = ChoiceFactory.inline(stringChoices, null, null, {
+                        inlineOr: PromptCultureModels.English.inlineOr,
+                        inlineOrMore: PromptCultureModels.English.inlineOrMore,
+                        inlineSeparator: PromptCultureModels.English.separator,
+                    }).text;
+                    assert.strictEqual(activity.text, `Please choose a color.${ expectedChoices }`);
+                });
+        }));   
     });
 
     it('should accept and recognize custom locale dict', async function() {

--- a/libraries/botbuilder-dialogs/tests/confirmPrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/confirmPrompt.test.js
@@ -521,6 +521,41 @@ describe('ConfirmPrompt', function () {
             .assertReply(`The result found is 'true'.`);
     });
 
+    it('should recogize valid number and default to en if locale is null.', async function () {
+        const adapter = new TestAdapter(async (turnContext) => {
+
+            turnContext.activity.locale = null;
+
+            const dc = await dialogs.createContext(turnContext);
+
+            const results = await dc.continueDialog();
+            if (results.status === DialogTurnStatus.empty) {
+                await dc.prompt('prompt', {
+                    prompt: { text: 'Please confirm.', type: ActivityTypes.Message },
+                    retryPrompt: { text: 'Please confirm, say "yes" or "no" or something like that.', type: ActivityTypes.Message }
+                });
+            } else if (results.status === DialogTurnStatus.complete) {
+                await turnContext.sendActivity(`The result found is '${ results.result }'.`);
+            }
+            await convoState.saveChanges(turnContext);
+        });
+
+        const convoState = new ConversationState(new MemoryStorage());
+
+        const dialogState = convoState.createProperty('dialogState');
+        const dialogs = new DialogSet(dialogState);
+        const prompt = new ConfirmPrompt('prompt');
+        prompt.choiceOptions = { includeNumbers: true };
+        dialogs.add(prompt);
+
+        await adapter.send('Hello')
+            .assertReply('Please confirm. (1) Yes or (2) No')
+            .send('lala')
+            .assertReply('Please confirm, say "yes" or "no" or something like that. (1) Yes or (2) No')
+            .send('1')
+            .assertReply(`The result found is 'true'.`);
+    });
+
     it('should recogize valid number and default to en if locale invalid string.', async function () {
         const adapter = new TestAdapter(async (turnContext) => {
 

--- a/libraries/botbuilder-dialogs/tests/confirmPrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/confirmPrompt.test.js
@@ -521,7 +521,7 @@ describe('ConfirmPrompt', function () {
             .assertReply(`The result found is 'true'.`);
     });
 
-    it('should recogize valid number and default to en if locale is null.', async function () {
+    it('should recognize valid number and default to en if locale is null.', async function () {
         const adapter = new TestAdapter(async (turnContext) => {
 
             turnContext.activity.locale = null;


### PR DESCRIPTION
Per standup, this is a cherry pick against 4.6 of [this already-merged-with-master PR](https://github.com/microsoft/botbuilder-js/pull/1400)

---

Parity with: https://github.com/microsoft/botbuilder-dotnet/pull/2943

# Changes

* `ChoicePrompt`: Ensures that locale defaults to English and handles mapping to the nearest locale more gracefully
* `PromptCultureModels`: Implements our own version of [Recognizers-Text's `MapToNearestLanguage`](https://github.com/microsoft/Recognizers-Text/blob/7b20c1bbbfdebc3a801fbc61b094706ceebd7acf/.NET/Microsoft.Recognizers.Text/Culture.cs#L66) -- They added a bunch of other supported languages that will break this without doing this.
* `ChoicePromptTests`: Added a test to specifically set the Locale to null

# Other Notes

* ConfirmPrompt already handled this fine and had tests for it
* I'll also work on some tests for PromptCultureModels, but I figured this should get out the door, first.
* Since Recognizers-Text added a bunch of supported languages, I'll see about adding them here in a future PR

## Workarounds until this is Merged

* Downgrade to < 4.6, or
* set `defaultLocale` on `ChoicePrompt`