### PR TITLE
[Streaming, Preview] rewrite useWebSocket for low-level usage, remove from processActivity

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -38,7 +38,8 @@
     "nock": "^10.0.3",
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-applicationinsights/package.json
+++ b/libraries/botbuilder-applicationinsights/package.json
@@ -33,7 +33,8 @@
     "mocha": "^5.2.0",
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-azure/package.json
+++ b/libraries/botbuilder-azure/package.json
@@ -35,10 +35,11 @@
     "@types/semaphore": "^1.1.0",
     "codelyzer": "^4.1.0",
     "mocha": "^5.2.0",
-    "nyc": "^11.4.1",
     "nock": "^10.0.3",
+    "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-core/package.json
+++ b/libraries/botbuilder-core/package.json
@@ -30,6 +30,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
+    "typescript": "3.5.3",
     "unzip": "^0.1.11"
   },
   "scripts": {

--- a/libraries/botbuilder-core/src/skypeMentionNormalizeMiddleware.ts
+++ b/libraries/botbuilder-core/src/skypeMentionNormalizeMiddleware.ts
@@ -5,7 +5,9 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Activity, Middleware, TurnContext } from 'botbuilder-core';
+import { Activity } from 'botframework-schema';
+import { Middleware } from './middlewareSet';
+import { TurnContext } from './turnContext';
 
 
 /**

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -35,7 +35,8 @@
     "mocha": "^5.2.0",
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-testing/package.json
+++ b/libraries/botbuilder-testing/package.json
@@ -34,6 +34,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
+    "typescript": "3.5.3",
     "unzip": "^0.1.11",
     "uuid": "^3.3.2"
   },

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -36,6 +36,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
+    "typescript": "3.5.3",
     "uuid": "^3.3.2"
   },
   "scripts": {

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -6,13 +6,12 @@
  * Licensed under the MIT License.
  */
 
-import { IncomingMessage, STATUS_CODES } from 'http';
-import { Socket } from 'net';
+import { STATUS_CODES } from 'http';
 import * as os from 'os';
 
 import { Activity, ActivityTypes, BotAdapter, BotCallbackHandlerKey, ChannelAccount, ConversationAccount, ConversationParameters, ConversationReference, ConversationsResult, IUserTokenProvider, ResourceResponse, TokenResponse, TurnContext } from 'botbuilder-core';
 import { AuthenticationConstants, ChannelValidation, ConnectorClient, EmulatorApiClient, GovernmentConstants, GovernmentChannelValidation, JwtTokenValidation, MicrosoftAppCredentials, SimpleCredentialProvider, TokenApiClient, TokenStatus, TokenApiModels } from 'botframework-connector';
-import { IReceiveRequest, ISocket, IStreamingTransportServer, NamedPipeServer, NodeWebSocketFactory, NodeWebSocketFactoryBase, RequestHandler, StreamingResponse, WebSocketServer } from 'botframework-streaming';
+import { INodeBuffer, INodeSocket, IReceiveRequest, ISocket, IStreamingTransportServer, NamedPipeServer, NodeWebSocketFactory, NodeWebSocketFactoryBase, RequestHandler, StreamingResponse, WebSocketServer } from 'botframework-streaming';
 
 import { StreamingHttpClient, TokenResolver } from './streaming';
 
@@ -1149,7 +1148,7 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
      * @param res The response sent on error or connection termination.
      * @param logic The logic that will handle incoming requests.
      */
-    public async useWebSocket(req: IncomingMessage, socket: Socket, head: Buffer, logic: (context: TurnContext) => Promise<any>): Promise<void> {   
+    public async useWebSocket(req: WebRequest, socket: INodeSocket, head: INodeBuffer, logic: (context: TurnContext) => Promise<any>): Promise<void> {   
         if (!this.webSocketFactory || !this.webSocketFactory.createWebSocket) {
             throw new Error('BotFrameworkAdapter must have a WebSocketFactory in order to support streaming.');
         }
@@ -1304,7 +1303,7 @@ function delay(timeout: number): Promise<void> {
     });
 }
 
-function abortWebSocketUpgrade(socket: Socket, code: number) {
+function abortWebSocketUpgrade(socket: INodeSocket, code: number) {
     if (socket.writable) {
         const connectionHeader = `Connection: 'close'\r\n`;
         socket.write(`HTTP/1.1 ${code} ${STATUS_CODES[code]}\r\n${connectionHeader}\r\n`);

--- a/libraries/botbuilder/tests/streaming/botFrameworkAdapterStreaming.test.js
+++ b/libraries/botbuilder/tests/streaming/botFrameworkAdapterStreaming.test.js
@@ -16,10 +16,9 @@ const createNetSocket = (readable = true, writable = true) => {
 };
 
 class TestAdapterSettings {
-    constructor(appId = undefined, appPassword = undefined, channelAuthTenant, oAuthEndpoint, openIdMetadata, channelServce) {
+    constructor(appId, appPassword) {
         this.appId = appId;
         this.appPassword = appPassword;
-        this.enableWebSockets = true;
     }
 }
 

--- a/libraries/botbuilder/tests/streaming/mockHttpRequest.js
+++ b/libraries/botbuilder/tests/streaming/mockHttpRequest.js
@@ -1,0 +1,32 @@
+const { randomBytes } = require('crypto');
+
+class MockHttpRequest {
+    constructor(options = {}) {
+        const config = Object.assign({
+            method: 'GET',
+            headers: {
+                'upgrade': 'websocket',
+                'sec-websocket-key': randomBytes(16).toString('base64'),
+                'sec-websocket-version': '13',
+                'sec-websocket-protocol': ''
+            }
+        }, options);
+
+        this.method = config.method;
+        this.headers = config.headers;
+    }
+
+    setHeader(key, value) {
+        this.headers[key] = value;
+    }
+
+    streams(value) {
+        this.streamsVal = value;
+    }
+
+    streams() {
+        return this.streamsVal;
+    }
+}
+
+module.exports.MockHttpRequest = MockHttpRequest;

--- a/libraries/botbuilder/tests/streaming/mockNetSocket.js
+++ b/libraries/botbuilder/tests/streaming/mockNetSocket.js
@@ -1,0 +1,18 @@
+const { STATUS_CODES } = require('http');
+
+class MockNetSocket {
+    constructor(readable = true, writable = true) {
+        this.readable = readable;
+        this.writable = writable;
+    }
+
+    write(response) { }
+
+    destroy(err) { }
+}
+
+MockNetSocket.createNonSuccessResponse = (code) => {
+    return `HTTP/1.1 ${code} ${STATUS_CODES[code]}\r\nConnection: 'close'\r\n\r\n`;
+};
+
+module.exports.MockNetSocket = MockNetSocket;

--- a/libraries/botframework-config/package.json
+++ b/libraries/botframework-config/package.json
@@ -26,7 +26,8 @@
   },
   "devDependencies": {
     "@types/uuid": "^3.4.3",
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "typescript": "3.5.3"
   },
   "dependencies": {
     "fs-extra": "^7.0.0",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -38,7 +38,8 @@
     "nyc": "^11.4.1",
     "should": "^13.2.3",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "build": "tsc",

--- a/libraries/botframework-schema/package.json
+++ b/libraries/botframework-schema/package.json
@@ -9,8 +9,9 @@
   ],
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
-  "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "typescript": "3.5.3"
+  },
   "scripts": {
     "build": "tsc",
     "clean": "erase /q /s .\\lib",
@@ -26,6 +27,6 @@
   },
   "files": [
     "/lib",
-    "/src"   
+    "/src"
   ]
 }

--- a/libraries/botframework-streaming/package.json
+++ b/libraries/botframework-streaming/package.json
@@ -37,7 +37,8 @@
     "mocha": "^6.2.0",
     "nyc": "^14.1.1",
     "sinon": "^7.4.1",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "build": "tsc",

--- a/libraries/botframework-streaming/src/index.ts
+++ b/libraries/botframework-streaming/src/index.ts
@@ -9,6 +9,9 @@
 export { ContentStream } from './contentStream';
 export { HttpContent } from './httpContentStream';
 export {
+    INodeBuffer,
+    INodeIncomingMessage,
+    INodeSocket,
     IReceiveRequest,
     IReceiveResponse,
     ISocket,

--- a/libraries/botframework-streaming/src/interfaces/INodeBuffer.ts
+++ b/libraries/botframework-streaming/src/interfaces/INodeBuffer.ts
@@ -1,0 +1,14 @@
+/**
+ * @module botframework-streaming
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Represents a Buffer from the `buffer` module in Node.js.
+ * 
+ * This interface supports the framework and is not intended to be called directly for your code.
+ */
+export interface INodeBuffer { }

--- a/libraries/botframework-streaming/src/interfaces/INodeIncomingMessage.ts
+++ b/libraries/botframework-streaming/src/interfaces/INodeIncomingMessage.ts
@@ -1,0 +1,24 @@
+/**
+ * @module botframework-streaming
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Represents a IncomingMessage from the `http` module in Node.js.
+ * 
+ * This interface supports the framework and is not intended to be called directly for your code.
+ */
+export interface INodeIncomingMessage {
+    /***
+     * Optional. The request headers.
+     */
+    headers?: any;
+
+    /***
+     * Optional. The request method.
+     */
+    method?: any;
+}

--- a/libraries/botframework-streaming/src/interfaces/INodeSocket.ts
+++ b/libraries/botframework-streaming/src/interfaces/INodeSocket.ts
@@ -1,0 +1,18 @@
+/**
+ * @module botframework-streaming
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Represents a Socket from the `net` module in Node.js.
+ * 
+ * This interface supports the framework and is not intended to be called directly for your code.
+ */
+export interface INodeSocket {
+    writable: boolean;
+    write(str: string, cb?: Function): boolean;
+    destroy(error?: Error): void;
+}

--- a/libraries/botframework-streaming/src/interfaces/index.ts
+++ b/libraries/botframework-streaming/src/interfaces/index.ts
@@ -5,6 +5,10 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+
+export * from './INodeBuffer';
+export * from './INodeIncomingMessage';
+export * from './INodeSocket';
 export * from './IReceiveRequest';
 export * from './IReceiveResponse';
 export * from './ISocket';

--- a/libraries/botframework-streaming/src/webSocket/factories/nodeWebSocketFactory.ts
+++ b/libraries/botframework-streaming/src/webSocket/factories/nodeWebSocketFactory.ts
@@ -6,9 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { IncomingMessage } from 'http';
-import { Socket } from 'net';
-
+import { INodeIncomingMessage, INodeBuffer, INodeSocket } from '../../interfaces';
 import { NodeWebSocket } from '../nodeWebSocket';
 import { NodeWebSocketFactoryBase } from './nodeWebSocketFactoryBase';
 
@@ -25,7 +23,7 @@ export class NodeWebSocketFactory extends NodeWebSocketFactoryBase {
      * @param socket The Socket connecting the bot and the server, from the 'net' module in Node.js.
      * @param head The first packet of the upgraded stream which may be empty per https://nodejs.org/api/http.html#http_event_upgrade_1.
      */
-    public async createWebSocket(req: IncomingMessage, socket: Socket, head: Buffer): Promise<NodeWebSocket> {
+    public async createWebSocket(req: INodeIncomingMessage, socket: INodeSocket, head: INodeBuffer): Promise<NodeWebSocket> {
         const s = new NodeWebSocket();
         await s.create(req, socket, head);
         

--- a/libraries/botframework-streaming/src/webSocket/factories/nodeWebSocketFactoryBase.ts
+++ b/libraries/botframework-streaming/src/webSocket/factories/nodeWebSocketFactoryBase.ts
@@ -6,10 +6,8 @@
  * Licensed under the MIT License.
  */
 
-import { IncomingMessage } from 'http';
-import { Socket } from 'net';
-import { ISocket } from '../../interfaces';
+import { INodeIncomingMessage, INodeBuffer, INodeSocket, ISocket } from '../../interfaces';
 
 export abstract class NodeWebSocketFactoryBase {
-    public abstract createWebSocket(req: IncomingMessage, socket: Socket, head: Buffer): Promise<ISocket>;
+    public abstract createWebSocket(req: INodeIncomingMessage, socket: INodeSocket, head: INodeBuffer): Promise<ISocket>;
 }

--- a/libraries/botframework-streaming/src/webSocket/nodeWebSocket.ts
+++ b/libraries/botframework-streaming/src/webSocket/nodeWebSocket.ts
@@ -11,7 +11,7 @@ import { IncomingMessage, request } from 'http';
 import { Socket } from 'net';
 import * as WebSocket from 'ws';
 
-import { ISocket } from '../interfaces';
+import { INodeIncomingMessage, INodeBuffer, INodeSocket, ISocket } from '../interfaces';
 const NONCE_LENGTH = 16;
 
 export class NodeWebSocket implements ISocket {
@@ -29,15 +29,15 @@ export class NodeWebSocket implements ISocket {
 
     /**
      * Create and set a `ws` WebSocket with an HTTP Request, Socket and Buffer.
-     * @param req IncomingMessage
-     * @param socket Socket
-     * @param head Buffer
+     * @param req INodeIncomingMessage
+     * @param socket INodeSocket
+     * @param head INodeBuffer
      */
-    public async create(req: IncomingMessage, socket: Socket, head: Buffer): Promise<void> {
+    public async create(req: INodeIncomingMessage, socket: INodeSocket, head: INodeBuffer): Promise<void> {
         this.wsServer = new WebSocket.Server({ noServer: true });
         return new Promise<void>((resolve, reject) => {
             try {
-                this.wsServer.handleUpgrade(req, socket, head, (websocket) => {
+                this.wsServer.handleUpgrade(req as IncomingMessage, socket as Socket, head as Buffer, (websocket) => {
                     this.wsSocket = websocket;
                     resolve();
                 });
@@ -59,7 +59,7 @@ export class NodeWebSocket implements ISocket {
      *
      * @param buffer The buffer of data to send across the connection.
      */
-    public write(buffer: Buffer): void {
+    public write(buffer: INodeBuffer): void {
         this.wsSocket.send(buffer);
     }
 

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
     "build": "lerna run build",
     "clean": "lerna run clean",
     "functional-test": "lerna run build && nyc mocha \"libraries/functional-tests/tests/*.test.js\"",
-    "test": "lerna run build && nyc mocha \"libraries/bot*/tests/*.test.js\"",
-    "test:coveralls": "lerna run build && nyc mocha \"libraries/bot*/tests/*.test.js\" && nyc report --reporter=text-lcov | coveralls",
-    "test-coverage": "nyc mocha \"libraries/bot*/tests/*.test.js\" ",
+    "test": "lerna run build && nyc mocha \"libraries/bot*/tests/**/*.test.js\"",
+    "test:coveralls": "lerna run build && nyc mocha \"libraries/bot*/tests/**/*.test.js\" && nyc report --reporter=text-lcov | coveralls",
+    "test-coverage": "nyc mocha \"libraries/bot*/tests/**/*.test.js\" ",
     "upload-coverage": "nyc report --reporter=text-lcov | coveralls",
     "build-docs": "lerna run build-docs",
     "eslint": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts",
     "eslint-fix": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts --fix",
-    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ^${Version} botframework-streaming botbuilder botbuilder-choices botbuilder-dialogs botbuilder-core botbuilder-prompts botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ^${Version} botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-testing",
+    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ${Version} botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-core botbuilder-applicationinsights botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ${Version} botbuilder botbuilder-ai botbuilder-dialogs",
     "update-versions": "lerna run set-version && npm run set-dependency-versions"
   },
   "dependencies": {
@@ -33,8 +33,7 @@
     "sinon": "^7.3.2",
     "typedoc": "^0.15.0",
     "typedoc-plugin-external-module-name": "^2.1.0",
-    "typedoc-plugin-markdown": "^2.2.10",
-    "typescript": "^3.5.2"
+    "typedoc-plugin-markdown": "^2.2.10"
   },
   "nyc": {
     "exclude": [

--- a/transcripts/package.json
+++ b/transcripts/package.json
@@ -10,9 +10,9 @@
     "dependencies": {
         "@types/node": "^10.12.18",
         "@types/restify": "^7.2.1",
-        "botbuilder": "^4.2.1",
-        "botbuilder-ai": "^4.2.1",
-        "botbuilder-dialogs": "^4.2.1"
+        "botbuilder": "4.1.6",
+        "botbuilder-ai": "4.1.6",
+        "botbuilder-dialogs": "4.1.6"
     },
     "devDependencies": {
         "mocha": "^5.2.0",


### PR DESCRIPTION
Fixes #1386

## Description
Change entry point for WebSocket Streaming connections from `processActivity()` to only `useWebSocket()`.

useWebSocket() also no longer relies on `restify` to expose the socket and head for WebSocket consumption. As such, it is now a method that should be called in a handler for the ['upgrade'](https://nodejs.org/api/http.html#http_event_upgrade_1) event. (See **Testing** for more information)

useWebSocket() continues to perform the authentication of the WebSocket Upgrade request from the client, and will send back the correct status code and close the socket connection if the `authenticateConnection()` call fails.

## Specific Changes
  - BotFrameworkAdapter.useWebSocket() signature change
    - **from** `public async useWebSocket(req: WebRequest, res: WebResponse, logic: (context: TurnContext) => Promise<any>): Promise<void>`
    - **to** `public async useWebSocket(req: IncomingMessage, socket: Socket, head: Buffer, logic: (context: TurnContext) => Promise<any>): Promise<void>`
  - Remove `restify` dependencies in BotFrameworkAdapter
  - BotFrameworkAdapter.useWebSocket() now sends the correct status code back to the channel when the Upgrade request fails authentication
___
  - Testing:
    - Added test for `BotFrameworkAdapter.useWebSocket()` sad-path via the `this.authenticateConnection()` call.
    - Moved Helper classes out of `botFrameworkAdapterStreaming.test.js` and into separate files
    - Cleaned up tests
    - Finished the removal of using one helper class to cover both HTTP and Streaming Requests

## Testing
Manually tested changes to BotFrameworkAdapter.useWebSocket() with 3 DLS clients concurrently. 

The following code snippet shows the relevant information (i.e. the handling of the `'upgrade'` event from the HTTP Server); but is otherwise derived from the Node.js 02.echo-bot sample.

```js
// Create HTTP server.
const server = restify.createServer();
server.listen(process.env.port || process.env.PORT || 3978, () => {
    console.log(`\n${ server.name } listening to ${ server.url }`);
});

// BotFrameworkAdapterSettings configuration object
// Must have a valid appId and appPassword to use Direct Line Speech
const adapterSettings = {
    appId: process.env.MicrosoftAppId,
    appPassword: process.env.MicrosoftAppPassword
};

const { EchoBot } = require('./bot');
const myBot = new EchoBot();

// Listen for Upgrade requests to the same route to accept Upgrade requests for Streaming.
server.on('upgrade', async (req, socket, head) => {
    // Create an adapter scoped to this WebSocket connection to allow storing session data.
    const streamingAdapter = new BotFrameworkAdapter({
        ...adapterSettings,
        enableWebSockets: true
    });

    try {
        await streamingAdapter.useWebSocket(req, socket, head, async (context) => {
            // After connecting via WebSocket, run this logic for every request sent over
            // the WebSocket connection.
            await myBot.run(context);
        });
    } catch (err) {
        console.error(err);
    }
});
```