### PR TITLE
[4.6.x] Pin TypeScript devDependency in each library. (Fixes #1436)

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -38,7 +38,8 @@
     "nock": "^10.0.3",
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.2"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -39,7 +39,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
-    "typescript": "3.5.2"
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-applicationinsights/package.json
+++ b/libraries/botbuilder-applicationinsights/package.json
@@ -34,7 +34,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
-    "typescript": "3.5.2"
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-applicationinsights/package.json
+++ b/libraries/botbuilder-applicationinsights/package.json
@@ -33,7 +33,8 @@
     "mocha": "^5.2.0",
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.2"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-azure/package.json
+++ b/libraries/botbuilder-azure/package.json
@@ -35,10 +35,11 @@
     "@types/semaphore": "^1.1.0",
     "codelyzer": "^4.1.0",
     "mocha": "^5.2.0",
-    "nyc": "^11.4.1",
     "nock": "^10.0.3",
+    "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.2"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-azure/package.json
+++ b/libraries/botbuilder-azure/package.json
@@ -39,7 +39,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
-    "typescript": "3.5.2"
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-core/package.json
+++ b/libraries/botbuilder-core/package.json
@@ -30,6 +30,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
+    "typescript": "3.5.2",
     "unzip": "^0.1.11"
   },
   "scripts": {

--- a/libraries/botbuilder-core/package.json
+++ b/libraries/botbuilder-core/package.json
@@ -30,7 +30,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
-    "typescript": "3.5.2",
+    "typescript": "3.5.3",
     "unzip": "^0.1.11"
   },
   "scripts": {

--- a/libraries/botbuilder-core/src/skypeMentionNormalizeMiddleware.ts
+++ b/libraries/botbuilder-core/src/skypeMentionNormalizeMiddleware.ts
@@ -5,7 +5,9 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Activity, Middleware, TurnContext } from 'botbuilder-core';
+import { Activity } from 'botframework-schema';
+import { Middleware } from './middlewareSet';
+import { TurnContext } from './turnContext';
 
 
 /**

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -35,7 +35,8 @@
     "mocha": "^5.2.0",
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.2"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -36,7 +36,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
-    "typescript": "3.5.2"
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-testing/package.json
+++ b/libraries/botbuilder-testing/package.json
@@ -34,6 +34,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
+    "typescript": "3.5.2",
     "unzip": "^0.1.11",
     "uuid": "^3.3.2"
   },

--- a/libraries/botbuilder-testing/package.json
+++ b/libraries/botbuilder-testing/package.json
@@ -34,7 +34,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
-    "typescript": "3.5.2",
+    "typescript": "3.5.3",
     "unzip": "^0.1.11",
     "uuid": "^3.3.2"
   },

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -35,7 +35,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
-    "typescript": "3.5.2",
+    "typescript": "3.5.3",
     "uuid": "^3.3.2"
   },
   "scripts": {

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -35,6 +35,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
+    "typescript": "3.5.2",
     "uuid": "^3.3.2"
   },
   "scripts": {

--- a/libraries/botframework-config/package.json
+++ b/libraries/botframework-config/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/uuid": "^3.4.3",
     "mocha": "^5.2.0",
-    "typescript": "3.5.2"
+    "typescript": "3.5.3"
   },
   "dependencies": {
     "fs-extra": "^7.0.0",

--- a/libraries/botframework-config/package.json
+++ b/libraries/botframework-config/package.json
@@ -26,7 +26,8 @@
   },
   "devDependencies": {
     "@types/uuid": "^3.4.3",
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "typescript": "3.5.2"
   },
   "dependencies": {
     "fs-extra": "^7.0.0",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -38,7 +38,8 @@
     "nyc": "^11.4.1",
     "should": "^13.2.3",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.2"
   },
   "scripts": {
     "build": "tsc",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -39,7 +39,7 @@
     "should": "^13.2.3",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
-    "typescript": "3.5.2"
+    "typescript": "3.5.3"
   },
   "scripts": {
     "build": "tsc",

--- a/libraries/botframework-schema/package.json
+++ b/libraries/botframework-schema/package.json
@@ -9,8 +9,9 @@
   ],
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
-  "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "typescript": "3.5.2"
+  },
   "scripts": {
     "build": "tsc",
     "clean": "erase /q /s .\\lib",
@@ -26,6 +27,6 @@
   },
   "files": [
     "/lib",
-    "/src"   
+    "/src"
   ]
 }

--- a/libraries/botframework-schema/package.json
+++ b/libraries/botframework-schema/package.json
@@ -10,7 +10,7 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "devDependencies": {
-    "typescript": "3.5.2"
+    "typescript": "3.5.3"
   },
   "scripts": {
     "build": "tsc",

--- a/libraries/botframework-streaming/package.json
+++ b/libraries/botframework-streaming/package.json
@@ -39,7 +39,8 @@
     "sinon": "^7.4.1",
     "ts-node": "^4.1.0",
     "tslint": "^5.16.0",
-    "tslint-microsoft-contrib": "^5.2.1"
+    "tslint-microsoft-contrib": "^5.2.1",
+    "typescript": "3.5.2"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botframework-streaming/package.json
+++ b/libraries/botframework-streaming/package.json
@@ -40,7 +40,7 @@
     "ts-node": "^4.1.0",
     "tslint": "^5.16.0",
     "tslint-microsoft-contrib": "^5.2.1",
-    "typescript": "3.5.2"
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "sinon": "^7.3.2",
     "typedoc": "^0.15.0",
     "typedoc-plugin-external-module-name": "^2.1.0",
-    "typedoc-plugin-markdown": "^2.2.10",
-    "typescript": "^3.5.2"
+    "typedoc-plugin-markdown": "^2.2.10"
   },
   "nyc": {
     "exclude": [

--- a/transcripts/package.json
+++ b/transcripts/package.json
@@ -10,9 +10,9 @@
     "dependencies": {
         "@types/node": "^10.12.18",
         "@types/restify": "^7.2.1",
-        "botbuilder": "^4.2.1",
-        "botbuilder-ai": "^4.2.1",
-        "botbuilder-dialogs": "^4.2.1"
+        "botbuilder": "4.1.6",
+        "botbuilder-ai": "4.1.6",
+        "botbuilder-dialogs": "4.1.6"
     },
     "devDependencies": {
         "mocha": "^5.2.0",


### PR DESCRIPTION
Fixes #1436

## Description
Pins `typescript` as devDependency in each library to fix bug of transpiling 4.6.1 libraries with 3.7.2.

## Specific Changes
  - Remove `typescript@^3.5.2` devDependency from root package.json
  - Create `typescript@3.5.3` devDependency in each library
  - Change botbuilder, botbuilder-ai and botbuilder-dialogs dependencies in `transcripts/` to instead be `4.1.6`, not `^4.2.1` which led to `4.6.1` botbuilder-js libraries being hoisted at the root
  - Fix uncaught import bug in `botbuilder-core` `SkypeMentionNormalizeMiddleware`
    - The class was importing from `botbuilder-core`, the library it is in
