### PR TITLE
[4.6.x] Fix set-dependency-versions script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-docs": "lerna run build-docs",
     "eslint": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts",
     "eslint-fix": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts --fix",
-    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ^${Version} botframework-streaming botbuilder botbuilder-choices botbuilder-dialogs botbuilder-core botbuilder-prompts botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ^${Version} botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-testing",
+    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ~${Version} botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-core botbuilder-applicationinsights botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ~${Version} botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-testing",
     "update-versions": "lerna run set-version && npm run set-dependency-versions"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-docs": "lerna run build-docs",
     "eslint": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts",
     "eslint-fix": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts --fix",
-    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ~${Version} botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-core botbuilder-applicationinsights botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ~${Version} botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-testing",
+    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ${Version} botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-core botbuilder-applicationinsights botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ${Version} botbuilder botbuilder-ai botbuilder-dialogs",
     "update-versions": "lerna run set-version && npm run set-dependency-versions"
   },
   "dependencies": {


### PR DESCRIPTION
## Description
- Update root package.json "**set-dependency-versions**" script to use `${Version}` instead of `^${Version}`
- Update first half of "**set-dependency-versions**" script: 
    - Replace `botbuilder-choices` & `botbuilder-prompts` with `botbuilder-ai` & `botbuilder-applicationinsights`
- Remove unnecessary packages from second half of `"set-dependency-versions"` script.