### PR TITLE
Fix issue with state manager not being clonned

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/src/sequenceContext.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/sequenceContext.ts
@@ -5,12 +5,14 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { DialogContext, DialogState, DialogSet } from 'botbuilder-dialogs';
+import { DialogContext, DialogState, DialogSet, DialogInstance } from 'botbuilder-dialogs';
 
 export interface AdaptiveDialogState<O extends Object> {
     options: O;
+    _adaptive: {
+        actions?: ActionState[];
+    };
     result?: any;
-    actions?: ActionState[];
 }
 
 export interface ActionState extends DialogState {
@@ -43,28 +45,43 @@ export enum AdaptiveEventNames {
 }
 
 export class SequenceContext<O extends object = {}> extends DialogContext {
-    private readonly changeKey: symbol;
+    private _actions: ActionState[];
+    private _changeKey: symbol;
 
     /**
-     * Creates a new `SequenceContext` instance.
+     * Clones an existing `DialogContext` instance into being a `SequenceContext`.
      */
-    constructor(dialogs: DialogSet, dc: DialogContext, state: DialogState, actions: ActionState[], changeKey: symbol) {
-        super(dialogs, dc.context, state);
-        this.actions = actions;
-        this.changeKey = changeKey;
+    static clone(dc: DialogContext, actions: ActionState[], changeKey: symbol): SequenceContext {
+        const context = new SequenceContext(dc);
+        context._actions = actions;
+        context._changeKey = changeKey;
+        return context;
+    }
+
+    /**
+     * Creates a new `SequenceContext` instance for a child action.
+     */
+    static create(parent: DialogContext, dialogs: DialogSet, stack: DialogInstance<any>[], actions: ActionState[], changeKey: symbol): SequenceContext {
+        const context = new SequenceContext(dialogs, parent.context, { dialogStack: stack });
+        context._actions = actions;
+        context._changeKey = changeKey;
+        context.parent = parent;
+        return context;
     }
 
     /**
      * Array of changes that are queued to be applied
      */
     public get changes(): ActionChangeList[] {
-        return this.context.turnState.get(this.changeKey) || [];
+        return this.context.turnState.get(this._changeKey) || [];
     }
 
     /**
      * Array of actions being executed.
      */
-    public readonly actions: ActionState[];
+    public get actions(): ActionState[] {
+        return this._actions;
+    }
 
     /**
      * Queues up a set of changes that will be applied when [applyChanges()](#applychanges)
@@ -72,9 +89,9 @@ export class SequenceContext<O extends object = {}> extends DialogContext {
      * @param changes Action changes to queue up.
      */
     public queueChanges(changes: ActionChangeList): void {
-        const queue = this.context.turnState.get(this.changeKey) || [];
+        const queue = this.context.turnState.get(this._changeKey) || [];
         queue.push(changes);
-        this.context.turnState.set(this.changeKey, queue);
+        this.context.turnState.set(this._changeKey, queue);
     }
 
     /**
@@ -87,9 +104,9 @@ export class SequenceContext<O extends object = {}> extends DialogContext {
      * @returns true if there were any changes to apply.
      */
     public async applyChanges(): Promise<boolean> {
-        const queue: ActionChangeList[] = this.context.turnState.get(this.changeKey) || [];
+        const queue: ActionChangeList[] = this.context.turnState.get(this._changeKey) || [];
         if (Array.isArray(queue) && queue.length > 0) {
-            this.context.turnState.delete(this.changeKey);
+            this.context.turnState.delete(this._changeKey);
 
             // Apply each queued set of changes
             for (let i = 0; i < queue.length; i++) {

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -80,16 +80,29 @@ export class DialogContext {
     /**
       * Creates an new instance of the [DialogContext](xref:botbuilder-dialogs.DialogContext) class.
       * 
+      * @remarks
+      * Passing in a dialog context instance will clone the dialog context.
       * @param dialogs The dialog set for which to create the dialog context.
       * @param context The context object for the current turn of the bot.
       * @param state The state object to use to read and write dialog state to storage.
+      * @param dialogContext The dialog context to clone.
       */
-    constructor(dialogs: DialogSet, context: TurnContext, state: DialogState) {
-        if (!Array.isArray(state.dialogStack)) { state.dialogStack = []; }
-        this.dialogs = dialogs;
-        this.context = context;
-        this.stack = state.dialogStack;
-        this.state = new DialogStateManager(this);
+     constructor(dialogContext: DialogContext);
+     constructor(dialogs: DialogSet, context: TurnContext, state: DialogState);
+     constructor(dialogsOrDC: DialogSet|DialogContext, context?: TurnContext, state?: DialogState) {
+        if (dialogsOrDC instanceof DialogContext) {
+            this.dialogs = dialogsOrDC.dialogs;
+            this.context = dialogsOrDC.context;
+            this.stack = dialogsOrDC.stack;
+            this.state = dialogsOrDC.state;
+            this.parent = dialogsOrDC.parent;
+        } else {
+            if (!Array.isArray(state.dialogStack)) { state.dialogStack = []; }
+            this.dialogs = dialogsOrDC;
+            this.context = context;
+            this.stack = state.dialogStack;
+            this.state = new DialogStateManager(this);
+        }
     }
 
     /**

--- a/libraries/botbuilder-dialogs/src/waterfallStepContext.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallStepContext.ts
@@ -59,9 +59,8 @@ export class WaterfallStepContext<O extends object = {}> extends DialogContext {
      * @param info Values to initialize the step context with.
      */
     constructor(dc: DialogContext, info: WaterfallStepInfo<O>) {
-        super(dc.dialogs, dc.context, { dialogStack: dc.stack });
+        super(dc);
         this._info = info;
-        this.parent = dc.parent;
     }
 
     /**


### PR DESCRIPTION
We were losing the configured memory scopes when AdaptiveDialog tried to convert a DialogContext into a SequenceContext.  These changes fix the issue by moving the task of cloning a DC into the DC class itself.

I also cleaned up the SequenceContext by adding a couple of static methods to seperate the logic for creating vs. cloning a SequenceContext.

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - 
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->