### PR TITLE
[R7, Cherry-pick] Cherry-pick TypeScript 3.5.3 pin from 4.6 branch

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -38,7 +38,8 @@
     "nock": "^10.0.3",
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-applicationinsights/package.json
+++ b/libraries/botbuilder-applicationinsights/package.json
@@ -33,7 +33,8 @@
     "mocha": "^5.2.0",
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-azure/package.json
+++ b/libraries/botbuilder-azure/package.json
@@ -35,10 +35,11 @@
     "@types/semaphore": "^1.1.0",
     "codelyzer": "^4.1.0",
     "mocha": "^5.2.0",
-    "nyc": "^11.4.1",
     "nock": "^10.0.3",
+    "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-core/package.json
+++ b/libraries/botbuilder-core/package.json
@@ -30,6 +30,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
+    "typescript": "3.5.3",
     "unzip": "^0.1.11"
   },
   "scripts": {

--- a/libraries/botbuilder-core/src/skypeMentionNormalizeMiddleware.ts
+++ b/libraries/botbuilder-core/src/skypeMentionNormalizeMiddleware.ts
@@ -5,7 +5,9 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Activity, Middleware, TurnContext } from 'botbuilder-core';
+import { Activity } from 'botframework-schema';
+import { Middleware } from './middlewareSet';
+import { TurnContext } from './turnContext';
 
 
 /**

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -35,7 +35,8 @@
     "mocha": "^5.2.0",
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/libraries/botbuilder-lg/package.json
+++ b/libraries/botbuilder-lg/package.json
@@ -29,7 +29,8 @@
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.18",
     "nyc": "^11.4.1",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/ --timeout 60000",

--- a/libraries/botbuilder-testing/package.json
+++ b/libraries/botbuilder-testing/package.json
@@ -34,6 +34,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
+    "typescript": "3.5.3",
     "unzip": "^0.1.11",
     "uuid": "^3.3.2"
   },

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -35,6 +35,7 @@
     "nyc": "^11.4.1",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
+    "typescript": "3.5.3",
     "uuid": "^3.3.2"
   },
   "scripts": {

--- a/libraries/botframework-config/package.json
+++ b/libraries/botframework-config/package.json
@@ -26,7 +26,8 @@
   },
   "devDependencies": {
     "@types/uuid": "^3.4.3",
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "typescript": "3.5.3"
   },
   "dependencies": {
     "fs-extra": "^7.0.0",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -38,7 +38,8 @@
     "nyc": "^11.4.1",
     "should": "^13.2.3",
     "source-map-support": "^0.5.3",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "build": "tsc",

--- a/libraries/botframework-expressions/package.json
+++ b/libraries/botframework-expressions/package.json
@@ -35,7 +35,8 @@
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.18",
     "nyc": "^11.4.1",
-    "ts-node": "^4.1.0"
+    "ts-node": "^4.1.0",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "build": "tsc",

--- a/libraries/botframework-schema/package.json
+++ b/libraries/botframework-schema/package.json
@@ -19,8 +19,9 @@
   },
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
-  "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "typescript": "3.5.3"
+  },
   "scripts": {
     "build": "tsc",
     "clean": "erase /q /s .\\lib",
@@ -28,6 +29,6 @@
   },
   "files": [
     "/lib",
-    "/src"   
+    "/src"
   ]
 }

--- a/libraries/botframework-streaming/package.json
+++ b/libraries/botframework-streaming/package.json
@@ -39,7 +39,8 @@
     "sinon": "^7.4.1",
     "ts-node": "^4.1.0",
     "tslint": "^5.16.0",
-    "tslint-microsoft-contrib": "^5.2.1"
+    "tslint-microsoft-contrib": "^5.2.1",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "test": "tsc && nyc mocha tests/",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "sinon": "^7.3.2",
     "typedoc": "^0.15.0",
     "typedoc-plugin-external-module-name": "^2.1.0",
-    "typedoc-plugin-markdown": "^2.2.10",
-    "typescript": "^3.5.2"
+    "typedoc-plugin-markdown": "^2.2.10"
   },
   "nyc": {
     "exclude": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-docs": "lerna run build-docs",
     "eslint": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts",
     "eslint-fix": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts --fix",
-    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ^${Version} botframework-expressions botbuilder-lg botframework-streaming botbuilder botbuilder-choices botbuilder-dialogs botbuilder-core botbuilder-prompts botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ^${Version} botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-testing",
+    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ${Version} botframework-expressions botbuilder-lg botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-core botbuilder-applicationinsights botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ${Version} botbuilder botbuilder-ai botbuilder-dialogs",
     "update-versions": "lerna run set-version && npm run set-dependency-versions"
   },
   "dependencies": {

--- a/transcripts/package.json
+++ b/transcripts/package.json
@@ -10,9 +10,9 @@
     "dependencies": {
         "@types/node": "^10.12.18",
         "@types/restify": "^7.2.1",
-        "botbuilder": "^4.2.1",
-        "botbuilder-ai": "^4.2.1",
-        "botbuilder-dialogs": "^4.2.1"
+        "botbuilder": "4.1.6",
+        "botbuilder-ai": "4.1.6",
+        "botbuilder-dialogs": "4.1.6"
     },
     "devDependencies": {
         "mocha": "^5.2.0",


### PR DESCRIPTION
Fixes #1436

## Description
- Cherry picks #1437, and #1438 to master
- Add `typescript@3.5.3` devDependency to `botbuilder-lg` and `botframework-expressions`

See #1437, #1438 for more information