### PR TITLE
[Skills] add skill support in BotFrameworkAdapter

### DIFF
--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -10,7 +10,7 @@ import { STATUS_CODES } from 'http';
 import * as os from 'os';
 
 import { Activity, ActivityTypes, BotAdapter, BotCallbackHandlerKey, ChannelAccount, ConversationAccount, ConversationParameters, ConversationReference, ConversationsResult, IUserTokenProvider, ResourceResponse, TokenResponse, TurnContext } from 'botbuilder-core';
-import { AuthenticationConstants, ChannelValidation, ConnectorClient, EmulatorApiClient, GovernmentConstants, GovernmentChannelValidation, JwtTokenValidation, MicrosoftAppCredentials, AppCredentials, CertificateAppCredentials, SimpleCredentialProvider, TokenApiClient, TokenStatus, TokenApiModels } from 'botframework-connector';
+import { AuthenticationConfiguration, AuthenticationConstants, ChannelValidation, ClaimsIdentity, ConnectorClient, EmulatorApiClient, GovernmentConstants, GovernmentChannelValidation, JwtTokenValidation, MicrosoftAppCredentials, AppCredentials, CertificateAppCredentials, SimpleCredentialProvider, TokenApiClient, TokenStatus, TokenApiModels, SkillValidation } from 'botframework-connector';
 import { INodeBuffer, INodeSocket, IReceiveRequest, ISocket, IStreamingTransportServer, NamedPipeServer, NodeWebSocketFactory, NodeWebSocketFactoryBase, RequestHandler, StreamingResponse, WebSocketServer } from 'botframework-streaming';
 
 import { StreamingHttpClient, TokenResolver } from './streaming';
@@ -155,6 +155,11 @@ export interface BotFrameworkAdapterSettings {
      * Optional. Certificate key to authenticate the appId against AAD.
      */
     certificatePrivateKey?: string;
+    
+    /**
+     * Optional. Recommended for Skills
+     */
+    authConfig?: AuthenticationConfiguration;
 }
 
 /**
@@ -232,6 +237,8 @@ export const INVOKE_RESPONSE_KEY: symbol = Symbol('invokeResponse');
  * ```
  */
 export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvider, RequestHandler {
+    public static readonly BotIdentityKey: string = 'BotIdentity';
+    public static readonly ConnectorClientKey: string = 'ConnectorClient';
     protected readonly credentials: AppCredentials;
     protected readonly credentialsProvider: SimpleCredentialProvider;
     protected readonly settings: BotFrameworkAdapterSettings;
@@ -667,8 +674,7 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
      * 
      * @returns The [TokenStatus](xref:botframework-connector.TokenStatus) objects retrieved.
      */
-    public async getTokenStatus(context: TurnContext, userId?: string, includeFilter?: string ): Promise<TokenStatus[]>
-    {
+    public async getTokenStatus(context: TurnContext, userId?: string, includeFilter?: string ): Promise<TokenStatus[]> {
         if (!userId && (!context.activity.from || !context.activity.from.id)) {
             throw new Error(`BotFrameworkAdapter.getTokenStatus(): missing from or from.id`);
         }
@@ -785,9 +791,14 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
             const authHeader: string = req.headers.authorization || req.headers.Authorization || '';
             await this.authenticateRequest(request, authHeader);
 
+            const identity = await this.authenticateRequestInternal(request, authHeader);
+            
             // Process received activity
             status = 500;
             const context: TurnContext = this.createContext(request);
+            context.turnState.set(BotFrameworkAdapter.BotIdentityKey, identity);
+            const connectorClient = await this.createConnectorClientWithIdentity(request.serviceUrl, identity);
+            context.turnState.set(BotFrameworkAdapter.ConnectorClientKey, connectorClient);
             context.turnState.set(BotCallbackHandlerKey, logic);
             await this.runMiddleware(context, logic);
 
@@ -968,8 +979,58 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
      * Override this in a derived class to create a mock connector client for unit testing.
      */
     public createConnectorClient(serviceUrl: string): ConnectorClient {
-        if (BotFrameworkAdapter.isStreamingServiceUrl(serviceUrl)) {
+        return this.createConnectorClientInternal(serviceUrl, this.credentials);
+    }
 
+    /**
+     * Create a ConnectorClient with a ClaimsIdentity.
+     * @remarks
+     * If the ClaimsIdentity contains the claims for a Skills request, create a ConnectorClient for use with Skills.
+     * @param serviceUrl 
+     * @param identity ClaimsIdentity
+     */
+    public async createConnectorClientWithIdentity(serviceUrl: string, identity: ClaimsIdentity): Promise<ConnectorClient> {
+        if (!identity) {
+            throw new Error('BotFrameworkAdapter.createConnectorClientWithScope(): invalid identity parameter.');
+        }
+
+        const botAppId = identity.getClaimValue(AuthenticationConstants.AudienceClaim) ||
+            identity.getClaimValue(AuthenticationConstants.AppIdClaim);
+
+        // Anonymous claims and non-skill claims should fall through without modifying the scope.
+        let credentials: AppCredentials = this.credentials;
+
+        // If the request is for skills, we need to create an AppCredentials instance with
+        // the correct scope for communication between the caller and the skill.
+        if (botAppId && SkillValidation.isSkillClaim(identity.claims)) {
+            const scope = JwtTokenValidation.getAppIdFromClaims(identity.claims);
+            if (this.credentials.oAuthScope === scope) {
+                // Do nothing, the current credentials and its scope are valid for the skill.
+                // i.e. the adatper instance is pre-configured to talk with one skill.
+            } else {
+                // Since the scope is different, we will create a new instance of the AppCredentials
+                // so this.credentials.oAuthScope isn't overridden.
+                credentials = await this.getAppCredentials(botAppId, scope);
+
+                if (JwtTokenValidation.isGovernment(this.settings.channelService)) {
+                    credentials.oAuthEndpoint = GovernmentConstants.ToChannelFromBotLoginUrl;
+                    // Not sure that this code is correct because the scope was set earlier.
+                    credentials.oAuthScope = GovernmentConstants.ToChannelFromBotOAuthScope;
+                }
+            }
+        }
+
+        const client: ConnectorClient = this.createConnectorClientInternal(serviceUrl, credentials);
+        return client;
+    }
+
+    /**
+     * @private
+     * @param serviceUrl The client's service URL.
+     * @param credentials AppCredentials instance to construct the ConnectorClient with.
+     */
+    private createConnectorClientInternal(serviceUrl: string, credentials: AppCredentials): ConnectorClient {
+        if (BotFrameworkAdapter.isStreamingServiceUrl(serviceUrl)) {
             // Check if we have a streaming server. Otherwise, requesting a connector client
             // for a non-existent streaming connection results in an error
             if (!this.streamingServer) {
@@ -977,7 +1038,7 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
             }
 
             return new ConnectorClient(
-                this.credentials,
+                credentials,
                 {
                     baseUri: serviceUrl,
                     userAgent: USER_AGENT,
@@ -985,8 +1046,20 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
                 });
         }
 
-        const client: ConnectorClient = new ConnectorClient(this.credentials, { baseUri: serviceUrl, userAgent: USER_AGENT} );
-        return client;
+        return new ConnectorClient(credentials, { baseUri: serviceUrl, userAgent: USER_AGENT });
+    }
+
+    /**
+     * @private
+     * @remarks
+     * @param appId 
+     * @param oAuthScope 
+     */
+    private async getAppCredentials(appId: string, oAuthScope: string = ''): Promise<AppCredentials> {
+        // There is no cache for AppCredentials in JS as opposed to C#.
+        // Instead of retrieving an AppCredentials from the Adapter instance, generate a new one
+        const appPassword = await this.credentialsProvider.getAppPassword(appId);
+        return new MicrosoftAppCredentials(appId, appPassword, oAuthScope);
     }
 
     /**
@@ -1003,17 +1076,31 @@ export class BotFrameworkAdapter extends BotAdapter implements IUserTokenProvide
     }
 
     /**
-     * Allows for the overriding of authentication in unit tests.
+    * Allows for the overriding of authentication in unit tests.
+    * @param request Received request.
+    * @param authHeader Received authentication header.
+    */
+    protected async authenticateRequest(request: Partial<Activity>, authHeader: string): Promise<void> {
+        const claims = await this.authenticateRequestInternal(request, authHeader);
+        if (!claims.isAuthenticated) { throw new Error('Unauthorized Access. Request is not authorized'); }
+    }
+
+    /**
+     * @ignore
+     * @private
+     * Returns the actual ClaimsIdentity from the JwtTokenValidation.authenticateRequest() call.
+     * @remarks
+     * This method is used instead of authenticateRequest() in processActivity() to obtain the ClaimsIdentity for caching in the TurnContext.turnState.
+     * 
      * @param request Received request.
      * @param authHeader Received authentication header.
      */
-    protected async authenticateRequest(request: Partial<Activity>, authHeader: string): Promise<void> {
-        const claims = await JwtTokenValidation.authenticateRequest(
+    private authenticateRequestInternal(request: Partial<Activity>, authHeader: string): Promise<ClaimsIdentity> {
+        return JwtTokenValidation.authenticateRequest(
             request as Activity, authHeader,
             this.credentialsProvider,
             this.settings.channelService
         );
-        if (!claims.isAuthenticated) { throw new Error('Unauthorized Access. Request is not authorized'); }
     }
 
     /**


### PR DESCRIPTION
## Description
Refactoring around BotFrameworkAdapter to add Skill support

## Specific Changes
 - ClaimsIdentity and a ConnectorClient are now cached in the `context.turnState` in `processActivity()`
 - **BotFrameworkAdapter.createConnectorClient()**
    - returns result from createConnectorClientInternal()
 - **private createConnectorClientInternal(serviceUrl: string, credentials: AppCredentials)**
    - Contains logic formerly in createConnectorClient()
    - If the serviceUrl is a streaming URL, it uses the StreamingHttpClient instead of the default HttpClient from ms-rest. (#1464)
 - **public async createConnectorClientWithIdentity(serviceUrl: string, identity: ClaimsIdentity)**
    - Creates a ConnectorClient and uses the ClaimsIdentity to determine if the request was a Skills request
 - **private async getAppCredentials(appId: string, oAuthScope: string = '')**
    - Gets a new AppCredentials for use with skills
    - There is no instance-level cache of AppCredentials per BotFrameworkAdapter, so it currently makes a new AppCredentials instance which is expensive (due to an `adal-node`-level token cache which is confined to the instance of the AppCredentials) 

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->