### PR TITLE
[Streaming] change isConnected() to a getter

### DIFF
--- a/libraries/botframework-streaming/src/interfaces/ITransport.ts
+++ b/libraries/botframework-streaming/src/interfaces/ITransport.ts
@@ -10,6 +10,6 @@
  * Abstraction for a generic transport definition.
  */
 export interface ITransport {
-    isConnected(): boolean;
+    isConnected: boolean;
     close();
 }

--- a/libraries/botframework-streaming/src/namedPipe/namedPipeTransport.ts
+++ b/libraries/botframework-streaming/src/namedPipe/namedPipeTransport.ts
@@ -67,7 +67,7 @@ export class NamedPipeTransport implements ITransportSender, ITransportReceiver 
     /**
      * Returns true if currently connected.
      */
-    public isConnected(): boolean {
+    public get isConnected(): boolean {
         return !(!this._socket || this._socket.destroyed || this._socket.connecting);
     }
 

--- a/libraries/botframework-streaming/src/webSocket/webSocketTransport.ts
+++ b/libraries/botframework-streaming/src/webSocket/webSocketTransport.ts
@@ -60,7 +60,7 @@ export class WebSocketTransport implements ITransportSender, ITransportReceiver 
     /**
      * Returns true if the transport is connected to a socket.
      */
-    public isConnected(): boolean {
+    public get isConnected(): boolean {
         return this._socket.isConnected;
     }
 

--- a/libraries/botframework-streaming/tests/NamedPipe.test.js
+++ b/libraries/botframework-streaming/tests/NamedPipe.test.js
@@ -192,7 +192,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             sock.writable = true;
             let transport = new npt.NamedPipeTransport(sock, 'fakeSocket2');
             expect(transport).to.be.instanceOf(npt.NamedPipeTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             expect( () => transport.close()).to.not.throw;
         });
 
@@ -203,9 +203,8 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             sock.writable = true;
             let transport = new npt.NamedPipeTransport(sock, 'fakeSocket3');
             expect(transport).to.be.instanceOf(npt.NamedPipeTransport);
-            expect( transport.close()).to.not.throw;
-            let exists = transport.isConnected();
-            expect(exists).to.be.false;
+            expect(transport.close()).to.not.throw;
+            expect(transport.isConnected).to.be.false;
         });
 
         it('writes to the socket', () => {
@@ -215,7 +214,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             sock.writable = true;
             let transport = new npt.NamedPipeTransport(sock, 'fakeSocket4');
             expect(transport).to.be.instanceOf(npt.NamedPipeTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             let buff = Buffer.from('hello', 'utf8');
             let sent = transport.send(buff);
             expect(sent).to.equal(5);
@@ -229,7 +228,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             sock.writable = true;
             let transport = new npt.NamedPipeTransport(sock, 'fakeSocket5');
             expect(transport).to.be.instanceOf(npt.NamedPipeTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             sock.writable = false;
             let buff = Buffer.from('hello', 'utf8');
             let sent = transport.send(buff);
@@ -244,7 +243,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             sock.writable = true;
             let transport = new npt.NamedPipeTransport(sock, 'fakeSocket5');
             expect(transport).to.be.instanceOf(npt.NamedPipeTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             expect(transport.receive(5)).to.throw;
             expect( () => transport.close()).to.not.throw;
         });
@@ -256,7 +255,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             sock.writable = true;
             let transport = new npt.NamedPipeTransport(sock);
             expect(transport).to.be.instanceOf(npt.NamedPipeTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             transport.receive(12).catch();
             transport.socketReceive(Buffer.from('Hello World!', 'utf8'));
 
@@ -271,7 +270,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             sock.writable = true;
             let transport = new npt.NamedPipeTransport(sock, 'fakeSocket6');
             expect(transport).to.be.instanceOf(npt.NamedPipeTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             transport.socketClose();
             expect(transport._active).to.be.null;
             expect(transport._activeReceiveResolve).to.be.null;
@@ -288,7 +287,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             sock.writable = true;
             let transport = new npt.NamedPipeTransport(sock, 'fakeSocket6');
             expect(transport).to.be.instanceOf(npt.NamedPipeTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             transport.socketError();
             expect(transport._active).to.be.null;
             expect(transport._activeReceiveResolve).to.be.null;
@@ -305,7 +304,7 @@ describe('Streaming Extensions NamedPipe Library Tests', () => {
             sock.writable = true;
             let transport = new npt.NamedPipeTransport(sock, 'fakeSocket6');
             expect(transport).to.be.instanceOf(npt.NamedPipeTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             let buff = Buffer.from('hello', 'utf8');
             expect(transport.socketReceive(buff)).to.not.throw;
         });

--- a/libraries/botframework-streaming/tests/WebSocket.test.js
+++ b/libraries/botframework-streaming/tests/WebSocket.test.js
@@ -32,7 +32,7 @@ describe('Streaming Extensions WebSocket Library Tests', () => {
             sock.writable = true;
             let transport = new wst.WebSocketTransport(sock);
             expect(transport).to.be.instanceOf(wst.WebSocketTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             expect( () => transport.close()).to.not.throw;
         });
 
@@ -43,9 +43,8 @@ describe('Streaming Extensions WebSocket Library Tests', () => {
             sock.writable = true;
             let transport = new wst.WebSocketTransport(sock);
             expect(transport).to.be.instanceOf(wst.WebSocketTransport);
-            expect( transport.close()).to.not.throw;
-            let exists = transport.isConnected();
-            expect(exists).to.be.false;
+            expect(transport.close()).to.not.throw;
+            expect(transport.isConnected).to.be.false;
         });
 
         it('writes to the socket', () => {
@@ -55,7 +54,7 @@ describe('Streaming Extensions WebSocket Library Tests', () => {
             sock.writable = true;
             let transport = new wst.WebSocketTransport(sock);
             expect(transport).to.be.instanceOf(wst.WebSocketTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             let buff = Buffer.from('hello', 'utf8');
             let sent = transport.send(buff);
             expect(sent).to.equal(5);
@@ -69,7 +68,7 @@ describe('Streaming Extensions WebSocket Library Tests', () => {
             sock.writable = true;
             let transport = new wst.WebSocketTransport(sock);
             expect(transport).to.be.instanceOf(wst.WebSocketTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             sock.writable = false;
             sock.connected = false;
             let buff = Buffer.from('hello', 'utf8');
@@ -85,7 +84,7 @@ describe('Streaming Extensions WebSocket Library Tests', () => {
             sock.writable = true;
             let transport = new wst.WebSocketTransport(sock);
             expect(transport).to.be.instanceOf(wst.WebSocketTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             expect(transport.receive(5)).to.throw;
             expect( () => transport.close()).to.not.throw;
         });
@@ -97,7 +96,7 @@ describe('Streaming Extensions WebSocket Library Tests', () => {
             sock.writable = true;
             let transport = new wst.WebSocketTransport(sock);
             expect(transport).to.be.instanceOf(wst.WebSocketTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             transport.receive(12).catch();
             transport.onReceive(Buffer.from('{"VERB":"POST", "PATH":"somewhere/something"}', 'utf8'));
 
@@ -111,7 +110,7 @@ describe('Streaming Extensions WebSocket Library Tests', () => {
             sock.writable = true;
             let transport = new wst.WebSocketTransport(sock);
             expect(transport).to.be.instanceOf(wst.WebSocketTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             transport.onClose();
             expect(transport._active).to.be.null;
             expect(transport._activeReceiveResolve).to.be.null;
@@ -128,7 +127,7 @@ describe('Streaming Extensions WebSocket Library Tests', () => {
             sock.writable = true;
             let transport = new wst.WebSocketTransport(sock);
             expect(transport).to.be.instanceOf(wst.WebSocketTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             transport.onError();
             expect(transport._active).to.be.null;
             expect(transport._activeReceiveResolve).to.be.null;
@@ -145,7 +144,7 @@ describe('Streaming Extensions WebSocket Library Tests', () => {
             sock.writable = true;
             let transport = new wst.WebSocketTransport(sock);
             expect(transport).to.be.instanceOf(wst.WebSocketTransport);
-            expect(transport.isConnected()).to.be.true;
+            expect(transport.isConnected).to.be.true;
             let buff = Buffer.from('hello', 'utf8');
             expect(transport.onReceive(buff)).to.not.throw;
         });


### PR DESCRIPTION
Fixes #1427

## Description
Convert `isConnected` function into getter.

## Testing
Touched up unit tests to not call isConnected, tested with multiple DLS connections to a bot.