### PR TITLE
build: add preview package support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-docs": "lerna run build-docs",
     "eslint": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts",
     "eslint-fix": "eslint  ./libraries/*/src/*.ts ./libraries/*/src/**/*.ts --fix",
-    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ${Version} botframework-expressions botbuilder-lg botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-core botbuilder-applicationinsights botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ${Version} botbuilder botbuilder-ai botbuilder-dialogs",
+    "set-dependency-versions": "node tools/util/updateDependenciesInPackageJsons.js ./libraries ${Version} ${PreviewPackageVersion} botframework-expressions botbuilder-lg botframework-streaming botbuilder botbuilder-ai botbuilder-dialogs botbuilder-core botbuilder-applicationinsights botbuilder-testing botframework-connector botframework-config botframework-schema testbot && node tools/util/updateDependenciesInPackageJsons.js ./transcripts ${Version} botbuilder botbuilder-ai botbuilder-dialogs",
     "update-versions": "lerna run set-version && npm run set-dependency-versions"
   },
   "dependencies": {

--- a/tools/util/updateDependenciesInPackageJsons.js
+++ b/tools/util/updateDependenciesInPackageJsons.js
@@ -14,8 +14,7 @@ if(previewVersion === 'botframework-expressions') {
 }
 var previewPackages = {
     'botbuilder-lg': true,
-    'botframework-expressions': true,
-    'botframework-streaming': true
+    'botframework-expressions': true
 }
 var dependencies = myArgs.slice(previewVersion ? 3 : 2);
 console.log('newVersion =', newVersion);

--- a/tools/util/updateDependenciesInPackageJsons.js
+++ b/tools/util/updateDependenciesInPackageJsons.js
@@ -7,13 +7,13 @@ console.log('Started ' + (new Date()));
 var myArgs = process.argv.slice(2);
 var rootPath = myArgs[0];
 var newVersion = myArgs[1];
-var previewVersion = process.env.PreviewPackageVersion;
+var previewVersion = myArgs[2] || process.env.PreviewPackageVersion;
 var previewPackages = {
     'botbuilder-lg': true,
     'botframework-expressions': true,
     'botframework-streaming': true
 }
-var dependencies = myArgs.slice(2);
+var dependencies = myArgs.slice(3);
 console.log('newVersion =', newVersion);
 console.log('previewVersion = ' + previewVersion);
 console.log('dependencies =');

--- a/tools/util/updateDependenciesInPackageJsons.js
+++ b/tools/util/updateDependenciesInPackageJsons.js
@@ -8,12 +8,16 @@ var myArgs = process.argv.slice(2);
 var rootPath = myArgs[0];
 var newVersion = myArgs[1];
 var previewVersion = myArgs[2] || process.env.PreviewPackageVersion;
+// This is a hack to deal with the inconsistencies between CI and daily builds right now
+if(previewVersion === 'botframework-expressions') {
+    previewVersion = undefined;
+}
 var previewPackages = {
     'botbuilder-lg': true,
     'botframework-expressions': true,
     'botframework-streaming': true
 }
-var dependencies = myArgs.slice(3);
+var dependencies = myArgs.slice(previewVersion ? 3 : 2);
 console.log('newVersion =', newVersion);
 console.log('previewVersion = ' + previewVersion);
 console.log('dependencies =');

--- a/tools/util/updateDependenciesInPackageJsons.js
+++ b/tools/util/updateDependenciesInPackageJsons.js
@@ -15,8 +15,11 @@ var previewPackages = {
 }
 var dependencies = myArgs.slice(2);
 console.log('newVersion =', newVersion);
+console.log('previewVersion = ' + previewVersion);
 console.log('dependencies =');
 console.log(dependencies);
+console.log('Preview packages: ');
+console.log(JSON.stringify(previewPackages, null, ' '));
 
 // Update versions for specified dependencies in package.json file
 function updateDependencies(filePath) {
@@ -26,10 +29,13 @@ function updateDependencies(filePath) {
             return console.log(err);
         }
 
+        console.log('Updating file: ' + filePath);
+
         var result = '';
         dependencies.forEach(function (dependency) {
             var findString = new RegExp('("dependencies":)(.+?)("' + dependency + '":\\s*")([^\/"]+)', 'gms')
             var replaceString = '$1$2$3' + ((previewVersion && previewPackages[dependency]) ? previewVersion : newVersion);
+            console.log('Replace string: ' + replaceString);
             result = data.replace(findString, replaceString);
             data = result;
         });

--- a/tools/util/updateDependenciesInPackageJsons.js
+++ b/tools/util/updateDependenciesInPackageJsons.js
@@ -7,6 +7,12 @@ console.log('Started ' + (new Date()));
 var myArgs = process.argv.slice(2);
 var rootPath = myArgs[0];
 var newVersion = myArgs[1];
+var previewVersion = process.env.PreviewPackageVersion;
+var previewPackages = {
+    'botbuilder-lg': true,
+    'botframework-expressions': true,
+    'botframework-streaming': true
+}
 var dependencies = myArgs.slice(2);
 console.log('newVersion =', newVersion);
 console.log('dependencies =');
@@ -22,8 +28,8 @@ function updateDependencies(filePath) {
 
         var result = '';
         dependencies.forEach(function (dependency) {
-            var findString = new RegExp('("dependencies":)(.+?)("' + dependency + '":\\s*")([^\/"]+)', "gms")
-            var replaceString = '$1$2$3' + newVersion;
+            var findString = new RegExp('("dependencies":)(.+?)("' + dependency + '":\\s*")([^\/"]+)', 'gms')
+            var replaceString = '$1$2$3' + ((previewVersion && previewPackages[dependency]) ? previewVersion : newVersion);
             result = data.replace(findString, replaceString);
             data = result;
         });


### PR DESCRIPTION
## Description

Adjusted dependency updater to take a preview version for a hardcoded list of preview packages.

This is not ideal and is a spot fix for 4.7 release.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - update ./tools/utils/updateDependenciesInPackageJsons.js to take in an env var for preview version and conditionally use that version for a fixed set of packages

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
None. Will test via CI pipeline. 🤡