### PR TITLE
[Dialogs] add vendor/ to botbuilder-dialogs incl. files

### DIFF
--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -46,6 +46,7 @@
   },
   "files": [
     "/lib",
-    "/src"
+    "/src",
+    "/vendor"
   ]
 }


### PR DESCRIPTION
## Description
The cldr-data files were not included in the `npm pack` which meant the `botbuilder-dialogs` library would fail at runtime.

## Testing
Manually packed and inspected contents which contained the `vendor/` folder as expected.