### PR TITLE
fix casing on relative import references for NamedPipeTransport

### DIFF
--- a/libraries/botframework-streaming/src/namedPipe/namedPipeClient.ts
+++ b/libraries/botframework-streaming/src/namedPipe/namedPipeClient.ts
@@ -14,7 +14,7 @@ import {
     PayloadReceiver,
     PayloadSender
 } from '../payloadTransport';
-import { NamedPipeTransport } from './NamedPipeTransport';
+import { NamedPipeTransport } from './namedPipeTransport';
 import { IStreamingTransportClient, IReceiveResponse } from '../interfaces';
 
 /**

--- a/libraries/botframework-streaming/src/namedPipe/namedPipeServer.ts
+++ b/libraries/botframework-streaming/src/namedPipe/namedPipeServer.ts
@@ -14,7 +14,7 @@ import {
     PayloadReceiver,
     PayloadSender
 } from '../payloadTransport';
-import { NamedPipeTransport } from './NamedPipeTransport';
+import { NamedPipeTransport } from './namedPipeTransport';
 import { IStreamingTransportServer, IReceiveResponse } from '../interfaces';
 
 /**


### PR DESCRIPTION
## Description
Fixes duplicate https://github.com/Microsoft/TypeScript/issues/18678 for NamedPipeTransport in Streaming library.

## Specific Changes
  - Fix incorrect relative imports of NamedPipeTransport. 

## Testing
Build and manually inspected code for irregularities