### PR TITLE
Cleanup in botbuilder

### DIFF
--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -13,6 +13,7 @@ import { Activity, ActivityTypes, BotAdapter, BotCallbackHandlerKey, ChannelAcco
 import { AuthenticationConfiguration, AuthenticationConstants, ChannelValidation, ClaimsIdentity, ConnectorClient, EmulatorApiClient, GovernmentConstants, GovernmentChannelValidation, JwtTokenValidation, MicrosoftAppCredentials, AppCredentials, CertificateAppCredentials, SimpleCredentialProvider, TokenApiClient, TokenStatus, TokenApiModels, SkillValidation } from 'botframework-connector';
 import { INodeBuffer, INodeSocket, IReceiveRequest, ISocket, IStreamingTransportServer, NamedPipeServer, NodeWebSocketFactory, NodeWebSocketFactoryBase, RequestHandler, StreamingResponse, WebSocketServer } from 'botframework-streaming';
 
+import { InvokeResponse, WebRequest, WebResponse } from './interfaces';
 import { StreamingHttpClient, TokenResolver } from './streaming';
 
 export enum StatusCodes {
@@ -31,90 +32,6 @@ export class StatusCodeError extends Error {
         super(message);
         this.statusCode = statusCode;
     }
-}
-
-/**
- * Represents an Express or Restify request object.
- * 
- * This interface supports the framework and is not intended to be called directly for your code.
- */
-export interface WebRequest {
-    /**
-     * Optional. The request body.
-     */
-    body?: any;
-
-    /***
-     * Optional. The request headers.
-     */
-    headers: any;
-
-    /***
-     * Optional. The request method.
-     */
-    method?: any;
-
-    /***
-     * Optional. The request parameters from the url.
-     */
-    params?: any;
-
-    /***
-     * Optional. The values from the query string.
-     */
-    query?: any;
-
-    /**
-     * When implemented in a derived class, adds a listener for an event.
-     * The framework uses this method to retrieve the request body when the
-     * [body](xref:botbuilder.WebRequest.body) property is `null` or `undefined`.
-     * 
-     * @param event The event name.
-     * @param args Arguments used to handle the event.
-     * 
-     * @returns A reference to the request object.
-     */
-    on(event: string, ...args: any[]): any;
-}
-
-/**
- * Represents an Express or Restify response object.
- * 
- * This interface supports the framework and is not intended to be called directly for your code.
- */
-export interface WebResponse {
-    /**
-     * 
-     * Optional. The underlying socket.
-     */
-    socket?: any;
-
-    /**
-     * When implemented in a derived class, sends a FIN packet.
-     * 
-     * @param args The arguments for the end event.
-     * 
-     * @returns A reference to the response object.
-     */
-    end(...args: any[]): any;
-
-    /**
-     * When implemented in a derived class, sends the response.
-     * 
-     * @param body The response payload.
-     * 
-     * @returns A reference to the response object.
-     */
-    send(body: any): any;
-
-    /**
-     * When implemented in a derived class, sets the HTTP status code for the response.
-     * 
-     * @param status The status code to use.
-     * 
-     * @returns The status code.
-     */
-    status(status: number): any;
 }
 
 /**
@@ -170,23 +87,6 @@ export interface BotFrameworkAdapterSettings {
      * Optional. Used to require specific endorsements and verify claims. Recommended for Skills.
      */
     authConfig?: AuthenticationConfiguration;
-}
-
-/**
- * Represents a response returned by a bot when it receives an `invoke` activity.
- * 
- * This interface supports the framework and is not intended to be called directly for your code.
- */
-export interface InvokeResponse {
-    /**
-     * The HTTP status code of the response.
-     */
-    status: number;
-
-    /**
-     * Optional. The body of the response.
-     */
-    body?: any;
 }
 
 // Retrieve additional information, i.e., host operating system, host OS release, architecture, Node.js version

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -14,7 +14,7 @@ import { AuthenticationConfiguration, AuthenticationConstants, ChannelValidation
 import { INodeBuffer, INodeSocket, IReceiveRequest, ISocket, IStreamingTransportServer, NamedPipeServer, NodeWebSocketFactory, NodeWebSocketFactoryBase, RequestHandler, StreamingResponse, WebSocketServer } from 'botframework-streaming';
 
 import { InvokeResponse, WebRequest, WebResponse } from './interfaces';
-import { StreamingHttpClient, TokenResolver } from './streaming';
+import { defaultPipeName, GET, POST, MESSAGES_PATH, StreamingHttpClient, TokenResolver, VERSION_PATH } from './streaming';
 
 export enum StatusCodes {
     OK = 200,
@@ -101,13 +101,6 @@ export const USER_AGENT: string = `Microsoft-BotFramework/3.1 BotBuilder/${ pjso
     `(Node.js,Version=${ NODE_VERSION }; ${ TYPE } ${ RELEASE }; ${ ARCHITECTURE })`;
 const OAUTH_ENDPOINT = 'https://api.botframework.com';
 const US_GOV_OAUTH_ENDPOINT = 'https://api.botframework.azure.us';
-
-// Streaming-specific constants
-const defaultPipeName = 'bfv4.pipes';
-const VERSION_PATH: string = '/api/version';
-const MESSAGES_PATH: string = '/api/messages';
-const GET: string = 'GET';
-const POST: string = 'POST';
 
 // This key is exported internally so that the TeamsActivityHandler will not overwrite any already set InvokeResponses.
 export const INVOKE_RESPONSE_KEY: symbol = Symbol('invokeResponse');

--- a/libraries/botbuilder/src/botFrameworkHttpClient.ts
+++ b/libraries/botbuilder/src/botFrameworkHttpClient.ts
@@ -16,7 +16,8 @@ import {
     MicrosoftAppCredentials
 } from 'botframework-connector';
 
-import { InvokeResponse, USER_AGENT } from './botFrameworkAdapter';
+import { USER_AGENT } from './botFrameworkAdapter';
+import { InvokeResponse } from './interfaces';
 
 /**
  * HttpClient for calling skills from a Node.js BotBuilder V4 SDK bot.

--- a/libraries/botbuilder/src/channelServiceRoutes.ts
+++ b/libraries/botbuilder/src/channelServiceRoutes.ts
@@ -6,9 +6,11 @@
  * Licensed under the MIT License.
  */
 
-import { ChannelServiceHandler } from './channelServiceHandler';
 import { Activity, ConversationParameters, Transcript, AttachmentData } from 'botbuilder-core';
-import { WebRequest, WebResponse, StatusCodeError, StatusCodes } from './botFrameworkAdapter';
+
+import { ChannelServiceHandler } from './channelServiceHandler';
+import { StatusCodeError, StatusCodes } from './botFrameworkAdapter';
+import { WebRequest, WebResponse } from './interfaces';
 
 export type RouteHandler = (request: WebRequest, response: WebResponse) => void;
 

--- a/libraries/botbuilder/src/index.ts
+++ b/libraries/botbuilder/src/index.ts
@@ -24,7 +24,7 @@ export {
     WebResponse
 } from './interfaces';
 export * from './skills';
-export * from './streaming';
+export { StreamingHttpClient, TokenResolver } from './streaming';
 export * from './teamsActivityHandler';
 export * from './teamsActivityHelpers';
 export * from './teamsInfo';

--- a/libraries/botbuilder/src/index.ts
+++ b/libraries/botbuilder/src/index.ts
@@ -9,18 +9,20 @@
 export {
     BotFrameworkAdapter,
     BotFrameworkAdapterSettings,
-    InvokeResponse,
     INVOKE_RESPONSE_KEY,
     StatusCodes,
     StatusCodeError,
-    WebRequest,
-    WebResponse
 } from './botFrameworkAdapter';
 export { BotFrameworkHttpClient } from './botFrameworkHttpClient';
 export { ChannelServiceHandler } from './channelServiceHandler';
 export { ChannelServiceRoutes, RouteHandler, WebServer } from './channelServiceRoutes';
 export * from './fileTranscriptStore';
 export * from './inspectionMiddleware';
+export {
+    InvokeResponse,
+    WebRequest,
+    WebResponse
+} from './interfaces';
 export * from './skills';
 export * from './streaming';
 export * from './teamsActivityHandler';

--- a/libraries/botbuilder/src/interfaces/index.ts
+++ b/libraries/botbuilder/src/interfaces/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @module botbuilder
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export * from './invokeResponse';
+export * from './webRequest';
+export * from './webResponse';

--- a/libraries/botbuilder/src/interfaces/invokeResponse.ts
+++ b/libraries/botbuilder/src/interfaces/invokeResponse.ts
@@ -1,0 +1,24 @@
+/**
+ * @module botbuilder
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Represents a response returned by a bot when it receives an `invoke` activity.
+ * 
+ * This interface supports the framework and is not intended to be called directly for your code.
+ */
+export interface InvokeResponse {
+    /**
+     * The HTTP status code of the response.
+     */
+    status: number;
+
+    /**
+     * Optional. The body of the response.
+     */
+    body?: any;
+}

--- a/libraries/botbuilder/src/interfaces/webRequest.ts
+++ b/libraries/botbuilder/src/interfaces/webRequest.ts
@@ -1,0 +1,51 @@
+/**
+ * @module botbuilder
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Represents an Express or Restify request object.
+ * 
+ * This interface supports the framework and is not intended to be called directly for your code.
+ */
+export interface WebRequest {
+    /**
+     * Optional. The request body.
+     */
+    body?: any;
+
+    /***
+     * Optional. The request headers.
+     */
+    headers: any;
+
+    /***
+     * Optional. The request method.
+     */
+    method?: any;
+
+    /***
+     * Optional. The request parameters from the url.
+     */
+    params?: any;
+
+    /***
+     * Optional. The values from the query string.
+     */
+    query?: any;
+
+    /**
+     * When implemented in a derived class, adds a listener for an event.
+     * The framework uses this method to retrieve the request body when the
+     * [body](xref:botbuilder.WebRequest.body) property is `null` or `undefined`.
+     * 
+     * @param event The event name.
+     * @param args Arguments used to handle the event.
+     * 
+     * @returns A reference to the request object.
+     */
+    on(event: string, ...args: any[]): any;
+}

--- a/libraries/botbuilder/src/interfaces/webResponse.ts
+++ b/libraries/botbuilder/src/interfaces/webResponse.ts
@@ -1,0 +1,47 @@
+/**
+ * @module botbuilder
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Represents an Express or Restify response object.
+ * 
+ * This interface supports the framework and is not intended to be called directly for your code.
+ */
+export interface WebResponse {
+    /**
+     * 
+     * Optional. The underlying socket.
+     */
+    socket?: any;
+
+    /**
+     * When implemented in a derived class, sends a FIN packet.
+     * 
+     * @param args The arguments for the end event.
+     * 
+     * @returns A reference to the response object.
+     */
+    end(...args: any[]): any;
+
+    /**
+     * When implemented in a derived class, sends the response.
+     * 
+     * @param body The response payload.
+     * 
+     * @returns A reference to the response object.
+     */
+    send(body: any): any;
+
+    /**
+     * When implemented in a derived class, sets the HTTP status code for the response.
+     * 
+     * @param status The status code to use.
+     * 
+     * @returns The status code.
+     */
+    status(status: number): any;
+}

--- a/libraries/botbuilder/src/skills/skillHttpClient.ts
+++ b/libraries/botbuilder/src/skills/skillHttpClient.ts
@@ -7,9 +7,9 @@
  */
 import { Activity, ConversationReference, TurnContext } from 'botbuilder-core';
 import { ICredentialProvider } from 'botframework-connector';
-import { InvokeResponse } from '../botFrameworkAdapter';
 import { BotFrameworkHttpClient } from '../botFrameworkHttpClient';
 import { BotFrameworkSkill } from './botFrameworkSkill';
+import { InvokeResponse } from '../interfaces';
 import { SkillConversationIdFactoryBase } from './skillConversationIdFactoryBase';    
 
 /**

--- a/libraries/botbuilder/src/streaming/constants.ts
+++ b/libraries/botbuilder/src/streaming/constants.ts
@@ -1,0 +1,13 @@
+/**
+ * @module botbuilder
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export const defaultPipeName = 'bfv4.pipes';
+export const VERSION_PATH: string = '/api/version';
+export const MESSAGES_PATH: string = '/api/messages';
+export const GET: string = 'GET';
+export const POST: string = 'POST';

--- a/libraries/botbuilder/src/streaming/index.ts
+++ b/libraries/botbuilder/src/streaming/index.ts
@@ -6,5 +6,6 @@
  * Licensed under the MIT License.
  */
 
+export * from './constants';
 export * from './streamingHttpClient';
 export * from './tokenResolver';

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -6,13 +6,12 @@
  * Licensed under the MIT License.
  */
 
-import { InvokeResponse, INVOKE_RESPONSE_KEY } from './botFrameworkAdapter';
+import { INVOKE_RESPONSE_KEY } from './botFrameworkAdapter';
 
 import {
     ActivityHandler,
     ActivityTypes,
     AppBasedLinkQuery,
-    ChannelAccount,
     ChannelInfo,
     FileConsentCardResponse,
     MessagingExtensionAction,
@@ -21,15 +20,14 @@ import {
     MessagingExtensionResponse,
     O365ConnectorCardActionQuery,
     SigninStateVerificationQuery,
-    TaskModuleTaskInfo,
     TaskModuleRequest,
     TaskModuleResponse,
-    TaskModuleResponseBase,
     TeamsChannelData,
     TeamsChannelAccount,
     TeamInfo,
     TurnContext
 } from 'botbuilder-core';
+import { InvokeResponse } from './interfaces';
 import { TeamsInfo } from './teamsInfo';
 
 export class TeamsActivityHandler extends ActivityHandler {


### PR DESCRIPTION
## Description
Cleanup in `botbuilder`

## Specific Changes
  - https://github.com/microsoft/botbuilder-js/commit/1380be6b2a93e8e107673d52db4b363a0f4dfcc5
    - Move `InvokeResponse`, `WebRequest`, `WebResponse` into individual files in new `interfaces/` folder.
  - https://github.com/microsoft/botbuilder-js/commit/ec07d7eee9663a1b09b5f764d868a1daf45f3dc7
    - Move **INTERNAL** streaming constants out of BotFrameworkAdapter and into `streaming/constants.ts`

## Testing
Rebuilt libraries and locally re-ran tests.