### PR TITLE
Fresh French Number PR

### DIFF
--- a/libraries/botbuilder-dialogs/scripts/gen-cldr-data.js
+++ b/libraries/botbuilder-dialogs/scripts/gen-cldr-data.js
@@ -1,6 +1,7 @@
-/*
+/* 
 import * as Chinese from 'cldr-data/main/zh/numbers.json';
 import * as English from 'cldr-data/main/en/numbers.json';
+import * as French from 'cldr-data/main/fr/numbers.json';
 import * as Dutch from 'cldr-data/main/nl/numbers.json';
 import * as German from 'cldr-data/main/de/numbers.json';
 import * as Japanese from 'cldr-data/main/ja/numbers.json';
@@ -37,6 +38,7 @@ const cldrDataPackageVersion = '35.1.0';
 const numbersDirectoryPaths = [
     'main/zh',
     'main/en',
+    'main/fr',
     'main/nl',
     'main/de',
     'main/ja',

--- a/libraries/botbuilder-dialogs/src/i18n.ts
+++ b/libraries/botbuilder-dialogs/src/i18n.ts
@@ -7,6 +7,7 @@
  */
 const Chinese = require('../vendor/cldr-data/main/zh/numbers.json');
 const English = require('../vendor/cldr-data/main/en/numbers.json');
+const French = require('../vendor/cldr-data/main/fr/numbers.json');
 const German = require('../vendor/cldr-data/main/de/numbers.json');
 const Dutch = require('../vendor/cldr-data/main/nl/numbers.json');
 const Japanese = require('../vendor/cldr-data/main/ja/numbers.json');
@@ -15,4 +16,4 @@ const NumberingSystem = require('../vendor/cldr-data/supplemental/numberingSyste
 const Portuguese = require('../vendor/cldr-data/main/pt/numbers.json');
 const Spanish = require('../vendor/cldr-data/main/es/numbers.json');
 
-export { Chinese, English, German, Dutch, Japanese, LikelySubtags, NumberingSystem, Portuguese, Spanish }
+export { Chinese, English, French, German, Dutch, Japanese, LikelySubtags, NumberingSystem, Portuguese, Spanish }

--- a/libraries/botbuilder-dialogs/src/prompts/numberPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/numberPrompt.ts
@@ -9,11 +9,11 @@ import * as Recognizers from '@microsoft/recognizers-text-number';
 import { Activity, InputHints, TurnContext } from 'botbuilder-core';
 import { Prompt, PromptOptions, PromptRecognizerResult, PromptValidator } from './prompt';
 
-import { Chinese, Dutch, English, German, Japanese, LikelySubtags, NumberingSystem, Portuguese, Spanish } from "../i18n";
+import { Chinese, Dutch, English, French, German, Japanese, LikelySubtags, NumberingSystem, Portuguese, Spanish } from "../i18n";
 
 import * as Globalize from 'globalize';
 Globalize.load(
-    Chinese, English, Dutch, German, Japanese, LikelySubtags, NumberingSystem, Portuguese, Spanish    
+    Chinese, English, Dutch, French, German, Japanese, LikelySubtags, NumberingSystem, Portuguese, Spanish    
 );
 
 /**

--- a/libraries/botbuilder-dialogs/vendor/cldr-data/main/fr/numbers.json
+++ b/libraries/botbuilder-dialogs/vendor/cldr-data/main/fr/numbers.json
@@ -1,0 +1,157 @@
+{
+  "main": {
+    "fr": {
+      "identity": {
+        "version": {
+          "_number": "$Revision: 14982 $",
+          "_cldrVersion": "35.1"
+        },
+        "language": "fr"
+      },
+      "numbers": {
+        "defaultNumberingSystem": "latn",
+        "otherNumberingSystems": {
+          "native": "latn"
+        },
+        "minimumGroupingDigits": "1",
+        "symbols-numberSystem-latn": {
+          "decimal": ",",
+          "group": " ",
+          "list": ";",
+          "percentSign": "%",
+          "plusSign": "+",
+          "minusSign": "-",
+          "exponential": "E",
+          "superscriptingExponent": "×",
+          "perMille": "‰",
+          "infinity": "∞",
+          "nan": "NaN",
+          "timeSeparator": ":"
+        },
+        "decimalFormats-numberSystem-latn": {
+          "standard": "#,##0.###",
+          "long": {
+            "decimalFormat": {
+              "1000-count-one": "0 millier",
+              "1000-count-other": "0 mille",
+              "10000-count-one": "00 mille",
+              "10000-count-other": "00 mille",
+              "100000-count-one": "000 mille",
+              "100000-count-other": "000 mille",
+              "1000000-count-one": "0 million",
+              "1000000-count-other": "0 millions",
+              "10000000-count-one": "00 million",
+              "10000000-count-other": "00 millions",
+              "100000000-count-one": "000 million",
+              "100000000-count-other": "000 millions",
+              "1000000000-count-one": "0 milliard",
+              "1000000000-count-other": "0 milliards",
+              "10000000000-count-one": "00 milliard",
+              "10000000000-count-other": "00 milliards",
+              "100000000000-count-one": "000 milliard",
+              "100000000000-count-other": "000 milliards",
+              "1000000000000-count-one": "0 billion",
+              "1000000000000-count-other": "0 billions",
+              "10000000000000-count-one": "00 billion",
+              "10000000000000-count-other": "00 billions",
+              "100000000000000-count-one": "000 billion",
+              "100000000000000-count-other": "000 billions"
+            }
+          },
+          "short": {
+            "decimalFormat": {
+              "1000-count-one": "0 k",
+              "1000-count-other": "0 k",
+              "10000-count-one": "00 k",
+              "10000-count-other": "00 k",
+              "100000-count-one": "000 k",
+              "100000-count-other": "000 k",
+              "1000000-count-one": "0 M",
+              "1000000-count-other": "0 M",
+              "10000000-count-one": "00 M",
+              "10000000-count-other": "00 M",
+              "100000000-count-one": "000 M",
+              "100000000-count-other": "000 M",
+              "1000000000-count-one": "0 Md",
+              "1000000000-count-other": "0 Md",
+              "10000000000-count-one": "00 Md",
+              "10000000000-count-other": "00 Md",
+              "100000000000-count-one": "000 Md",
+              "100000000000-count-other": "000 Md",
+              "1000000000000-count-one": "0 Bn",
+              "1000000000000-count-other": "0 Bn",
+              "10000000000000-count-one": "00 Bn",
+              "10000000000000-count-other": "00 Bn",
+              "100000000000000-count-one": "000 Bn",
+              "100000000000000-count-other": "000 Bn"
+            }
+          }
+        },
+        "scientificFormats-numberSystem-latn": {
+          "standard": "#E0"
+        },
+        "percentFormats-numberSystem-latn": {
+          "standard": "#,##0 %"
+        },
+        "currencyFormats-numberSystem-latn": {
+          "currencySpacing": {
+            "beforeCurrency": {
+              "currencyMatch": "[:^S:]",
+              "surroundingMatch": "[:digit:]",
+              "insertBetween": " "
+            },
+            "afterCurrency": {
+              "currencyMatch": "[:^S:]",
+              "surroundingMatch": "[:digit:]",
+              "insertBetween": " "
+            }
+          },
+          "standard": "#,##0.00 ¤",
+          "accounting": "#,##0.00 ¤;(#,##0.00 ¤)",
+          "short": {
+            "standard": {
+              "1000-count-one": "0 k ¤",
+              "1000-count-other": "0 k ¤",
+              "10000-count-one": "00 k ¤",
+              "10000-count-other": "00 k ¤",
+              "100000-count-one": "000 k ¤",
+              "100000-count-other": "000 k ¤",
+              "1000000-count-one": "0 M ¤",
+              "1000000-count-other": "0 M ¤",
+              "10000000-count-one": "00 M ¤",
+              "10000000-count-other": "00 M ¤",
+              "100000000-count-one": "000 M ¤",
+              "100000000-count-other": "000 M ¤",
+              "1000000000-count-one": "0 Md ¤",
+              "1000000000-count-other": "0 Md ¤",
+              "10000000000-count-one": "00 Md ¤",
+              "10000000000-count-other": "00 Md ¤",
+              "100000000000-count-one": "000 Md ¤",
+              "100000000000-count-other": "000 Md ¤",
+              "1000000000000-count-one": "0 Bn ¤",
+              "1000000000000-count-other": "0 Bn ¤",
+              "10000000000000-count-one": "00 Bn ¤",
+              "10000000000000-count-other": "00 Bn ¤",
+              "100000000000000-count-one": "000 Bn ¤",
+              "100000000000000-count-other": "000 Bn ¤"
+            }
+          },
+          "unitPattern-count-one": "{0} {1}",
+          "unitPattern-count-other": "{0} {1}"
+        },
+        "miscPatterns-numberSystem-latn": {
+          "approximately": "≈{0}",
+          "atLeast": "≥{0}",
+          "atMost": "≤{0}",
+          "range": "{0}–{1}"
+        },
+        "minimalPairs": {
+          "pluralMinimalPairs-count-one": "{0} jour",
+          "pluralMinimalPairs-count-other": "{0} jours",
+          "one": "Prenez la {0}re à droite.",
+          "other": "Prenez la {0}e à droite."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1484 

## Description
Adds French language support to NumberPrompt. This is already supported in Confirm and Choice prompts, as well as the C# SDK.

## Testing

![image](https://user-images.githubusercontent.com/40401643/70480334-4d256600-1a94-11ea-8aac-622e574af240.png)
