### PR TITLE
remove "dom" from bf-streaming tsconfig and refactor code

### DIFF
--- a/libraries/botframework-streaming/src/interfaces/IBrowserFileReader.ts
+++ b/libraries/botframework-streaming/src/interfaces/IBrowserFileReader.ts
@@ -1,0 +1,19 @@
+/**
+ * @module botframework-streaming
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Partially represents a FileReader from the W3C FileAPI Working Draft.
+ * For more information, see https://w3c.github.io/FileAPI/#APIASynch.
+ * 
+ * This interface supports the framework and is not intended to be called directly for your code.
+ */
+export interface IBrowserFileReader {
+    result: any;
+    onload: (event: any) => void;
+    readAsArrayBuffer: (blobOrFile: any) => void;
+}

--- a/libraries/botframework-streaming/src/interfaces/IBrowserWebSocket.ts
+++ b/libraries/botframework-streaming/src/interfaces/IBrowserWebSocket.ts
@@ -1,0 +1,24 @@
+/**
+ * @module botframework-streaming
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Partially represents a WebSocket from the HTML Living Standard.
+ * For more information, see https://html.spec.whatwg.org/multipage/web-sockets.html.
+ * 
+ * This interface supports the framework and is not intended to be called directly for your code.
+ */
+export interface IBrowserWebSocket {
+    onclose: (event: any) => void;
+    onerror: (event: any) => void;
+    onmessage: (event: any) => void;
+    onopen: (event: any) => void;
+    readyState: number;
+
+    close(): void;
+    send(buffer: any): void;
+}

--- a/libraries/botframework-streaming/src/interfaces/index.ts
+++ b/libraries/botframework-streaming/src/interfaces/index.ts
@@ -6,6 +6,8 @@
  * Licensed under the MIT License.
  */
 
+export * from './IBrowserFileReader';
+export * from './IBrowserWebSocket';
 export * from './INodeBuffer';
 export * from './INodeIncomingMessage';
 export * from './INodeSocket';

--- a/libraries/botframework-streaming/src/utilities/doesGlobalFileReaderExist.ts
+++ b/libraries/botframework-streaming/src/utilities/doesGlobalFileReaderExist.ts
@@ -1,0 +1,9 @@
+/**
+ * @module botframework-streaming
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export const doesGlobalFileReaderExist = new Function('try {return typeof FileReader !== "undefined" && FileReader !== null;}catch(e){ return false;}');

--- a/libraries/botframework-streaming/src/utilities/doesGlobalWebSocketExist.ts
+++ b/libraries/botframework-streaming/src/utilities/doesGlobalWebSocketExist.ts
@@ -1,0 +1,9 @@
+/**
+ * @module botframework-streaming
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export const doesGlobalWebSocketExist = new Function('try {return typeof WebSocket !== "undefined" && WebSocket !== null;}catch(e){ return false;}');

--- a/libraries/botframework-streaming/src/utilities/index.ts
+++ b/libraries/botframework-streaming/src/utilities/index.ts
@@ -6,5 +6,6 @@
  * Licensed under the MIT License.
  */
 
-export * from './isBrowser';
+export * from './doesGlobalFileReaderExist';
+export * from './doesGlobalWebSocketExist';
 export * from './protocol-base';

--- a/libraries/botframework-streaming/src/utilities/index.ts
+++ b/libraries/botframework-streaming/src/utilities/index.ts
@@ -6,4 +6,5 @@
  * Licensed under the MIT License.
  */
 
+export * from './isBrowser';
 export * from './protocol-base';

--- a/libraries/botframework-streaming/src/utilities/isBrowser.ts
+++ b/libraries/botframework-streaming/src/utilities/isBrowser.ts
@@ -1,0 +1,9 @@
+/**
+ * @module botframework-streaming
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export const isBrowser = new Function('try {return this===window;}catch(e){ return false;}');

--- a/libraries/botframework-streaming/src/utilities/isBrowser.ts
+++ b/libraries/botframework-streaming/src/utilities/isBrowser.ts
@@ -1,9 +1,0 @@
-/**
- * @module botframework-streaming
- */
-/**
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License.
- */
-
-export const isBrowser = new Function('try {return this===window;}catch(e){ return false;}');

--- a/libraries/botframework-streaming/src/webSocket/browserWebSocket.ts
+++ b/libraries/botframework-streaming/src/webSocket/browserWebSocket.ts
@@ -6,23 +6,23 @@
  * Licensed under the MIT License.
  */
 import { IBrowserFileReader, IBrowserWebSocket, ISocket } from '../interfaces';
-import { isBrowser } from '../utilities';
+import { doesGlobalFileReaderExist, doesGlobalWebSocketExist } from '../utilities';
 
 const createWebSocket = function(url: string): IBrowserWebSocket {
     if (!url) {
         throw new TypeError('Unable to create WebSocket without url.');
     }
-    if (isBrowser()) {
+    if (doesGlobalWebSocketExist()) {
         return new Function(`return new WebSocket('${ url }');`)();
     }
-    throw new ReferenceError('Incorrect environment detected for BrowserWebSocket. Unable to create backing WebSocket for BrowserWebSocket.');
+    throw new ReferenceError('Unable to find global.WebSocket which is required for constructing a BrowserWebSocket.');
 };
 
 const createFileReader = function(): IBrowserFileReader {
-    if (isBrowser()) {
+    if (doesGlobalFileReaderExist()) {
         return new Function(`return new FileReader();`)();
     }
-    throw new ReferenceError('Incorrect environment detected for BrowserWebSocket. Unable to create backing FileReader for BrowserWebSocket.');
+    throw new ReferenceError('Unable to find global.FileReader. Unable to create FileReader for BrowserWebSocket.');
 };
 
 export class BrowserWebSocket implements ISocket {

--- a/libraries/botframework-streaming/src/webSocket/browserWebSocket.ts
+++ b/libraries/botframework-streaming/src/webSocket/browserWebSocket.ts
@@ -5,17 +5,35 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ISocket } from '../interfaces/ISocket';
+import { IBrowserFileReader, IBrowserWebSocket, ISocket } from '../interfaces';
+import { isBrowser } from '../utilities';
+
+const createWebSocket = function(url: string): IBrowserWebSocket {
+    if (!url) {
+        throw new TypeError('Unable to create WebSocket without url.');
+    }
+    if (isBrowser()) {
+        return new Function(`return new WebSocket('${ url }');`)();
+    }
+    throw new ReferenceError('Incorrect environment detected for BrowserWebSocket. Unable to create backing WebSocket for BrowserWebSocket.');
+};
+
+const createFileReader = function(): IBrowserFileReader {
+    if (isBrowser()) {
+        return new Function(`return new FileReader();`)();
+    }
+    throw new ReferenceError('Incorrect environment detected for BrowserWebSocket. Unable to create backing FileReader for BrowserWebSocket.');
+};
 
 export class BrowserWebSocket implements ISocket {
-    private webSocket: WebSocket;
+    private webSocket: IBrowserWebSocket;
 
     /**
      * Creates a new instance of the [BrowserWebSocket](xref:botframework-streaming.BrowserWebSocket) class.
      *
      * @param socket The socket object to build this connection on.
      */
-    public constructor(socket?: WebSocket) {
+    public constructor(socket?: IBrowserWebSocket) {
         if (socket) {
             this.webSocket = socket;
         }
@@ -31,7 +49,7 @@ export class BrowserWebSocket implements ISocket {
         let rejector;
 
         if (!this.webSocket) {
-            this.webSocket = new WebSocket(serverAddress);
+            this.webSocket = createWebSocket(serverAddress);
         }
 
         this.webSocket.onerror = (e): void => {
@@ -79,11 +97,11 @@ export class BrowserWebSocket implements ISocket {
         const bufferKey: string = 'buffer';
         let packets = [];
         this.webSocket.onmessage = (evt): void => {
-            let fileReader = new FileReader();
+            let fileReader = createFileReader();
             let queueEntry = {buffer: null};
             packets.push(queueEntry);
             fileReader.onload = (e): void => {
-                let t: FileReader = e.target as FileReader;
+                let t = e.target as IBrowserFileReader;
                 queueEntry[bufferKey] = t.result;
                 if (packets[0] === queueEntry) {
                     while(0 < packets.length && packets[0][bufferKey]) {

--- a/libraries/botframework-streaming/src/webSocket/webSocketClient.ts
+++ b/libraries/botframework-streaming/src/webSocket/webSocketClient.ts
@@ -16,6 +16,7 @@ import {
 } from '../payloadTransport';
 import { BrowserWebSocket } from './browserWebSocket';
 import { NodeWebSocket } from './nodeWebSocket';
+import { isBrowser } from '../utilities';
 import { WebSocketTransport } from './webSocketTransport';
 import { IStreamingTransportClient, IReceiveResponse } from '../interfaces';
 
@@ -59,7 +60,7 @@ export class WebSocketClient implements IStreamingTransportClient {
      * @returns A promise that will not resolve until the client stops listening for incoming messages.
      */
     public async connect(): Promise<void> {
-        if (typeof WebSocket !== 'undefined') {
+        if (isBrowser()) {
             const ws = new BrowserWebSocket();
             await ws.connect(this._url);
             const transport = new WebSocketTransport(ws);

--- a/libraries/botframework-streaming/src/webSocket/webSocketClient.ts
+++ b/libraries/botframework-streaming/src/webSocket/webSocketClient.ts
@@ -16,7 +16,7 @@ import {
 } from '../payloadTransport';
 import { BrowserWebSocket } from './browserWebSocket';
 import { NodeWebSocket } from './nodeWebSocket';
-import { isBrowser } from '../utilities';
+import { doesGlobalWebSocketExist } from '../utilities';
 import { WebSocketTransport } from './webSocketTransport';
 import { IStreamingTransportClient, IReceiveResponse } from '../interfaces';
 
@@ -60,7 +60,7 @@ export class WebSocketClient implements IStreamingTransportClient {
      * @returns A promise that will not resolve until the client stops listening for incoming messages.
      */
     public async connect(): Promise<void> {
-        if (isBrowser()) {
+        if (doesGlobalWebSocketExist()) {
             const ws = new BrowserWebSocket();
             await ws.connect(this._url);
             const transport = new WebSocketTransport(ws);

--- a/libraries/botframework-streaming/tests/InternalUtilities.test.js
+++ b/libraries/botframework-streaming/tests/InternalUtilities.test.js
@@ -1,0 +1,10 @@
+const { isBrowser } = require('../lib/utilities');
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('Internal Utilities', () => {
+    it('isBrowser() should return false when being run via Node.js', () => {
+        // More specifically, it should return false when the global object is not window.
+        expect(isBrowser()).to.be.false;
+    });
+});

--- a/libraries/botframework-streaming/tests/InternalUtilities.test.js
+++ b/libraries/botframework-streaming/tests/InternalUtilities.test.js
@@ -1,10 +1,45 @@
-const { isBrowser } = require('../lib/utilities');
+const { doesGlobalFileReaderExist, doesGlobalWebSocketExist } = require('../lib/utilities');
 const chai = require('chai');
 const expect = chai.expect;
 
 describe('Internal Utilities', () => {
-    it('isBrowser() should return false when being run via Node.js', () => {
-        // More specifically, it should return false when the global object is not window.
-        expect(isBrowser()).to.be.false;
+    it('doesGlobalWebSocketExist() should return true if global.WebSocket is truthy', () => {
+        global.WebSocket = {};
+        try {
+            expect(doesGlobalWebSocketExist()).to.be.true;
+        } finally {
+            global.WebSocket = undefined;
+        }
+    });
+
+    it('doesGlobalWebSocketExist() should return false if global.WebSocket is null or undefined', () => {
+        expect(doesGlobalWebSocketExist()).to.be.false;
+
+        global.WebSocket = null;
+        try {
+            expect(doesGlobalWebSocketExist()).to.be.false;
+        } finally {
+            global.WebSocket = undefined;
+        }
+    });
+
+    it('doesGlobalFileReaderExist() should return true if global.FileReader is truthy', () => {
+        global.FileReader = {};
+        try {
+            expect(doesGlobalFileReaderExist()).to.be.true;
+        } finally {
+            global.FileReader = undefined;
+        }
+    });
+
+    it('doesGlobalFileReaderExist() should return false if global.FileReader is null or undefined', () => {
+        expect(doesGlobalFileReaderExist()).to.be.false;
+
+        global.FileReader = null;
+        try {
+            expect(doesGlobalFileReaderExist()).to.be.false;
+        } finally {
+            global.FileReader = undefined;
+        }
     });
 });

--- a/libraries/botframework-streaming/tsconfig.json
+++ b/libraries/botframework-streaming/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "lib": ["es2015", "dom"],
+    "lib": ["es2015"],
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
Fixes #1565 in `4.7` branch.

## Description
For the 4.7.0 release, botbuilder and bf-streaming shipped with an inadvertent requirement for TypeScript developers to include the `"dom"` lib in the developer's own `tsconfig.json`.

This problem arises for users even when they don't take a direct dependency on botframework-streaming. Building a library that uses only botbuilder fails without including `"dom"`. (https://github.com/howdyai/botkit/issues/1894)

Additionally, another side effect of relying on WebSocket and FileReader types and definitions via TypeScript leads us to potential breaking changes in the future. The `"dom"` types included are also tightly coupled with the version of TypeScript, so relying on these types could allow the code to successfully transpile, but not actually work at runtime.

## Specific Changes
  - Create IBrowserWebSocket and IBrowserFileReader interfaces for WebSocket and FileReader
  - Add helper methods to create [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) and [FileReader](https://developer.mozilla.org/en-US/docs/Web/API/FileReader) without relying on `"dom"` being in the tsconfig.json.

## Testing
Unit tests run locally pass.