### PR TITLE
Declare return types in waterfallDialog.ts

### DIFF
--- a/libraries/botbuilder-dialogs/src/waterfallDialog.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallDialog.ts
@@ -245,7 +245,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
                 'InstanceId': instanceId,
             }});
         } else if (reason === DialogReason.cancelCalled) {
-            var index = state.stepIndex;
+            var index = instance.state[state.stepIndex];
             var stepName = this.waterfallStepName(index);
             this.telemetryClient.trackEvent({name: 'WaterfallCancel', properties: {
                 'DialogId': this.id,
@@ -288,7 +288,7 @@ interface WaterfallDialogState {
  * Source: https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
  */  
 function generate_guid(): string {
-    function s4():string {
+    function s4(): string {
         return Math.floor((1 + Math.random()) * 0x10000)
             .toString(16)
             .substring(1);

--- a/libraries/botbuilder-dialogs/src/waterfallDialog.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallDialog.ts
@@ -236,8 +236,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
      * @param instance The instance of the current dialog.
      * @param reason The reason the dialog is ending.
      */
-    public async endDialog(context: TurnContext, instance: DialogInstance, reason: DialogReason) {
-
+    public async endDialog(context: TurnContext, instance: DialogInstance, reason: DialogReason): Promise<void> {
         const state: WaterfallDialogState = instance.state as WaterfallDialogState;
         const instanceId = state.values['instanceId'];
         if (reason === DialogReason.endCalled) {
@@ -256,7 +255,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
         }
     }
 
-    private waterfallStepName(index) {
+    private waterfallStepName(index): string {
         // Log Waterfall Step event. Each event has a distinct name to hook up
         // to the Application Insights funnel.
         var stepName = '';
@@ -288,7 +287,7 @@ interface WaterfallDialogState {
  * instances of a given waterfall dialog.
  * Source: https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
  */  
-function generate_guid() {
+function generate_guid(): string {
     function s4() {
         return Math.floor((1 + Math.random()) * 0x10000)
             .toString(16)

--- a/libraries/botbuilder-dialogs/src/waterfallDialog.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallDialog.ts
@@ -245,7 +245,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
                 'InstanceId': instanceId,
             }});
         } else if (reason === DialogReason.cancelCalled) {
-            var index = instance.state[state.stepIndex];
+            var index = state.stepIndex;
             var stepName = this.waterfallStepName(index);
             this.telemetryClient.trackEvent({name: 'WaterfallCancel', properties: {
                 'DialogId': this.id,
@@ -255,7 +255,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
         }
     }
 
-    private waterfallStepName(index): string {
+    private waterfallStepName(index: number): string {
         // Log Waterfall Step event. Each event has a distinct name to hook up
         // to the Application Insights funnel.
         var stepName = '';
@@ -288,7 +288,7 @@ interface WaterfallDialogState {
  * Source: https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
  */  
 function generate_guid(): string {
-    function s4() {
+    function s4():string {
         return Math.floor((1 + Math.random()) * 0x10000)
             .toString(16)
             .substring(1);


### PR DESCRIPTION
See files for small fixes

Edit: My second commit fixes an actual bug rather than just cleaning up code. If you cancelled a waterfall during a named step (a step not defined by an anonymous function), the telemetry logger would treat it as an unnamed step. I noticed that by reading the code. The bug is not in the other repos though it may have originated by copying code from Python and not adapting it correctly.