### PR TITLE
[Cherry-pick to master] remove "dom" from bf-streaming tsconfig and refactor code

### DIFF
--- a/libraries/botframework-streaming/src/interfaces/IBrowserFileReader.ts
+++ b/libraries/botframework-streaming/src/interfaces/IBrowserFileReader.ts
@@ -1,0 +1,19 @@
+/**
+ * @module botframework-streaming
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Partially represents a FileReader from the W3C FileAPI Working Draft.
+ * For more information, see https://w3c.github.io/FileAPI/#APIASynch.
+ * 
+ * This interface supports the framework and is not intended to be called directly for your code.
+ */
+export interface IBrowserFileReader {
+    result: any;
+    onload: (event: any) => void;
+    readAsArrayBuffer: (blobOrFile: any) => void;
+}

--- a/libraries/botframework-streaming/src/interfaces/IBrowserWebSocket.ts
+++ b/libraries/botframework-streaming/src/interfaces/IBrowserWebSocket.ts
@@ -1,0 +1,24 @@
+/**
+ * @module botframework-streaming
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Partially represents a WebSocket from the HTML Living Standard.
+ * For more information, see https://html.spec.whatwg.org/multipage/web-sockets.html.
+ * 
+ * This interface supports the framework and is not intended to be called directly for your code.
+ */
+export interface IBrowserWebSocket {
+    onclose: (event: any) => void;
+    onerror: (event: any) => void;
+    onmessage: (event: any) => void;
+    onopen: (event: any) => void;
+    readyState: number;
+
+    close(): void;
+    send(buffer: any): void;
+}

--- a/libraries/botframework-streaming/src/interfaces/index.ts
+++ b/libraries/botframework-streaming/src/interfaces/index.ts
@@ -6,6 +6,8 @@
  * Licensed under the MIT License.
  */
 
+export * from './IBrowserFileReader';
+export * from './IBrowserWebSocket';
 export * from './INodeBuffer';
 export * from './INodeIncomingMessage';
 export * from './INodeSocket';

--- a/libraries/botframework-streaming/src/utilities/doesGlobalFileReaderExist.ts
+++ b/libraries/botframework-streaming/src/utilities/doesGlobalFileReaderExist.ts
@@ -1,0 +1,9 @@
+/**
+ * @module botframework-streaming
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export const doesGlobalFileReaderExist = new Function('try {return typeof FileReader !== "undefined" && FileReader !== null;}catch(e){ return false;}');

--- a/libraries/botframework-streaming/src/utilities/doesGlobalWebSocketExist.ts
+++ b/libraries/botframework-streaming/src/utilities/doesGlobalWebSocketExist.ts
@@ -1,0 +1,9 @@
+/**
+ * @module botframework-streaming
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export const doesGlobalWebSocketExist = new Function('try {return typeof WebSocket !== "undefined" && WebSocket !== null;}catch(e){ return false;}');

--- a/libraries/botframework-streaming/src/utilities/index.ts
+++ b/libraries/botframework-streaming/src/utilities/index.ts
@@ -6,4 +6,6 @@
  * Licensed under the MIT License.
  */
 
+export * from './doesGlobalFileReaderExist';
+export * from './doesGlobalWebSocketExist';
 export * from './protocol-base';

--- a/libraries/botframework-streaming/src/webSocket/webSocketClient.ts
+++ b/libraries/botframework-streaming/src/webSocket/webSocketClient.ts
@@ -16,6 +16,7 @@ import {
 } from '../payloadTransport';
 import { BrowserWebSocket } from './browserWebSocket';
 import { NodeWebSocket } from './nodeWebSocket';
+import { doesGlobalWebSocketExist } from '../utilities';
 import { WebSocketTransport } from './webSocketTransport';
 import { IStreamingTransportClient, IReceiveResponse } from '../interfaces';
 
@@ -59,7 +60,7 @@ export class WebSocketClient implements IStreamingTransportClient {
      * @returns A promise that will not resolve until the client stops listening for incoming messages.
      */
     public async connect(): Promise<void> {
-        if (typeof WebSocket !== 'undefined') {
+        if (doesGlobalWebSocketExist()) {
             const ws = new BrowserWebSocket();
             await ws.connect(this._url);
             const transport = new WebSocketTransport(ws);

--- a/libraries/botframework-streaming/tests/InternalUtilities.test.js
+++ b/libraries/botframework-streaming/tests/InternalUtilities.test.js
@@ -1,0 +1,45 @@
+const { doesGlobalFileReaderExist, doesGlobalWebSocketExist } = require('../lib/utilities');
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('Internal Utilities', () => {
+    it('doesGlobalWebSocketExist() should return true if global.WebSocket is truthy', () => {
+        global.WebSocket = {};
+        try {
+            expect(doesGlobalWebSocketExist()).to.be.true;
+        } finally {
+            global.WebSocket = undefined;
+        }
+    });
+
+    it('doesGlobalWebSocketExist() should return false if global.WebSocket is null or undefined', () => {
+        expect(doesGlobalWebSocketExist()).to.be.false;
+
+        global.WebSocket = null;
+        try {
+            expect(doesGlobalWebSocketExist()).to.be.false;
+        } finally {
+            global.WebSocket = undefined;
+        }
+    });
+
+    it('doesGlobalFileReaderExist() should return true if global.FileReader is truthy', () => {
+        global.FileReader = {};
+        try {
+            expect(doesGlobalFileReaderExist()).to.be.true;
+        } finally {
+            global.FileReader = undefined;
+        }
+    });
+
+    it('doesGlobalFileReaderExist() should return false if global.FileReader is null or undefined', () => {
+        expect(doesGlobalFileReaderExist()).to.be.false;
+
+        global.FileReader = null;
+        try {
+            expect(doesGlobalFileReaderExist()).to.be.false;
+        } finally {
+            global.FileReader = undefined;
+        }
+    });
+});

--- a/libraries/botframework-streaming/tsconfig.json
+++ b/libraries/botframework-streaming/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "lib": ["es2015", "dom"],
+    "lib": ["es2015"],
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
Fixes #1565 in `master` by cherry-picking #1575
___

### _Copy-paste from #1575:_


## Description
For the 4.7.0 release, botbuilder and bf-streaming shipped with an inadvertent requirement for TypeScript developers to include the `"dom"` lib in the developer's own `tsconfig.json`.

This problem arises for users even when they don't take a direct dependency on botframework-streaming. Building a library that uses only botbuilder fails without including `"dom"`. (https://github.com/howdyai/botkit/issues/1894)

Additionally, another side effect of relying on WebSocket and FileReader types and definitions via TypeScript leads us to potential breaking changes in the future. The `"dom"` types included are also tightly coupled with the version of TypeScript, so relying on these types could allow the code to successfully transpile, but not actually work at runtime.

## Specific Changes
  - Create IBrowserWebSocket and IBrowserFileReader interfaces for WebSocket and FileReader
  - Add helper methods to create [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) and [FileReader](https://developer.mozilla.org/en-US/docs/Web/API/FileReader) without relying on `"dom"` being in the tsconfig.json.

## Testing
Unit tests run locally pass.

____

### _[Second comment](https://github.com/microsoft/botbuilder-js/pull/1575#issuecomment-574374408):_

https://github.com/microsoft/botbuilder-js/pull/1575/commits/f6434298f12d6a67a58575698ceb3740b02b8c92 removes the `isBrowser()` utility and instead adds helpers that check for the presence of global `WebSocket` and `FileReader` to better align with the shipped implementation.

With @ckkashyap's help I tested the code against his branch ([`ckk/protocoljs`](https://github.com/microsoft/BotFramework-DirectLineJS/tree/ckk/protocoljs)) in [microsoft/BotFramework-DirectLineJS](https://github.com/microsoft/BotFramework-DirectLineJS) to verify no breaking changes downstream. Live and recorded tests were passing against this branch.