### PR TITLE
[Skills] TrustServiceUrl from original conversationReference in SkillHandler

### DIFF
--- a/libraries/botbuilder/src/skills/skillHandler.ts
+++ b/libraries/botbuilder/src/skills/skillHandler.ts
@@ -14,7 +14,7 @@ import {
     ResourceResponse,
     TurnContext
 } from 'botbuilder-core';
-import { AuthenticationConfiguration, ICredentialProvider, ClaimsIdentity } from 'botframework-connector';
+import { AuthenticationConfiguration, AppCredentials, ICredentialProvider, ClaimsIdentity } from 'botframework-connector';
 
 import { ChannelServiceHandler } from '../channelServiceHandler';
 import { SkillConversationIdFactoryBase } from './skillConversationIdFactoryBase';
@@ -169,6 +169,11 @@ export class SkillHandler extends ChannelServiceHandler {
                     break;
             }
         };
+
+        // Add the channel service URL to the trusted services list so we can send messages back.
+        // the service URL for skills is trusted because it is applied based on the original request
+        // received by the root bot.
+        AppCredentials.trustServiceUrl(conversationReference.serviceUrl);
 
         await this.adapter.continueConversation(conversationReference, callback);
         return { id: uuid() };


### PR DESCRIPTION
Fixes #1580 in `4.7`

## Description
Add `AppCredentials.trustServiceUrl()` call in SkillHandler to trust serviceUrl that was received in message from channel.

This allows for all instances of the parent bot to fetch a token when it attempts to forward the activity from the Skill to the User (via the use of the SkillHandler class).

### Additional Context (C#)
- Issue: https://github.com/microsoft/botbuilder-dotnet/pull/3244
- PR: https://github.com/microsoft/botbuilder-dotnet/issues/3245


## Testing
Manually tested by having one parent bot use the endpoint of the **second** parent bot as the serviceUrl for activities sent to the skill.

Added specific unit test for verifying the serviceUrl is trusted after SkillHandler.processActivity() is run.