### PR TITLE
[QoL] add declarationMap to tsconfig.json in libraries

### DIFF
--- a/libraries/botbuilder-ai/tsconfig.json
+++ b/libraries/botbuilder-ai/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es2015"],
     "module": "commonjs",
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "outDir": "./lib",
     "rootDir": "./src",

--- a/libraries/botbuilder-applicationinsights/tsconfig.json
+++ b/libraries/botbuilder-applicationinsights/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es2015"],
     "module": "commonjs",
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "outDir": "./lib",
     "rootDir": "./src",

--- a/libraries/botbuilder-azure/tsconfig.json
+++ b/libraries/botbuilder-azure/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es2015"],
     "module": "commonjs",
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "outDir": "./lib",
     "rootDir": "./src",

--- a/libraries/botbuilder-core/tsconfig.json
+++ b/libraries/botbuilder-core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "esModuleInterop": true,
     "sourceMap": true,
     "module": "commonjs",

--- a/libraries/botbuilder-dialogs/tsconfig.json
+++ b/libraries/botbuilder-dialogs/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es2015", "dom"],
     "module": "commonjs",
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "outDir": "./lib",
     "rootDir": "./src",

--- a/libraries/botbuilder-lg/tsconfig.json
+++ b/libraries/botbuilder-lg/tsconfig.json
@@ -6,6 +6,7 @@
       "target": "ESNext",
       "module": "commonjs",
       "declaration": true,
+      "declarationMap": true,
       "sourceMap": true,
       "outDir": "./lib",
       "rootDirs": ["./src"],

--- a/libraries/botbuilder-testing/tsconfig.json
+++ b/libraries/botbuilder-testing/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es2015"],
     "module": "commonjs",
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "outDir": "./lib",
     "rootDir": "./src",

--- a/libraries/botbuilder/tsconfig.json
+++ b/libraries/botbuilder/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es2015", "dom"],
     "module": "commonjs",
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "outDir": "./lib",
     "rootDir": "./src",

--- a/libraries/botframework-config/tsconfig.json
+++ b/libraries/botframework-config/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es2015"],
     "module": "commonjs",
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "outDir": "./lib",
     "rootDir": "./src",

--- a/libraries/botframework-connector/tsconfig.json
+++ b/libraries/botframework-connector/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "strict": false,
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "outDir": "./lib",
     "rootDir": "./src",

--- a/libraries/botframework-expressions/tsconfig.json
+++ b/libraries/botframework-expressions/tsconfig.json
@@ -6,6 +6,7 @@
       "target": "ESNext",
       "module": "commonjs",
       "declaration": true,
+      "declarationMap": true,
       "sourceMap": true,
       "outDir": "./lib",
       "rootDirs": ["./src"],

--- a/libraries/botframework-schema/tsconfig.json
+++ b/libraries/botframework-schema/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es2015"],
     "module": "commonjs",
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "outDir": "./lib",
     "rootDir": "./src",

--- a/libraries/botframework-streaming/tsconfig.json
+++ b/libraries/botframework-streaming/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["es2015"],
     "module": "commonjs",
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "outDir": "./lib",
     "rootDir": "./src",


### PR DESCRIPTION
## Description
Enables `"go to definition"` from supporting editors (e.g. VS Code) to go straight to the source code instead of the `.d.ts` files.

[TypeScript Compiler Options](https://www.typescriptlang.org/docs/handbook/compiler-options.html)

![image](https://user-images.githubusercontent.com/14935595/73108601-93544e80-3eb5-11ea-817f-13a32a76141f.png)

Thanks for the tip @a-b-r-o-w-n 🚀 

## Specific Changes
  - Add `"declarationMap": true,` to libraries' tsconfig.json files.
