### PR TITLE
Kyled/waterfall cancel telemetry

### DIFF
--- a/libraries/botbuilder-dialogs/src/waterfallDialog.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallDialog.ts
@@ -245,7 +245,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
                 'InstanceId': instanceId,
             }});
         } else if (reason === DialogReason.cancelCalled) {
-            var index = instance.state[state.stepIndex];
+            var index = state.stepIndex;
             var stepName = this.waterfallStepName(index);
             this.telemetryClient.trackEvent({name: 'WaterfallCancel', properties: {
                 'DialogId': this.id,

--- a/libraries/botbuilder-dialogs/tests/waterfallDialog.test.js
+++ b/libraries/botbuilder-dialogs/tests/waterfallDialog.test.js
@@ -618,9 +618,11 @@ describe('WaterfallDialog', function () {
         const id = 'waterfall';
         const index = 1;
         const dialog = new MyWaterfall(id);
+        var trackEventCalled;
         dialog.telemetryClient = {
             trackEvent(telemetry) {
                 assert(telemetry.properties.StepName == dialog.steps[index].name, `telemetry contains incorrect step name: "${telemetry.properties.StepName}"`);
+                trackEventCalled = true;
             }
         };
         await dialog.endDialog({}, {
@@ -630,5 +632,6 @@ describe('WaterfallDialog', function () {
                 values: { instanceId: '(guid)' }
             }
         }, DialogReason.cancelCalled);
+        assert(trackEventCalled, 'trackEvent was never called.');
     });
 });

--- a/libraries/botbuilder-dialogs/tests/waterfallDialog.test.js
+++ b/libraries/botbuilder-dialogs/tests/waterfallDialog.test.js
@@ -1,5 +1,5 @@
 const { ActivityTypes, ConversationState, MemoryStorage, TestAdapter } = require('botbuilder-core');
-const { Dialog, DialogSet, WaterfallDialog, DialogTurnStatus } = require('../');
+const { Dialog, DialogReason, DialogSet, DialogTurnStatus, WaterfallDialog } = require('../');
 
 const assert = require('assert');
 
@@ -28,7 +28,6 @@ class MyWaterfall extends WaterfallDialog {
         return await step.endDialog('ending WaterfallDialog.');
     }
 }
-
 
 describe('WaterfallDialog', function () {
     this.timeout(5000);
@@ -613,5 +612,23 @@ describe('WaterfallDialog', function () {
             .send('continue.')
             .assertReply('done.')
             .startTest();
+    });
+
+    it('should record the correct step name when cancelled.', async function() {
+        const id = 'waterfall';
+        const index = 1;
+        const dialog = new MyWaterfall(id);
+        dialog.telemetryClient = {
+            trackEvent(telemetry) {
+                assert(telemetry.properties.StepName == dialog.steps[index].name, `telemetry contains incorrect step name: "${telemetry.properties.StepName}"`);
+            }
+        };
+        await dialog.endDialog({}, {
+            id,
+            state: {
+                stepIndex: index,
+                values: { instanceId: '(guid)' }
+            }
+        }, DialogReason.cancelCalled);
     });
 });


### PR DESCRIPTION
Fixes #1619

## Description
Small typo fix

## Specific Changes

  - waterfallDialog.ts line 248: `var index = state.stepIndex;`

## Testing
Included