### PR TITLE
Change the target to es5 to support IE11

### DIFF
--- a/libraries/botframework-streaming/tsconfig.json
+++ b/libraries/botframework-streaming/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es5",
     "lib": ["es2015"],
     "module": "commonjs",
     "declaration": true,


### PR DESCRIPTION
This change is needed so that the library works on IE11. A bug was reported for this - https://github.com/microsoft/botbuilder-js/issues/1670