### PR TITLE
Updated ShowTypingMiddleware to re throw errors

### DIFF
--- a/libraries/botbuilder-core/src/showTypingMiddleware.ts
+++ b/libraries/botbuilder-core/src/showTypingMiddleware.ts
@@ -89,6 +89,11 @@ export class ShowTypingMiddleware implements Middleware {
             if (hTimeout) { clearTimeout(hTimeout); }
         }
 
+        function stopIntervalWithError(err: Error): void {
+            stopInterval();
+            throw err;
+        }
+
         if (context.activity.type === ActivityTypes.Message) {
             // Set a property to track whether or not the turn is finished.
             // When it flips to true, we won't send anymore typing indicators.
@@ -98,7 +103,7 @@ export class ShowTypingMiddleware implements Middleware {
 
         // Let the rest of the process run.
         // After everything has run, stop the indicator!
-        return await next().then(stopInterval, stopInterval);
+        return await next().then(stopInterval, stopIntervalWithError);
 
     }
     private async sendTypingActivity(context: TurnContext): Promise<void> {

--- a/libraries/botbuilder-core/src/showTypingMiddleware.ts
+++ b/libraries/botbuilder-core/src/showTypingMiddleware.ts
@@ -84,16 +84,6 @@ export class ShowTypingMiddleware implements Middleware {
             );
         }
 
-        function stopInterval(): void {
-            finished = true;
-            if (hTimeout) { clearTimeout(hTimeout); }
-        }
-
-        function stopIntervalWithError(err: Error): void {
-            stopInterval();
-            throw err;
-        }
-
         if (context.activity.type === ActivityTypes.Message) {
             // Set a property to track whether or not the turn is finished.
             // When it flips to true, we won't send anymore typing indicators.
@@ -103,8 +93,16 @@ export class ShowTypingMiddleware implements Middleware {
 
         // Let the rest of the process run.
         // After everything has run, stop the indicator!
-        return await next().then(stopInterval, stopIntervalWithError);
-
+        try {
+            return await next();
+        }
+        finally
+        {
+            finished = true;
+            if (hTimeout) {
+                clearTimeout(hTimeout);
+            }
+        }
     }
     private async sendTypingActivity(context: TurnContext): Promise<void> {
 


### PR DESCRIPTION
Fixes #726 

Typing indicator works as normal, unless an error is thrown, in which case it is now re thrown to the adapter.