### PR TITLE
create browser (es5) output in botframework-streaming

### DIFF
--- a/libraries/botframework-streaming/.gitignore
+++ b/libraries/botframework-streaming/.gitignore
@@ -1,3 +1,4 @@
+/browser
 /lib
 /node_modules
 *.js.map

--- a/libraries/botframework-streaming/package.json
+++ b/libraries/botframework-streaming/package.json
@@ -20,6 +20,7 @@
     "url": "https://github.com/microsoft/botbuilder-js.git"
   },
   "main": "lib/index.js",
+  "browser": "browser/index-browser.js",
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@types/ws": "^6.0.3",
@@ -41,12 +42,12 @@
     "typescript": "3.5.3"
   },
   "scripts": {
-    "build": "tsc",
-    "clean": "erase /q /s .\\lib",
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig-browser.json",
+    "clean": "erase /q /s .\\lib .\\browser",
     "eslint": "eslint  ./src/*.ts ./src/**/*.ts",
     "eslint-fix": "eslint  ./src/*.ts ./src/**/*.ts --fix",
     "set-version": "npm version --allow-same-version ${Version}",
-    "test": "tsc && nyc mocha tests/"
+    "test": "npm run build && nyc mocha tests/"
   },
   "files": [
     "/lib",

--- a/libraries/botframework-streaming/package.json
+++ b/libraries/botframework-streaming/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "/lib",
-    "/src"
+    "/src",
+    "/browser"
   ]
 }

--- a/libraries/botframework-streaming/src/index-browser.ts
+++ b/libraries/botframework-streaming/src/index-browser.ts
@@ -1,0 +1,29 @@
+/**
+ * @module botframework-streaming
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export { ContentStream } from './contentStream';
+export { HttpContent } from './httpContentStream';
+export {
+    INodeBuffer,
+    INodeIncomingMessage,
+    INodeSocket,
+    IReceiveRequest,
+    IReceiveResponse,
+    ISocket,
+    IStreamingTransportClient,
+    IStreamingTransportServer,
+} from './interfaces';
+export { RequestHandler } from './requestHandler';
+export { StreamingRequest } from './streamingRequest';
+export { StreamingResponse } from './streamingResponse';
+export { SubscribableStream } from './subscribableStream';
+export {
+    BrowserWebSocket,
+    WebSocketClient,
+    WebSocketServer
+} from './webSocket/index-browser';

--- a/libraries/botframework-streaming/src/webSocket/index-browser.ts
+++ b/libraries/botframework-streaming/src/webSocket/index-browser.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-export * from './browserWebSocket';
-export * from './webSocketClient';
-export * from './webSocketServer';
-export * from './webSocketTransport';
+export { BrowserWebSocket } from './browserWebSocket';
+export { WebSocketClient } from './webSocketClient';
+export { WebSocketServer } from './webSocketServer';
+export { WebSocketTransport } from './webSocketTransport';

--- a/libraries/botframework-streaming/src/webSocket/index-browser.ts
+++ b/libraries/botframework-streaming/src/webSocket/index-browser.ts
@@ -1,0 +1,12 @@
+/**
+ * @module botframework-streaming
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+export * from './browserWebSocket';
+export * from './webSocketClient';
+export * from './webSocketServer';
+export * from './webSocketTransport';

--- a/libraries/botframework-streaming/tsconfig-browser.json
+++ b/libraries/botframework-streaming/tsconfig-browser.json
@@ -1,19 +1,22 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es5",
     "lib": ["es2015"],
     "module": "commonjs",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "outDir": "./lib",
+    "outDir": "./browser",
     "rootDir": "./src",
     "types" : ["node"]
   },
   "exclude": [
-    "**/index-browser.ts",
     "browser",
     "lib",
-    "node_modules"
+    "node_modules",
+    "./src/index.ts",
+    "./src/webSocket/index.ts",
+    "./src/webSocket/nodeWebSocket.ts",
+    "src/namedPipe"
   ]
 }


### PR DESCRIPTION
Fixes #1669 
Fixes #1670

## Description
Creates a browser/es5 output of botframework-streaming
- Stop exporting Node.js-specific bits in the browser packages.

## Testing
@ckkashyap?