### PR TITLE
[Expression] Fix result when the second arg is null in lastIndexOf function

### DIFF
--- a/libraries/adaptive-expressions/src/expressionFunctions.ts
+++ b/libraries/adaptive-expressions/src/expressionFunctions.ts
@@ -2217,7 +2217,13 @@ export class ExpressionFunctions {
                     if (!error) {
                         if (args[0] == undefined || typeof args[0] === 'string') {
                             if (args[1] === undefined || typeof args[1] === 'string') {
-                                value = ExpressionFunctions.parseStringOrNull(args[0]).lastIndexOf(ExpressionFunctions.parseStringOrNull(args[1]));
+                                const str = ExpressionFunctions.parseStringOrNull(args[0]);
+                                const searchValue = ExpressionFunctions.parseStringOrNull(args[1]);
+                                if (searchValue === '') {
+                                    value = str.length - 1;
+                                } else {
+                                    value = str.lastIndexOf(searchValue);
+                                } 
                             } else {
                                 error = `Can only look for indexof string in ${ expression }`;
                             }

--- a/libraries/adaptive-expressions/src/expressionFunctions.ts
+++ b/libraries/adaptive-expressions/src/expressionFunctions.ts
@@ -2219,11 +2219,7 @@ export class ExpressionFunctions {
                             if (args[1] === undefined || typeof args[1] === 'string') {
                                 const str = ExpressionFunctions.parseStringOrNull(args[0]);
                                 const searchValue = ExpressionFunctions.parseStringOrNull(args[1]);
-                                if (searchValue === '' && str !== '') {
-                                    value = str.length - 1;
-                                } else {
-                                    value = str.lastIndexOf(searchValue);
-                                } 
+                                value = str.lastIndexOf(searchValue, str.length - 1);
                             } else {
                                 error = `Can only look for indexof string in ${ expression }`;
                             }

--- a/libraries/adaptive-expressions/src/expressionFunctions.ts
+++ b/libraries/adaptive-expressions/src/expressionFunctions.ts
@@ -2219,7 +2219,7 @@ export class ExpressionFunctions {
                             if (args[1] === undefined || typeof args[1] === 'string') {
                                 const str = ExpressionFunctions.parseStringOrNull(args[0]);
                                 const searchValue = ExpressionFunctions.parseStringOrNull(args[1]);
-                                if (searchValue === '') {
+                                if (searchValue === '' && str !== '') {
                                     value = str.length - 1;
                                 } else {
                                     value = str.lastIndexOf(searchValue);

--- a/libraries/adaptive-expressions/tests/expression.test.js
+++ b/libraries/adaptive-expressions/tests/expression.test.js
@@ -171,6 +171,7 @@ const dataSource = [
     ['indexOf(createArray(\'abc\', \'def\', \'ghi\'), \'klm\')', -1],
     ['lastIndexOf(nullObj, \'-\')', -1],
     ['lastIndexOf(hello, nullObj)', 4],
+    ['lastIndexOf(nullObj, nullObj)', 0],
     ['lastIndexOf(newGuid(), \'-\')', 23],
     ['lastIndexOf(newGuid(), \'-\')', 23],
     ['lastIndexOf(hello, \'-\')', -1],

--- a/libraries/adaptive-expressions/tests/expression.test.js
+++ b/libraries/adaptive-expressions/tests/expression.test.js
@@ -170,7 +170,7 @@ const dataSource = [
     ['indexOf(createArray(\'abc\', \'def\', \'ghi\'), \'def\')', 1],
     ['indexOf(createArray(\'abc\', \'def\', \'ghi\'), \'klm\')', -1],
     ['lastIndexOf(nullObj, \'-\')', -1],
-    ['lastIndexOf(hello, nullObj)', 5],
+    ['lastIndexOf(hello, nullObj)', 4],
     ['lastIndexOf(newGuid(), \'-\')', 23],
     ['lastIndexOf(newGuid(), \'-\')', 23],
     ['lastIndexOf(hello, \'-\')', -1],


### PR DESCRIPTION
Parity the result of lastIndexOf  function when either arg is null
lastIndexOf(hello, null) will return 4
lastIndexOf(null, null) will return 0
