### PR TITLE
Initial check-in of flatten, unique and

### DIFF
--- a/libraries/adaptive-expressions/src/expressionFunctions.ts
+++ b/libraries/adaptive-expressions/src/expressionFunctions.ts
@@ -1430,8 +1430,15 @@ export class ExpressionFunctions {
                 }
 
                 result = tempList;
-            } else {
-                error = `${ expression.children[0] } is not array.`;
+            } if (typeof value === 'object') {
+                const tempList = [];
+                for (let [index, val] of Object.entries(value)) {
+                    tempList.push({index: index, value: val});
+                }
+
+                result = tempList;
+            }else {
+                error = `${ expression.children[0] } is not array or object.`;
             }
         }
 
@@ -2012,6 +2019,23 @@ export class ExpressionFunctions {
                 ExpressionFunctions.sortBy(true),
                 ReturnType.Object,
                 (expression: Expression): void => ExpressionFunctions.validateOrder(expression, [ReturnType.String], ReturnType.Object)
+            ),
+            new ExpressionEvaluator(
+                ExpressionType.Flatten,
+                ExpressionFunctions.apply(
+                    args => {
+                        let array = args[0]
+                        let depth = args.length > 1 ? args[1] : 100
+                        return (array as any).flat(depth)
+                    }),
+                ReturnType.Object,
+                (expression: Expression): void => ExpressionFunctions.validateOrder(expression, [ReturnType.Number], ReturnType.Object)
+            ),
+            new ExpressionEvaluator(
+                ExpressionType.Unique,
+                ExpressionFunctions.apply(args => [... new Set(args[0])]),
+                ReturnType.Object,
+                (expression: Expression): void => ExpressionFunctions.validateOrder(expression, [], ReturnType.Object)
             ),
             new ExpressionEvaluator(ExpressionType.IndicesAndValues, 
                 (expression: Expression, state: any): {value: any; error: string} => ExpressionFunctions.indicesAndValues(expression, state), 

--- a/libraries/adaptive-expressions/src/expressionType.ts
+++ b/libraries/adaptive-expressions/src/expressionType.ts
@@ -123,6 +123,8 @@ export class ExpressionType {
     public static readonly SortBy: string = 'sortBy';
     public static readonly SortByDescending: string = 'sortByDescending';
     public static readonly IndicesAndValues: string = 'indicesAndValues';
+    public static readonly Flatten: string = 'flatten';
+    public static readonly Unique: string = 'unique';
 
     // Misc
     public static readonly Constant: string = 'Constant';

--- a/libraries/adaptive-expressions/tests/expression.test.js
+++ b/libraries/adaptive-expressions/tests/expression.test.js
@@ -425,6 +425,7 @@ const dataSource = [
     ['first(1)', undefined],
     ['first(nestedItems).x', 1, ['nestedItems']],
     ['first(where(indicesAndValues(items), elt, elt.index > 1)).value', 'two'],
+    ['first(where(indicesAndValues(bag), elt, elt.index === "three")).value', 3.0]
     ['join(items,\',\')', 'zero,one,two'],
     ['join(createArray(\'a\', \'b\', \'c\'), \'.\')', 'a.b.c'],
     ['join(createArray(\'a\', \'b\', \'c\'), \',\', \' and \')', 'a,b and c'],
@@ -463,7 +464,10 @@ const dataSource = [
     ['sortBy(nestedItems, \'x\')[0].x', 1],
     ['sortByDescending(items)', ['zero', 'two', 'one']],
     ['sortByDescending(nestedItems, \'x\')[0].x', 3],
-
+    ['flatten(createArray([1, [2], [[3, 4], [5, 6]]))', [1, 2, 3, 4, 5, 6]],
+    ['flatten(createArray([1, [2], [[3, 4], [5, 6]], 1))', [1, 2, [3, 4], [5, 6]]],
+    ['unique(createArray([1, 5, 1]))', [1, 5]],
+ 
     // Object manipulation and construction functions tests
     ['string(addProperty(json(\'{"key1":"value1"}\'), \'key2\',\'value2\'))', '{"key1":"value1","key2":"value2"}'],
     ['string(setProperty(json(\'{"key1":"value1"}\'), \'key1\',\'value2\'))', '{"key1":"value2"}'],


### PR DESCRIPTION
Enable indicesAndValues to work over objects.
Add flatten(array, [depth]) which will flatten all arrays or to optional depth.
Add unique(array) which will remove duplicate items from array.

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Testing
Tests for all three fesatures.