### PR TITLE
Update docs on valid scoreThreshold range for QnAMakerOptions

### DIFF
--- a/libraries/botbuilder-ai/src/qnamaker-interfaces/qnamakerOptions.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-interfaces/qnamakerOptions.ts
@@ -14,7 +14,7 @@ import { QnARequestContext } from './qnaRequestContext';
  */
 export interface QnAMakerOptions {
     /**
-     * (Optional) minimum score accepted.
+     * (Optional) The minimum score threshold, used to filter returned results. Values range from score of 0.0 to 1.0.
      *
      * @remarks
      * Defaults to "0.3".


### PR DESCRIPTION

Fixes #1808

## Description
JS repo doesn't explicitly let users know that the valid `scoreThreshold` range is from 0.0 to 1.0, unlike the C# repo.

## Specific Changes
Updated the `QnAMakerOptions.scoreThreshold` doc to specify range explicitly, in line with the docs on the dotnet side

## Testing
n/a -- it's a comment change