### PR TITLE
Added null check for activity.text in ConfirmPrompt

### DIFF
--- a/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
@@ -105,6 +105,9 @@ export class ConfirmPrompt extends Prompt<boolean> {
         const result: PromptRecognizerResult<boolean> = { succeeded: false };
         const activity: Activity = context.activity;
         const utterance: string = activity.text;
+        if (utterance == null) {
+            return result;
+        }
         const culture: string = this.determineCulture(context.activity);
         const results: any = Recognizers.recognizeBoolean(utterance, culture);
         if (results.length > 0 && results[0].resolution) {

--- a/libraries/botbuilder-dialogs/tests/confirmPrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/confirmPrompt.test.js
@@ -204,6 +204,39 @@ describe('ConfirmPrompt', function () {
             .assertReply(`The result found is 'false'.`)
     });
 
+    it('should send retryPrompt if user sends attachment and no text.', async function () {
+        const adapter = new TestAdapter(async (turnContext) => {
+            const dc = await dialogs.createContext(turnContext);
+
+            const results = await dc.continueDialog();
+            if (results.status === DialogTurnStatus.empty) {
+                await dc.prompt('prompt', {
+                    prompt: 'Please confirm. Yes or No',
+                    retryPrompt: `Please reply with 'Yes' or 'No'.`
+                });
+            } else if (results.status === DialogTurnStatus.complete) {
+                await turnContext.sendActivity(`The result found is '${ results.result }'.`);
+            }
+            await convoState.saveChanges(turnContext);
+        });
+
+        const convoState = new ConversationState(new MemoryStorage());
+
+        const dialogState = convoState.createProperty('dialogState');
+        const dialogs = new DialogSet(dialogState);
+        const confirmPrompt = new ConfirmPrompt('prompt');
+        confirmPrompt.style = ListStyle.none;
+        dialogs.add(confirmPrompt);
+
+
+        await adapter.send('Hello')
+            .assertReply('Please confirm. Yes or No')
+            .send({ type: ActivityTypes.Message, attachments: ['ignoreThis']})
+            .assertReply(`Please reply with 'Yes' or 'No'.`)
+            .send('no')
+            .assertReply(`The result found is 'false'.`)
+    });
+
     it('should use defaultLocale when rendering choices', async function () {
         const adapter = new TestAdapter(async (turnContext) => {
             const dc = await dialogs.createContext(turnContext);


### PR DESCRIPTION
Fixes #1798 

## Description

If the user sends an attachment in response to the ConfirmPrompt, an exception is thrown and the retry prompt is not shown.
```js
TypeError: Cannot read property 'toLowerCase' of undefined
```

`toLowerCase` is called within a `Recognizers-Text` package, so before calling it, we just return `{ succeeded: false }` if `activity.text` is null

## Specific Changes

Added:

```js
if (utterance == null) {
    return result;
}
```

## Testing

Added a test.

Before:

![image](https://user-images.githubusercontent.com/40401643/75709493-9f32ed80-5c77-11ea-9c10-ff8de5b3f0e7.png)

After:

![image](https://user-images.githubusercontent.com/40401643/75709502-a3f7a180-5c77-11ea-9096-3151e8094a93.png)

