### PR TITLE
Add tests for SkillDialog

### DIFF
--- a/libraries/botbuilder-dialogs/src/skillDialog.ts
+++ b/libraries/botbuilder-dialogs/src/skillDialog.ts
@@ -134,7 +134,7 @@ export class SkillDialog extends Dialog {
         // Only accept Message or Event activities
         if (dialogArgs.activity.type !== ActivityTypes.Message && dialogArgs.activity.type !== ActivityTypes.Event) {
             // Just forward to the remote skill
-            throw new TypeError(`Only ${ ActivityTypes.Message } and ${ ActivityTypes.Event } activities are supported. Received activity of type ${ dialogArgs.activity.type } in options.`);
+            throw new TypeError(`Only "${ ActivityTypes.Message }" and "${ ActivityTypes.Event }" activities are supported. Received activity of type "${ dialogArgs.activity.type }" in options.`);
         }
 
         return dialogArgs;
@@ -165,7 +165,7 @@ export class SkillDialog extends Dialog {
         const skillInfo = this.dialogOptions.skill;
         await this.dialogOptions.conversationState.saveChanges(context, true);
 
-        const response = await this.dialogOptions.skillClient.postActivity<Activity[]>(this.dialogOptions.botId, skillInfo.appId, skillInfo.skillEndpoint, skillInfo.skillEndpoint, skillConversationId, activity);
+        const response = await this.dialogOptions.skillClient.postActivity<Activity[]>(this.dialogOptions.botId, skillInfo.appId, skillInfo.skillEndpoint, this.dialogOptions.skillHostEndpoint, skillConversationId, activity);
 
         // Inspect the skill response status
         if (!(response.status >= 200 && response.status <= 299)) {

--- a/libraries/botbuilder-dialogs/tests/skillDialog.test.js
+++ b/libraries/botbuilder-dialogs/tests/skillDialog.test.js
@@ -1,0 +1,153 @@
+const { equal, ok: assert, strictEqual } = require('assert');
+const { ActivityTypes, TestAdapter, SkillConversationIdFactoryBase, TurnContext } = require('botbuilder-core');
+const { DialogContext, SkillDialog } = require('../');
+
+const DEFAULT_OAUTHSCOPE = 'https://api.botframework.com';
+const DEFAULT_GOV_OAUTHSCOPE = 'https://api.botframework.us';
+
+const defaultSkillDialogOptions = {
+    botId: 'botId',
+    conversationIdFactory: {},
+    conversationState: {},
+    skill: {},
+    skillHostEndpoint: {}
+};
+
+function typeErrorValidator(e, expectedMessage) {
+    assert(e instanceof TypeError);
+    strictEqual(e.message, expectedMessage);
+}
+
+describe('SkillDialog', function() {
+    this.timeout(3000);
+
+    it('', async () => {
+
+    });
+
+    describe('(private) validateBeginDialogArgs()', () => {
+        it('should fail if options is falsy', () => {
+            const activity = {
+                type: ActivityTypes.Message,
+                text: 'Hello SkillDialog!'
+            };
+            const validatedArgs = SkillDialog.validateBeginDialogArgs({ activity });
+            const validatedActivity = validatedArgs.activity;
+            strictEqual(validatedActivity.type, ActivityTypes.Message);
+            strictEqual(validatedActivity.text, 'Hello SkillDialog!');
+        });
+
+        it('should fail if options is falsy', () => {
+            try {
+                SkillDialog.validateBeginDialogArgs();
+            } catch (e) {
+                typeErrorValidator(e, 'Missing options parameter');
+            }
+        });
+
+        it('should fail if dialogArgs.activity is falsy', () => {
+            try {
+                SkillDialog.validateBeginDialogArgs({});
+            } catch (e) {
+                typeErrorValidator(e, '"activity" is undefined or null in options.');
+            }
+        });
+
+        it('should fail if dialogArgs.activity.type is not "message" or "event"', () => {
+            const type = ActivityTypes.EndOfConversation;
+            try {
+                SkillDialog.validateBeginDialogArgs({ activity: { type } });
+            } catch (e) {
+                typeErrorValidator(e, `Only "${ ActivityTypes.Message }" and "${ ActivityTypes.Event }" activities are supported. Received activity of type "${ type }" in options.`);
+            }
+        });
+    });
+
+    describe('(private) sendToSkill()', () => {
+        it(`should rethrow the error if its message is not "Not Implemented" error`, async () => {
+            const adapter = new TestAdapter(/* logic param not required */);
+            const context = new TurnContext(adapter, { activity: {} });
+            context.turnState.set(adapter.OAuthScopeKey, DEFAULT_OAUTHSCOPE);
+            const dialog = new SkillDialog({
+                botId: 'botId',
+                conversationIdFactory: { createSkillConversationIdWithOptions: async () => { throw new Error('Whoops'); }
+                },
+                conversationState: {},
+                skill: {},
+                skillHostEndpoint: 'http://localhost:3980/api/messages'
+            } , 'SkillDialog');
+            
+            try {
+                await dialog.sendToSkill(context, {});
+            } catch (e) {
+                strictEqual(e.message, 'Whoops');
+            }
+        });
+
+        it('should not rethrow if Error.message is "Not Implemented"', (done) => {
+            const adapter = new TestAdapter(/* logic param not required */);
+            const context = new TurnContext(adapter, { activity: {} });
+            context.turnState.set(adapter.OAuthScopeKey, DEFAULT_OAUTHSCOPE);
+            const dialog = new SkillDialog({
+                botId: 'botId',
+                conversationIdFactory: { 
+                    createSkillConversationIdWithOptions: async () => { throw new Error('Not Implemented'); },
+                    createSkillConversationId: async () => done()
+                },
+                conversationState: {
+                    saveChanges: () => null
+                },
+                skill: {},
+                skillHostEndpoint: 'http://localhost:3980/api/messages',
+                skillClient: {
+                    postActivity: async () => { return { status: 200 }; }
+                }
+            } , 'SkillDialog');
+            
+            dialog.sendToSkill(context, {}).then((a) => assert(typeof a === 'undefined'), (e) => done(e));
+        });
+    });
+});
+
+/**
+ * @param {string} fromBotOAuthScope 
+ * @param {string} fromBotId 
+ * @param {object} activity 
+ * @param {object} botFrameworkSkill { id, appId, skillEndpoint }
+ */
+function createFactoryOptions(fromBotOAuthScope, fromBotId, activity, botFrameworkSkill) {
+    return { fromBotOAuthScope, fromBotId, activity, botFrameworkSkill };
+}
+
+class SkillConversationIdFactory extends SkillConversationIdFactoryBase {
+    constructor(config = { disableCreateWithOpts: false, disableGetSkillRef: false }) {
+        super();
+        this.disableCreateWithOpts = config.disableCreateWithOpts;
+        this.disableGetSkillRef = config.disableGetSkillRef;
+    }
+
+    async createSkillConversationIdWithOptions(opts) {
+        if (this.disableCreateWithOpts) {
+            return super.createSkillConversationIdWithOptions();
+        }
+    }
+
+    async createSkillConversationId() {
+
+    }
+
+    async getConversationReference() {
+
+    }
+
+    async getSkillConversationReference() {
+        if (this.disableGetSkillRef) {
+            return super.getSkillConversationReference();
+        }
+    }
+
+    deleteConversationReference() {
+
+    }
+
+}


### PR DESCRIPTION
## Description

Increase test coverage and fix bugs for Skill-related classes (e.g. SkillDialog)

## Specific Changes
  - `SkillDialog.postToSkill()` bugfix: `skillEndpoint` was being used instead of `skillHostEndpoint`
  - Add tests for **SkillDialog**
     - `validateBeginDialogArgs()`
     - `postToSkill()`
