### PR TITLE
Add interruption support to SkillDialog and runDialog helper method

### DIFF
--- a/libraries/botbuilder-dialogs/src/dialog.ts
+++ b/libraries/botbuilder-dialogs/src/dialog.ts
@@ -234,7 +234,7 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
      * 
      * @param dialogId Optional. unique ID of the dialog.
      */
-    constructor(dialogId?: string) {
+    public constructor(dialogId?: string) {
         super();
         this.id = dialogId;
     }
@@ -245,16 +245,16 @@ export abstract class Dialog<O extends object = {}> extends Configurable {
      * @remarks
      * This will be automatically generated if not specified.
      */
-   public get id(): string {
-       if (this._id === undefined) {
-           this._id = this.onComputeId();
-       }
-       return this._id;
-   }
+    public get id(): string {
+        if (this._id === undefined) {
+            this._id = this.onComputeId();
+        }
+        return this._id;
+    }
 
-   public set id(value: string) {
-       this._id = value;
-   }
+    public set id(value: string) {
+        this._id = value;
+    }
 
     /** 
      * Gets the telemetry client for this dialog.

--- a/libraries/botbuilder-dialogs/src/dialogHelper.ts
+++ b/libraries/botbuilder-dialogs/src/dialogHelper.ts
@@ -1,0 +1,70 @@
+import { Activity, ActivityTypes, TurnContext, StatePropertyAccessor } from 'botbuilder-core';
+import { DialogContext, DialogState } from './dialogContext';
+import { Dialog, DialogTurnStatus } from './dialog';
+import { DialogEvents } from './dialogEvents';
+import { DialogSet } from './dialogSet';
+import { isSkillClaim } from './prompts/skillsHelpers';
+
+export async function runDialog(dialog: Dialog, context: TurnContext, accessor: StatePropertyAccessor<DialogState>): Promise<void> {
+    const dialogSet = new DialogSet(accessor);
+    dialogSet.telemetryClient = dialog.telemetryClient;
+    dialogSet.add(dialog);
+
+    const dialogContext = await dialogSet.createContext(context);
+    const telemetryEventName = `runDialog(${ dialog.constructor.name })`;
+
+    const identity = context.turnState.get(context.adapter.BotIdentityKey);
+    if (identity && isSkillClaim(identity.claims)) {
+        // The bot is running as a skill.
+        if (context.activity.type === ActivityTypes.EndOfConversation && dialogContext.stack.length > 0) {
+            // Handle remote cancellation request if we have something in the stack.
+            const activeDialogContext = getActiveDialogContext(dialogContext);
+            
+            const remoteCancelText = 'Skill was canceled by a request from the host.';
+            await context.sendTraceActivity(telemetryEventName, undefined, undefined, `${ remoteCancelText }`);
+
+            // Send cancellation message to the top dialog in the stack to ensure all the parents are canceled in the right order. 
+            await activeDialogContext.cancelAllDialogs(true);
+        } else {
+            // Process a reprompt event sent from the parent.
+            if (context.activity.type === ActivityTypes.Event && context.activity.name === DialogEvents.repromptDialog && dialogContext.stack.length > 0) {
+                await dialogContext.repromptDialog();
+                return;
+            }
+
+            // Run the Dialog with the new message Activity and capture the results so we can send end of conversation if needed.
+            let result = await dialogContext.continueDialog();
+            if (result.status === DialogTurnStatus.empty) {
+                const startMessageText = `Starting ${ dialog.id }.`;
+                await context.sendTraceActivity(telemetryEventName, undefined, undefined, `${ startMessageText }`);
+                result = await dialogContext.beginDialog(dialog.id, null);
+            }
+
+            // Send end of conversation if it is completed or cancelled.
+            if (result.status === DialogTurnStatus.complete || result.status === DialogTurnStatus.cancelled) {
+                const endMessageText = `Dialog ${ dialog.id } has **completed**. Sending EndOfConversation.`;
+                await context.sendTraceActivity(telemetryEventName, result.result, undefined, `${ endMessageText }`);
+
+                // Send End of conversation at the end.
+                const activity: Partial<Activity> = { type: ActivityTypes.EndOfConversation, value: result.result };
+                await context.sendActivity(activity);
+            }
+        }
+    } else {
+        // The bot is running as a standard bot.
+        const results = await dialogContext.continueDialog();
+        if (results.status === DialogTurnStatus.empty) {
+            await dialogContext.beginDialog(dialog.id);
+        }
+    }
+}
+
+// Recursively walk up the DC stack to find the active DC.
+function getActiveDialogContext(dialogContext: DialogContext): DialogContext {
+    const child = dialogContext.child;
+    if (!child) {
+        return dialogContext;
+    }
+
+    return getActiveDialogContext(child);
+}

--- a/libraries/botbuilder-dialogs/src/index.ts
+++ b/libraries/botbuilder-dialogs/src/index.ts
@@ -5,18 +5,20 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+
+export * from './beginSkillDialogOptions';
 export * from './choices';
-export * from './memory';
-export * from './prompts';
-export * from './dialog';
 export * from './componentDialog';
 export * from './configurable';
+export * from './dialog';
 export * from './dialogContainer';
 export * from './dialogContext';
 export * from './dialogEvents';
+export { runDialog } from './dialogHelper';
 export * from './dialogSet';
+export * from './memory';
+export * from './prompts';
 export * from './skillDialog';
 export * from './skillDialogOptions';
-export * from './beginSkillDialogOptions';
 export * from './waterfallDialog';
 export * from './waterfallStepContext';

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Activity, ActivityTypes, Attachment, AppCredentials, CardFactory, Channels, InputHints, MessageFactory, OAuthLoginTimeoutKey, TokenResponse, TurnContext, OAuthCard, ActionTypes, ExtendedUserTokenProvider, verifyStateOperationName, StatusCodes, tokenExchangeOperationName, tokenResponseEventName } from 'botbuilder-core';
+import { Activity, ActivityTypes, Attachment, AppCredentials, BotAdapter, CardFactory, Channels, InputHints, MessageFactory, OAuthLoginTimeoutKey, TokenResponse, TurnContext, OAuthCard, ActionTypes, ExtendedUserTokenProvider, verifyStateOperationName, StatusCodes, tokenExchangeOperationName, tokenResponseEventName } from 'botbuilder-core';
 import { Dialog, DialogTurnResult } from '../dialog';
 import { DialogContext } from '../dialogContext';
 import { PromptOptions, PromptRecognizerResult,  PromptValidator } from './prompt';
@@ -279,7 +279,7 @@ export class OAuthPrompt extends Dialog {
                 let cardActionType = ActionTypes.Signin;
                 const signInResource = await (context.adapter as ExtendedUserTokenProvider).getSignInResource(context, this.settings.connectionName, context.activity.from.id, null, this.settings.oAuthAppCredentials);
                 let link = signInResource.signInLink;
-                const identity = context.turnState.get((context.adapter as any).BotIdentityKey);
+                const identity = context.turnState.get((context.adapter as BotAdapter).BotIdentityKey);
                 if((identity && isSkillClaim(identity.claims)) || OAuthPrompt.isFromStreamingConnection(context.activity)) {
                     if(context.activity.channelId === Channels.Emulator) {
                         cardActionType = ActionTypes.OpenUrl;

--- a/libraries/botbuilder-dialogs/src/prompts/skillsHelpers.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/skillsHelpers.ts
@@ -22,7 +22,7 @@ export const AuthConstants = {
 
 export const GovConstants = {
     ToBotFromChannelTokenIssuer: 'https://api.botframework.us'
-}
+};
 
 /**
  * @ignore
@@ -82,20 +82,20 @@ export function getAppIdFromClaims(claims: { [key: string]: any }[]): string {
     }
     let appId: string;
 
-        // Depending on Version, the AppId is either in the
-        // appid claim (Version 1) or the 'azp' claim (Version 2).
-        const versionClaim = claims.find(c => c.type === AuthConstants.VersionClaim);
-        const versionValue = versionClaim && versionClaim.value;
-        if (!versionValue || versionValue === '1.0') {
-            // No version or a version of '1.0' means we should look for
-            // the claim in the 'appid' claim.
-            const appIdClaim = claims.find(c => c.type === AuthConstants.AppIdClaim);
-            appId = appIdClaim && appIdClaim.value;
-        } else if (versionValue === '2.0') {
-            // Version '2.0' puts the AppId in the 'azp' claim.
-            const azpClaim = claims.find(c => c.type === AuthConstants.AuthorizedParty);
-            appId = azpClaim && azpClaim.value;
-        }
+    // Depending on Version, the AppId is either in the
+    // appid claim (Version 1) or the 'azp' claim (Version 2).
+    const versionClaim = claims.find(c => c.type === AuthConstants.VersionClaim);
+    const versionValue = versionClaim && versionClaim.value;
+    if (!versionValue || versionValue === '1.0') {
+        // No version or a version of '1.0' means we should look for
+        // the claim in the 'appid' claim.
+        const appIdClaim = claims.find(c => c.type === AuthConstants.AppIdClaim);
+        appId = appIdClaim && appIdClaim.value;
+    } else if (versionValue === '2.0') {
+        // Version '2.0' puts the AppId in the 'azp' claim.
+        const azpClaim = claims.find(c => c.type === AuthConstants.AuthorizedParty);
+        appId = azpClaim && azpClaim.value;
+    }
 
         return appId;
 }


### PR DESCRIPTION
Fixes #1860

## Specific Changes
  - Add new public helper method **runDialog** (C# parity method is [DialogExtensions.RunAsync](https://github.com/microsoft/botbuilder-dotnet/blob/276ffeadd77e2b34a6bbaa64bc4d72f1ff7d748f/libraries/Microsoft.Bot.Builder.Dialogs/DialogExtensions.cs#L31))
    - `runDialog(dialog: Dialog, context: TurnContext, accessor: StatePropertyAccessor<DialogState>): Promise<void>`
  - Add resumeDialog, repromptDialog to SkillDialog
    - add tests for new methods
