### PR TITLE
Revert breaking changes around BotFrameworkClient implementations

### DIFF
--- a/libraries/botbuilder-core/src/index.ts
+++ b/libraries/botbuilder-core/src/index.ts
@@ -31,7 +31,11 @@ export * from './propertyManager';
 export * from './recognizerResult';
 export * from './showTypingMiddleware';
 export * from './signInConstants';
-export { BotFrameworkSkill, BotFrameworkClient, SkillConversationIdFactoryBase, SkillConversationReference,
+export {
+    BotFrameworkSkill,
+    BotFrameworkClient,
+    SkillConversationIdFactoryBase,
+    SkillConversationReference,
     SkillConversationIdFactoryOptions } from './skills';
 export * from './skypeMentionNormalizeMiddleware';
 export * from './statusCodes';

--- a/libraries/botbuilder-core/src/skills/botFrameworkClient.ts
+++ b/libraries/botbuilder-core/src/skills/botFrameworkClient.ts
@@ -9,7 +9,7 @@
 import { Activity } from 'botframework-schema';
 import { InvokeResponse } from '../invokeResponse';
 
-export abstract class BotFrameworkClient {   
+export interface BotFrameworkClient {   
     /**
      * Forwards an activity to a another bot.
      * @remarks
@@ -21,5 +21,5 @@ export abstract class BotFrameworkClient {
      * @param conversationId A conversation ID to use for the conversation with the skill.
      * @param activity Activity to forward.
      */
-    public abstract postActivity<T>(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity): Promise<InvokeResponse<T>>
+    postActivity: (<T>(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity) => Promise<InvokeResponse<T>>) | ((fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity) => Promise<InvokeResponse>);
 }

--- a/libraries/botbuilder-dialogs/src/dialogHelper.ts
+++ b/libraries/botbuilder-dialogs/src/dialogHelper.ts
@@ -91,5 +91,5 @@ function getActiveDialogContext(dialogContext: DialogContext): DialogContext {
 function isEocComingFromParent(context: TurnContext): boolean {
     // To determine the direction we check callerId property which is set to the parent bot
     // by the BotFrameworkHttpClient on outgoing requests.
-    return !(!!context.activity.callerId);
+    return !!context.activity.callerId;
 }

--- a/libraries/botbuilder/src/skills/skillHttpClient.ts
+++ b/libraries/botbuilder/src/skills/skillHttpClient.ts
@@ -13,8 +13,8 @@ import { BotFrameworkHttpClient } from '../botFrameworkHttpClient';
  * A BotFrameworkHttpClient specialized for Skills that encapsulates Conversation ID generation.
  */
 export class SkillHttpClient extends BotFrameworkHttpClient {
-
     private readonly conversationIdFactory: SkillConversationIdFactoryBase;
+
     public constructor(credentialProvider: ICredentialProvider, conversationIdFactory: SkillConversationIdFactoryBase, channelService?: string) {
         super(credentialProvider, channelService);
         if (!conversationIdFactory) {
@@ -24,19 +24,26 @@ export class SkillHttpClient extends BotFrameworkHttpClient {
         this.conversationIdFactory = conversationIdFactory;
     }
 
-
     /**
-     * 
-     * @param originatingAudience 
-     * @param fromBotId 
-     * @param toSkill 
-     * @param callbackUrl 
-     * @param activity 
+     * Uses the SkillConversationIdFactory to create or retrieve a Skill Conversation Id, and sends the activity.
+     * @template T The type of body in the InvokeResponse. 
+     * @param originatingAudience The OAuth audience scope, used during token retrieval. (Either https://api.botframework.com or bot app id.)
+     * @param fromBotId The MicrosoftAppId of the bot sending the activity.
+     * @param toSkill The skill to create the Conversation Id for.
+     * @param callbackUrl The callback Url for the skill host.
+     * @param activity The activity to send.
      */
     public async postToSkill<T>(originatingAudience: string, fromBotId: string, toSkill: BotFrameworkSkill, callbackUrl: string, activity: Activity): Promise<InvokeResponse<T>>;
-    public async postToSkill<T>(fromBotId: string, toSkill: BotFrameworkSkill, callbackUrl: string, activity: Activity): Promise<InvokeResponse>;
-    public async postToSkill<T>(audienceOrFromBotId: string, fromBotIdOrSkill: string | BotFrameworkSkill, toSkillOrCallbackUrl: BotFrameworkSkill | string, callbackUrlOrActivity: string | Activity, activityToForward?: Activity): Promise<InvokeResponse<T>> {
-        
+    /**
+     * Uses the SkillConversationIdFactory to create or retrieve a Skill Conversation Id, and sends the activity.
+     * @deprecated This overload is deprecated. Please use SkillHttpClient.postToSkill() that takes an `originatingAudience`.
+     * @param fromBotId The MicrosoftAppId of the bot sending the activity.
+     * @param toSkill The skill to create the Conversation Id for.
+     * @param callbackUrl The callback Url for the skill host.
+     * @param activity The activity to send.
+     */
+    public async postToSkill(fromBotId: string, toSkill: BotFrameworkSkill, callbackUrl: string, activity: Activity): Promise<InvokeResponse>;
+    public async postToSkill<T = any>(audienceOrFromBotId: string, fromBotIdOrSkill: string | BotFrameworkSkill, toSkillOrCallbackUrl: BotFrameworkSkill | string, callbackUrlOrActivity: string | Activity, activityToForward?: Activity): Promise<InvokeResponse<T>> {
         let originatingAudience: string;
         let fromBotId: string;
         if (typeof fromBotIdOrSkill === 'string') {


### PR DESCRIPTION
## Description
Fixes breaking changes caused by adding `<T>` to BotframeworkClient and its subclasses
Adds overloads to BotFrameworkHttpClient and SkillHttpClient

### **BREAKING CHANGES: Those extending either of the BotFrameworkHttpClient or the SkillClient will need to implement the new templated overload.**

**Those using the base implementation of the class should not have to change any code.** 

____

## Specific Changes
  - **BotFrameworkClient is now an interface with a Union-type for the postActivity() property.**
    - The only difference in the union type is that one of the subtypes takes a template (`T`) for its return value
     - The implementation of the interface would look like this: `postActivity<T>(...): Promise<InvokeResponse<T>>`
     - The union type is for enabling future implementations of BotFrameworkClient to not have to implement an unused abstract method while not breaking current implementations of BotFrameworkClient
  - Fix bug in `runDialog()`


## Testing

<details>
<summary>4.7.2 BotFrameworkHttpClient typings</summary>

There was no BotFrameworkClient interface so the type below is the current type in usage.

```ts
export declare class BotFrameworkHttpClient {
    private readonly credentialProvider;
    private readonly channelService?;
    /**
     * Cache for appCredentials to speed up token acquisition (a token is not requested unless is expired)
     * AppCredentials are cached using appId + scope (this last parameter is only used if the app credentials are used to call a skill)
     */
    private static readonly appCredentialMapCache;
    constructor(credentialProvider: ICredentialProvider, channelService?: string);
    /**
     * Forwards an activity to a another bot.
     * @remarks
     *
     * @param fromBotId The MicrosoftAppId of the bot sending the activity.
     * @param toBotId The MicrosoftAppId of the bot receiving the activity.
     * @param toUrl The URL of the bot receiving the activity.
     * @param serviceUrl The callback Url for the skill host.
     * @param conversationId A conversation ID to use for the conversation with the skill.
     * @param activity Activity to forward.
     */
    postActivity(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity): Promise<InvokeResponse>;
    /**
     * Gets the application credentials. App Credentials are cached so as to ensure we are not refreshing
     * token every time.
     * @private
     * @param appId The application identifier (AAD Id for the bot).
     * @param oAuthScope The scope for the token, skills will use the Skill App Id.
     */
    private getAppCredentials;
}
```
</details>

<details>
<summary><i>4.8.0-rc0's breaking changes BotFrameworkClient typings</i></summary>

The problem below is in the addition of the Template `T`

```ts
export declare abstract class BotFrameworkClient {
    /**
     * Forwards an activity to a another bot.
     * @remarks
     *
     * @param fromBotId The MicrosoftAppId of the bot sending the activity.
     * @param toBotId The MicrosoftAppId of the bot receiving the activity.
     * @param toUrl The URL of the bot receiving the activity.
     * @param serviceUrl The callback Url for the skill host.
     * @param conversationId A conversation ID to use for the conversation with the skill.
     * @param activity Activity to forward.
     */
    abstract postActivity<T>(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity): Promise<InvokeResponse<T>>;
}
```
</details>

<details>
<summary><strong>PR's BotFrameworkClient typings</strong></summary>

```ts
export interface BotFrameworkClient {
    /**
     * Forwards an activity to a another bot.
     * @remarks
     *
     * @param fromBotId The MicrosoftAppId of the bot sending the activity.
     * @param toBotId The MicrosoftAppId of the bot receiving the activity.
     * @param toUrl The URL of the bot receiving the activity.
     * @param serviceUrl The callback Url for the skill host.
     * @param conversationId A conversation ID to use for the conversation with the skill.
     * @param activity Activity to forward.
     */
    postActivity: (<T>(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity) => Promise<InvokeResponse<T>>) | ((fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity) => Promise<InvokeResponse>);
}
```
</details>

<details>
<summary><strong>PR's BotFrameworkHttpClient typings</strong></summary>

```ts
export declare class BotFrameworkHttpClient implements BotFrameworkClient {
    protected readonly channelService: string;
    /**
     * Cache for appCredentials to speed up token acquisition (a token is not requested unless is expired)
     * AppCredentials are cached using appId + scope (this last parameter is only used if the app credentials are used to call a skill)
     */
    private static readonly appCredentialMapCache;
    private readonly credentialProvider;
    constructor(credentialProvider: ICredentialProvider, channelService?: string);
    /**
     * Forwards an activity to a another bot.
     * @remarks
     *
     * @template T The type of body in the InvokeResponse.
     * @param fromBotId The MicrosoftAppId of the bot sending the activity.
     * @param toBotId The MicrosoftAppId of the bot receiving the activity.
     * @param toUrl The URL of the bot receiving the activity.
     * @param serviceUrl The callback Url for the skill host.
     * @param conversationId A conversation ID to use for the conversation with the skill.
     * @param activity Activity to forward.
     */
    postActivity<T>(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity): Promise<InvokeResponse<T>>;
    postActivity(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity): Promise<InvokeResponse>;
    protected buildCredentials(appId: string, oAuthScope?: string): Promise<AppCredentials>;
    /**
     * Gets the application credentials. App Credentials are cached so as to ensure we are not refreshing
     * token every time.
     * @private
     * @param appId The application identifier (AAD Id for the bot).
     * @param oAuthScope The scope for the token, skills will use the Skill App Id.
     */
    private getAppCredentials;
}
```
</details>

## SkillHttpClient typings

<details>
<summary>4.7.2 SkillHttpClient typings</summary>

```ts
export declare class SkillHttpClient extends BotFrameworkHttpClient {
    private readonly conversationIdFactory;
    constructor(credentialProvider: ICredentialProvider, conversationIdFactory: SkillConversationIdFactoryBase, channelService?: string);
    postToSkill(fromBotId: string, toSkill: BotFrameworkSkill, serviceUrl: string, activity: Activity): Promise<InvokeResponse>;
}
```
</details>


<details>
<summary><i>4.8.0-rc0's breaking changes SkillHttpClient typings</i></summary>

The problem below is in the addition of the Template `T`

```ts
export declare class SkillHttpClient extends BotFrameworkHttpClient {
    private readonly conversationIdFactory;
    constructor(credentialProvider: ICredentialProvider, conversationIdFactory: SkillConversationIdFactoryBase, channelService?: string);
    /**
     *
     * @param originatingAudience
     * @param fromBotId
     * @param toSkill
     * @param callbackUrl
     * @param activity
     */
    postToSkill<T>(originatingAudience: string, fromBotId: string, toSkill: BotFrameworkSkill, callbackUrl: string, activity: Activity): Promise<InvokeResponse<T>>;
    postToSkill<T>(fromBotId: string, toSkill: BotFrameworkSkill, callbackUrl: string, activity: Activity): Promise<InvokeResponse>;
}
```
</details>

<details>
<summary><strong>PR's SkillHttpClient typings</strong></summary>

```ts
export declare class SkillHttpClient extends BotFrameworkHttpClient {
    private readonly conversationIdFactory;
    constructor(credentialProvider: ICredentialProvider, conversationIdFactory: SkillConversationIdFactoryBase, channelService?: string);
    /**
     * Uses the SkillConversationIdFactory to create or retrieve a Skill Conversation Id, and sends the activity.
     * @template T The type of body in the InvokeResponse.
     * @param originatingAudience The OAuth audience scope, used during token retrieval. (Either https://api.botframework.com or bot app id.)
     * @param fromBotId The MicrosoftAppId of the bot sending the activity.
     * @param toSkill The skill to create the Conversation Id for.
     * @param callbackUrl The callback Url for the skill host.
     * @param activity The activity to send.
     */
    postToSkill<T>(originatingAudience: string, fromBotId: string, toSkill: BotFrameworkSkill, callbackUrl: string, activity: Activity): Promise<InvokeResponse<T>>;
    /**
     * Uses the SkillConversationIdFactory to create or retrieve a Skill Conversation Id, and sends the activity.
     * @deprecated This overload is deprecated. Please use SkillHttpClient.postToSkill() that takes an `originatingAudience`.
     * @param fromBotId The MicrosoftAppId of the bot sending the activity.
     * @param toSkill The skill to create the Conversation Id for.
     * @param callbackUrl The callback Url for the skill host.
     * @param activity The activity to send.
     */
    postToSkill(fromBotId: string, toSkill: BotFrameworkSkill, callbackUrl: string, activity: Activity): Promise<InvokeResponse>;
}
```
</details>