### PR TITLE
fix runDialog helper, fix callerId generation in BotFrameworkHttpClient

### DIFF
--- a/libraries/botbuilder-dialogs/tests/dialogHelper.test.js
+++ b/libraries/botbuilder-dialogs/tests/dialogHelper.test.js
@@ -1,0 +1,40 @@
+const { strictEqual } = require('assert');
+const { runDialog } = require('../');
+
+describe('runDialog()', function() {
+    this.timeout(300);
+
+    describe('parameter validation', () => {
+        it('should throw if missing dialog parameter', (done) => {
+            runDialog().then(
+                () => done(new Error('should have throw error')),
+                (err) => {
+                    done(strictEqual(err.message, 'runDialog(): missing dialog'));
+                });
+        });
+
+        it('should throw if missing context parameter', (done) => {
+            runDialog({}).then(
+                () => done(new Error('should have throw error')),
+                (err) => {
+                    done(strictEqual(err.message, 'runDialog(): missing context'));
+                });
+        });
+
+        it('should throw if missing context.activity', (done) => {
+            runDialog({}, {}).then(
+                () => done(new Error('should have throw error')),
+                (err) => {
+                    done(strictEqual(err.message, 'runDialog(): missing context.activity'));
+                });
+        });
+
+        it('should throw if missing accessor parameter', (done) => {
+            runDialog({}, { activity: {} }).then(
+                () => done(new Error('should have throw error')),
+                (err) => {
+                    done(strictEqual(err.message, 'runDialog(): missing accessor'));
+                });
+        });
+    });
+});

--- a/libraries/botbuilder/src/botFrameworkHttpClient.ts
+++ b/libraries/botbuilder/src/botFrameworkHttpClient.ts
@@ -90,7 +90,7 @@ export class BotFrameworkHttpClient extends BotFrameworkClient {
             };
             activity.conversation.id = conversationId;
             activity.serviceUrl = serviceUrl;
-            activity.callerId = fromBotId;
+            activity.callerId = `urn:botframework:aadappid:${ fromBotId }`;
             const config = {
                 headers: {
                     Accept: 'application/json',


### PR DESCRIPTION
Fixes #1895,
Fixes #1897

## Description
Port of https://github.com/microsoft/botbuilder-dotnet/pull/3540 to JS

## Specific Changes
  - Follow spec for `callerId`
  - Inspect EndOfConversation activities for routing in `runDialog()`
  - Add parameter validation checks and tests to `runDialog()`
