### PR TITLE
make WebRequest.on optional

### DIFF
--- a/libraries/botbuilder/src/interfaces/webRequest.ts
+++ b/libraries/botbuilder/src/interfaces/webRequest.ts
@@ -47,5 +47,5 @@ export interface WebRequest {
      * 
      * @returns A reference to the request object.
      */
-    on(event: string, ...args: any[]): any;
+    on?(event: string, ...args: any[]): any;
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-js/issues/1589

## Description
Make `on(...` optional on `WebRequest`