### PR TITLE
[PORT] cache Antlr parse result

### DIFF
--- a/libraries/botbuilder-lg/src/staticChecker.ts
+++ b/libraries/botbuilder-lg/src/staticChecker.ts
@@ -27,10 +27,10 @@ export class StaticChecker extends AbstractParseTreeVisitor<Diagnostic[]> implem
     private visitedTemplateNames: string[];
     private _expressionParser: ExpressionParserInterface;
 
-    public constructor(templates: Templates, expressionParser?: ExpressionParser) {
+    public constructor(templates: Templates) {
         super();
         this.templates = templates;
-        this.baseExpressionParser = expressionParser || new ExpressionParser();
+        this.baseExpressionParser = templates.expressionParser || new ExpressionParser();
     }
 
     // Create a property because we want this to be lazy loaded


### PR DESCRIPTION
Fixes #1955
The import chain of LG file is like a graph, there may be various reference logic.
Antlr's parse takes a lot of time in it, If LG SDK can cache the results of Antlr parse(single call life cycle), the performance will be greatly improved.

After experiments, it can save more than half of time for complex lg call chain.

issue link: https://github.com/microsoft/BotFramework-Composer/issues/2374