### PR TITLE
[PORT] Update IMemory interface and tryEvaluate for expression

### DIFF
--- a/libraries/adaptive-expressions/src/expression.ts
+++ b/libraries/adaptive-expressions/src/expression.ts
@@ -460,6 +460,8 @@ export class Expression {
         if(!Extensions.isMemoryInterface(state)) {
             state = SimpleObjectMemory.wrap(state);
         }
+
+        options = options? options : new Options();
         return this.evaluator.tryEvaluate(this, state, options);
     }
 

--- a/libraries/adaptive-expressions/src/expression.ts
+++ b/libraries/adaptive-expressions/src/expression.ts
@@ -12,6 +12,7 @@ import { ExpressionType } from './expressionType';
 import { SimpleObjectMemory, MemoryInterface } from './memory';
 import { Extensions } from './extensions';
 import { ExpressionParser } from './parser';
+import { Options } from './options';
 
 /**
  * Type expected from evalating an expression.
@@ -360,7 +361,7 @@ export class Expression {
      */	
     public static lambda(func: (arg0: any) => any): Expression {
         return new Expression(ExpressionType.Lambda, new ExpressionEvaluator(ExpressionType.Lambda,
-            (_expression: Expression, state: any): { value: any; error: string } => {
+            (_expression: Expression, state: any, _: Options): { value: any; error: string } => {
                 let value: any;
                 let error: string;
                 try {
@@ -455,11 +456,11 @@ export class Expression {
      * Global state to evaluate accessor expressions against.  Can Dictionary be otherwise reflection is used to access property and then indexer.
      * @param state
      */
-    public tryEvaluate(state: MemoryInterface | any): { value: any; error: string } {
+    public tryEvaluate(state: MemoryInterface | any, options: Options = undefined): { value: any; error: string } {
         if(!Extensions.isMemoryInterface(state)) {
             state = SimpleObjectMemory.wrap(state);
         }
-        return this.evaluator.tryEvaluate(this, state);
+        return this.evaluator.tryEvaluate(this, state, options);
     }
 
     public toString(): string {

--- a/libraries/adaptive-expressions/src/expressionEvaluator.ts
+++ b/libraries/adaptive-expressions/src/expressionEvaluator.ts
@@ -7,6 +7,7 @@
  */
 import { Expression, ReturnType } from './expression';
 import { MemoryInterface } from './memory';
+import { Options } from './options';
 
 /**
  * Delegate for doing static validation on an expression.
@@ -18,7 +19,7 @@ export type ValidateExpressionDelegate = (expression: Expression) => any;
  * Delegate to evaluate an expression.
  * Evaluators should verify runtime arguments when appropriate and return an error rather than throw exceptions if possible.
  */
-export type EvaluateExpressionDelegate = (expression: Expression, state: MemoryInterface) => { value: any; error: string };
+export type EvaluateExpressionDelegate = (expression: Expression, state: MemoryInterface, options: Options) => { value: any; error: string };
 
 /**
  * Delegate to lookup function information from the type.
@@ -65,7 +66,7 @@ export class ExpressionEvaluator {
      * @param expression Expression to evaluate.
      * @param state Global state information.
      */
-    public tryEvaluate = (expression: Expression, state: MemoryInterface): { value: any; error: string } => this._evaluator(expression, state);
+    public tryEvaluate = (expression: Expression, state: MemoryInterface, options: Options): { value: any; error: string } => this._evaluator(expression, state, options);
     /**
      * Validate an expression.
      * @param expression Expression to validate.

--- a/libraries/adaptive-expressions/src/expressionFunctions.ts
+++ b/libraries/adaptive-expressions/src/expressionFunctions.ts
@@ -1010,11 +1010,11 @@ export class ExpressionFunctions {
 
     private static wrapGetValue(state: MemoryInterface, path: string, options: Options): any {
         let result = state.getValue(path);
-        if (result !== undefined) {
+        if (result !== undefined && result !== null) {
             return result;
         }
 
-        if(options && options.nullSubstitution !== undefined) {
+        if(options.nullSubstitution !== undefined) {
             return options.nullSubstitution(path);
         }
 

--- a/libraries/adaptive-expressions/src/index.ts
+++ b/libraries/adaptive-expressions/src/index.ts
@@ -15,6 +15,7 @@ export * from './extensions';
 export * from './timeZoneConverter';
 export * from './generated';
 export * from './commonRegex';
+export * from './options';
 export * from './parser';
 export * from './memory';
 export * from './regexErrorListener';

--- a/libraries/adaptive-expressions/src/memory/simpleObjectMemory.ts
+++ b/libraries/adaptive-expressions/src/memory/simpleObjectMemory.ts
@@ -1,7 +1,6 @@
 import { MemoryInterface } from './memoryInterface';
 import { Extensions } from '../extensions';
 import { ExpressionFunctions } from '../expressionFunctions';
-import { Options } from '../options';
 
 /**
  * @module adaptive-expressions

--- a/libraries/adaptive-expressions/src/memory/simpleObjectMemory.ts
+++ b/libraries/adaptive-expressions/src/memory/simpleObjectMemory.ts
@@ -1,6 +1,7 @@
 import { MemoryInterface } from './memoryInterface';
 import { Extensions } from '../extensions';
 import { ExpressionFunctions } from '../expressionFunctions';
+import { Options } from '../options';
 
 /**
  * @module adaptive-expressions

--- a/libraries/adaptive-expressions/src/options.ts
+++ b/libraries/adaptive-expressions/src/options.ts
@@ -14,7 +14,7 @@
 export class Options {
     public nullSubstitution: (name: string) => object;
 
-    public constructor(opt?: (name: string) => object) {
-        this.nullSubstitution = opt? opt : undefined;
+    public constructor(opt?: Options) {
+        this.nullSubstitution = opt? opt.nullSubstitution : undefined;
     }
 }

--- a/libraries/adaptive-expressions/src/options.ts
+++ b/libraries/adaptive-expressions/src/options.ts
@@ -1,0 +1,20 @@
+/**
+ * @module adaptive-expressions
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Options used to define evaluation behaviors.
+ */
+
+
+export class Options {
+    public nullSubstitution: (name: string) => object;
+
+    public constructor(opt?: (name: string) => object) {
+        this.nullSubstitution = opt? opt : undefined;
+    }
+}


### PR DESCRIPTION
fixes: #1966 

Add an optional parameter options in tryEvaluate.

Inside options, we allows user to set a callback function which been called whenever there is a null found in memory path, except for those in boolean context. 