### PR TITLE
Remove "botbuilder-core" dependency from LG

### DIFF
--- a/libraries/botbuilder-lg/package.json
+++ b/libraries/botbuilder-lg/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "adaptive-expressions": "4.1.6",
     "antlr4ts": "0.5.0-alpha.1",
-    "botbuilder-core": "4.1.6",
     "lodash": "^4.17.11",
     "path": "^0.12.7",
     "uuid": "^3.3.3"

--- a/libraries/botbuilder-lg/tests/ActivityFactory.test.js
+++ b/libraries/botbuilder-lg/tests/ActivityFactory.test.js
@@ -1,3 +1,5 @@
+// this test would be migrated to adaptive dialog package
+/*
 const { Templates } = require('../lib');
 const {ActivityFactory} = require('botbuilder-core')
 const assert = require('assert');
@@ -623,3 +625,5 @@ function assertReceiptCardActivity(activity) {
     assert.strictEqual(items[1].quantity, '720');
     
 }
+
+*/


### PR DESCRIPTION
Originally LG depends on "botbuilder-core" to achieve the bot schema to build the Activity througth `ActivityFactory`.
But now, `ActivityFactory` has been moved to "botbuilder-core" library, so, there is no need to depends on any bot library in LG. Which would keep LG as a pure and independent library.