### PR TITLE
[Port] make custom function easier

### DIFF
--- a/libraries/adaptive-expressions/src/expression.ts
+++ b/libraries/adaptive-expressions/src/expression.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ExpressionFunctions } from './expressionFunctions';
+import { FunctionTable } from './functionTable';
 import { Constant } from './constant';
 import { ExpressionEvaluator, EvaluateExpressionDelegate, EvaluatorLookup } from './expressionEvaluator';
 import { ExpressionType } from './expressionType';
@@ -68,95 +68,11 @@ export class Expression {
     protected readonly evaluator: ExpressionEvaluator;
 
     /**
-     * FunctionTable is a dictionary which merges BuiltinFunctions.Functions with a CustomDictionary.
-     */
-    private static readonly FunctionTable = class implements Map<string, ExpressionEvaluator> {
-        private readonly customFunctions = new Map<string, ExpressionEvaluator>();
-
-        public keys(): IterableIterator<string> {
-            const keysOfAllFunctions = Array.from(ExpressionFunctions.standardFunctions.keys()).concat(Array.from(this.customFunctions.keys()));
-            return keysOfAllFunctions[Symbol.iterator]();
-        }
-
-        public values(): IterableIterator<ExpressionEvaluator> {
-            const valuesOfAllFunctions = Array.from(ExpressionFunctions.standardFunctions.values()).concat(Array.from(this.customFunctions.values()));
-            return valuesOfAllFunctions[Symbol.iterator]();
-        }
-
-        public get size(): number {
-            return ExpressionFunctions.standardFunctions.size + this.customFunctions.size;
-        }
-
-        public get isReadOnly(): boolean { 
-            return false;
-        }
-
-        public get(key: string): ExpressionEvaluator {
-
-            if(ExpressionFunctions.standardFunctions.get(key)) {
-                return ExpressionFunctions.standardFunctions.get(key);
-            }
-
-            if (this.customFunctions.get(key)) {
-                return this.customFunctions.get(key);
-            }
-
-            return undefined;
-        }
-
-        public set(key: string, value: ExpressionEvaluator): this {
-            if(ExpressionFunctions.standardFunctions.get(key)) {
-                throw Error(`You can't overwrite a built in function.`);
-            }
-
-            this.customFunctions.set(key, value);
-            return this;
-
-        }
-
-        public add(item: {key: string; value: ExpressionEvaluator} | string, value: ExpressionEvaluator|undefined): void{
-            if(arguments.length === 1 && item instanceof Object) {
-                this.set(item.key, item.value);
-            } else if (arguments.length == 2 && typeof item === 'string') {
-                this.set(item, value);
-            }
-        }
-
-        public clear(): void {
-            this.customFunctions.clear();
-        }
-
-        public has(key: string): boolean {
-            return ExpressionFunctions.standardFunctions.has(key) || this.customFunctions.has(key);
-        }
-
-        public delete(key: string): boolean {
-            return this.customFunctions.delete(key);
-        }
-
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        public forEach(_callbackfn: (value: ExpressionEvaluator, key: string, map: Map<string, ExpressionEvaluator>) => void, thisArg?: any): void {
-            throw Error(`forEach function not implemented`);
-        }
-
-        public entries(): IterableIterator<[string, ExpressionEvaluator]> {
-            throw Error(`entries function not implemented`);
-        }
-
-        public get [Symbol.iterator](): () => IterableIterator<[string, ExpressionEvaluator]>  {
-            throw Error(`Symbol.iterator function not implemented`);
-        }
-
-        public get [Symbol.toStringTag](): string {
-            throw Error(`Symbol.toStringTag function not implemented`);
-        }
-    }
-    /**
      * Dictionary of function => ExpressionEvaluator.
      * This is all available functions, you can add custom functions to it, but you cannot
      * replace builtin functions.  If you clear the dictionary, it will be reset to the built in functions.
      */
-    public static readonly functions: Map<string, ExpressionEvaluator> = new Expression.FunctionTable();
+    public static readonly functions: FunctionTable = new FunctionTable();
 
     /**
      * expression constructor.

--- a/libraries/adaptive-expressions/src/functionTable.ts
+++ b/libraries/adaptive-expressions/src/functionTable.ts
@@ -58,17 +58,20 @@ export class FunctionTable implements Map<string, ExpressionEvaluator> {
 
     }
 
-    public add(item: {key: string; value: ExpressionEvaluator} | string, value?: ExpressionEvaluator | customFunction): void{
+    public add(item: {key: string; value: ExpressionEvaluator}): void;
+    public add(key: string, value: ExpressionEvaluator): void;
+    public add(key: string, value: customFunction): void;
+    public add(param1: {key: string; value: ExpressionEvaluator} | string, param2?: ExpressionEvaluator | customFunction): void{
         if(arguments.length === 1) {
-            if (item instanceof Object) {
-                this.set(item.key, item.value);
+            if (param1 instanceof Object) {
+                this.set(param1.key, param1.value);
             }
         } else {
-            if (typeof item === 'string') {
-                if (value instanceof ExpressionEvaluator){
-                    this.set(item, value);
+            if (typeof param1 === 'string') {
+                if (param2 instanceof ExpressionEvaluator){
+                    this.set(param1, param2);
                 } else {
-                    this.set(item, new ExpressionEvaluator(item, ExpressionFunctions.apply(value)));
+                    this.set(param1, new ExpressionEvaluator(param1, ExpressionFunctions.apply(param2)));
                 }
             } 
         }

--- a/libraries/adaptive-expressions/src/functionTable.ts
+++ b/libraries/adaptive-expressions/src/functionTable.ts
@@ -1,0 +1,105 @@
+/**
+ * @module adaptive-expressions
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ExpressionEvaluator } from './expressionEvaluator';
+import { ExpressionFunctions } from './expressionFunctions';
+
+type customFunction = (args: any[]) => any;
+
+/**
+ * FunctionTable is a dictionary which merges BuiltinFunctions.Functions with a CustomDictionary.
+ */
+export class FunctionTable implements Map<string, ExpressionEvaluator> {
+    private readonly customFunctions = new Map<string, ExpressionEvaluator>();
+
+    public keys(): IterableIterator<string> {
+        const keysOfAllFunctions = Array.from(ExpressionFunctions.standardFunctions.keys()).concat(Array.from(this.customFunctions.keys()));
+        return keysOfAllFunctions[Symbol.iterator]();
+    }
+
+    public values(): IterableIterator<ExpressionEvaluator> {
+        const valuesOfAllFunctions = Array.from(ExpressionFunctions.standardFunctions.values()).concat(Array.from(this.customFunctions.values()));
+        return valuesOfAllFunctions[Symbol.iterator]();
+    }
+
+    public get size(): number {
+        return ExpressionFunctions.standardFunctions.size + this.customFunctions.size;
+    }
+
+    public get isReadOnly(): boolean { 
+        return false;
+    }
+
+    public get(key: string): ExpressionEvaluator {
+
+        if(ExpressionFunctions.standardFunctions.get(key)) {
+            return ExpressionFunctions.standardFunctions.get(key);
+        }
+
+        if (this.customFunctions.get(key)) {
+            return this.customFunctions.get(key);
+        }
+
+        return undefined;
+    }
+
+    public set(key: string, value: ExpressionEvaluator): this {
+        if(ExpressionFunctions.standardFunctions.get(key)) {
+            throw Error(`You can't overwrite a built in function.`);
+        }
+
+        this.customFunctions.set(key, value);
+        return this;
+
+    }
+
+    public add(item: {key: string; value: ExpressionEvaluator} | string, value?: ExpressionEvaluator | customFunction): void{
+        if(arguments.length === 1) {
+            if (item instanceof Object) {
+                this.set(item.key, item.value);
+            }
+        } else {
+            if (typeof item === 'string') {
+                if (value instanceof ExpressionEvaluator){
+                    this.set(item, value);
+                } else {
+                    this.set(item, new ExpressionEvaluator(item, ExpressionFunctions.apply(value)));
+                }
+            } 
+        }
+    }
+
+    public clear(): void {
+        this.customFunctions.clear();
+    }
+
+    public has(key: string): boolean {
+        return ExpressionFunctions.standardFunctions.has(key) || this.customFunctions.has(key);
+    }
+
+    public delete(key: string): boolean {
+        return this.customFunctions.delete(key);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public forEach(_callbackfn: (value: ExpressionEvaluator, key: string, map: Map<string, ExpressionEvaluator>) => void, thisArg?: any): void {
+        throw Error(`forEach function not implemented`);
+    }
+
+    public entries(): IterableIterator<[string, ExpressionEvaluator]> {
+        throw Error(`entries function not implemented`);
+    }
+
+    public get [Symbol.iterator](): () => IterableIterator<[string, ExpressionEvaluator]>  {
+        throw Error(`Symbol.iterator function not implemented`);
+    }
+
+    public get [Symbol.toStringTag](): string {
+        throw Error(`Symbol.toStringTag function not implemented`);
+    }
+}

--- a/libraries/adaptive-expressions/src/index.ts
+++ b/libraries/adaptive-expressions/src/index.ts
@@ -21,3 +21,4 @@ export * from './memory';
 export * from './regexErrorListener';
 export * from './componentExpressionFunctions';
 export * from './datetimeFormatConverter';
+export * from './functionTable';

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -854,4 +854,20 @@ describe('LG', function() {
         result = templates.evaluate('callSub', {});
         assert.strictEqual(result, 12);
     });
+
+    it('TestCustomFunction2', function() {
+        Expression.functions.add('contoso.sqrt', (args) => {
+            let result = null;
+            if (args[0] !== undefined ) {
+                const inputFloat = parseFloat(args[0]);
+                result = Math.sqrt(inputFloat);
+            }
+
+            return result;
+        });
+
+        let templates = Templates.parseFile(GetExampleFilePath('CustomFunction2.lg'), undefined);
+        var evaled = templates.evaluate('custom', {});
+        assert.equal(evaled, 6.0);
+    });
 });

--- a/libraries/botbuilder-lg/tests/testData/examples/customFunction2.lg
+++ b/libraries/botbuilder-lg/tests/testData/examples/customFunction2.lg
@@ -1,0 +1,2 @@
+# custom
+- ${contoso.sqrt("16") + contoso.sqrt("4")} 


### PR DESCRIPTION
Fixes #1931 

Make customized function in LG and expression easier by accepting just a lambda.

At the cost of expose FunctionTable instead of a generic IDictionary.

Now you can do
```JavaScript
Expression.functions.add('contoso.sqrt', (args) => {
            let result = null;
            if (args[0] !== undefined ) {
                const inputFloat = parseFloat(args[0]);
                result = Math.sqrt(inputFloat);
            }

            return result;
        });
```

to add a new function