### PR TITLE
[PORT]Refine Error message and remove duplicate code

### DIFF
--- a/libraries/botbuilder-lg/src/expander.ts
+++ b/libraries/botbuilder-lg/src/expander.ts
@@ -319,29 +319,14 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGFi
 
         if (this.strictMode && (error || !result))
         {
-            let errorMsg = '';
-
-            let childErrorMsg = '';
-            if (error)
-            {
-                childErrorMsg += error;
-            }
-            else if (!result)
-            {
-                childErrorMsg += TemplateErrors.nullExpression(exp);
-            }
-
-            if (context)
-            {
-                errorMsg += TemplateErrors.errorExpression(context.text, this.currentTarget().templateName, errorPrefix);
-            }
+            const templateName = this.currentTarget().templateName;
 
             if (this.evaluationTargetStack.length > 0)
             {
                 this.evaluationTargetStack.pop();
             }
 
-            throw new Error(childErrorMsg + errorMsg);
+            Evaluator.checkExpressionResult(exp, error, result, templateName, context, errorPrefix);
         } else if (error || !result)
         {
             return false;
@@ -358,29 +343,14 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGFi
 
         if (error || (result ===  undefined && this.strictMode))
         {
-            let errorMsg = '';
-
-            let childErrorMsg = '';
-            if (error)
-            {
-                childErrorMsg += error;
-            }
-            else if (result === undefined)
-            {
-                childErrorMsg += TemplateErrors.nullExpression(exp);
-            }
-
-            if (context !== undefined)
-            {
-                errorMsg += TemplateErrors.errorExpression(context.text, this.currentTarget().templateName, errorPrefix);
-            }
+            const templateName = this.currentTarget().templateName;
 
             if (this.evaluationTargetStack.length > 0)
             {
                 this.evaluationTargetStack.pop();
             }
 
-            throw new Error(childErrorMsg + errorMsg);
+            Evaluator.checkExpressionResult(exp, error, result, templateName, context, errorPrefix);
         } else if (result === undefined && !this.strictMode)
         {
             result = `null`;

--- a/libraries/botbuilder-lg/src/staticChecker.ts
+++ b/libraries/botbuilder-lg/src/staticChecker.ts
@@ -308,7 +308,8 @@ export class StaticChecker extends AbstractParseTreeVisitor<Diagnostic[]> implem
             try {
                 this.expressionParser.parse(exp);
             } catch (e) {
-                const errorMsg = prefix + TemplateErrors.expressionParseError(exp) + e.message;
+                const suffixErrorMsg = Evaluator.concatErrorMsg(TemplateErrors.expressionParseError(exp), e.message);
+                const errorMsg = Evaluator.concatErrorMsg(prefix, suffixErrorMsg);
                 result.push(this.buildLGDiagnostic(errorMsg, undefined, context));
     
                 return result;

--- a/libraries/botbuilder-lg/src/templateErrors.ts
+++ b/libraries/botbuilder-lg/src/templateErrors.ts
@@ -10,83 +10,83 @@
   * Centralized LG errors.
   */
 export class TemplateErrors {
-    public static readonly noTemplate: string = `LG file must have at least one template definition. `;
+    public static readonly noTemplate: string = `LG file must have at least one template definition.`;
  
-    public static readonly invalidTemplateName: string = `Invalid template name. Template name should start with letter/number/_ and can only contains letter/number/_/./-. `;
+    public static readonly invalidTemplateName: string = `Invalid template name. Template name should start with letter/number/_ and can only contains letter/number/_/./-.`;
  
-    public static readonly invalidTemplateBody: string = `Invalid template body. Expecting '-' prefix. `;
+    public static readonly invalidTemplateBody: string = `Invalid template body. Expecting '-' prefix.`;
  
     public static readonly invalidStrucName: string = `Invalid structure name. name should start with letter/number/_ and can only contains letter/number/_/./-.`;
  
-    public static readonly missingStrucEnd: string = `Invalid structure body. Expecting ']' at the end of the body. `;
+    public static readonly missingStrucEnd: string = `Invalid structure body. Expecting ']' at the end of the body.`;
  
-    public static readonly emptyStrucContent: string = `Invalid structure body. Body cannot be empty. `;
+    public static readonly emptyStrucContent: string = `Invalid structure body. Body cannot be empty.`;
  
-    public static readonly invalidStrucBody: string = 'Invalid structure body. Body can include <PropertyName>: string = <Value> pairs or ${reference()} template reference. ';
+    public static readonly invalidStrucBody: string = 'Invalid structure body. Body can include <PropertyName>: string = <Value> pairs or ${reference()} template reference.';
  
-    public static readonly invalidWhitespaceInCondition: string = `Invalid condition: At most 1 whitespace allowed between 'IF/ELSEIF/ELSE' and ':'. `;
+    public static readonly invalidWhitespaceInCondition: string = `Invalid condition: At most 1 whitespace allowed between 'IF/ELSEIF/ELSE' and ':'.`;
  
-    public static readonly notStartWithIfInCondition: string = `Invalid condition: Conditions must start with 'IF/ELSEIF/ELSE' prefix `;
+    public static readonly notStartWithIfInCondition: string = `Invalid condition: Conditions must start with 'IF/ELSEIF/ELSE' prefix.`;
  
-    public static readonly multipleIfInCondition: string = `Invalid template body. There cannot be more than one 'IF' condition. Expecting 'IFELSE' or 'ELSE' statement. `;
+    public static readonly multipleIfInCondition: string = `Invalid template body. There cannot be more than one 'IF' condition. Expecting 'IFELSE' or 'ELSE' statement.`;
  
-    public static readonly notEndWithElseInCondition: string = `Conditional response template does not end with 'ELSE' condition. `;
+    public static readonly notEndWithElseInCondition: string = `Conditional response template does not end with 'ELSE' condition.`;
  
-    public static readonly invalidMiddleInCondition: string = `Invalid template body. Expecting 'ELSEIF'. `;
+    public static readonly invalidMiddleInCondition: string = `Invalid template body. Expecting 'ELSEIF'.`;
  
-    public static readonly invalidExpressionInCondition: string = `Invalid condition. 'IF', 'ELSEIF' definitions must include a valid expression. `;
+    public static readonly invalidExpressionInCondition: string = `Invalid condition. 'IF', 'ELSEIF' definitions must include a valid expression.`;
  
-    public static readonly extraExpressionInCondition: string = `Invalid condition. 'ELSE' definition cannot include an expression. `;
+    public static readonly extraExpressionInCondition: string = `Invalid condition. 'ELSE' definition cannot include an expression.`;
  
-    public static readonly missingTemplateBodyInCondition: string = `Invalid condition body. Conditions must include a valid body. `;
+    public static readonly missingTemplateBodyInCondition: string = `Invalid condition body. Conditions must include a valid body.`;
  
-    public static readonly invalidWhitespaceInSwitchCase: string = `Invalid condition: At most 1 whitespace allowed between 'SWITCH/CASE/DEFAULT' and ':'. `;
+    public static readonly invalidWhitespaceInSwitchCase: string = `Invalid condition: At most 1 whitespace allowed between 'SWITCH/CASE/DEFAULT' and ':'.`;
  
-    public static readonly notStartWithSwitchInSwitchCase: string = `Invalid conditional response template. Expecting a 'SWITCH' statement? `;
+    public static readonly notStartWithSwitchInSwitchCase: string = `Invalid conditional response template. Expecting a 'SWITCH' statement?`;
  
-    public static readonly multipleSwithStatementInSwitchCase: string = `Invalid template body. There cannot be more than one 'SWITCH' statement. Expecting 'CASE' or 'DEFAULT' statement. `;
+    public static readonly multipleSwithStatementInSwitchCase: string = `Invalid template body. There cannot be more than one 'SWITCH' statement. Expecting 'CASE' or 'DEFAULT' statement.`;
  
-    public static readonly invalidStatementInMiddlerOfSwitchCase: string = `Invalid template body. Expecting a 'CASE' statement. `;
+    public static readonly invalidStatementInMiddlerOfSwitchCase: string = `Invalid template body. Expecting a 'CASE' statement.`;
  
-    public static readonly notEndWithDefaultInSwitchCase: string = `Conditional response template does not end with 'DEFAULT' condition. `;
+    public static readonly notEndWithDefaultInSwitchCase: string = `Conditional response template does not end with 'DEFAULT' condition.`;
  
-    public static readonly missingCaseInSwitchCase: string = `Invalid template body. Expecting at least one 'CASE' statement. `;
+    public static readonly missingCaseInSwitchCase: string = `Invalid template body. Expecting at least one 'CASE' statement.`;
  
-    public static readonly invalidExpressionInSwiathCase: string = `Invalid condition. 'SWITCH' and 'CASE' statements must include a valid expression. `;
+    public static readonly invalidExpressionInSwiathCase: string = `Invalid condition. 'SWITCH' and 'CASE' statements must include a valid expression.`;
  
-    public static readonly extraExpressionInSwitchCase: string = `Invalid condition. 'DEFAULT' statement cannot include an expression. `;
+    public static readonly extraExpressionInSwitchCase: string = `Invalid condition. 'DEFAULT' statement cannot include an expression.`;
  
-    public static readonly missingTemplateBodyInSwitchCase: string = `Invalid condition body. Expecing valid body inside a 'CASE' or 'DEFAULT' block. `;
+    public static readonly missingTemplateBodyInSwitchCase: string = `Invalid condition body. Expecing valid body inside a 'CASE' or 'DEFAULT' block.`;
  
-    public static readonly noEndingInMultiline: string = 'Expecting "```" to close the multi-line block. ';
+    public static readonly noEndingInMultiline: string = 'Expecting "```" to close the multi-line block.';
  
-    public static readonly noCloseBracket: string = `Close } is missing in Expression`;
+    public static readonly noCloseBracket: string = `Close } is missing in Expression.`;
  
     public static readonly loopDetected: string = `Loop detected:`;
  
-    public static readonly syntaxError: string = `Unexpected content. Expecting either a comment or a template definition or an import statement. `;
+    public static readonly syntaxError: string = `Unexpected content. Expecting either a comment or a template definition or an import statement.`;
  
-    public static readonly invalidMemory: string = `Scope is not a LG customized memory. `;
+    public static readonly invalidMemory: string = `Scope is not a LG customized memory.`;
  
-    public static readonly staticFailure: string = `Static failure with the following error. `;
+    public static readonly staticFailure: string = `Static failure with the following error.`;
  
-    public static readonly duplicatedTemplateInSameTemplate = (templateName: string): string => `Duplicated definitions found for template: '${ templateName }'. `;
+    public static readonly duplicatedTemplateInSameTemplate = (templateName: string): string => `Duplicated definitions found for template: '${ templateName }'.`;
  
-    public static readonly duplicatedTemplateInDiffTemplate = (templateName: string, source: string): string => `Duplicated definitions found for template: '${ templateName }' in '${ source }'. `;
+    public static readonly duplicatedTemplateInDiffTemplate = (templateName: string, source: string): string => `Duplicated definitions found for template: '${ templateName }' in '${ source }'.`;
  
-    public static readonly noTemplateBody = (templateName: string): string => `Missing template body in template '${ templateName }'. `;
+    public static readonly noTemplateBody = (templateName: string): string => `Missing template body in template '${ templateName }'.`;
  
-    public static readonly templateNotExist = (templateName: string): string => `No such template '${ templateName }'. `;
+    public static readonly templateNotExist = (templateName: string): string => `No such template '${ templateName }'.`;
  
-    public static readonly errorExpression = (refFullText: string, templateName: string, prefixText: string): string => `[${ templateName }] ${ prefixText } Error occurred when evaluating '${ refFullText }'. `;
+    public static readonly errorExpression = (refFullText: string, templateName: string, prefixText: string): string => `[${ templateName }] ${ prefixText } Error occurred when evaluating '${ refFullText }'.`;
  
-    public static readonly nullExpression = (expression): string => `'${ expression }' evaluated to null. `;
+    public static readonly nullExpression = (expression): string => `'${ expression }' evaluated to null.`;
  
-    public static readonly argumentMismatch = (templateName: string, expectedCount: number, actualCount: number): string => `arguments mismatch for template '` + `${ templateName }` + `'. Expecting '` + `${ expectedCount }` +`' arguments, actual '` + `${ actualCount }` +`'. `;
+    public static readonly argumentMismatch = (templateName: string, expectedCount: number, actualCount: number): string => `arguments mismatch for template '` + `${ templateName }` + `'. Expecting '` + `${ expectedCount }` +`' arguments, actual '` + `${ actualCount }` +`'.`;
  
-    public static readonly errorTemplateNameformat = (templateName: string): string => `'${ templateName }' cannot be used as a template name. Template names must be avalid . `;
+    public static readonly errorTemplateNameformat = (templateName: string): string => `'${ templateName }' cannot be used as a template name. Template names must be avalid .`;
  
-    public static readonly templateExist = (templateName: string): string => `template '${ templateName }' already exists. `;
+    public static readonly templateExist = (templateName: string): string => `template '${ templateName }' already exists.`;
  
-    public static readonly expressionParseError = (exp: string): string => `Error occurred when parsing expression '${ exp }'. `;
+    public static readonly expressionParseError = (exp: string): string => `Error occurred when parsing expression '${ exp }'.`;
 }

--- a/libraries/botbuilder-lg/tests/lgDiagnostic.test.js
+++ b/libraries/botbuilder-lg/tests/lgDiagnostic.test.js
@@ -203,7 +203,7 @@ describe(`LGExceptionTest`, function() {
     it(`TestLoopDetected`, function() {
         var templates = GetLGFile(`LoopDetected.lg`);
         
-        assert.throws(() => templates.evaluate(`wPhrase`), Error(`Loop detected: welcome-user => wPhrase[wPhrase]  Error occurred when evaluating '-\${wPhrase()}'. [welcome-user]  Error occurred when evaluating '-\${welcome-user()}'. `));
+        assert.throws(() => templates.evaluate(`wPhrase`), Error(`Loop detected: welcome-user => wPhrase [wPhrase]  Error occurred when evaluating '-\${wPhrase()}'. [welcome-user]  Error occurred when evaluating '-\${welcome-user()}'.`));
         
         assert.throws(() => templates.analyzeTemplate(`wPhrase`), Error('Loop detected: welcome-user => wPhrase'),);
     });
@@ -216,31 +216,31 @@ describe(`LGExceptionTest`, function() {
 
     it(`TestErrorExpression`, function() {
         var templates = GetLGFile(`ErrorExpression.lg`);
-        assert.throws(() => templates.evaluate(`template1`), Error(`first(createArray(1, 2)) is neither a string nor a null object.[template1]  Error occurred when evaluating '-\${length(first(createArray(1,2)))}'. `));
+        assert.throws(() => templates.evaluate(`template1`), Error(`first(createArray(1, 2)) is neither a string nor a null object. [template1]  Error occurred when evaluating '-\${length(first(createArray(1,2)))}'.`));
     });
 
     it('TestRunTimeErrors', function() {
         var templates = GetLGFile('RunTimeErrors.lg');
 
-        assert.throws(() => templates.evaluate(`template1`), Error(`'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'. `));
+        assert.throws(() => templates.evaluate(`template1`), Error(`'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'.`));
 
-        assert.throws(() => templates.evaluate(`prebuilt1`), Error(`'dialog.abc' evaluated to null.[prebuilt1]  Error occurred when evaluating '-I want \${foreach(dialog.abc, item, template1())}'. `));
+        assert.throws(() => templates.evaluate(`prebuilt1`), Error(`'dialog.abc' evaluated to null. [prebuilt1]  Error occurred when evaluating '-I want \${foreach(dialog.abc, item, template1())}'.`));
 
-        assert.throws(() => templates.evaluate(`template2`), Error(`'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'. [template2]  Error occurred when evaluating '-With composition \${template1()}'. `));
+        assert.throws(() => templates.evaluate(`template2`), Error(`'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'. [template2]  Error occurred when evaluating '-With composition \${template1()}'.`));
 
-        assert.throws(() => templates.evaluate('conditionalTemplate1', { dialog : true }), Error(`'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'. [conditionalTemplate1] Condition '\${dialog}':  Error occurred when evaluating '-I want \${template1()}'. `));
+        assert.throws(() => templates.evaluate('conditionalTemplate1', { dialog : true }), Error(`'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'. [conditionalTemplate1] Condition '\${dialog}':  Error occurred when evaluating '-I want \${template1()}'.`));
 
-        assert.throws(() => templates.evaluate(`conditionalTemplate2`), Error(`'dialog.abc' evaluated to null. [conditionalTemplate2] Condition '\${dialog.abc}': Error occurred when evaluating '-IF :\${dialog.abc}'. `));
+        assert.throws(() => templates.evaluate(`conditionalTemplate2`), Error(`'dialog.abc' evaluated to null. [conditionalTemplate2] Condition '\${dialog.abc}': Error occurred when evaluating '-IF :\${dialog.abc}'.`));
 
-        assert.throws(() => templates.evaluate(`structured1`), Error(`'dialog.abc' evaluated to null. [structured1] Property 'Text': Error occurred when evaluating 'Text=I want \${dialog.abc}'. `));
+        assert.throws(() => templates.evaluate(`structured1`), Error(`'dialog.abc' evaluated to null. [structured1] Property 'Text': Error occurred when evaluating 'Text=I want \${dialog.abc}'.`));
 
-        assert.throws(() => templates.evaluate(`structured2`), Error(`'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want \${template1()}'. `));
+        assert.throws(() => templates.evaluate(`structured2`), Error(`'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want \${template1()}'.`));
         
-        assert.throws(() => templates.evaluate(`structured3`), Error(`'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want \${template1()}'. [structured3]  Error occurred when evaluating '\${structured2()}'. `));
+        assert.throws(() => templates.evaluate(`structured3`), Error(`'dialog.abc' evaluated to null. [template1]  Error occurred when evaluating '-I want \${dialog.abc}'. [structured2] Property 'Text': Error occurred when evaluating 'Text=I want \${template1()}'. [structured3]  Error occurred when evaluating '\${structured2()}'.`));
         
-        assert.throws(() => templates.evaluate(`switchcase1`, { turn : { testValue : 1 } }), Error(`'dialog.abc' evaluated to null. [switchcase1] Case '\${1}': Error occurred when evaluating '-I want \${dialog.abc}'. `));
+        assert.throws(() => templates.evaluate(`switchcase1`, { turn : { testValue : 1 } }), Error(`'dialog.abc' evaluated to null. [switchcase1] Case '\${1}': Error occurred when evaluating '-I want \${dialog.abc}'.`));
         
-        assert.throws(() => templates.evaluate(`switchcase2`, { turn : { testValue : 0 } }), Error(`'dialog.abc' evaluated to null. [switchcase2] Case 'Default': Error occurred when evaluating '-I want \${dialog.abc}'. `));
+        assert.throws(() => templates.evaluate(`switchcase2`, { turn : { testValue : 0 } }), Error(`'dialog.abc' evaluated to null. [switchcase2] Case 'Default': Error occurred when evaluating '-I want \${dialog.abc}'.`));
     });
 });
 


### PR DESCRIPTION
close: #1988
1. Originally LG use the end white space of error message to separate the error layer to make it more readable.

But it is strange to have such message. So, we concat the error stack at runtime with white space.

2. There are many duplicate code to build the stack error message,  extract them make the code clean and pure.