### PR TITLE
refactor expander

### DIFF
--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -191,7 +191,7 @@ export class Templates implements Iterable<Template> {
      * @param scope The state visible in the evaluation.
      * @returns Expand result.
      */
-    public expandTemplate(templateName: string, scope?: object): string[] {
+    public expandTemplate(templateName: string, scope?: object): any[] {
         this.checkErrors();
 
         const expander = new Expander(this.allTemplates, this.expressionParser, this.strictMode);

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -383,31 +383,31 @@ describe('LG', function() {
         assert.strictEqual(evaled, 'Hi');
     });
 
-    it('TestExpandTemplate', function() {
+    it('TestExpandTemplate', function () {
         var templates = Templates.parseFile(GetExampleFilePath('Expand.lg'));
-        
+
         // without scope
         var evaled = templates.expandTemplate('FinalGreeting');
-        assert.strictEqual(evaled.length, 4, `Evaled is ${ evaled }`);
+        assert.strictEqual(evaled.length, 4, `Evaled is ${evaled}`);
         let expectedResults = ['Hi Morning', 'Hi Evening', 'Hello Morning', 'Hello Evening'];
         expectedResults.forEach(x => assert(evaled.includes(x)));
 
         // with scope
-        evaled = templates.expandTemplate('TimeOfDayWithCondition', { time: 'evening'});
-        assert.strictEqual(evaled.length, 2, `Evaled is ${ evaled }`);
+        evaled = templates.expandTemplate('TimeOfDayWithCondition', {time: 'evening'});
+        assert.strictEqual(evaled.length, 2, `Evaled is ${evaled}`);
         expectedResults = ['Hi Evening', 'Hello Evening'];
         expectedResults.forEach(x => assert(evaled.includes(x)));
 
         // with scope
         evaled = templates.expandTemplate('greetInAWeek', {day:'Sunday'});
-        assert.strictEqual(evaled.length, 2, `Evaled is ${ evaled }`);
+        assert.strictEqual(evaled.length, 2, `Evaled is ${evaled}`);
         expectedResults = ['Nice Sunday!', 'Happy Sunday!'];
         expectedResults.forEach(x => assert(evaled.includes(x)));
     });
 
-    it('TestExpandTemplateWithRef', function() {
+    it('TestExpandTemplateWithRef', function () {
         var templates = Templates.parseFile(GetExampleFilePath('Expand.lg'));
-        
+
         const alarms = [
             {
                 time: '7 am',
@@ -418,16 +418,16 @@ describe('LG', function() {
                 date: 'tomorrow'
             }
         ];
-        
-        var evaled = templates.expandTemplate('ShowAlarmsWithLgTemplate', {alarms});
-        assert.strictEqual(evaled.length, 2, `Evaled is ${ evaled }`);
-        assert.strictEqual(evaled[0], 'You have 2 alarms, they are 8 pm at tomorrow', `Evaled is ${ evaled }`);
-        assert.strictEqual(evaled[1], 'You have 2 alarms, they are 8 pm of tomorrow', `Evaled is ${ evaled }`);
+
+        var evaled = templates.expandTemplate('ShowAlarmsWithLgTemplate', { alarms });
+        assert.strictEqual(evaled.length, 2, `Evaled is ${evaled}`);
+        assert.strictEqual(evaled[0], 'You have 2 alarms, they are 8 pm at tomorrow', `Evaled is ${evaled}`);
+        assert.strictEqual(evaled[1], 'You have 2 alarms, they are 8 pm of tomorrow', `Evaled is ${evaled}`);
     });
 
-    it('TestExpandTemplateWithRefInMultiLine', function() {
+    it('TestExpandTemplateWithRefInMultiLine', function () {
         var templates = Templates.parseFile(GetExampleFilePath('Expand.lg'));
-        
+
         const alarms = [
             {
                 time: '7 am',
@@ -438,18 +438,18 @@ describe('LG', function() {
                 date: 'tomorrow'
             }
         ];
-        
-        var evaled = templates.expandTemplate('ShowAlarmsWithMultiLine', {alarms});
-        assert.strictEqual(evaled.length, 2, `Evaled is ${ evaled }`);
+
+        var evaled = templates.expandTemplate('ShowAlarmsWithMultiLine', { alarms });
+        assert.strictEqual(evaled.length, 2, `Evaled is ${evaled}`);
         const eval1Options = ['\r\nYou have 2 alarms.\r\nThey are 8 pm at tomorrow\r\n', '\nYou have 2 alarms.\nThey are 8 pm at tomorrow\n'];
         const eval2Options = ['\r\nYou have 2 alarms.\r\nThey are 8 pm of tomorrow\r\n', '\nYou have 2 alarms.\nThey are 8 pm of tomorrow\n'];
         assert(eval1Options.includes(evaled[0]));
         assert(eval2Options.includes(evaled[1]));
     });
 
-    it('TestExpandTemplateWithFunction', function() {
+    it('TestExpandTemplateWithFunction', function () {
         var templates = Templates.parseFile(GetExampleFilePath('Expand.lg'));
-        
+
         const alarms = [
             {
                 time: '7 am',
@@ -460,9 +460,9 @@ describe('LG', function() {
                 date: 'tomorrow'
             }
         ];
-        
-        var evaled = templates.expandTemplate('ShowAlarmsWithForeach', {alarms});
-        assert.strictEqual(evaled.length, 1, `Evaled is ${ evaled }`);
+
+        var evaled = templates.expandTemplate('ShowAlarmsWithForeach', { alarms });
+        assert.strictEqual(evaled.length, 1, `Evaled is ${evaled}`);
         const evalOptions = [
             'You have 2 alarms, 7 am at tomorrow and 8 pm at tomorrow',
             'You have 2 alarms, 7 am at tomorrow and 8 pm of tomorrow',
@@ -473,16 +473,100 @@ describe('LG', function() {
         assert(evalOptions.includes(evaled[0]));
 
         evaled = templates.expandTemplate('T2');
-        assert.strictEqual(evaled.length, 1, `Evaled is ${ evaled }`);
+        assert.strictEqual(evaled.length, 1, `Evaled is ${evaled}`);
         assert(evaled[0] === '3' || evaled[0] === '5');
 
         evaled = templates.expandTemplate('T3');
-        assert.strictEqual(evaled.length, 1, `Evaled is ${ evaled }`);
+        assert.strictEqual(evaled.length, 1, `Evaled is ${evaled}`);
         assert(evaled[0] === '3' || evaled[0] === '5');
 
         evaled = templates.expandTemplate('T4');
-        assert.strictEqual(evaled.length, 1, `Evaled is ${ evaled }`);
+        assert.strictEqual(evaled.length, 1, `Evaled is ${evaled}`);
         assert(evaled[0] === 'ey' || evaled[0] === 'el');
+    });
+
+    it('TestExpandTemplateWithIsTemplateFunction', function () {
+        const templates = Templates.parseFile(GetExampleFilePath('Expand.lg'));
+
+        let evaled = templates.expandTemplate('template2', { templateName: 'Greeting' });
+        assert.strictEqual(evaled.length, 2);
+        assert.strictEqual(evaled[0], 'Hi');
+        assert.strictEqual(evaled[1], 'Hello');
+
+        evaled = templates.expandTemplate('template2', { templateName: 'xxx' });
+        assert.strictEqual(evaled.length, 2);
+        assert.strictEqual(evaled[0], 'Morning');
+        assert.strictEqual(evaled[1], 'Evening');
+    });
+
+    it('TestExpandTemplateWithTemplateFunction', function () {
+        const templates = Templates.parseFile(GetExampleFilePath('Expand.lg'));
+
+        let evaled = templates.expandTemplate('template3', { templateName: 'Greeting' });
+        assert.strictEqual(evaled.length, 2);
+        assert.strictEqual(evaled[0], 'Hi');
+        assert.strictEqual(evaled[1], 'Hello');
+    });
+
+    it('TestExpandTemplateWithDoubleQuotation', function () {
+        const templates = Templates.parseFile(GetExampleFilePath('Expand.lg'));
+
+        let evaled = templates.expandTemplate('ExpanderT1');
+        assert.strictEqual(evaled.length, 2);
+        const expectedResults = [
+            "{\"lgType\":\"MyStruct\",\"text\":\"Hi \\\"quotes\\\" allowed\",\"speak\":\"how old are you?\"}",
+            "{\"lgType\":\"MyStruct\",\"text\":\"Hi \\\"quotes\\\" allowed\",\"speak\":\"what's your age?\"}"
+        ];
+
+        expectedResults.forEach((value, index) => {
+            assert.strictEqual(JSON.stringify(evaled[index]), JSON.stringify(JSON.parse(value)));
+        });
+    });
+
+    it('TestExpandTemplateWithEscapeCharacter', function () {
+        const templates = Templates.parseFile(GetExampleFilePath('EscapeCharacter.lg'));
+        var evaled = templates.expandTemplate('wPhrase');
+        assert.strictEqual(evaled[0], 'Hi \r\n\t\\');
+
+        evaled = templates.expandTemplate('AtEscapeChar');
+        assert.strictEqual(evaled[0], 'Hi{1+1}[wPhrase]{wPhrase()}${wPhrase()}2${1+1}');
+
+        evaled = templates.expandTemplate('otherEscape');
+        assert.strictEqual(evaled[0], 'Hi \\y \\');
+
+        evaled = templates.expandTemplate('escapeInExpression');
+        assert.strictEqual(evaled[0], 'Hi hello\\\\');
+
+        evaled = templates.expandTemplate('escapeInExpression2');
+        assert.strictEqual(evaled[0], "Hi hello'");
+
+        evaled = templates.expandTemplate('escapeInExpression3');
+        assert.strictEqual(evaled[0], 'Hi hello\"');
+
+        evaled = templates.expandTemplate('escapeInExpression4');
+        assert.strictEqual(evaled[0], 'Hi hello\"');
+
+        evaled = templates.expandTemplate('escapeInExpression5');
+        assert.strictEqual(evaled[0], 'Hi hello\n');
+
+        evaled = templates.expandTemplate('escapeInExpression6');
+        assert.strictEqual(evaled[0], 'Hi hello\n');
+
+        var todos = ['A', 'B', 'C'];
+        evaled = templates.expandTemplate('showTodo', { todos });
+        assert.strictEqual(evaled[0].toString().replace(/\r\n/g, '\n'), '\n    Your most recent 3 tasks are\n    * A\n* B\n* C\n    ');
+
+        evaled = templates.expandTemplate('showTodo');
+        assert.strictEqual(evaled[0].toString().replace(/\r\n/g, '\n'), "\n    You don't have any \"t\\\\odo'\".\n    ");
+
+        evaled = templates.expandTemplate('getUserName');
+        assert.strictEqual(evaled[0], "super \"x man\"");
+
+        evaled = templates.expandTemplate('structure1');
+        assert.strictEqual(JSON.stringify(evaled[0]), "{\"lgType\":\"struct\",\"list\":[\"a\",\"b|c\"]}");
+
+        evaled = templates.expandTemplate('dollarsymbol');
+        assert.strictEqual(evaled[0], "$ $ ${'hi'} hi");
     });
 
     it('TestInlineEvaluate', function() {
@@ -676,18 +760,24 @@ describe('LG', function() {
             '{"lgType":"Activity","text":"what\'s your age?","speak":"how old are you?"}',
             '{"lgType":"Activity","text":"what\'s your age?","speak":"what\'s your age?"}'
         ];
-        expectedResults.forEach( u => assert(evaled.includes(u)));
+
+        expectedResults.forEach((value, index) => {
+            assert.strictEqual(JSON.stringify(evaled[index]), JSON.stringify(JSON.parse(value)));
+        });
 
         evaled = templates.expandTemplate('ExpanderT1');
         assert.strictEqual(evaled.length, 4, `Evaled is ${ evaled }`);
     
         expectedResults = [
             '{"lgType":"MyStruct","text":"Hi","speak":"how old are you?"}',
-            '{"lgType":"MyStruct","text":"Hi","speak":"what\'s your age?"}',
             '{"lgType":"MyStruct","text":"Hello","speak":"how old are you?"}',
+            '{"lgType":"MyStruct","text":"Hi","speak":"what\'s your age?"}',
             '{"lgType":"MyStruct","text":"Hello","speak":"what\'s your age?"}'
         ];
-        expectedResults.forEach( u => assert(evaled.includes(u)));
+
+        expectedResults.forEach((value, index) => {
+            assert.strictEqual(JSON.stringify(evaled[index]), JSON.stringify(JSON.parse(value)));
+        });
     });
 
     it('TestExpressionextract', function() {

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -383,31 +383,31 @@ describe('LG', function() {
         assert.strictEqual(evaled, 'Hi');
     });
 
-    it('TestExpandTemplate', function () {
+    it('TestExpandTemplate', function() {
         var templates = Templates.parseFile(GetExampleFilePath('Expand.lg'));
-
+        
         // without scope
         var evaled = templates.expandTemplate('FinalGreeting');
-        assert.strictEqual(evaled.length, 4, `Evaled is ${evaled}`);
+        assert.strictEqual(evaled.length, 4, `Evaled is ${ evaled }`);
         let expectedResults = ['Hi Morning', 'Hi Evening', 'Hello Morning', 'Hello Evening'];
         expectedResults.forEach(x => assert(evaled.includes(x)));
 
         // with scope
-        evaled = templates.expandTemplate('TimeOfDayWithCondition', {time: 'evening'});
-        assert.strictEqual(evaled.length, 2, `Evaled is ${evaled}`);
+        evaled = templates.expandTemplate('TimeOfDayWithCondition', { time: 'evening'});
+        assert.strictEqual(evaled.length, 2, `Evaled is ${ evaled }`);
         expectedResults = ['Hi Evening', 'Hello Evening'];
         expectedResults.forEach(x => assert(evaled.includes(x)));
 
         // with scope
         evaled = templates.expandTemplate('greetInAWeek', {day:'Sunday'});
-        assert.strictEqual(evaled.length, 2, `Evaled is ${evaled}`);
+        assert.strictEqual(evaled.length, 2, `Evaled is ${ evaled }`);
         expectedResults = ['Nice Sunday!', 'Happy Sunday!'];
         expectedResults.forEach(x => assert(evaled.includes(x)));
     });
 
-    it('TestExpandTemplateWithRef', function () {
+    it('TestExpandTemplateWithRef', function() {
         var templates = Templates.parseFile(GetExampleFilePath('Expand.lg'));
-
+        
         const alarms = [
             {
                 time: '7 am',
@@ -418,16 +418,16 @@ describe('LG', function() {
                 date: 'tomorrow'
             }
         ];
-
-        var evaled = templates.expandTemplate('ShowAlarmsWithLgTemplate', { alarms });
-        assert.strictEqual(evaled.length, 2, `Evaled is ${evaled}`);
-        assert.strictEqual(evaled[0], 'You have 2 alarms, they are 8 pm at tomorrow', `Evaled is ${evaled}`);
-        assert.strictEqual(evaled[1], 'You have 2 alarms, they are 8 pm of tomorrow', `Evaled is ${evaled}`);
+        
+        var evaled = templates.expandTemplate('ShowAlarmsWithLgTemplate', {alarms});
+        assert.strictEqual(evaled.length, 2, `Evaled is ${ evaled }`);
+        assert.strictEqual(evaled[0], 'You have 2 alarms, they are 8 pm at tomorrow', `Evaled is ${ evaled }`);
+        assert.strictEqual(evaled[1], 'You have 2 alarms, they are 8 pm of tomorrow', `Evaled is ${ evaled }`);
     });
 
-    it('TestExpandTemplateWithRefInMultiLine', function () {
+    it('TestExpandTemplateWithRefInMultiLine', function() {
         var templates = Templates.parseFile(GetExampleFilePath('Expand.lg'));
-
+        
         const alarms = [
             {
                 time: '7 am',
@@ -438,18 +438,18 @@ describe('LG', function() {
                 date: 'tomorrow'
             }
         ];
-
-        var evaled = templates.expandTemplate('ShowAlarmsWithMultiLine', { alarms });
-        assert.strictEqual(evaled.length, 2, `Evaled is ${evaled}`);
+        
+        var evaled = templates.expandTemplate('ShowAlarmsWithMultiLine', {alarms});
+        assert.strictEqual(evaled.length, 2, `Evaled is ${ evaled }`);
         const eval1Options = ['\r\nYou have 2 alarms.\r\nThey are 8 pm at tomorrow\r\n', '\nYou have 2 alarms.\nThey are 8 pm at tomorrow\n'];
         const eval2Options = ['\r\nYou have 2 alarms.\r\nThey are 8 pm of tomorrow\r\n', '\nYou have 2 alarms.\nThey are 8 pm of tomorrow\n'];
         assert(eval1Options.includes(evaled[0]));
         assert(eval2Options.includes(evaled[1]));
     });
 
-    it('TestExpandTemplateWithFunction', function () {
+    it('TestExpandTemplateWithFunction', function() {
         var templates = Templates.parseFile(GetExampleFilePath('Expand.lg'));
-
+        
         const alarms = [
             {
                 time: '7 am',
@@ -460,9 +460,9 @@ describe('LG', function() {
                 date: 'tomorrow'
             }
         ];
-
-        var evaled = templates.expandTemplate('ShowAlarmsWithForeach', { alarms });
-        assert.strictEqual(evaled.length, 1, `Evaled is ${evaled}`);
+        
+        var evaled = templates.expandTemplate('ShowAlarmsWithForeach', {alarms});
+        assert.strictEqual(evaled.length, 1, `Evaled is ${ evaled }`);
         const evalOptions = [
             'You have 2 alarms, 7 am at tomorrow and 8 pm at tomorrow',
             'You have 2 alarms, 7 am at tomorrow and 8 pm of tomorrow',
@@ -473,42 +473,42 @@ describe('LG', function() {
         assert(evalOptions.includes(evaled[0]));
 
         evaled = templates.expandTemplate('T2');
-        assert.strictEqual(evaled.length, 1, `Evaled is ${evaled}`);
+        assert.strictEqual(evaled.length, 1, `Evaled is ${ evaled }`);
         assert(evaled[0] === '3' || evaled[0] === '5');
 
         evaled = templates.expandTemplate('T3');
-        assert.strictEqual(evaled.length, 1, `Evaled is ${evaled}`);
+        assert.strictEqual(evaled.length, 1, `Evaled is ${ evaled }`);
         assert(evaled[0] === '3' || evaled[0] === '5');
 
         evaled = templates.expandTemplate('T4');
-        assert.strictEqual(evaled.length, 1, `Evaled is ${evaled}`);
+        assert.strictEqual(evaled.length, 1, `Evaled is ${ evaled }`);
         assert(evaled[0] === 'ey' || evaled[0] === 'el');
     });
 
-    it('TestExpandTemplateWithIsTemplateFunction', function () {
+    it('TestExpandTemplateWithIsTemplateFunction', function() {
         const templates = Templates.parseFile(GetExampleFilePath('Expand.lg'));
 
-        let evaled = templates.expandTemplate('template2', { templateName: 'Greeting' });
+        let evaled = templates.expandTemplate('template2', {templateName: 'Greeting'});
         assert.strictEqual(evaled.length, 2);
         assert.strictEqual(evaled[0], 'Hi');
         assert.strictEqual(evaled[1], 'Hello');
 
-        evaled = templates.expandTemplate('template2', { templateName: 'xxx' });
+        evaled = templates.expandTemplate('template2', {templateName: 'xxx'});
         assert.strictEqual(evaled.length, 2);
         assert.strictEqual(evaled[0], 'Morning');
         assert.strictEqual(evaled[1], 'Evening');
     });
 
-    it('TestExpandTemplateWithTemplateFunction', function () {
+    it('TestExpandTemplateWithTemplateFunction', function() {
         const templates = Templates.parseFile(GetExampleFilePath('Expand.lg'));
 
-        let evaled = templates.expandTemplate('template3', { templateName: 'Greeting' });
+        let evaled = templates.expandTemplate('template3', {templateName: 'Greeting'});
         assert.strictEqual(evaled.length, 2);
         assert.strictEqual(evaled[0], 'Hi');
         assert.strictEqual(evaled[1], 'Hello');
     });
 
-    it('TestExpandTemplateWithDoubleQuotation', function () {
+    it('TestExpandTemplateWithDoubleQuotation', function() {
         const templates = Templates.parseFile(GetExampleFilePath('Expand.lg'));
 
         let evaled = templates.expandTemplate('ExpanderT1');
@@ -523,7 +523,7 @@ describe('LG', function() {
         });
     });
 
-    it('TestExpandTemplateWithEscapeCharacter', function () {
+    it('TestExpandTemplateWithEscapeCharacter', function() {
         const templates = Templates.parseFile(GetExampleFilePath('EscapeCharacter.lg'));
         var evaled = templates.expandTemplate('wPhrase');
         assert.strictEqual(evaled[0], 'Hi \r\n\t\\');
@@ -553,7 +553,7 @@ describe('LG', function() {
         assert.strictEqual(evaled[0], 'Hi hello\n');
 
         var todos = ['A', 'B', 'C'];
-        evaled = templates.expandTemplate('showTodo', { todos });
+        evaled = templates.expandTemplate('showTodo', {todos});
         assert.strictEqual(evaled[0].toString().replace(/\r\n/g, '\n'), '\n    Your most recent 3 tasks are\n    * A\n* B\n* C\n    ');
 
         evaled = templates.expandTemplate('showTodo');

--- a/libraries/botbuilder-lg/tests/testData/examples/Expand.lg
+++ b/libraries/botbuilder-lg/tests/testData/examples/Expand.lg
@@ -76,3 +76,28 @@ They are ${ShowAlarm(alarms[1])}
 
 # T4
 - ${substring(T1(), 1, 2)}
+
+# template2(templateName)
+- IF: ${isTemplate(templateName)}
+    - ${Greeting()}
+- ELSE:
+    - ${TimeOfDay()}
+
+# template3(templateName)
+  - ${template(templateName)}
+
+# GetAge
+- how old are you?
+- what's your age?
+
+# ExpanderT1
+[MyStruct
+    Text = Hi "quotes" allowed
+    ${ExpanderT2()}
+]
+
+# ExpanderT2
+[MyStruct
+    Speak = ${GetAge()}
+    Text = zoo
+]


### PR DESCRIPTION
Fixes #3523 https://github.com/microsoft/botbuilder-dotnet/issues/3523
Fixes #2014 

## Description
Refactor lg expander to support full functions of LG and fix several issues such as excape, double quotation. Also change the return type from string array to object array.

## Specific Changes
- [x] Support all kinds of LG functions

- [x] Discard the 'builtin.' prefix

- [x] Fix escape issues, including double quotation, escape character

- [x] change return type from string array to object array

## Testing
Corresponding test cases are added in lg.test.js