### PR TITLE
[PORT] update adaptive inputs to set inputHint = expectingInput

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/src/input/inputDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/inputDialog.ts
@@ -199,24 +199,30 @@ export abstract class InputDialog extends Dialog {
     }
 
     protected async onRenderPrompt(dc: DialogContext, state: InputState): Promise<Partial<Activity>> {
+        let msg: Partial<Activity>;
         switch (state) {
             case InputState.unrecognized:
                 if (this.unrecognizedPrompt) {
-                    return await this.unrecognizedPrompt.bindToData(dc.context, dc.state);
+                    msg = await this.unrecognizedPrompt.bindToData(dc.context, dc.state);
                 } else if (this.invalidPrompt) {
-                    return await this.invalidPrompt.bindToData(dc.context, dc.state);
+                    msg = await this.invalidPrompt.bindToData(dc.context, dc.state);
                 }
                 break;
             case InputState.invalid:
                 if (this.invalidPrompt) {
-                    return await this.invalidPrompt.bindToData(dc.context, dc.state);
+                    msg = await this.invalidPrompt.bindToData(dc.context, dc.state);
                 } else if (this.unrecognizedPrompt) {
-                    return await this.unrecognizedPrompt.bindToData(dc.context, dc.state);
+                    msg = await this.unrecognizedPrompt.bindToData(dc.context, dc.state);
                 }
                 break;
         }
 
-        return await this.prompt.bindToData(dc.context, dc.state);
+        if (!msg) {
+            msg = await this.prompt.bindToData(dc.context, dc.state);
+        }
+
+        msg.inputHint = InputHints.ExpectingInput;
+        return msg; 
     }
 
     protected getDefaultInput(dc: DialogContext): any {


### PR DESCRIPTION
close: #1776
At first, LG `ActivityFactory` use `MessageFactory.Text()` to generate message activity result from LG output, but `MessageFactory.Text()` would inject `inputhint = expectingInput ` into activity, and the prompt of input relies on this feature.

 Then we found there is no reason to add `inputhint` into pure text activity, so we removed it.

At the same time, we should update adaptive inputs to set `inputHint = expectingInput` whenever we are issuing a prompt or reprompt (unrecognized/ invalid prompt).
