### PR TITLE
bump chromedriver to ^81.0.0

### DIFF
--- a/libraries/browser-functional-tests/package.json
+++ b/libraries/browser-functional-tests/package.json
@@ -4,10 +4,10 @@
   "description": "Test to check browser compatibility",
   "main": "",
   "devDependencies": {
-    "chromedriver": "^79.0.0",
+    "chromedriver": "^81.0.0",
     "dotenv": "^8.0.0",
-    "nightwatch": "^1.2.4",
     "geckodriver": "^1.19.1",
+    "nightwatch": "^1.2.4",
     "selenium-server": "^3.141.59"
   },
   "directories": {


### PR DESCRIPTION
Fixes broken browser-functional-tests
e.g. https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=122521&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=05a7d88e-decf-5c29-7849-5d16879a64a4&l=32

![image](https://user-images.githubusercontent.com/14935595/79912342-bb7d1c00-83d6-11ea-944c-20b6902ccd42.png)
## Specific Changes
  - bump devDependency chromedriver to `"^81.0.0"` in `browser-functional-tests` package
