### PR TITLE
refactor TestMultiLangImport tests

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/tests/LGGenerator.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/LGGenerator.test.js
@@ -45,38 +45,65 @@ describe('LGLanguageGenerator', function() {
         assert.throws(() => {lg.generate(context, '${tesdfdfsst()}', undefined);}, Error);
     });
 
-    it('TestMultiLangImport', async function() {
-        const lgResourceGroup = await LanguageResourceLoader.groupByLocale(resourceExplorer);
+    describe('TestMultiLangImport', () => {
+        let lgResourceGroup;
+        this.beforeAll(async function() {
+            lgResourceGroup = await LanguageResourceLoader.groupByLocale(resourceExplorer);
+        });
+        describe('Test MultiLang Import with specified locale', async function() {
+            let generator;
+            this.beforeAll(async function() {
+                const resource = await resourceExplorer.getResource('a.en-US.lg');
+                generator = new TemplateEngineLanguageGenerator(resource.fullName, lgResourceGroup);
+            });
 
-        let resource = await resourceExplorer.getResource('a.en-US.lg');
-        const generator = new TemplateEngineLanguageGenerator(resource.fullName, lgResourceGroup);
-        let result = await generator.generate(getTurnContext(), '${templatea()}', undefined);
-        assert.strictEqual(result, 'from a.en-us.lg');
+            it('"${templatea()}", no data', async () => {
+                const result = await generator.generate(getTurnContext(), '${templatea()}', undefined);
+                assert.strictEqual(result, 'from a.en-us.lg');
+            });
 
-        result = await generator.generate(getTurnContext(), '${templateb()}', undefined);
-        assert.strictEqual(result, 'from b.en-us.lg');
+            it('"${templateb()}", no data', async () => {
+                const result = await generator.generate(getTurnContext(), '${templateb()}', undefined);
+                assert.strictEqual(result, 'from b.en-us.lg');
+            });
 
-        result = await generator.generate(getTurnContext(), '${templatec()}', undefined);
-        assert.strictEqual(result, 'from c.en.lg');
+            it('"${templatec()}", no data', async () => {
+                const result = await generator.generate(getTurnContext(), '${templatec()}', undefined);
+                assert.strictEqual(result, 'from c.en.lg');
+            });
 
-        assert.throws(() => {generator.generate(getTurnContext(), '${greeting()}', undefined);}, Error);
+            it('should throw for missing template: "${greeting()}", no data', async () => {
+                assert.throws(() => {generator.generate(getTurnContext(), '${greeting()}', undefined);}, Error);
+            });       
+        });
+        
+        describe('Test Multi-Language Import with no locale', function() {   
+            let generator; 
+            this.beforeAll(async function() {
+                const resource = await resourceExplorer.getResource('a.lg');
+                generator = new TemplateEngineLanguageGenerator(resource.fullName, lgResourceGroup);
+            });
 
-        resource = await resourceExplorer.getResource('a.lg');
-        const generator1 = new TemplateEngineLanguageGenerator(resource.fullName, lgResourceGroup);
+            it('"${templatea()}", no data', async () => {
+                const result = await generator.generate(getTurnContext(), '${templatea()}', undefined);
+                assert.strictEqual(result, 'from a.lg');
+            });
 
-        result = await generator1.generate(getTurnContext(), '${templatea()}', undefined);
-        assert.strictEqual(result, 'from a.lg');
+            it('"${templateb()}", no data', async () => {
+                const result = await generator.generate(getTurnContext(), '${templateb()}', undefined);
+                assert.strictEqual(result, 'from b.lg');
+            });
 
-        result = await generator1.generate(getTurnContext(), '${templateb()}', undefined);
-        assert.strictEqual(result, 'from b.lg');
+            it('"${templatec()}", no data', async () => {
+                const result = await generator.generate(getTurnContext(), '${templatec()}', undefined);
+                assert.strictEqual(result, 'from c.lg');
+            });
 
-        result = await generator1.generate(getTurnContext(), '${templatec()}', undefined);
-        assert.strictEqual(result, 'from c.lg');
-
-        result = await generator1.generate(getTurnContext(), '${greeting()}', undefined);
-        assert.strictEqual(result, 'hi');
-
-
+            it('"${greeting()}", no data', async () => {
+                const result = await generator.generate(getTurnContext(), '${greeting()}', undefined);
+                assert.strictEqual(result, 'hi');
+            });    
+        });
     });
 
     describe('TestMultiLangGenerator', () => {


### PR DESCRIPTION
Fixes [test timeout](https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=125615&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=9a2d4836-1661-5df9-4d60-5f662004d588&l=3311) that caused Build 1255615's failure for commit https://github.com/microsoft/botbuilder-js/commit/18cb9822fe4f1a745158ae532872c9db4f3f6e29

Same refactoring as https://github.com/microsoft/botbuilder-js/pull/2076