### PR TITLE
Skills use correct ConnectorClient in OAuthPrompt, add ConnectorClientBuilder

### DIFF
--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -9,7 +9,7 @@ import { Activity, ActivityTypes, Attachment, CoreAppCredentials, BotAdapter, Ca
 import { Dialog, DialogTurnResult } from '../dialog';
 import { DialogContext } from '../dialogContext';
 import { PromptOptions, PromptRecognizerResult,  PromptValidator } from './prompt';
-import { isSkillClaim } from './skillsHelpers';
+import { isSkillClaim, getAppIdFromClaims } from './skillsHelpers';
 
 /**
  * Response body returned for a token exchange invoke activity.
@@ -124,6 +124,7 @@ export interface OAuthPromptSettings {
  * ```
  */
 export class OAuthPrompt extends Dialog {
+    private readonly PersistedCaller: string = 'botbuilder-dialogs.caller';
     /**
      * Creates a new OAuthPrompt instance.
      * @param dialogId Unique ID of the dialog within its parent `DialogSet` or `ComponentDialog`.
@@ -150,6 +151,7 @@ export class OAuthPrompt extends Dialog {
         state.state = {};
         state.options = o;
         state.expires = new Date().getTime() + timeout;
+        state[this.PersistedCaller] = OAuthPrompt.createCallerInfo(dc.context);
 
         // Attempt to get the users token
         const output: TokenResponse = await this.getUserToken(dc.context);
@@ -166,7 +168,7 @@ export class OAuthPrompt extends Dialog {
 
     public async continueDialog(dc: DialogContext): Promise<DialogTurnResult> {
         // Recognize token
-        const recognized: PromptRecognizerResult<TokenResponse> = await this.recognizeToken(dc.context);
+        const recognized: PromptRecognizerResult<TokenResponse> = await this.recognizeToken(dc);
 
         // Check for timeout
         const state: OAuthPromptState = dc.activeDialog.state as OAuthPromptState;
@@ -320,10 +322,33 @@ export class OAuthPrompt extends Dialog {
         await context.sendActivity(msg);
     }
 
-    private async recognizeToken(context: TurnContext): Promise<PromptRecognizerResult<TokenResponse>> {
+    private async recognizeToken(dc: DialogContext): Promise<PromptRecognizerResult<TokenResponse>> {
+        const context = dc.context;
         let token: TokenResponse|undefined;
         if (this.isTokenResponseEvent(context)) {
             token = context.activity.value as TokenResponse;
+
+            // Fix-up the DialogContext's state context if this was received from a skill host caller.
+            const state: CallerInfo = dc.activeDialog.state[this.PersistedCaller];
+            if (state !== null) {
+                // Set the ServiceUrl to the skill host's Url
+                dc.context.activity.serviceUrl = state.callerServiceUrl;
+
+                // Recreate a ConnectorClient and set it in TurnState so replies use the correct one
+                if (!(typeof (context.adapter as any).createConnectorClientWithIdentity === 'function')) {
+                    throw new TypeError('OAuthPrompt: ConnectorClientBuilder interface not implemented by the current adapter');
+                }
+
+                // The ConnectorClientBuilder interface is currently not browser friendly, and therefore
+                // not availble in botbuilder-dialogs. Instead the context.adapter is cast to any.
+                const connectorClientBuilder: any = context.adapter;
+                const claimsIdentity = context.turnState.get(context.adapter.BotIdentityKey);
+                const connectorClient = await (context.adapter as any).createConnectorClientWithIdentity(dc.context.activity.serviceUrl, claimsIdentity, state.scope);
+
+                // For JavaScript Maps, set() functions as Add() and Set() in the C# TurnContextStateCollection
+                context.turnState.set(connectorClientBuilder.ConnectorClientKey, connectorClient);
+
+            }
         } else if (this.isTeamsVerificationInvoke(context)) {
             const code: any = context.activity.value.state;
             try {
@@ -394,6 +419,18 @@ export class OAuthPrompt extends Dialog {
         }
 
         return token !== undefined ? { succeeded: true, value: token } : { succeeded: false };
+    }
+
+    private static createCallerInfo(context: TurnContext) {
+        const botIdentity = context.turnState.get(context.adapter.BotIdentityKey);
+        if (botIdentity && isSkillClaim(botIdentity.claims)) {
+            return {
+                callerServiceUrl: context.activity.serviceUrl,
+                scope: getAppIdFromClaims(botIdentity.claims),
+            };
+        }
+
+        return null;
     }
 
     private getTokenExchangeInvokeResponse(status: number, failureDetail: string, id?: string): Activity {
@@ -474,4 +511,12 @@ interface OAuthPromptState  {
     state: any;
     options: PromptOptions;
     expires: number;        // Timestamp of when the prompt will timeout.
+}
+
+/**
+ * @private
+ */
+interface CallerInfo {
+    callerServiceUrl: string;
+    scope: string;
 }

--- a/libraries/botbuilder/src/interfaces/connectorClientBuilder.ts
+++ b/libraries/botbuilder/src/interfaces/connectorClientBuilder.ts
@@ -1,0 +1,22 @@
+/**
+ * @module botbuilder
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ClaimsIdentity, ConnectorClient } from 'botframework-connector';
+
+/**
+ * Abstraction to build connector clients.
+ */
+export interface ConnectorClientBuilder {
+    /**
+     * Creates the connector client asynchronous.
+     * @param serviceUrl The service URL.
+     * @param claimsIdentity The claims claimsIdentity.
+     * @param audience The target audience for the ConnectorClient.
+     */
+    createConnectorClientWithIdentity: (serviceUrl: string, claimsIdentity: ClaimsIdentity, audience: string) => Promise<ConnectorClient>
+}

--- a/libraries/botbuilder/src/interfaces/index.ts
+++ b/libraries/botbuilder/src/interfaces/index.ts
@@ -6,5 +6,6 @@
  * Licensed under the MIT License.
  */
 
-export * from './webRequest';
-export * from './webResponse';
+export { ConnectorClientBuilder } from './connectorClientBuilder';
+export { WebRequest } from './webRequest';
+export { WebResponse } from './webResponse';


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-js/issues/1991

## Specific Changes
  - Create `ConnectorClientBuilder` in botbuilder package with property `createConnectorClientWithIdentity`
      - `createConnectorClient` is a synchronous method on the BotFrameworkAdapter, hence the change in name
      - `createConnectorClientWithIdentity` is a property, not a function so that we can deprecate it (and make it optional) if we want to continue using the `ConnectorClientBuilder` interface
  - Port OAuthPrompt changes (https://github.com/microsoft/botbuilder-dotnet/pull/3822) to differentiate between regular and skill mode when receiving tokens
      - The Prompt casts `context.adapter` to `any` instead of `ConnectorClientBuilder` for browser compatibility; but does a property check to see if the adapter contains a `createConnectorClientWithIdentity` function
