### PR TITLE
Update SkillDialog to handle all activity types (e.g. set DeliveryMode for Invokes)

### DIFF
--- a/libraries/botbuilder-core/tests/turnContext.test.js
+++ b/libraries/botbuilder-core/tests/turnContext.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { BotAdapter, MessageFactory, TurnContext, ActivityTypes } = require('../');
+const { ActivityTypes, BotAdapter, DeliveryModes, MessageFactory, TurnContext } = require('../');
 
 const activityId = `activity ID`;
 
@@ -460,4 +460,24 @@ describe(`TurnContext`, function () {
             done();
         });
     });
+
+    it('should add to bufferedReplyActivities if TurnContext.activity.deliveryMode === DeliveryModes.ExpectReplies', async () => {
+        const activity = JSON.parse(JSON.stringify(testMessage));
+        activity.deliveryMode = DeliveryModes.ExpectReplies;
+        const context = new TurnContext(new SimpleAdapter(), activity);
+
+        const activities = [ MessageFactory.text('test'), MessageFactory.text('second test') ];
+        const responses = await context.sendActivities(activities);
+
+        assert.strictEqual(responses.length, 2);
+        
+        // For expectReplies all ResourceResponses should have no id.
+        const ids = responses.filter(response => response.id === undefined);
+        assert.strictEqual(ids.length, 2);
+
+        const replies = context.bufferedReplyActivities;
+        assert.strictEqual(replies.length, 2);
+        assert.strictEqual(replies[0].text, 'test');
+        assert.strictEqual(replies[1].text, 'second test');
+    })
 });

--- a/libraries/botbuilder-dialogs/src/skillDialog.ts
+++ b/libraries/botbuilder-dialogs/src/skillDialog.ts
@@ -60,7 +60,7 @@ export class SkillDialog extends Dialog {
     }
 
     public async beginDialog(dc: DialogContext, options?: any): Promise<DialogTurnResult> {
-        const dialogArgs = SkillDialog.validateBeginDialogArgs(options);
+        const dialogArgs = this.validateBeginDialogArgs(options);
 
         await dc.context.sendTraceActivity(`${ this.id }.beginDialog()`, undefined, undefined, `Using activity of type: ${ dialogArgs.activity.type }`);
 
@@ -70,7 +70,7 @@ export class SkillDialog extends Dialog {
         // Apply conversation reference and common properties from incoming activity before sending.
         const skillActivity = TurnContext.applyConversationReference(clonedActivity, TurnContext.getConversationReference(dc.context.activity), true) as Activity;
 
-        // Store the deliveryMode of the first forwarded activity
+        // Store delivery mode and connection name in dialog state for later use.
         dc.activeDialog.state[this.DeliveryModeStateKey] = dialogArgs.activity.deliveryMode;
         dc.activeDialog.state[this.SsoConnectionNameKey] = dialogArgs.connectionName;
 
@@ -83,8 +83,11 @@ export class SkillDialog extends Dialog {
     }
 
     public async continueDialog(dc: DialogContext): Promise<DialogTurnResult> {
-        await dc.context.sendTraceActivity(`${ this.id }.continueDialog()`, undefined, undefined, `ActivityType: ${ dc.context.activity.type }`);
+        if (!this.onValidateActivity(dc.context.activity)) {
+            return Dialog.EndOfTurn;
+        }
 
+        await dc.context.sendTraceActivity(`${ this.id }.continueDialog()`, undefined, undefined, `ActivityType: ${ dc.context.activity.type }`);
 
         // Handle EndOfConversation from the skill (this will be sent to the this dialog by the SkillHandler if received from the Skill)
         if (dc.context.activity.type === ActivityTypes.EndOfConversation) {
@@ -92,18 +95,16 @@ export class SkillDialog extends Dialog {
             return await dc.endDialog(dc.context.activity.value);
         }
 
-        // Forward only Message and Event activities to the skill
-        if (dc.context.activity.type === ActivityTypes.Message || dc.context.activity.type === ActivityTypes.Event) {
-            // Create deep clone of the original activity to avoid altering it before forwarding it.
-            const skillActivity = this.cloneActivity(dc.context.activity);
-            skillActivity.deliveryMode = dc.activeDialog.state[this.DeliveryModeStateKey] as string;
-            const connectionName = dc.activeDialog.state[this.SsoConnectionNameKey] as string;
+        // Create deep clone of the original activity to avoid altering it before forwarding it.
+        const skillActivity: Activity = this.cloneActivity(dc.context.activity);
 
-            // Just forward to the remote skill
-            const eocActivity = await this.sendToSkill(dc.context, skillActivity, connectionName);
-            if (eocActivity) {
-                return await dc.endDialog(eocActivity.value);
-            }
+        skillActivity.deliveryMode = dc.activeDialog.state[this.DeliveryModeStateKey] as string;
+        const connectionName = dc.activeDialog.state[this.SsoConnectionNameKey] as string;
+
+        // Just forward to the remote skill
+        const eocActivity = await this.sendToSkill(dc.context, skillActivity, connectionName);
+        if (eocActivity) {
+            return await dc.endDialog(eocActivity.value);
         }
 
         return Dialog.EndOfTurn;
@@ -144,14 +145,28 @@ export class SkillDialog extends Dialog {
     }
 
     /**
+     * @protected
+     * Validates the activity sent during continueDialog.
+     * @remarks
+     * Override this method to implement a custom validator for the activity being sent during the continueDialog.
+     * This method can be used to ignore activities of a certain type if needed.
+     * If this method returns false, the dialog will end the turn without processing the activity.
+     * @param activity The Activity for the current turn of conversation.
+     */
+    protected onValidateActivity(activity: Activity): boolean {
+        return true;
+    }
+
+    /**
+     * @private
      * Clones the Activity entity.
      * @param activity Activity to clone.
      */
     private cloneActivity(activity: Partial<Activity>): Activity {
-        return Object.assign({} as Activity, activity);
+        return JSON.parse(JSON.stringify(activity));
     }
 
-    private static validateBeginDialogArgs(options: any): BeginSkillDialogOptions {
+    private validateBeginDialogArgs(options: any): BeginSkillDialogOptions {
         if (!options) {
             throw new TypeError('Missing options parameter');
         }
@@ -162,34 +177,17 @@ export class SkillDialog extends Dialog {
             throw new TypeError(`"activity" is undefined or null in options.`);
         }
 
-        // Only accept Message or Event activities
-        if (dialogArgs.activity.type !== ActivityTypes.Message && dialogArgs.activity.type !== ActivityTypes.Event) {
-            // Just forward to the remote skill
-            throw new TypeError(`Only "${ ActivityTypes.Message }" and "${ ActivityTypes.Event }" activities are supported. Received activity of type "${ dialogArgs.activity.type }" in options.`);
-        }
-
         return dialogArgs;
     }
 
     private async sendToSkill(context: TurnContext, activity: Activity, connectionName: string): Promise<Activity> {
-        // Create a conversationId to interact with the skill and send the activity
-        const conversationIdFactoryOptions: SkillConversationIdFactoryOptions = {
-            fromBotOAuthScope: context.turnState.get(context.adapter.OAuthScopeKey),
-            fromBotId: this.dialogOptions.botId,
-            activity: activity,
-            botFrameworkSkill: this.dialogOptions.skill
-        };
-
-        // Create a conversationId to interact with the skill and send the activity
-        let skillConversationId: string;
-        try {
-            skillConversationId = await this.dialogOptions.conversationIdFactory.createSkillConversationIdWithOptions(conversationIdFactoryOptions);
-        } catch (err) {
-            if (err.message !== 'Not Implemented') throw err;
-            // If the SkillConversationIdFactoryBase implementation doesn't support createSkillConversationIdWithOptions(),
-            // use createSkillConversationId() instead.
-            skillConversationId = await this.dialogOptions.conversationIdFactory.createSkillConversationId(TurnContext.getConversationReference(activity) as ConversationReference);
+        if (activity.type === ActivityTypes.Invoke) {
+            // Force ExpectReplies for invoke activities so we can get the replies right away and send them back to the channel if needed.
+            // This makes sure that the dialog will receive the Invoke response from the skill and any other activities sent, including EoC.
+            activity.deliveryMode = DeliveryModes.ExpectReplies;
         }
+
+        const skillConversationId = await this.createSkillConversationId(context, activity);
 
         // Always save state before forwarding
         // (the dialog stack won't get updated with the skillDialog and things won't work if you don't)
@@ -199,53 +197,50 @@ export class SkillDialog extends Dialog {
         const response = await this.dialogOptions.skillClient.postActivity<ExpectedReplies>(this.dialogOptions.botId, skillInfo.appId, skillInfo.skillEndpoint, this.dialogOptions.skillHostEndpoint, skillConversationId, activity);
 
         // Inspect the skill response status
-        if (!(response.status >= 200 && response.status <= 299)) {
+        if (!isSuccessStatusCode(response.status)) {
             throw new Error(`Error invoking the skill id: "${ skillInfo.id }" at "${ skillInfo.skillEndpoint }" (status is ${ response.status }). \r\n ${ response.body }`);
         }
 
         let eocActivity: Activity;
-        if (activity.deliveryMode == DeliveryModes.ExpectReplies && response.body && response.body.activities) {
-            // Process replies in the response.Body.
-            if (Array.isArray(response.body.activities)) {
-                response.body.activities.forEach(async (fromSkillActivity: Activity): Promise<void> => {
-                    if (fromSkillActivity.type === ActivityTypes.EndOfConversation) {
-                        // Capture the EndOfConversation activity if it was sent from skill
-                        eocActivity = fromSkillActivity;
-                    } else if (await this.interceptOAuthCards(context, fromSkillActivity, connectionName)) {
-                        // Do nothing. The token exchange succeeded, so no OAuthCard needs to be shown to the user.
-                    } else {
-                        await context.sendActivity(fromSkillActivity);
-                    }
-                });
-            }
+        const activities = typeof response.body !== 'undefined' && (response.body as ExpectedReplies).activities;
+        if (activity.deliveryMode === DeliveryModes.ExpectReplies && Array.isArray(activities)) {
+            // Process replies in the response.body.
+            for (const activityFromSkill of activities) {
+                if (activityFromSkill.type === ActivityTypes.EndOfConversation) {
+                    // Capture the EndOfConversation activity if it was sent from skill
+                    eocActivity = activityFromSkill;
+                } else if (await this.interceptOAuthCards(context, activityFromSkill, connectionName)) {
+                    // Do nothing. The token exchange succeeded, so no OAuthCard needs to be shown to the user.
+                } else {
+                    await context.sendActivity(activityFromSkill);
+                }
+            };
         }
 
         return eocActivity;
     }
 
     /**
-     * Intercept any Skill-sent OAuthCards for SSO.
+     * Tells us if we should intercept the OAuthCard message.
      * @remarks
-     * This method will attempt to exchange tokens for the Skill.
-     * 
-     * Returns true for a successful token exchange and false to indicate the activity should be
-     * forwarded to its recipient.
+     * The SkillDialog only attempts to intercept OAuthCards when the following criteria are met:
+     * 1. An OAuthCard was sent from the skill
+     * 2. The SkillDialog was called with a connectionName
+     * 3. The current adapter supports token exchange
+     * If any of these criteria are false, return false.
      * @private
      */
     private async interceptOAuthCards(context: TurnContext, activity: Activity, connectionName: string): Promise<boolean> {
-        const attachments = activity.attachments || [];
-        const oAuthCardAttachment: Attachment = attachments.find((c) => c.contentType === CardFactory.contentTypes.oauthCard);
+        if (!connectionName || !('exchangeToken' in context.adapter)) {
+            // The adapter may choose not to support token exchange, in which case we fallback to showing skill's OAuthCard to the user.
+            return false;
+        }
 
-        // The SkillDialog only attempts to intercept OAuthCards when the following criteria are met:
-        // 1. An OAuthCard was sent from the skill
-        // 2. The SkillDialog was called with a connectionName
-        // 3. The current adapter supports token exchange
-        // If any of these criteria are false, return false.
-        if (oAuthCardAttachment && connectionName && 'exchangeToken' in context.adapter) {
+        const oAuthCardAttachment: Attachment = (activity.attachments || []).find((c) => c.contentType === CardFactory.contentTypes.oauthCard);
+        if (oAuthCardAttachment) {
             const tokenExchangeProvider: ExtendedUserTokenProvider = context.adapter as ExtendedUserTokenProvider;
             const oAuthCard: OAuthCard = oAuthCardAttachment.content;
 
-            // The value for uri is either tokenExchangeResource.uri or undefined.
             const uri = oAuthCard && oAuthCard.tokenExchangeResource && oAuthCard.tokenExchangeResource.uri;
             if (uri) {
                 try {
@@ -257,11 +252,12 @@ export class SkillDialog extends Dialog {
                     
                     if (result && result.token) {
                         // If token above is null or undefined, then SSO has failed and we return false.
-                        // Send an invoke back to the skill
+                        // If not, send an invoke to the skill with the token.
                         return await this.sendTokenExchangeInvokeToSkill(activity, oAuthCard.tokenExchangeResource.id, oAuthCard.connectionName, result.token);
                     }
                 } catch (err) {
                     // Failures in token exchange are not fatal. They simply mean that the user needs to be shown the skill's OAuthCard.
+                    return false;
                 }
             }
         }
@@ -280,6 +276,32 @@ export class SkillDialog extends Dialog {
         const response = await this.dialogOptions.skillClient.postActivity<ExpectedReplies>(this.dialogOptions.botId, skillInfo.appId, skillInfo.skillEndpoint, this.dialogOptions.skillHostEndpoint, incomingActivity.conversation.id, activity);
 
         // Check response status: true if success, false if failure
-        return response.status === StatusCodes.OK;
+        return isSuccessStatusCode(response.status);
     }
+
+    private async createSkillConversationId(context: TurnContext, activity: Activity) {
+        // Create a conversationId to interact with the skill and send the activity
+        const conversationIdFactoryOptions: SkillConversationIdFactoryOptions = {
+            fromBotOAuthScope: context.turnState.get(context.adapter.OAuthScopeKey),
+            fromBotId: this.dialogOptions.botId,
+            activity: activity,
+            botFrameworkSkill: this.dialogOptions.skill
+        };
+
+        // Create a conversationId to interact with the skill and send the activity
+        let skillConversationId: string;
+        try {
+            skillConversationId = await this.dialogOptions.conversationIdFactory.createSkillConversationIdWithOptions(conversationIdFactoryOptions);
+        } catch (err) {
+            if (err.message !== 'Not Implemented') throw err;
+            // If the SkillConversationIdFactoryBase implementation doesn't support createSkillConversationIdWithOptions(),
+            // use createSkillConversationId() instead.
+            skillConversationId = await this.dialogOptions.conversationIdFactory.createSkillConversationId(TurnContext.getConversationReference(activity) as ConversationReference);
+        }
+        return skillConversationId;
+    }
+}
+
+function isSuccessStatusCode(status: number): boolean {
+    return status >= StatusCodes.OK && status < StatusCodes.MULTIPLE_CHOICES;
 }

--- a/libraries/botbuilder-dialogs/tests/skillDialog.test.js
+++ b/libraries/botbuilder-dialogs/tests/skillDialog.test.js
@@ -10,11 +10,12 @@ const {
     MessageFactory,
     TestAdapter,
     SkillConversationIdFactoryBase,
+    StatusCodes,
     TurnContext,
     AutoSaveStateMiddleware,
 } = require('botbuilder-core');
 const { spy, stub } = require('sinon');
-const { Dialog, SkillDialog } = require('../');
+const { Dialog, DialogTurnStatus, SkillDialog } = require('../');
 
 const DEFAULT_OAUTHSCOPE = 'https://api.botframework.com';
 const DEFAULT_GOV_OAUTHSCOPE = 'https://api.botframework.us';
@@ -34,6 +35,151 @@ function typeErrorValidator(e, expectedMessage) {
 
 describe('SkillDialog', function() {
     this.timeout(3000);
+
+    describe('beginDialog should call skill', () => {
+        let BOTBUILDER = null;
+        let BOTBUILDER_TESTING = null;
+        // Use botbuilder for tests
+        try {
+            BOTBUILDER = require('../../botbuilder');
+            BOTBUILDER_TESTING = require('../../botbuilder-testing');
+        } catch (err) {
+            console.warn('=====\nUnable to load botbuilder or botbuilder-testing module. "beginDialog should call skill" tests will not be run.\n');
+        }
+
+        if (BOTBUILDER !== null && BOTBUILDER_TESTING !== null) {
+            const { DialogTestClient } = BOTBUILDER_TESTING;
+
+            /**
+             * @remarks
+             * Port of BeginDialogShouldCallSkill from C#
+             * https://github.com/microsoft/botbuilder-dotnet/blob/41120728b22c709ec2d9247393505fdc778b2de1/tests/Microsoft.Bot.Builder.Dialogs.Tests/SkillDialogTests.cs#L47-L49
+             * @param {string} deliveryMode 
+             */
+            async function beginDialogShouldCallSkill(deliveryMode) {
+                let activitySent; // Activity
+                let fromBotIdSent; // string
+                let toBotIdSent; // string
+                let toUriSent; // string (URI)
+
+                // Callback to capture the parameters sent to the skill
+                const captureAction = (fromBotId, toBotId, toUri, serviceUrl, conversationId, activity) => {
+                    // Capture values sent to the skill so we can assert the right parameters were used.
+                    fromBotIdSent = fromBotId;
+                    toBotIdSent = toBotId;
+                    toUriSent = toUri;
+                    activitySent = activity;
+                }
+
+                // Create BotFrameworkHttpClient and postActivityStub
+                const [skillClient, postActivityStub] = createSkillClientAndStub(captureAction);
+
+                // Use Memory for conversation state
+                const conversationState = new ConversationState(new MemoryStorage());
+                const dialogOptions = createSkillDialogOptions(conversationState, skillClient);
+
+                // Create the SkillDialogInstance and the activity to send.
+                const dialog = new SkillDialog(dialogOptions, 'SkillDialog');
+                const activityToSend = { type: ActivityTypes.Message, attachments: [], entities: [] }; // Activity.CreateMessageActivity()
+                activityToSend.deliveryMode = deliveryMode;
+                const activityToSendText = 'activityToSendText';
+                activityToSend.text = activityToSendText;
+                const client = new DialogTestClient(Channels.Test, dialog, { activity: activityToSend }, undefined, conversationState);
+
+                // Send something to the dialog to start it
+                await client.sendActivity('irrelevant');
+
+                // Assert results and data sent to the SkillClient for first turn
+                strictEqual(fromBotIdSent, dialogOptions.botId);
+                strictEqual(toBotIdSent, dialogOptions.skill.appId);
+                strictEqual(toUriSent, dialogOptions.skill.skillEndpoint);
+                strictEqual(activitySent.text, activityToSendText);
+                strictEqual(client.dialogTurnResult.status, DialogTurnStatus.waiting);
+                ok(postActivityStub.calledOnce);
+
+                // Send a second message to continue the dialog
+                await client.sendActivity('Second message');
+
+                // Assert results for second turn
+                strictEqual(activitySent.text, 'Second message');
+                strictEqual(client.dialogTurnResult.status, DialogTurnStatus.waiting);
+                ok(postActivityStub.calledTwice);
+
+                // Send EndOfConversation to the dialog
+                await client.sendActivity({ type: ActivityTypes.EndOfConversation }); // Activity.CreateEndOfConversationActivity()
+
+                // Assert we are done.
+                strictEqual(client.dialogTurnResult.status, DialogTurnStatus.complete);
+                ok(postActivityStub.calledTwice);
+            };
+
+            // "Data Rows"
+            it('when deliveryMode is undefined', async () => {
+                await beginDialogShouldCallSkill();
+            });
+
+            it('when deliveryMode is DeliveryModes.ExpectReplies', async () => {
+                await beginDialogShouldCallSkill(DeliveryModes.ExpectReplies);
+            });
+
+            it('and handle Invoke activities', async () => {
+                let activitySent; // Activity
+                let fromBotIdSent; // string
+                let toBotIdSent; // string
+                let toUriSent; // string (URI)
+
+                // Callback to capture the parameters sent to the skill
+                function captureAction(fromBotId, toBotId, toUri, serviceUrl, conversationId, activity) {
+                    // Capture values sent to the skill so we can assert the right parameters were used.
+                    fromBotIdSent = fromBotId;
+                    toBotIdSent = toBotId;
+                    toUriSent = toUri;
+                    activitySent = activity;
+                }
+
+                // Create BotFrameworkHttpClient and postActivityStub
+                const [skillClient, postActivityStub] = createSkillClientAndStub(captureAction);
+
+                // Use Memory for conversation state
+                const conversationState = new ConversationState(new MemoryStorage());
+                const dialogOptions = createSkillDialogOptions(conversationState, skillClient);
+
+                // Create the SkillDialogInstance and the activity to send.
+                const dialog = new SkillDialog(dialogOptions, 'SkillDialog');
+                const activityToSend = { type: ActivityTypes.Invoke }; // Activity.CreateInvokeActivity()
+                const activityToSendName = 'activityToSendName';
+                activityToSend.name = activityToSendName;
+                const client = new DialogTestClient(Channels.Test, dialog, { activity: activityToSend }, undefined, conversationState);
+
+                // Send something to the dialog to start it
+                await client.sendActivity('irrelevant');
+
+                // Assert results and data sent to the SkillClient for first turn
+                strictEqual(fromBotIdSent, dialogOptions.botId);
+                strictEqual(toBotIdSent, dialogOptions.skill.appId);
+                strictEqual(toUriSent, dialogOptions.skill.skillEndpoint);
+                strictEqual(activitySent.name, activityToSendName);
+                strictEqual(activitySent.deliveryMode, DeliveryModes.ExpectReplies);
+                strictEqual(client.dialogTurnResult.status, DialogTurnStatus.waiting);
+                ok(postActivityStub.calledOnce);
+
+                // Send a second message to continue the dialog
+                await client.sendActivity('Second message');
+
+                // Assert results for second turn
+                strictEqual(activitySent.text, 'Second message');
+                strictEqual(client.dialogTurnResult.status, DialogTurnStatus.waiting);
+                ok(postActivityStub.calledTwice);
+
+                // Send EndOfConversation to the dialog
+                await client.sendActivity({ type: ActivityTypes.EndOfConversation }); // Activity.CreateEndOfConversationActivity()
+
+                // Assert we are done.
+                strictEqual(client.dialogTurnResult.status, DialogTurnStatus.complete);
+                ok(postActivityStub.calledTwice);
+            });
+        }
+    });
 
     it('repromptDialog() should call sendToSkill()', async () => {
         const adapter = new TestAdapter(/* logic param not required */);
@@ -72,7 +218,8 @@ describe('SkillDialog', function() {
                 type: ActivityTypes.Message,
                 text: 'Hello SkillDialog!'
             };
-            const validatedArgs = SkillDialog.validateBeginDialogArgs({ activity });
+            const dialog = new SkillDialog({}, 'SkillDialog');
+            const validatedArgs = dialog.validateBeginDialogArgs({ activity });
             const validatedActivity = validatedArgs.activity;
             strictEqual(validatedActivity.type, ActivityTypes.Message);
             strictEqual(validatedActivity.text, 'Hello SkillDialog!');
@@ -80,7 +227,8 @@ describe('SkillDialog', function() {
 
         it('should fail if options is falsy', () => {
             try {
-                SkillDialog.validateBeginDialogArgs();
+                const dialog = new SkillDialog({}, 'SkillDialog');
+                dialog.validateBeginDialogArgs();
             } catch (e) {
                 typeErrorValidator(e, 'Missing options parameter');
             }
@@ -88,7 +236,8 @@ describe('SkillDialog', function() {
 
         it('should fail if dialogArgs.activity is falsy', () => {
             try {
-                SkillDialog.validateBeginDialogArgs({});
+                const dialog = new SkillDialog({}, 'SkillDialog');
+                dialog.validateBeginDialogArgs({});
             } catch (e) {
                 typeErrorValidator(e, '"activity" is undefined or null in options.');
             }
@@ -97,7 +246,8 @@ describe('SkillDialog', function() {
         it('should fail if dialogArgs.activity.type is not "message" or "event"', () => {
             const type = ActivityTypes.EndOfConversation;
             try {
-                SkillDialog.validateBeginDialogArgs({ activity: { type } });
+                const dialog = new SkillDialog({}, 'SkillDialog');
+                dialog.validateBeginDialogArgs({ activity: { type } });
             } catch (e) {
                 typeErrorValidator(e, `Only "${ ActivityTypes.Message }" and "${ ActivityTypes.Event }" activities are supported. Received activity of type "${ type }" in options.`);
             }
@@ -169,8 +319,8 @@ describe('SkillDialog', function() {
                 const firstResponse = { activities: [ createOAuthCardAttachmentActivity('https://test')] };
                 const skillClient = new BotFrameworkHttpClient({});
                 const postActivityStub = stub(skillClient, 'postActivity');
-                postActivityStub.onFirstCall().returns({ status: 200, body: firstResponse });
-                postActivityStub.onSecondCall().returns({ status: 200 });
+                postActivityStub.onFirstCall().returns(Promise.resolve({ status: 200, body: firstResponse }));
+                postActivityStub.onSecondCall().returns(Promise.resolve({ status: 200 }));
 
                 const conversationState = new ConversationState(new MemoryStorage());
                 const dialogOptions = createSkillDialogOptions(conversationState, skillClient);
@@ -184,7 +334,7 @@ describe('SkillDialog', function() {
                 client._testAdapter.addExchangeableToken(connectionName, Channels.Test, 'user1', 'https://test', 'https://test1');
 
                 const finalActivity = await client.sendActivity('irrelevant');
-                ok(sendTokenExchangeSpy.called);
+                ok(sendTokenExchangeSpy.calledOnce);
                 strictEqual(finalActivity, undefined);
             });
 
@@ -212,7 +362,7 @@ describe('SkillDialog', function() {
                 strictEqual(finalActivity.attachments.length, 1);
             });
 
-           it('should not intercept OAuthCards for EmptyToken', async () => {
+            it('should not intercept OAuthCards for EmptyToken', async () => {
                 const firstResponse = { activities: [ createOAuthCardAttachmentActivity('https://test')] };
                 const skillClient = new BotFrameworkHttpClient({});
                 const postActivityStub = stub(skillClient, 'postActivity');
@@ -290,6 +440,45 @@ describe('SkillDialog', function() {
 });
 
 /**
+ * @remarks
+ * captureAction should match the below signature:
+ * `(fromBotId: string, toBotId: string, toUrl: string, serviceUrl: string, conversationId: string, activity: Activity) => void`
+ * @param {Function} captureAction 
+ * @param {StatusCodes} returnStatusCode Defaults to StatusCodes.OK
+ * @returns [BotFrameworkHttpClient, postActivityStub]
+ */
+function createSkillClientAndStub(captureAction, returnStatusCode = StatusCodes.OK) {
+    // This require should not fail as this method should only be called after verifying that botbuilder is resolvable.
+    const { BotFrameworkHttpClient } = require('../../botbuilder');
+
+    if (captureAction && typeof captureAction !== 'function') {
+        throw new TypeError(`Failed test arrangement - createSkillClientAndStub() received ${typeof captureAction} instead of undefined or a function.`);
+    }
+
+    // Create ExpectedReplies object for response body
+    const dummyActivity = { type: ActivityTypes.Message, attachments: [], entities: [] };
+    dummyActivity.text = 'dummy activity';
+    const activityList = { activities: [dummyActivity] };
+
+    // Create wrapper for captureAction
+    function wrapAction(...args) {
+        captureAction(...args);
+        return { status: returnStatusCode, body: activityList };
+    }
+    // Create client and stub
+    const skillClient = new BotFrameworkHttpClient({});
+    const postActivityStub = stub(skillClient, 'postActivity');
+
+    if (captureAction) {
+        postActivityStub.callsFake(wrapAction);
+    } else {
+        postActivityStub.returns({ status: returnStatusCode, body: activityList });
+    }
+
+    return [ skillClient, postActivityStub ];
+}
+
+/**
  * 
  * @param {string} uri 
  */
@@ -317,13 +506,13 @@ function createOAuthCardAttachmentActivity(uri) {
  */
 function createSkillDialogOptions(conversationState, mockSkillClient) {
     const dialogOptions = {
-        botId: uuid(),
+        botId: 'SkillCallerId',
         skillHostEndpoint: 'http://test.contoso.com/skill/messages',
         conversationIdFactory: new SimpleConversationIdFactory(),
         conversationState: conversationState,
         skillClient: mockSkillClient,
         skill: {
-            appId: uuid(),
+            appId: 'SkillId',
             skillEndpoint: 'http://testskill.contoso.com/api/messages'
         }
     };
@@ -331,13 +520,13 @@ function createSkillDialogOptions(conversationState, mockSkillClient) {
     return dialogOptions;
 }
 
-function createSendActivity() {
+function createSendActivity(deliveryMode = DeliveryModes.ExpectReplies) {
     const activityToSend = {
         type: ActivityTypes.Message,
         attachments: [],
-        entities: []
+        entities: [],
+        deliveryMode
     };
-    activityToSend.deliveryMode = DeliveryModes.ExpectReplies;
     activityToSend.text = uuid();
     return activityToSend;
 }
@@ -383,6 +572,12 @@ class SimpleConversationIdFactory extends SkillConversationIdFactoryBase {
 
 }
 
+/**
+ * Create an UUID
+ * @remarks
+ * Replace `Guid.NewGuid().ToString();` with this function call.
+ * @returns UUID string 
+ */
 function uuid() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
         var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -1922,6 +1922,7 @@ export enum Channels {
  */
 export enum StatusCodes {
   OK = 200,
+  MULTIPLE_CHOICES = 300,
   BAD_REQUEST = 400,
   UNAUTHORIZED = 401,
   NOT_FOUND = 404,


### PR DESCRIPTION
Fixes https://github.com/microsoft/botbuilder-js/issues/2139

## Specific Changes
  - Add `StatusCodes.MULTIPLE_CHOICES = 300`
  - Add protected method `SkillDialog.onValidateActivity()`
  - `SkillDialog` now forwards all `ActivityTypes` to the Skill.
  - Add new C# SkillDialog tests and refactor old tests
  - Add missing test for TurnContext when deliveryMode === 'expectReplies'
  - Fix error message in `BotFrameworkAdapter.createConnectorClientWithIdentity()`
  - Add tests for `BotFrameworkAdapter.createConnectorClientWithIdentity()`
  - Add test for `BotFrameworkAdapter.processActivity()` when deliveryMode === 'expectReplies', type is `Invoke` and reply activities have type `invokeResponse`