### PR TITLE
[Port]  [LG] Inject LG templates as a global expression function

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-tests/resources/InjectLGTests/inject.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-tests/resources/InjectLGTests/inject.test.dialog
@@ -1,0 +1,54 @@
+{
+    "$schema": "../../../../schemas/sdk.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "No Language Generator",
+        "generator": "inject.lg",
+        "triggers": [
+    {
+      "$kind": "Microsoft.OnBeginDialog",
+      "actions": [
+        {
+          "$kind": "Microsoft.SetProperty",
+          "property": "user.message",
+          "value": "=foo.GetMessage()"
+        },
+        {
+          "$kind": "Microsoft.SetProperty",
+          "property": "user.tasks",
+          "value": [ "car", "washing", "food", "laundry" ]
+        },
+        {
+          "$kind": "Microsoft.SetProperty",
+          "property": "user.flatTasks",
+          "value": "=string(select(foo.GetList(user.tasks),iter,foo.Convert(iter.index,iter.value)))"
+        },
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "${user.flatTasks}"
+        },
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "${user.message}"
+        }
+
+      ]
+    }
+  ],
+    "defaultResultProperty": "dialog.result"
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserConversationUpdate"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "[{\"Topic\":\"car\"},{\"Id\":1,\"Topic\":\"washing\"},{\"Id\":2,\"Topic\":\"food\"},{\"Id\":3,\"Topic\":\"laundry\"}]"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "This is an injected message"
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-tests/resources/lg/inject.lg
+++ b/libraries/botbuilder-dialogs-adaptive-tests/resources/lg/inject.lg
@@ -1,0 +1,16 @@
+> !# @strict = false
+> !# @namespace = foo
+> !# @Exports = GetList, Convert, GetProperty, GetMessage
+
+
+# Convert(index, value)
+- ${setProperty(setProperty({}, "Id", index),"Topic",value)}
+
+#GetList(tasks)
+- ${indicesAndValues(tasks)}
+
+#GetProperty
+-user.tasks
+
+#GetMessage
+- This is an injected message

--- a/libraries/botbuilder-dialogs-adaptive-tests/src/injectLG.test.ts
+++ b/libraries/botbuilder-dialogs-adaptive-tests/src/injectLG.test.ts
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import 'mocha';
+import * as path from 'path';
+import { TestRunner } from './testing';
+
+describe('ActionScopeTests', function() {
+    this.timeout(5000);
+    const testRunner = new TestRunner(path.join(__dirname,  '../resources/InjectLGTests'));
+
+    it('InjectLGTest', async () => {
+        await testRunner.runTestScript('inject');
+    });
+
+});

--- a/libraries/botbuilder-lg/src/evaluator.ts
+++ b/libraries/botbuilder-lg/src/evaluator.ts
@@ -44,7 +44,7 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
     // to support broswer, use look-ahead replace look-behind
     // PCRE: (?<!\\)\${(('(\\('|\\)|[^'])*?')|("(\\("|\\)|[^"])*?")|(`(\\(`|\\)|[^`])*?`)|([^\r\n{}'"`])|({\s*}))+}?
     public static readonly expressionRecognizeReverseRegex: RegExp = new RegExp(/\}?(('((('|\\)\\)|[^'])*?')|("(\\("|\\)|[^"])*?")|(`(\\(`|\\)|[^`])*?`)|([^\r\n{}'"`])|({\s*}))+{\$(?!\\)/gm);
-    public readonly newLineRegex = /(\r?\n)/g;
+    
     public static readonly LGType = 'lgType';
     public static readonly activityAttachmentFunctionName = 'ActivityAttachment';
     public static readonly fromFileFunctionName = 'fromFile';
@@ -112,10 +112,6 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         }
 
         this.evaluationTargetStack.pop();
-
-        if (this.lgOptions.LineBreakStyle === LGLineBreakStyle.Markdown && typeof result === 'string') {
-            result = result.replace(this.newLineRegex, '$1$1');
-        }
 
         return result;
     }
@@ -247,7 +243,7 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
         }
 
         const parameters: string[] = this.templateMap[templateName].parameters;
-        const currentScope: any = this.currentTarget().scope;
+        const currentScope: any =  this.evaluationTargetStack.length > 0 ?  this.currentTarget().scope : new CustomizedMemory(undefined);
 
         if (args.length === 0) {
             // no args to construct, inherit from current scope

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -1053,7 +1053,7 @@ describe('LG', function() {
         assert.equal(evaled, 6.0);
     });
 
-    it.only('TestInjectLG', function() {
+    it('TestInjectLG', function() {
         var templates = Templates.parseFile(GetExampleFilePath('./injectionTest/inject.lg'));
 
         var {value: evaled, error} = Expression.parse('foo.bar()').tryEvaluate();

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -1052,4 +1052,32 @@ describe('LG', function() {
         var evaled = templates.evaluate('custom', {});
         assert.equal(evaled, 6.0);
     });
+
+    it.only('TestInjectLG', function() {
+        var templates = Templates.parseFile(GetExampleFilePath('./injectionTest/inject.lg'));
+
+        var {value: evaled, error} = Expression.parse('foo.bar()').tryEvaluate();
+        assert.strictEqual(3, evaled);
+
+        var {value: evaled, error} = Expression.parse('foo.cool(2)').tryEvaluate();
+        assert.strictEqual(3, evaled);
+
+        var {value: evaled, error} = Expression.parse('common.looking()').tryEvaluate();
+        assert.strictEqual('John', evaled);
+
+        var scope1 = { a: ['cat', 'dog'], b: 12.10, c: ['lion'] };
+        var {value: evaled, error} = Expression.parse('common.countTotal(a, c)').tryEvaluate(scope1);
+        assert.strictEqual(error, undefined);
+        assert.strictEqual(3, evaled);
+
+        var {value: evaled, error} = Expression.parse('common.countTotal()').tryEvaluate(scope1);
+        assert.strictEqual(error, `list1 is not a list or array. [countTotal]  Error occurred when evaluating '-\${count(union(list1,list2))}'.`);
+
+        var {value: evaled, error} = Expression.parse('common.countTotal(a, b, c)').tryEvaluate(scope1);
+        assert.strictEqual(error, `list2 is not a list or array. [countTotal]  Error occurred when evaluating '-\${count(union(list1,list2))}'.`);
+
+        var scope2 = { i: 1, j: 2, k: 3, l: 4 };
+        var {value: evaled, error} = Expression.parse('common.sumFourNumbers(i, j, k, l)').tryEvaluate(scope2);
+        assert.strictEqual(10, evaled);
+    });
 });

--- a/libraries/botbuilder-lg/tests/testData/examples/injectionTest/common.lg
+++ b/libraries/botbuilder-lg/tests/testData/examples/injectionTest/common.lg
@@ -1,0 +1,10 @@
+> !# @exports = looking, countTotal, sumFourNumbers
+
+#looking
+-${{user: {name: "John"}}.user.name}
+
+#countTotal(list1, list2)
+- ${count(union(list1,list2))}
+
+#sumFourNumbers(a,b,c,d)
+- ${a+b+c+d}

--- a/libraries/botbuilder-lg/tests/testData/examples/injectionTest/inject.lg
+++ b/libraries/botbuilder-lg/tests/testData/examples/injectionTest/inject.lg
@@ -1,0 +1,11 @@
+> !# @strict = false
+> !# @Namespace = foo
+> !# @Exports = bar, cool
+
+[import](common.lg)
+
+#bar()
+- ${add(1,2)}
+
+#cool(a)
+- ${add(1,a)}


### PR DESCRIPTION
close: #2129 
In this PR, users can register namespace for a lg file. Also, they can register some templates as a expression functions, which can be applied easily in dialog. 
Here is an example to use these options,
> !# @registerNamespace = foo
> !# @registerAsFunctions = template1, template2

After registration,  in a dialog file, such usage `"property": "=foo.template1()"` is enabled, foo.template1() just behaves like a customized function.

The limitation is this kind of 'LG template function' can not read any scope from dialogStateManager, which is the same as prebuilt functions. 

For example, 
we have a memory in dialogStateManager:
`user.tasks: [ "car", "washing", "food", "laundry" ]`
if you to join the list of user.tasks, you have to define the LG file as 
```
> !# @registerNamespace = foo
> !# @registerAsFunctions = joinList

#joinList(tasks)
- ${join(tasks, " ,")} 

```

Then call the function as 
```
=foo.joinList(user.tasks)
```

