### PR TITLE
Cherry-pick ES6 targeting and big-integer addition to master

### DIFF
--- a/libraries/adaptive-expressions/package.json
+++ b/libraries/adaptive-expressions/package.json
@@ -26,6 +26,7 @@
     "@types/xmldom": "^0.1.29",
     "antlr4ts": "0.5.0-alpha.1",
     "atob": "^2.1.2",
+    "big-integer": "^1.6.48",
     "jspath": "^0.4.0",
     "lodash": "^4.17.15",
     "lru-cache": "^5.1.1",

--- a/libraries/adaptive-expressions/tests/expressionParser.test.js
+++ b/libraries/adaptive-expressions/tests/expressionParser.test.js
@@ -4,6 +4,7 @@ const {Expression, SimpleObjectMemory, ExpressionFunctions, Options} = require('
 var {TimexProperty} = require('@microsoft/recognizers-text-data-types-timex-expression');
 const assert = require('assert');
 const moment = require('moment');
+const bigInt = require('big-integer')
 
 const one = ['one'];
 const oneTwo = ['one', 'two'];
@@ -506,7 +507,7 @@ const dataSource = [
     ['startOfDay(\'2018-03-15T13:30:30.000Z\')', '2018-03-15T00:00:00.000+00:00'],
     ['startOfHour(\'2018-03-15T13:30:30.000Z\')', '2018-03-15T13:00:00.000+00:00'],
     ['startOfMonth(\'2018-03-15T13:30:30.000Z\')', '2018-03-01T00:00:00.000+00:00'],
-    ['ticks(\'2018-01-01T08:00:00.000Z\')', 636503904000000000],
+    ['ticks(\'2018-01-01T08:00:00.000Z\')', bigInt('636503904000000000')],
 
     //URI parsing functions tests
     ['uriHost(\'https://www.localhost.com:8080\')', 'www.localhost.com'],
@@ -728,7 +729,7 @@ const scope = {
     timestampObj: new Date('2018-03-15T13:00:00.000Z'),
     unixTimestamp: 1521118800,
     unixTimestampFraction: 1521118800.5,
-    ticks: BigInt(637243624200000000),
+    ticks: bigInt('637243624200000000'),
     user:
     {
         income: 110.0,
@@ -914,8 +915,9 @@ var assertObjectEquals = (actual, expected) => {
         for (let i = 0; i < actual.length; i++) {
             assertObjectEquals(actual[i], expected[i], `actual is: ${actual[i]}, expected is ${expected[i]}`);
         }
+    } else if (bigInt.isInstance(actual) && bigInt.isInstance(expected)) {
+        assert(actual.equals(expected), `actual is: ${actual}, expected is ${expected}`);
     }
-
     else {
         assert.equal(actual, expected, `actual is: ${actual}, expected is ${expected}`);
     }

--- a/libraries/adaptive-expressions/tsconfig.json
+++ b/libraries/adaptive-expressions/tsconfig.json
@@ -1,10 +1,11 @@
 {
     "compilerOptions": {
-      "target": "ESNext",
+      "target": "es6",
       "lib": ["es2015", "dom"],
       "module": "commonjs",
       "declaration": true,
       "declarationMap": true,
+      "downlevelIteration": true,
       "sourceMap": true,
       "esModuleInterop": true,
       "outDir": "./lib",

--- a/libraries/botbuilder-dialogs-adaptive-tests/tsconfig.json
+++ b/libraries/botbuilder-dialogs-adaptive-tests/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "es6",
+    "lib": ["es2015", "dom"],
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,

--- a/libraries/botbuilder-dialogs-adaptive/package.json
+++ b/libraries/botbuilder-dialogs-adaptive/package.json
@@ -45,7 +45,7 @@
     "ts-node": "^4.1.0"
   },
   "scripts": {
-    "test": "tsc && tsc tests/*.ts && nyc mocha tests/",
+    "test": "tsc && tsc ./tests/expressionProperty.test.ts && nyc mocha tests/",
     "build": "tsc",
     "build-docs": "typedoc --theme markdown --entryPoint botbuilder-dialogs-adaptive --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\botbuilder-dialogs .\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK - Dialogs\" --readme none",
     "clean": "erase /q /s .\\lib",

--- a/libraries/botbuilder-dialogs-adaptive/tsconfig.json
+++ b/libraries/botbuilder-dialogs-adaptive/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "es6",
+    "lib": ["es2015", "dom"],
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,
     "outDir": "./lib",
     "rootDir": "./src",
-    "types" : ["node"],
-    "lib": ["es2020.string"]
+    "types" : ["node"]
   },
   "include": [
     "src/**/*"

--- a/libraries/botbuilder-dialogs-declarative/tsconfig.json
+++ b/libraries/botbuilder-dialogs-declarative/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "es6",
+    "lib": ["es2015", "dom"],
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
Fixes #2207

## Specific Changes
  - Updated packages to target ES6 (#2204)
  - Switch adaptive-expressions to es6 (#2205)