### PR TITLE
Missing break/return statements.

### DIFF
--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -163,9 +163,9 @@ export class TeamsActivityHandler extends ActivityHandler {
     protected async onSignInInvoke(context: TurnContext): Promise<void> {
         switch (context.activity.name) {
             case verifyStateOperationName:
-                await this.handleTeamsSigninVerifyState(context, context.activity.value);
+                return await this.handleTeamsSigninVerifyState(context, context.activity.value);
             case tokenExchangeOperationName:
-                await this.handleTeamsSigninTokenExchange(context, context.activity.value);
+                return await this.handleTeamsSigninTokenExchange(context, context.activity.value);
         }
     }
 


### PR DESCRIPTION
Fixes #2222

## Description
The teams handler had a switch statement that was falling through.
