### PR TITLE
Remove moment from botbuilder-ai

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -26,7 +26,6 @@
     "@types/node": "^10.12.18",
     "botbuilder-core": "4.1.6",
     "botbuilder-dialogs": "4.1.6",
-    "moment": "^2.25.1",
     "node-fetch": "^2.3.0",
     "url-parse": "^1.4.4"
   },

--- a/libraries/botbuilder-ai/src/luisSchema.d.ts
+++ b/libraries/botbuilder-ai/src/luisSchema.d.ts
@@ -4,8 +4,6 @@
  * regenerated.
  */
 
-import * as moment from 'moment';
-
 /**
  * @class
  * Initializes a new instance of the Entity class.


### PR DESCRIPTION
Fixes #2181

## Description

`moment` is imported but unused. Verified via search within `botbuilder-ai` package.

## Specific Changes

Remove `moment` from import statement and `package.json`
