### PR TITLE
[PORT]Make template name format consistent with function name format

### DIFF
--- a/libraries/botbuilder-lg/src/templateErrors.ts
+++ b/libraries/botbuilder-lg/src/templateErrors.ts
@@ -12,7 +12,7 @@
 export class TemplateErrors {
     public static readonly noTemplate: string = `LG file must have at least one template definition.`;
  
-    public static readonly invalidTemplateName: string = `Invalid template name. Template name should start with letter/number/_ and can only contains letter/number/./_.`;
+    public static readonly invalidTemplateName: string = `Invalid template name. Template names can only contain letter, underscore '_' or number. Any part of a template name (split by '.') cannot start with a number.`;
  
     public static readonly invalidTemplateBody: string = `Invalid template body. Expecting '-' prefix.`;
  

--- a/libraries/botbuilder-lg/src/templatesParser.ts
+++ b/libraries/botbuilder-lg/src/templatesParser.ts
@@ -222,6 +222,7 @@ export class TemplatesParser {
 
 class TemplatesTransformer extends AbstractParseTreeVisitor<any> implements LGTemplateParserVisitor<any> {
     private readonly identifierRegex: RegExp = new RegExp(/^[0-9a-zA-Z_]+$/);
+    private readonly templateNamePartRegex: RegExp = new RegExp(/^[a-zA-Z_][0-9a-zA-Z_]*$/);
     private readonly templates: Templates;
 
     public constructor(templates: Templates) {
@@ -312,7 +313,7 @@ class TemplatesTransformer extends AbstractParseTreeVisitor<any> implements LGTe
     private checkTemplateName(templateName: string, context: ParserRuleContext): void {
         const functionNameSplitDot = templateName.split('.');
         for(let id of functionNameSplitDot) {
-            if (!this.identifierRegex.test(id)) {
+            if (!this.templateNamePartRegex.test(id)) {
                 const diagnostic = this.buildTemplatesDiagnostic(TemplateErrors.invalidTemplateName, context);
                 this.templates.diagnostics.push(diagnostic);
             }

--- a/libraries/botbuilder-lg/tests/lgDiagnostic.test.js
+++ b/libraries/botbuilder-lg/tests/lgDiagnostic.test.js
@@ -115,7 +115,7 @@ describe(`LGExceptionTest`, function() {
     it(`TestErrorTemplateName`, function() {
         var diagnostics = GetDiagnostics(`ErrorTemplateName.lg`);
 
-        assert.strictEqual(6, diagnostics.length);
+        assert.strictEqual(7, diagnostics.length);
         for(const diagnostic of diagnostics)
         {
             assert.strictEqual(DiagnosticSeverity.Error, diagnostic.severity);

--- a/libraries/botbuilder-lg/tests/testData/exceptionExamples/ErrorTemplateName.lg
+++ b/libraries/botbuilder-lg/tests/testData/exceptionExamples/ErrorTemplateName.lg
@@ -22,3 +22,6 @@
 # t2-t1
 - hi
 
+> Template names can only contain letter, underscore '_' or number. Any part of a template name (split by '.') cannot start with a number.
+# t1.1
+- hi 


### PR DESCRIPTION
Original issue: https://github.com/microsoft/botbuilder-dotnet/issues/3942
close: #2258
The function name's format cannot cover all template name's formats. 

The valid format of template name is 
```
start with letter/number/_ and can only contains letter/number/./_
```
And the valid format of function name should meet
```
foreach(var part in expression.split('.')) 
{
    // part should start with letter/_ and can only contains letter/number/_
}
```

So, in some cases, user use template evaluation in expression with the "gap" format would throw exception.

Here is the remedy that disables the name that begins with number in each part of the split result from dot(.).

Now, the valid format of template name should be :
```
foreach(var part in expression.split('.')) 
{
    // part should start with letter/_ and can only contains letter/number/_
}
```
Same with the expression function name.