### PR TITLE
Remove antlr auto build with build/test script

### DIFF
--- a/libraries/adaptive-expressions/README.MD
+++ b/libraries/adaptive-expressions/README.MD
@@ -3,11 +3,11 @@ Bots, like any other application, require use of expressions to evaluate outcome
 
 Common expression language was put together to address this core need as well as to rationalize and snap to a common expression language that will be used across Bot Framework SDK and other conversational AI components that need an expression language.
 
-[More info](https://github.com/microsoft/BotBuilder-Samples/tree/master/experimental/common-expression-language)
+[More info](https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-concept-adaptive-expressions?view=azure-bot-service-4.0)
 
-See [API reference for Expression](https://github.com/microsoft/BotBuilder-Samples/blob/master/experimental/common-expression-language/api-reference.md) for API reference.
+See [API reference for Expression](https://docs.microsoft.com/en-us/azure/bot-service/adaptive-expressions/adaptive-expressions-api-reference?view=azure-bot-service-4.0) for API reference.
 
-See [Here](https://github.com/microsoft/BotBuilder-Samples/blob/master/experimental/common-expression-language/prebuilt-functions.md) for a complete list of prebuilt functions supported by the common expression language library.
+See [Here](https://docs.microsoft.com/en-us/azure/bot-service/adaptive-expressions/adaptive-expressions-prebuilt-functions?view=azure-bot-service-4.0) for a complete list of prebuilt functions supported by the common expression language library.
 
 ### develop
 ```
@@ -15,3 +15,5 @@ See [Here](https://github.com/microsoft/BotBuilder-Samples/blob/master/experimen
     npm run build
     npm test
 ```
+
+If you changed the g4 file, please use `antlr-build-expression` and `antlr-build-commonregex` to generate latest lexer/parser. By the way, You will need to have a modern version of Java (>= JRE 1.6) to use it.

--- a/libraries/adaptive-expressions/package.json
+++ b/libraries/adaptive-expressions/package.json
@@ -45,11 +45,11 @@
     "antlr4ts-cli": "0.5.0-alpha.3"
   },
   "scripts": {
-    "build": "npm run antlr-build-expression && npm run antlr-build-commonregex && tsc",
+    "build": "tsc",
     "build-docs": "typedoc --theme markdown --entryPoint adaptive-expressions --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\adaptive-expressions .\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK - Expression\" --readme none",
     "clean": "erase /q /s .\\lib",
     "set-version": "npm version --allow-same-version ${Version}",
-    "test": "npm run build && tsc ./tests/expressionProperty.test.ts && mocha tests/ --timeout 60000",
+    "test": "tsc && tsc ./tests/expressionProperty.test.ts && mocha tests/ --timeout 60000",
     "antlr-build-expression": "antlr4ts src/parser/ExpressionAntlrLexer.g4 -o src/parser/generated && antlr4ts src/parser/ExpressionAntlrParser.g4 -visitor -o src/parser/generated",
     "antlr-build-commonregex": "antlr4ts src/CommonRegex.g4 -o src/generated -visitor"
   },

--- a/libraries/botbuilder-dialogs-adaptive/tests/LGGenerator.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/LGGenerator.test.js
@@ -37,7 +37,7 @@ async function getTurnContext(locale, generator) {
 }
 
 describe('LGLanguageGenerator', function() {
-    this.timeout(8000);
+    this.timeout(10000);
 
     it('TestNotFoundTemplate', async function() {
         const context = getTurnContext('');

--- a/libraries/botbuilder-lg/README.MD
+++ b/libraries/botbuilder-lg/README.MD
@@ -109,9 +109,12 @@ If your template needs specific entity values to be passed for resolution/ expan
     await turnContext.sendActivity(templates.evaluate("WordGameReply", { GameName = "MarcoPolo" } ));
 ```
 
+## Develop notice
+If you changed the g4 file, please use `antlr-build-expression` and `antlr-build-commonregex` to generate latest lexer/parser. By the way, You will need to have a modern version of Java (>= JRE 1.6) to use it.
+
 [1]:https://github.com/Microsoft/BotBuilder/blob/master/specs/botframework-activity/botframework-activity.md
-[2]:https://github.com/microsoft/BotBuilder-Samples/blob/master/experimental/language-generation/docs/api-reference.md
-[3]:https://github.com/microsoft/BotBuilder-Samples/blob/master/experimental/language-generation/docs/lg-file-format.md
+[2]:https://docs.microsoft.com/en-us/azure/bot-service/language-generation/language-generation-api-reference?view=azure-bot-service-4.0
+[3]:https://docs.microsoft.com/en-us/azure/bot-service/file-format/bot-builder-lg-file-format?view=azure-bot-service-4.0
 [4]:https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder-lg/tests/testData/examples/StructuredTemplate.lg
 [5]:https://github.com/microsoft/botbuilder-js/blob/master/libraries/botbuilder-lg/tests/testData/examples/NormalStructuredLG.lg
 

--- a/libraries/botbuilder-lg/package.json
+++ b/libraries/botbuilder-lg/package.json
@@ -36,11 +36,11 @@
     "antlr4ts-cli": "0.5.0-alpha.3"
   },
   "scripts": {
-    "build": "npm run antlr-build && tsc",
+    "build": "tsc",
     "build-docs": "typedoc --theme markdown --entryPoint botbuilder-lg --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\botbuilder-lg .\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK - LG\" --readme none",
     "clean": "erase /q /s .\\lib",
     "set-version": "npm version --allow-same-version ${Version}",
-    "test": "npm run build && mocha tests/ --timeout 60000",
+    "test": "tsc && mocha tests/ --timeout 60000",
     "antlr-build": "antlr4ts src/LGFileLexer.g4 -o src/generated && antlr4ts src/LGFileParser.g4 -visitor -o src/generated && antlr4ts src/LGTemplateLexer.g4 -o src/generated && antlr4ts src/LGTemplateParser.g4 -visitor -o src/generated"
   },
   "files": [


### PR DESCRIPTION
We added `antlr4ts-cli` into dependency and would auto build g4 grammar when `build` and `test` script is executed. But `antlr4ts-cli` script depends on JAVA environment. the reference is here:
https://www.npmjs.com/package/antlr4ts-cli

So, remove the auto build of antlr, and instead, keep the antlr script, user can still run the script manually with local JAVA environment.