### PR TITLE
Removed fallback exception from version change logic.

### DIFF
--- a/libraries/botbuilder-dialogs/src/dialogContainer.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContainer.ts
@@ -65,9 +65,7 @@ export abstract class DialogContainer<O extends object = {}> extends Dialog<O> {
             //   change again.
             const handled = await dc.emitEvent(DialogEvents.versionChanged, this.id, true, false);
             if (!handled) {
-                // Throw an error for bot to catch
-                throw new Error(`Version change detected for '${this.id}' dialog.`);
-            }
+                console.warn(`Version change detected for '${this.id}' dialog and wasn't handled. You should add event handler to restart dialogs when this happens.`);            }
         }
     }
 }

--- a/libraries/botbuilder-dialogs/src/dialogContainer.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContainer.ts
@@ -63,9 +63,7 @@ export abstract class DialogContainer<O extends object = {}> extends Dialog<O> {
             // Give bot an opportunity to handle the change.
             // - If bot handles it the changeHash will have been updated as to avoid triggering the 
             //   change again.
-            const handled = await dc.emitEvent(DialogEvents.versionChanged, this.id, true, false);
-            if (!handled) {
-                console.warn(`Version change detected for '${this.id}' dialog and wasn't handled. You should add event handler to restart dialogs when this happens.`);            }
+            await dc.emitEvent(DialogEvents.versionChanged, this.id, true, false);
         }
     }
 }

--- a/libraries/botbuilder-dialogs/tests/componentDialog.test.js
+++ b/libraries/botbuilder-dialogs/tests/componentDialog.test.js
@@ -391,48 +391,6 @@ describe('ComponentDialog', function () {
             .assertReply('Second step.')
             .assertReply('Done.')
     });
-
-    it('should throw error if unhandled dialogChange event.', (done) => {
-        const conversationState = new ConversationState(new MemoryStorage());
-        const dialogState = conversationState.createProperty('dialog');
-
-        const childDialog = new WaterfallDialog('child', [
-            async step => {
-                component.addDialog(new WaterfallDialog('change'));
-                await step.context.sendActivity('First step.');
-                return Dialog.EndOfTurn;
-            },
-            async step => {
-                await step.context.sendActivity('Second step.');
-                return await step.endDialog();
-            }
-        ]);
-        const component = new ChangedDialog('test', false);
-        component.addDialog(childDialog);
-
-        const dialogs = new DialogSet(dialogState);
-        dialogs.add(component);
-
-        const adapter = new TestAdapter(async turnContext => {
-            try {
-                const dc = await dialogs.createContext(turnContext);
-                const results = await dc.continueDialog();
-
-                if (results.status === DialogTurnStatus.empty) {
-                    await dc.beginDialog('test');
-                }
-                await conversationState.saveChanges(turnContext);
-            } catch (err) {
-                await turnContext.sendActivity('Done.')
-                done();
-            }
-        });
-
-        adapter.send('Hi')
-            .assertReply('First step.')
-            .send('Hi again')
-            .assertReply('Done.')
-    });
 });
 
 


### PR DESCRIPTION
## Description
We added a new feature in 4.9 to automatically detect dialog changes. Some customers are complaining about the fallback logic we have to automatically throw an exception if the bot doesn't handle the new event we added.  We've decided to remove the fallback exception and make the feature entirely opt-in.