### PR TITLE
[Engineering] Create .yaml pipeline for API check 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+libraries/adaptive-expressions/src/generated/**/*
 libraries/botframework-connector/src/connectorApi/**/*
 libraries/botframework-connector/src/tokenApi/**/*
 libraries/botframework-schema/**/*

--- a/build/yaml/botbuilder-js-api-check.yaml
+++ b/build/yaml/botbuilder-js-api-check.yaml
@@ -4,6 +4,7 @@ name: $(Build.BuildId)
 
 pool:
   name: Azure Pipelines
+  vmImage: 'macOS-10.15'
 
 variables:
   version: 4.0.0-0

--- a/build/yaml/botbuilder-js-api-check.yaml
+++ b/build/yaml/botbuilder-js-api-check.yaml
@@ -62,7 +62,7 @@ steps:
    sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-core/package.json
    sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-dialogs/package.json
    sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-dialogs-adaptive/package.json
-   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-dialogs-adaptive-testing/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-dialogs-adaptive-tests/package.json
    sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-dialogs-declarative/package.json
    sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-lg/package.json
    sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-testing/package.json

--- a/build/yaml/botbuilder-js-api-check.yaml
+++ b/build/yaml/botbuilder-js-api-check.yaml
@@ -61,6 +61,9 @@ steps:
    sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-azure/package.json
    sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-core/package.json
    sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-dialogs/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-dialogs-adaptive/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-dialogs-adaptive-testing/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-dialogs-declarative/package.json
    sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-lg/package.json
    sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-testing/package.json
    sed -i '' 's/${Version}/$(version)/g' libraries/botframework-config/package.json

--- a/build/yaml/botbuilder-js-api-check.yaml
+++ b/build/yaml/botbuilder-js-api-check.yaml
@@ -1,0 +1,222 @@
+
+# "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
+name: $(Build.BuildId)
+
+pool:
+  name: Azure Pipelines
+
+variables:
+  version: 4.0.0-0
+
+steps:
+- task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+  displayName: 'Tag Build with version number. (Skip if a fork PR to avoid access denied error.)'
+  inputs:
+    tags: 'Version=$(version)'
+  continueOnError: true
+  condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'false'))
+
+- task: NodeTool@0
+  displayName: 'Use Node 10.x'
+  inputs:
+    versionSpec: 10.x
+
+- task: Npm@1
+  displayName: 'npm install lerna ...'
+  inputs:
+    command: custom
+    verbose: false
+    customCommand: 'install --global lerna@3.2.1 nyc mocha'
+
+- task: Npm@1
+  displayName: 'npm i -g @microsoft/api-extractor'
+  inputs:
+    command: custom
+    verbose: false
+    customCommand: 'i -g @microsoft/api-extractor@7.7.10'
+
+- task: Npm@1
+  displayName: '/tools npm install'
+  inputs:
+    workingDir: tools
+    verbose: false
+  enabled: false
+
+- task: Npm@1
+  displayName: 'npm install coveralls --save-dev'
+  inputs:
+    command: custom
+    workingDir: tools
+    verbose: false
+    customCommand: 'install coveralls --save-dev'
+  enabled: false
+
+- bash: |
+   sed -i '' 's/${Version}/$(version)/g' package.json 
+   sed -i '' 's/${Version}/$(version)/g' libraries/adaptive-expressions/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-ai/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-applicationinsights/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-azure/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-core/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-dialogs/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-lg/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-testing/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botframework-config/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botframework-connector/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botframework-schema/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botframework-streaming/package.json
+   
+  failOnStderr: true
+  displayName: 'Replace version number in package.json files'
+  continueOnError: true
+  env:
+    version: $(version)
+
+- task: Npm@1
+  displayName: 'npm update-versions'
+  inputs:
+    command: custom
+    verbose: false
+    customCommand: 'run update-versions'
+
+- powershell: |
+   $fileName = 'package-lock.json'
+   Get-ChildItem -Path ./tools -File | Where-Object {$_.Name -eq $fileName};
+   Write-Host "`nDeleting any files listed above";
+   Get-ChildItem -Path ./tools -File | Where-Object {$_.Name -eq $fileName} | Remove-Item -Force;
+  displayName: 'Delete tools/package-lock.json. Maybe avoids intermittent error in \"npm run postinstall\" ENOENT: no such file or directory, lchown ''/Users/runner/.npm/_locks/staging-7c222bec8116519f.lock'''
+  continueOnError: true
+
+- task: Npm@1
+  displayName: 'npm run postinstall'
+  inputs:
+    command: custom
+    verbose: false
+    customCommand: 'run postinstall'
+
+- task: Npm@1
+  displayName: 'npm run build'
+  inputs:
+    command: custom
+    verbose: false
+    customCommand: 'run build'
+
+- powershell: |
+   # All "check_api_for" Tasks should run only if the build succeeds,
+   # And continue running even if another "check_api_for" task fails.
+   
+   Write-Host "##vso[task.setvariable variable=buildPassed;]true"
+  displayName: 'Set "buildPassed" variable'
+
+- task: Npm@1
+  displayName: 'check_api_for botframework-schema'
+  inputs:
+    command: custom
+    workingDir: 'libraries/botframework-schema'
+    verbose: false
+    customCommand: 'run test:compat'
+  condition: eq(variables.buildPassed, 'true')
+
+- task: Npm@1
+  displayName: 'check_api_for botframework-streaming'
+  inputs:
+    command: custom
+    workingDir: 'libraries/botframework-streaming'
+    verbose: false
+    customCommand: 'run test:compat'
+  condition: eq(variables.buildPassed, 'true')
+
+- task: Npm@1
+  displayName: 'check_api_for botbuilder-core'
+  inputs:
+    command: custom
+    workingDir: 'libraries/botbuilder-core'
+    verbose: false
+    customCommand: 'run test:compat'
+  condition: eq(variables.buildPassed, 'true')
+
+- task: Npm@1
+  displayName: 'check_api_for botbuilder'
+  inputs:
+    command: custom
+    workingDir: libraries/botbuilder
+    verbose: false
+    customCommand: 'run test:compat'
+  condition: eq(variables.buildPassed, 'true')
+
+- task: Npm@1
+  displayName: 'check_api_for botbuilder-ai'
+  inputs:
+    command: custom
+    workingDir: 'libraries/botbuilder-ai'
+    verbose: false
+    customCommand: 'run test:compat'
+  condition: eq(variables.buildPassed, 'true')
+
+- task: Npm@1
+  displayName: 'check_api_for botbuilder-applicationinsights'
+  inputs:
+    command: custom
+    workingDir: 'libraries/botbuilder-applicationinsights'
+    verbose: false
+    customCommand: 'run test:compat'
+  condition: eq(variables.buildPassed, 'true')
+
+- task: Npm@1
+  displayName: 'check_api_for botbuilder-azure'
+  inputs:
+    command: custom
+    workingDir: 'libraries/botbuilder-azure'
+    verbose: false
+    customCommand: 'run test:compat'
+  condition: eq(variables.buildPassed, 'true')
+
+- task: Npm@1
+  displayName: 'check_api_for botbuilder-dialogs'
+  inputs:
+    command: custom
+    workingDir: 'libraries/botbuilder-dialogs'
+    verbose: false
+    customCommand: 'run test:compat'
+  condition: eq(variables.buildPassed, 'true')
+
+- task: Npm@1
+  displayName: 'check_api_for botbuilder-testing'
+  inputs:
+    command: custom
+    workingDir: 'libraries/botbuilder-testing'
+    verbose: false
+    customCommand: 'run test:compat'
+  condition: eq(variables.buildPassed, 'true')
+
+- task: Npm@1
+  displayName: 'check_api_for botframework-config'
+  inputs:
+    command: custom
+    workingDir: 'libraries/botframework-config'
+    verbose: false
+    customCommand: 'run test:compat'
+  condition: eq(variables.buildPassed, 'true')
+
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: 'Component Detection'
+  inputs:
+    verbosity: Normal
+    sourceScanPath: libraries
+    alertWarningLevel: Medium
+    failOnAlert: true
+    ignoreDirectories: 'libraries/teams-scenarios,swagger'
+  enabled: false
+  continueOnError: true
+
+- powershell: 'Get-ChildItem env:* | sort-object name'
+  displayName: 'Log environment variables'
+  continueOnError: true
+
+- powershell: |
+   pushd ..
+   Get-ChildItem -Recurse -Force | Where {$_.FullName -notlike "*node_modules*"}
+  displayName: 'Dir workspace except node-modules (takes 12 seconds)'
+  continueOnError: true
+  condition: succeededOrFailed()

--- a/libraries/botbuilder-ai/etc/botbuilder-ai.api.md
+++ b/libraries/botbuilder-ai/etc/botbuilder-ai.api.md
@@ -143,6 +143,7 @@ export interface LuisRecognizerOptionsV2 extends LuisRecognizerOptions {
 // @public (undocumented)
 export interface LuisRecognizerOptionsV3 extends LuisRecognizerOptions {
     apiVersion: "v3";
+    datetimeReference?: string;
     dynamicLists?: Array<any>;
     externalEntities?: Array<any>;
     includeAllIntents?: boolean;
@@ -262,7 +263,6 @@ export interface QnAMakerMetadata {
 
 // @public
 export interface QnAMakerOptions {
-    // Warning: (ae-forgotten-export) The symbol "QnARequestContext" needs to be exported by the entry point index.d.ts
     context?: QnARequestContext;
     isTest?: boolean;
     metadataBoost?: QnAMakerMetadata[];
@@ -308,6 +308,19 @@ export interface QnAMakerTraceInfo {
     scoreThreshold: number;
     strictFilters: any[];
     top: number;
+}
+
+// @public
+export interface QnARequestContext {
+    previousQnAId: number;
+    previousUserQuery: string;
+}
+
+// @public
+export class RankerTypes {
+    static readonly autoSuggestQuestion: string;
+    static readonly default: string;
+    static readonly questionOnly: string;
 }
 
 

--- a/libraries/botbuilder-applicationinsights/etc/botbuilder-applicationinsights.api.md
+++ b/libraries/botbuilder-applicationinsights/etc/botbuilder-applicationinsights.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import * as appInsights from 'applicationinsights';
+import { BotPageViewTelemetryClient } from 'botbuilder-core';
 import { BotTelemetryClient } from 'botbuilder-core';
 import { CorrelationContext } from 'applicationinsights/out/AutoCollection/CorrelationContextManager';
 import { Middleware } from 'botbuilder-core';
@@ -12,11 +13,12 @@ import { TelemetryDependency } from 'botbuilder-core';
 import { TelemetryEvent } from 'botbuilder-core';
 import { TelemetryException } from 'botbuilder-core';
 import { TelemetryLoggerMiddleware } from 'botbuilder-core';
+import { TelemetryPageView } from 'botbuilder-core';
 import { TelemetryTrace } from 'botbuilder-core';
 import { TurnContext } from 'botbuilder-core';
 
 // @public (undocumented)
-export class ApplicationInsightsTelemetryClient implements BotTelemetryClient {
+export class ApplicationInsightsTelemetryClient implements BotTelemetryClient, BotPageViewTelemetryClient {
     constructor(instrumentationKey: string);
     // (undocumented)
     readonly configuration: appInsights.Configuration;
@@ -30,6 +32,8 @@ export class ApplicationInsightsTelemetryClient implements BotTelemetryClient {
     trackEvent(telemetry: TelemetryEvent): void;
     // (undocumented)
     trackException(telemetry: TelemetryException): void;
+    // (undocumented)
+    trackPageView(telemetry: TelemetryPageView): void;
     // (undocumented)
     trackTrace(telemetry: TelemetryTrace): void;
 }

--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -20,6 +20,7 @@ import { ChannelAccount } from 'botbuilder-core';
 import { ChannelInfo } from 'botbuilder-core';
 import { ClaimsIdentity } from 'botframework-connector';
 import { ConnectorClient } from 'botframework-connector';
+import { ConnectorClientOptions } from 'botframework-connector';
 import { ConversationAccount } from 'botframework-schema';
 import { ConversationParameters } from 'botbuilder-core';
 import { ConversationReference } from 'botbuilder-core';
@@ -29,6 +30,7 @@ import { ConversationState } from 'botbuilder-core';
 import { CoreAppCredentials } from 'botbuilder-core';
 import { ExtendedUserTokenProvider } from 'botbuilder-core';
 import { FileConsentCardResponse } from 'botbuilder-core';
+import { HealthCheckResponse } from 'botbuilder-core';
 import { HttpClient } from '@azure/ms-rest-js';
 import { HttpOperationResponse } from '@azure/ms-rest-js';
 import { ICredentialProvider } from 'botframework-connector';
@@ -74,8 +76,10 @@ import { TurnContext } from 'botbuilder-core';
 import { UserState } from 'botbuilder-core';
 import { WebResource } from '@azure/ms-rest-js';
 
+// Warning: (ae-forgotten-export) The symbol "ConnectorClientBuilder" needs to be exported by the entry point index.d.ts
+//
 // @public
-export class BotFrameworkAdapter extends BotAdapter implements ExtendedUserTokenProvider, RequestHandler {
+export class BotFrameworkAdapter extends BotAdapter implements ConnectorClientBuilder, ExtendedUserTokenProvider, RequestHandler {
     constructor(settings?: Partial<BotFrameworkAdapterSettings>);
     protected authenticateRequest(request: Partial<Activity>, authHeader: string): Promise<void>;
     // (undocumented)
@@ -88,6 +92,7 @@ export class BotFrameworkAdapter extends BotAdapter implements ExtendedUserToken
     continueConversation(reference: Partial<ConversationReference>, oAuthScope: string, logic: (context: TurnContext) => Promise<void>): Promise<void>;
     createConnectorClient(serviceUrl: string): ConnectorClient;
     createConnectorClientWithIdentity(serviceUrl: string, identity: ClaimsIdentity): Promise<ConnectorClient>;
+    createConnectorClientWithIdentity(serviceUrl: string, identity: ClaimsIdentity, audience: string): Promise<ConnectorClient>;
     protected createContext(request: Partial<Activity>): TurnContext;
     createConversation(reference: Partial<ConversationReference>, logic?: (context: TurnContext) => Promise<void>): Promise<void>;
     protected createTokenApiClient(serviceUrl: string, oAuthAppCredentials?: CoreAppCredentials): TokenApiClient;
@@ -119,6 +124,8 @@ export class BotFrameworkAdapter extends BotAdapter implements ExtendedUserToken
     getUserToken(context: TurnContext, connectionName: string, magicCode?: string): Promise<TokenResponse>;
     // (undocumented)
     getUserToken(context: TurnContext, connectionName: string, magicCode?: string, oAuthAppCredentials?: CoreAppCredentials): Promise<TokenResponse>;
+    // (undocumented)
+    healthCheck(context: TurnContext): Promise<HealthCheckResponse>;
     readonly isStreamingConnectionOpen: boolean;
     protected oauthApiUrl(contextOrServiceUrl: TurnContext | string): string;
     processActivity(req: WebRequest, res: WebResponse, logic: (context: TurnContext) => Promise<any>): Promise<void>;
@@ -146,6 +153,7 @@ export interface BotFrameworkAdapterSettings {
     certificateThumbprint?: string;
     channelAuthTenant?: string;
     channelService?: string;
+    clientOptions?: ConnectorClientOptions;
     oAuthEndpoint?: string;
     openIdMetadata?: string;
     webSocketFactory?: NodeWebSocketFactoryBase;
@@ -265,8 +273,7 @@ export class SkillHandler extends ChannelServiceHandler {
     constructor(adapter: BotAdapter, bot: ActivityHandlerBase, conversationIdFactory: SkillConversationIdFactoryBase, credentialProvider: ICredentialProvider, authConfig: AuthenticationConfiguration, channelService?: string);
     protected onReplyToActivity(claimsIdentity: ClaimsIdentity, conversationId: string, activityId: string, activity: Activity): Promise<ResourceResponse>;
     protected onSendToConversation(claimsIdentity: ClaimsIdentity, conversationId: string, activity: Activity): Promise<ResourceResponse>;
-    // (undocumented)
-    readonly SkillConversationReferenceKey: Symbol;
+    readonly SkillConversationReferenceKey: symbol;
 }
 
 // @public

--- a/libraries/botframework-config/etc/botframework-config.api.md
+++ b/libraries/botframework-config/etc/botframework-config.api.md
@@ -314,11 +314,11 @@ export class LuisService extends ConnectedService implements ILuisService {
     constructor(source?: ILuisService, serviceType?: ServiceTypes);
     appId: string;
     authoringKey: string;
+    customEndpoint: string;
     // (undocumented)
     decrypt(secret: string, decryptString: (value: string, secret: string) => string): void;
     // (undocumented)
     encrypt(secret: string, encryptString: (value: string, secret: string) => string): void;
-    // (undocumented)
     getEndpoint(): string;
     region: string;
     subscriptionKey: string;

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -156,8 +156,8 @@ export interface AnimationCard {
 
 // @public
 export interface AppBasedLinkQuery {
-    url?: string;
     state?: string;
+    url?: string;
 }
 
 // @public
@@ -235,6 +235,13 @@ export type BotMessagePreviewActionType = 'edit' | 'send';
 
 // @public
 export type BotMessagePreviewType = 'message' | 'continue';
+
+// @public
+export class CallerIdConstants {
+    static readonly BotToBotPrefix: string;
+    static readonly PublicAzureChannel: string;
+    static readonly USGovChannel: string;
+}
 
 // @public
 export interface CardAction {
@@ -367,6 +374,7 @@ export interface ConversationReference {
     bot: ChannelAccount;
     channelId: string;
     conversation: ConversationAccount;
+    locale?: string;
     serviceUrl: string;
     user?: ChannelAccount;
 }
@@ -489,6 +497,20 @@ export interface GeoCoordinates {
     longitude: number;
     name: string;
     type: string;
+}
+
+// @public
+export interface HealthCheckResponse {
+    healthResults: HealthResults;
+}
+
+// @public
+export interface HealthResults {
+    "user-agent"?: string;
+    authorization?: string;
+    diagnostics?: any;
+    messages?: string[];
+    success: boolean;
 }
 
 // @public
@@ -615,6 +637,14 @@ export enum InstallationUpdateActionTypes {
     Add = "add",
     // (undocumented)
     Remove = "remove"
+}
+
+// @public (undocumented)
+export interface IStatusCodeError {
+    // (undocumented)
+    message?: string;
+    // (undocumented)
+    statusCode: StatusCodes;
 }
 
 // @public (undocumented)
@@ -1173,6 +1203,32 @@ export interface SignInUrlResponse {
 }
 
 // @public
+export enum StatusCodes {
+    // (undocumented)
+    BAD_GATEWAY = 502,
+    // (undocumented)
+    BAD_REQUEST = 400,
+    // (undocumented)
+    CONFLICT = 409,
+    // (undocumented)
+    INTERNAL_SERVER_ERROR = 500,
+    // (undocumented)
+    METHOD_NOT_ALLOWED = 405,
+    // (undocumented)
+    MULTIPLE_CHOICES = 300,
+    // (undocumented)
+    NOT_FOUND = 404,
+    // (undocumented)
+    NOT_IMPLEMENTED = 501,
+    // (undocumented)
+    OK = 200,
+    // (undocumented)
+    UNAUTHORIZED = 401,
+    // (undocumented)
+    UPGRADE_REQUIRED = 426
+}
+
+// @public
 export type Style = 'compact' | 'expanded';
 
 // @public
@@ -1249,8 +1305,8 @@ export interface TeamsChannelAccount extends ChannelAccount {
     email?: string;
     givenName?: string;
     surname?: string;
-    userPrincipalName?: string;
     tenantId?: string;
+    userPrincipalName?: string;
     userRole?: string;
 }
 
@@ -1310,6 +1366,13 @@ export interface ThumbnailCard {
 export interface ThumbnailUrl {
     alt: string;
     url: string;
+}
+
+// @public
+export interface TokenExchangeInvokeRequest {
+    connectionName: string;
+    id: string;
+    token: string;
 }
 
 // @public


### PR DESCRIPTION
Fixes #2320

## Specific Changes
- Create Azure DevOps .yaml pipeline for API check.
- Regenerates API documentation (`*.api.md`) in supported libraries
- Add generated adaptive-expressions code to .eslintignore

## Testing
Latest run of pipeline for this branch: [link](https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=136792&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=12f1170f-54f2-53f3-20dd-22fc7dff55f9)