### PR TITLE
[PORT]Enrich LG error message

### DIFF
--- a/libraries/botbuilder-lg/src/diagnostic.ts
+++ b/libraries/botbuilder-lg/src/diagnostic.ts
@@ -45,9 +45,9 @@ export class Diagnostic {
     public toString(): string {
         // ignore error range if source is "inline content"
         if (this.source === TemplatesParser.inlineContentId) {
-            return `[${ DiagnosticSeverity[this.severity] }] ${this.source} ${ this.message.toString() }`;
+            return `[${ DiagnosticSeverity[this.severity] }] ${ this.source } ${ this.message.toString() }`;
         } else {
-            return `[${ DiagnosticSeverity[this.severity] }] ${this.source}${ this.range.toString() }: ${ this.message.toString() }`;
+            return `[${ DiagnosticSeverity[this.severity] }] ${ this.source } ${ this.range.toString() }: ${ this.message.toString() }`;
         }
     }
 }

--- a/libraries/botbuilder-lg/src/diagnostic.ts
+++ b/libraries/botbuilder-lg/src/diagnostic.ts
@@ -7,6 +7,7 @@
  */
 
 import { Range } from './range';
+import { TemplatesParser } from './templatesParser';
 
 /**
  * DiagnosticSeverity enum
@@ -42,12 +43,11 @@ export class Diagnostic {
     }
 
     public toString(): string {
-
         // ignore error range if source is "inline content"
-        if (this.source === 'inline content') {
-            return `[${ DiagnosticSeverity[this.severity] }] ${ this.message.toString() }`;
+        if (this.source === TemplatesParser.inlineContentId) {
+            return `[${ DiagnosticSeverity[this.severity] }] ${this.source} ${ this.message.toString() }`;
         } else {
-            return `[${ DiagnosticSeverity[this.severity] }] ${ this.range.toString() }: ${ this.message.toString() }`;
+            return `[${ DiagnosticSeverity[this.severity] }] ${this.source}${ this.range.toString() }: ${ this.message.toString() }`;
         }
     }
 }

--- a/libraries/botbuilder-lg/src/errorListener.ts
+++ b/libraries/botbuilder-lg/src/errorListener.ts
@@ -38,7 +38,7 @@ export class ErrorListener implements ANTLRErrorListener<any> {
         const startPosition: Position = new Position(this.lineOffset + line, charPositionInLine);
         const stopPosition: Position = new Position(this.lineOffset + line, charPositionInLine + offendingSymbol.stopIndex - offendingSymbol.startIndex + 1);
         const range: Range = new Range(startPosition, stopPosition);
-        const diagnostic: Diagnostic = new Diagnostic(range, TemplateErrors.syntaxError, DiagnosticSeverity.Error, this.source);
+        const diagnostic: Diagnostic = new Diagnostic(range, TemplateErrors.syntaxError(msg), DiagnosticSeverity.Error, this.source);
 
         throw new TemplateException(diagnostic.toString(), [diagnostic]);
     }

--- a/libraries/botbuilder-lg/src/evaluator.ts
+++ b/libraries/botbuilder-lg/src/evaluator.ts
@@ -513,7 +513,7 @@ export class Evaluator extends AbstractParseTreeVisitor<any> implements LGTempla
 
         // Validate return type
         if ((children0.returnType & ReturnType.Object) === 0 && (children0.returnType & ReturnType.String) === 0) {
-            throw new Error(TemplateErrors.invalidTemplateName);
+            throw new Error(TemplateErrors.invalidTemplateNameType);
         }
 
         // Validate more if the name is string constant

--- a/libraries/botbuilder-lg/src/expander.ts
+++ b/libraries/botbuilder-lg/src/expander.ts
@@ -519,7 +519,7 @@ export class Expander extends AbstractParseTreeVisitor<string[]> implements LGTe
 
         // Validate return type
         if ((children0.returnType & ReturnType.Object) === 0 && (children0.returnType & ReturnType.String) === 0) {
-            throw new Error(TemplateErrors.invalidTemplateName);
+            throw new Error(TemplateErrors.invalidTemplateNameType);
         }
 
         // Validate more if the name is string constant

--- a/libraries/botbuilder-lg/src/staticChecker.ts
+++ b/libraries/botbuilder-lg/src/staticChecker.ts
@@ -309,9 +309,11 @@ export class StaticChecker extends AbstractParseTreeVisitor<Diagnostic[]> implem
         const lineOffset = this.currentTemplate !== undefined ? this.currentTemplate.sourceRange.range.start.line : 0;
 
         let templateNameInfo = '';
-        
-        message = this.currentTemplate !== undefined ? `[${ this.currentTemplate.name }]` + message : message;
+        if (this.currentTemplate !== undefined && this.currentTemplate.name !== Templates.inlineTemplateId) {
+            templateNameInfo = `[${ this.currentTemplate.name }]`;
+        }
+
         const range = context === undefined ? new Range(lineOffset + 1, 0, lineOffset + 1, 0) : TemplateExtensions.convertToRange(context, lineOffset);
-        return new Diagnostic(range, message, severity, this.templates.id);
+        return new Diagnostic(range, templateNameInfo + message, severity, this.templates.id);
     }
 }

--- a/libraries/botbuilder-lg/src/staticChecker.ts
+++ b/libraries/botbuilder-lg/src/staticChecker.ts
@@ -100,8 +100,9 @@ export class StaticChecker extends AbstractParseTreeVisitor<Diagnostic[]> implem
     public visitStructuredTemplateBody(context: lp.StructuredTemplateBodyContext): Diagnostic[] {
         let result: Diagnostic[] = [];
 
-        if (context.structuredBodyNameLine().errorStructuredName() !== undefined) {
-            result.push(this.buildLGDiagnostic(TemplateErrors.invalidStrucName, undefined, context.structuredBodyNameLine()));
+        const errorName = context.structuredBodyNameLine().errorStructuredName();
+        if (errorName !== undefined) {
+            result.push(this.buildLGDiagnostic(TemplateErrors.invalidStrucName(errorName.text), undefined, context.structuredBodyNameLine()));
         }
 
         if (context.structuredBodyEndLine() === undefined) {
@@ -111,7 +112,7 @@ export class StaticChecker extends AbstractParseTreeVisitor<Diagnostic[]> implem
         const errors = context.errorStructureLine();
         if (errors && errors.length > 0){
             for (const error of errors) {
-                result.push(this.buildLGDiagnostic(TemplateErrors.invalidStrucBody, undefined, error));
+                result.push(this.buildLGDiagnostic(TemplateErrors.invalidStrucBody(error.text), undefined, error));
             }
         } else {
             const bodys = context.structuredBodyContentLine();
@@ -306,6 +307,9 @@ export class StaticChecker extends AbstractParseTreeVisitor<Diagnostic[]> implem
 
     private buildLGDiagnostic( message: string, severity: DiagnosticSeverity = undefined, context: ParserRuleContext = undefined): Diagnostic {
         const lineOffset = this.currentTemplate !== undefined ? this.currentTemplate.sourceRange.range.start.line : 0;
+
+        let templateNameInfo = '';
+        
         message = this.currentTemplate !== undefined ? `[${ this.currentTemplate.name }]` + message : message;
         const range = context === undefined ? new Range(lineOffset + 1, 0, lineOffset + 1, 0) : TemplateExtensions.convertToRange(context, lineOffset);
         return new Diagnostic(range, message, severity, this.templates.id);

--- a/libraries/botbuilder-lg/src/templateErrors.ts
+++ b/libraries/botbuilder-lg/src/templateErrors.ts
@@ -12,17 +12,11 @@
 export class TemplateErrors {
     public static readonly noTemplate: string = `LG file must have at least one template definition.`;
  
-    public static readonly invalidTemplateName: string = `Invalid template name. Template names can only contain letter, underscore '_' or number. Any part of a template name (split by '.') cannot start with a number.`;
- 
     public static readonly invalidTemplateBody: string = `Invalid template body. Expecting '-' prefix.`;
- 
-    public static readonly invalidStrucName: string = `Invalid structure name. name should start with letter/number/_ and can only contains letter/number/./_.`;
  
     public static readonly missingStrucEnd: string = `Invalid structure body. Expecting ']' at the end of the body.`;
  
     public static readonly emptyStrucContent: string = `Invalid structure body. Body cannot be empty.`;
- 
-    public static readonly invalidStrucBody: string = 'Invalid structure body. Body can include <PropertyName>: string = <Value> pairs or ${reference()} template reference.';
  
     public static readonly invalidWhitespaceInCondition: string = `Invalid condition: At most 1 whitespace allowed between 'IF/ELSEIF/ELSE' and ':'.`;
  
@@ -64,12 +58,22 @@ export class TemplateErrors {
  
     public static readonly loopDetected: string = `Loop detected:`;
  
-    public static readonly syntaxError: string = `Unexpected content. Expecting a comment, template definition, import statement or option definition.`;
- 
     public static readonly invalidMemory: string = `Scope is not a LG customized memory.`;
  
     public static readonly staticFailure: string = `Static failure with the following error.`;
  
+    public static readonly invalidTemplateNameType: string = "Expected string type for the parameter of template function.";
+
+    public static readonly invalidStrucBody = (invalidBody: string) => `Invalid structure body: '${invalidBody}'. Body can include <PropertyName> = <Value> pairs or \${reference()} template reference.`;
+
+    public static readonly invalidStrucName = (invalidName: string): string => `Invalid structure name: '${invalidName}'. name should start with letter/number/_ and can only contains letter/number/./_.`;
+
+    public static readonly syntaxError = (unexpectedContent: string) => `${unexpectedContent}. Expecting a comment, template definition, import statement or option definition.`;
+
+    public static readonly invalidTemplateName = (invalidTemplateName: string) => `Invalid template name: '${invalidTemplateName}'. Template names can only contain letter, underscore '_' or number. Any part of a template name (split by '.') cannot start with a number.`;
+
+    public static readonly invalidParameter = (invalidParameter: string) => `Invalid parameter name: '${invalidParameter}'. Parameter names can only contain letter, underscore '_' or number.`;
+
     public static readonly duplicatedTemplateInSameTemplate = (templateName: string): string => `Duplicated definitions found for template: '${ templateName }'.`;
  
     public static readonly duplicatedTemplateInDiffTemplate = (templateName: string, source: string): string => `Duplicated definitions found for template: '${ templateName }' in '${ source }'.`;

--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -25,6 +25,11 @@ import { isAbsolute, basename } from 'path';
  * LG entrance, including properties that LG file has, and evaluate functions.
  */
 export class Templates implements Iterable<Template> {
+
+    /**
+     * Temp Template ID for inline content.
+     */
+    public static readonly inlineTemplateId: string = '__temp__';
     private readonly newLineRegex = /(\r?\n)/g;
     private readonly newLine: string = '\r\n';
     private readonly namespaceKey = '@namespace';
@@ -241,17 +246,16 @@ export class Templates implements Iterable<Template> {
         this.checkErrors();
 
         // wrap inline string with "# name and -" to align the evaluation process
-        const fakeTemplateId = '__temp__';
         const multiLineMark = '```';
 
         inlineStr = !(inlineStr.trim().startsWith(multiLineMark) && inlineStr.includes('\n'))
             ? `${ multiLineMark }${ inlineStr }${ multiLineMark }` : inlineStr;
 
-        const newContent = `#${ fakeTemplateId } ${ this.newLine } - ${ inlineStr }`;
+        const newContent = `#${ Templates.inlineTemplateId } ${ this.newLine } - ${ inlineStr }`;
 
         const newTemplates = TemplatesParser.parseTextWithRef(newContent, this);
         var evalOpt = opt !== undefined ? opt.merge(this.lgOptions) : this.lgOptions;
-        return newTemplates.evaluate(fakeTemplateId, scope, evalOpt);
+        return newTemplates.evaluate(Templates.inlineTemplateId, scope, evalOpt);
     }
 
     /**

--- a/libraries/botbuilder-lg/src/templatesParser.ts
+++ b/libraries/botbuilder-lg/src/templatesParser.ts
@@ -38,10 +38,18 @@ export declare type ImportResolverDelegate = (source: string, resourceId: string
 export class TemplatesParser {
 
     /**
+     * Inline text id.
+     */
+    public static readonly inlineContentId: string = 'inline content';
+
+    /**
      * option regex.
      */
     public static readonly optionRegex: RegExp = new RegExp(/>\s*!#(.*)$/);
 
+    /**
+     * Import regex.
+     */
     public static readonly importRegex: RegExp = new RegExp(/\[([^\]]*)\]\(([^\)]*)\)/);
     
     /**
@@ -80,7 +88,7 @@ export class TemplatesParser {
             throw Error(`templates is empty`);
         }
 
-        const id = 'inline content';
+        const id = TemplatesParser.inlineContentId;
         let newTemplates = new Templates();
         newTemplates.content = content;
         newTemplates.id = id;

--- a/libraries/botbuilder-lg/src/templatesParser.ts
+++ b/libraries/botbuilder-lg/src/templatesParser.ts
@@ -253,7 +253,7 @@ class TemplatesTransformer extends AbstractParseTreeVisitor<any> implements LGTe
     public visitErrorDefinition(context: lp.ErrorDefinitionContext): any {
         const lineContent = context.INVALID_LINE().text;
         if (lineContent === undefined || lineContent.trim() === '') {
-            this.templates.diagnostics.push(this.buildTemplatesDiagnostic(TemplateErrors.syntaxError, context));
+            this.templates.diagnostics.push(this.buildTemplatesDiagnostic(TemplateErrors.syntaxError(`Unexpected content: '${ lineContent }'`), context));
         }
         return;
     }
@@ -322,8 +322,9 @@ class TemplatesTransformer extends AbstractParseTreeVisitor<any> implements LGTe
         const functionNameSplitDot = templateName.split('.');
         for(let id of functionNameSplitDot) {
             if (!this.templateNamePartRegex.test(id)) {
-                const diagnostic = this.buildTemplatesDiagnostic(TemplateErrors.invalidTemplateName, context);
+                const diagnostic = this.buildTemplatesDiagnostic(TemplateErrors.invalidTemplateName(templateName), context);
                 this.templates.diagnostics.push(diagnostic);
+                break;
             }
         }
     }
@@ -331,7 +332,7 @@ class TemplatesTransformer extends AbstractParseTreeVisitor<any> implements LGTe
     private checkTemplateParameters(parameters: string[], context: ParserRuleContext): void {
         for (const parameter of parameters) {
             if (!this.identifierRegex.test(parameter)) {
-                const diagnostic = this.buildTemplatesDiagnostic(TemplateErrors.invalidTemplateName, context);
+                const diagnostic = this.buildTemplatesDiagnostic(TemplateErrors.invalidParameter(parameter), context);
                 this.templates.diagnostics.push(diagnostic);
             }
         }

--- a/libraries/botbuilder-lg/tests/lgDiagnostic.test.js
+++ b/libraries/botbuilder-lg/tests/lgDiagnostic.test.js
@@ -95,7 +95,7 @@ describe(`LGExceptionTest`, function() {
 
         assert.strictEqual(8, diagnostics.length);
         assert.strictEqual(DiagnosticSeverity.Error, diagnostics[0].severity);
-        assert.strictEqual(diagnostics[0].message.includes(TemplateErrors.invalidStrucBody), true);
+        assert.strictEqual(diagnostics[0].message.includes(TemplateErrors.invalidStrucBody('abc')), true);
         assert.strictEqual(DiagnosticSeverity.Error, diagnostics[1].severity);
         assert.strictEqual(diagnostics[1].message.includes(TemplateErrors.emptyStrucContent), true);
         assert.strictEqual(DiagnosticSeverity.Error, diagnostics[2].severity);
@@ -103,24 +103,33 @@ describe(`LGExceptionTest`, function() {
         assert.strictEqual(DiagnosticSeverity.Error, diagnostics[3].severity);
         assert.strictEqual(diagnostics[3].message.includes(`Error occurred when parsing expression 'NOTemplate()'. NOTemplate does not have an evaluator`), true);
         assert.strictEqual(DiagnosticSeverity.Error, diagnostics[4].severity);
-        assert.strictEqual(diagnostics[4].message.includes(TemplateErrors.invalidStrucName), true);
+        assert.strictEqual(diagnostics[4].message.includes(TemplateErrors.invalidStrucName('Activity%')), true);
         assert.strictEqual(DiagnosticSeverity.Error, diagnostics[5].severity);
-        assert.strictEqual(diagnostics[5].message.includes(TemplateErrors.invalidStrucName), true);
+        assert.strictEqual(diagnostics[5].message.includes(TemplateErrors.invalidStrucName('Activity]')), true);
         assert.strictEqual(DiagnosticSeverity.Error, diagnostics[6].severity);
         assert.strictEqual(diagnostics[6].message.includes(TemplateErrors.missingStrucEnd), true);
         assert.strictEqual(DiagnosticSeverity.Error, diagnostics[7].severity);
-        assert.strictEqual(diagnostics[7].message.includes(TemplateErrors.invalidStrucBody), true);
+        assert.strictEqual(diagnostics[7].message.includes(TemplateErrors.invalidStrucBody('- hi')), true);
     });
 
     it(`TestErrorTemplateName`, function() {
         var diagnostics = GetDiagnostics(`ErrorTemplateName.lg`);
 
         assert.strictEqual(7, diagnostics.length);
-        for(const diagnostic of diagnostics)
-        {
-            assert.strictEqual(DiagnosticSeverity.Error, diagnostic.severity);
-            assert.strictEqual(diagnostic.message.includes(TemplateErrors.invalidTemplateName), true);
-        }
+        assert.strictEqual(DiagnosticSeverity.Error, diagnostics[0].severity);
+        assert.strictEqual(diagnostics[0].message.includes(TemplateErrors.invalidParameter('param1; param2')), true);
+        assert.strictEqual(DiagnosticSeverity.Error, diagnostics[1].severity);
+        assert.strictEqual(diagnostics[1].message.includes(TemplateErrors.invalidParameter('param1 param2')), true);
+        assert.strictEqual(DiagnosticSeverity.Error, diagnostics[2].severity);
+        assert.strictEqual(diagnostics[2].message.includes(TemplateErrors.invalidTemplateName('template3(errorparams')), true);
+        assert.strictEqual(DiagnosticSeverity.Error, diagnostics[3].severity);
+        assert.strictEqual(diagnostics[3].message.includes(TemplateErrors.invalidParameter('a)test(param1')), true);
+        assert.strictEqual(DiagnosticSeverity.Error, diagnostics[4].severity);
+        assert.strictEqual(diagnostics[4].message.includes(TemplateErrors.invalidParameter('$%^')), true);
+        assert.strictEqual(DiagnosticSeverity.Error, diagnostics[5].severity);
+        assert.strictEqual(diagnostics[5].message.includes(TemplateErrors.invalidTemplateName('the-name-of-template')), true);
+        assert.strictEqual(DiagnosticSeverity.Error, diagnostics[6].severity);
+        assert.strictEqual(diagnostics[6].message.includes(TemplateErrors.invalidTemplateName('t1.1')), true);
     });
 
     it(`TestInvalidLGFileImportPath`, function() {
@@ -280,11 +289,11 @@ it(`TestErrorLine`, function() {
     
 
     assert.strictEqual(DiagnosticSeverity.Error, diagnostics[0].severity);
-    assert.strictEqual(diagnostics[0].message.includes(TemplateErrors.syntaxError), true);
+    assert.strictEqual(diagnostics[0].message.includes(TemplateErrors.syntaxError('mismatched input \'-\' expecting <EOF>')), true);
     assert.strictEqual(DiagnosticSeverity.Error, diagnostics[1].severity);
-    assert.strictEqual(diagnostics[1].message.includes(TemplateErrors.invalidStrucName), true);
+    assert.strictEqual(diagnostics[1].message.includes(TemplateErrors.invalidStrucName(']')), true);
     assert.strictEqual(DiagnosticSeverity.Error, diagnostics[2].severity);
     assert.strictEqual(diagnostics[2].message.includes(TemplateErrors.missingStrucEnd), true);
     assert.strictEqual(DiagnosticSeverity.Error, diagnostics[3].severity);
-    assert.strictEqual(diagnostics[3].message.includes(TemplateErrors.invalidStrucBody), true);
+    assert.strictEqual(diagnostics[3].message.includes(TemplateErrors.invalidStrucBody('- hi')), true);
 });

--- a/libraries/botbuilder-lg/tests/testData/exceptionExamples/ErrorStructuredTemplate.lg
+++ b/libraries/botbuilder-lg/tests/testData/exceptionExamples/ErrorStructuredTemplate.lg
@@ -26,4 +26,4 @@
 
 # ErrorTemplate1
 [Activity]
-- hi 
+- hi

--- a/libraries/botbuilder-lg/tests/testData/exceptionExamples/ErrorTemplateName.lg
+++ b/libraries/botbuilder-lg/tests/testData/exceptionExamples/ErrorTemplateName.lg
@@ -19,8 +19,8 @@
 - hi
 
 > Template name can not contain '-'
-# t2-t1
-- hi
+# the-name-of-template
+- the body of template
 
 > Template names can only contain letter, underscore '_' or number. Any part of a template name (split by '.') cannot start with a number.
 # t1.1


### PR DESCRIPTION
close: #2324
issue link: https://github.com/microsoft/botbuilder-dotnet/issues/3906
- Add more context info into some diagnostic errors.
- Add file path info into diagnostic errors.


|Item | Before | After|
|-- | -- | --|
|Invalid template name | Invalid template name. Template names can only contain letter... | Invalid template name: '{invalidName}'. Template names can only contain letter...|
|Invalid structure body | Invalid structure body. Body can include... | Invalid structure body: '{invalidBody}'. Body can include...|
|Syntax Error | Unexpected Content. Expecting a comment, template def... | {unexpectedContent}. Expecting a comment, template def...|
|Invalid Parameter | Invalid parameter name. Parameter names can ... | Invalid parameter name: '{invalidParameter}'. Parameter names can|
|Diagnostics | [Error] line 3:0 - line 3:8: [template]Invalid condition....[Error] line 10:0 - line 10:14: [template2]Invalid template body... | [Error] C:\\xx\\yy.lg line 3:0 - line 3:8: [template]Invalid condition...[Error] C:\\xx\\zz.lg line 10:0 - line 10:14: [template2]Invalid template body...|

