### PR TITLE
[PORT]Add EOL function for both browser and Nodejs

### DIFF
--- a/libraries/adaptive-expressions/package.json
+++ b/libraries/adaptive-expressions/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/Microsoft/botbuilder-js.git"
   },
   "main": "./lib/index.js",
+  "browser": "./lib/index_browser.js",
   "typings": "./lib/index.d.ts",
   "dependencies": {
     "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",

--- a/libraries/adaptive-expressions/src/builtinFunctions_browser/eol.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions_browser/eol.ts
@@ -1,0 +1,36 @@
+/**
+ * @module adaptive-expressions
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Expression } from '../expression';
+import { EvaluateExpressionDelegate, ExpressionEvaluator } from '../expressionEvaluator';
+import { ExpressionType } from '../expressionType';
+import { FunctionUtils } from '../functionUtils';
+import { ReturnType } from '../returnType';
+
+/**
+ * Return the ordinal number of the input number.
+ */
+export class EOL extends ExpressionEvaluator {
+    public constructor() {
+        super(ExpressionType.EOL, EOL.evaluator(), ReturnType.String, EOL.validator);
+    }
+
+    private static evaluator(): EvaluateExpressionDelegate {
+        return FunctionUtils.apply((): string => {
+            if (navigator.platform.includes('Win')) {
+                return '\r\n';
+            } else {
+                return '\n';
+            }
+        });
+    }
+
+    private static validator(expression: Expression): void {
+        FunctionUtils.validateArityAndAnyType(expression, 0, 0);
+    }
+}

--- a/libraries/adaptive-expressions/src/builtinFunctions_browser/index.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions_browser/index.ts
@@ -5,5 +5,5 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-export * from './index_common';
-export * from './builtinFunctions_node';
+
+export * from './inject';

--- a/libraries/adaptive-expressions/src/builtinFunctions_browser/inject.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions_browser/inject.ts
@@ -1,0 +1,16 @@
+import { EOL } from './eol';
+import { ExpressionEvaluator } from '../expressionEvaluator';
+import { Expression } from '../expression';
+
+/**
+ * Inject Browser-specific functions into the common builtin-function list.
+ */
+export const injectNodeFunctions = (function(): void {
+    const functions: ExpressionEvaluator[] = [
+        new EOL()
+    ];
+
+    functions.forEach((func: ExpressionEvaluator): void => {
+        Expression.functions.add(func.type, func);
+    });
+})(); 

--- a/libraries/adaptive-expressions/src/builtinFunctions_node/eol.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions_node/eol.ts
@@ -1,0 +1,33 @@
+/**
+ * @module adaptive-expressions
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { Expression } from '../expression';
+import { EvaluateExpressionDelegate, ExpressionEvaluator } from '../expressionEvaluator';
+import { ExpressionType } from '../expressionType';
+import { FunctionUtils } from '../functionUtils';
+import { ReturnType } from '../returnType';
+import * as os from 'os';
+
+/**
+ * Return the ordinal number of the input number.
+ */
+export class EOL extends ExpressionEvaluator {
+    public constructor() {
+        super(ExpressionType.EOL, EOL.evaluator(), ReturnType.String, EOL.validator);
+    }
+
+    private static evaluator(): EvaluateExpressionDelegate {
+        return FunctionUtils.apply((): string => {
+            return os.EOL;
+        });
+    }
+
+    private static validator(expression: Expression): void {
+        FunctionUtils.validateArityAndAnyType(expression, 0, 0);
+    }
+}

--- a/libraries/adaptive-expressions/src/builtinFunctions_node/index.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions_node/index.ts
@@ -5,5 +5,5 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-export * from './index_common';
-export * from './builtinFunctions_node';
+
+export * from './inject';

--- a/libraries/adaptive-expressions/src/builtinFunctions_node/inject.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions_node/inject.ts
@@ -1,0 +1,16 @@
+import { EOL } from './eol';
+import { ExpressionEvaluator } from '../expressionEvaluator';
+import { Expression } from '../expression';
+
+/**
+ * Inject Browser-specific functions into the common builtin-function list.
+ */
+export const injectNodeFunctions = (function(): void {
+    const functions: ExpressionEvaluator[] = [
+        new EOL()
+    ];
+
+    functions.forEach((func: ExpressionEvaluator): void => {
+        Expression.functions.add(func.type, func);
+    });
+})(); 

--- a/libraries/adaptive-expressions/src/expressionType.ts
+++ b/libraries/adaptive-expressions/src/expressionType.ts
@@ -61,6 +61,7 @@ export class ExpressionType {
     public static readonly NewGuid: string = 'newGuid';
     public static readonly IndexOf: string = 'indexOf';
     public static readonly LastIndexOf: string = 'lastIndexOf';
+    public static readonly EOL: string = 'EOL';
     public static readonly SentenceCase: string = 'sentenceCase';
     public static readonly TitleCase: string = 'titleCase';
 

--- a/libraries/adaptive-expressions/src/index_browser.ts
+++ b/libraries/adaptive-expressions/src/index_browser.ts
@@ -6,4 +6,4 @@
  * Licensed under the MIT License.
  */
 export * from './index_common';
-export * from './builtinFunctions_node';
+export * from './builtinFunctions_browser';

--- a/libraries/adaptive-expressions/src/index_common.ts
+++ b/libraries/adaptive-expressions/src/index_common.ts
@@ -1,0 +1,28 @@
+/**
+ * @module adaptive-expressions
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+export * from './expressionFunctions';
+export * from './constant';
+export * from './expression';
+export * from './expressionEvaluator';
+export * from './expressionParserInterface';
+export * from './expressionType';
+export * from './extensions';
+export * from './timeZoneConverter';
+export * from './generated';
+export * from './commonRegex';
+export * from './options';
+export * from './parser';
+export * from './memory';
+export * from './regexErrorListener';
+export * from './datetimeFormatConverter';
+export * from './functionTable';
+export * from './converters';
+export * from './expressionProperties';
+export * from './builtinFunctions';
+export * from './functionUtils';
+export * from './returnType';

--- a/libraries/adaptive-expressions/tests/badExpression.test.js
+++ b/libraries/adaptive-expressions/tests/badExpression.test.js
@@ -73,6 +73,7 @@ const badExpressions =
         'addOrdinal(one + 0.5)',// should have Integer param
         'addOrdinal(one, two)',// should have one param
         'newGuid(one)',// should have no parameters
+        'EOL(one)',// should have no parameters
         'indexOf(hello)',// should have two parameters
         'indexOf(hello, world, one)', // should have two parameters
         'indexOf(hello, one)', // second parameter should be string

--- a/libraries/adaptive-expressions/tests/expressionParser.test.js
+++ b/libraries/adaptive-expressions/tests/expressionParser.test.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 const moment = require('moment');
 const bigInt = require('big-integer');
 const { useFakeTimers } = require('sinon');
+const os = require('os');
 
 const one = ['one'];
 const oneTwo = ['one', 'two'];
@@ -230,6 +231,7 @@ const dataSource = [
     ['count(newGuid())', 36],
     ['indexOf(newGuid(), \'-\')', 8],
     ['indexOf(newGuid(), \'-\')', 8],
+    ['EOL()', os.EOL],
     ['indexOf(hello, \'-\')', -1],
     ['indexOf(nullObj, \'-\')', -1],
     ['indexOf(hello, nullObj)', 0],


### PR DESCRIPTION
Fixes #2288

## Description
Add EOL function for both browser and Nodejs

### browser environment
> tool: [navigator.platform](https://www.w3schools.com/jsref/prop_nav_platform.asp)
- windows platform -> '\r\n'
- macOS/unix platform -> '\n'

### node environment
> tool: [OS module](https://nodejs.org/api/os.html#os_os_eol)
- windows platform -> '\r\n'
- macOS/unix -> '\n'

## TODO
Add unit test for the browser environment
