### PR TITLE
Add linkToMessage to the MessageActionsPayload interface

### DIFF
--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -811,6 +811,10 @@ export interface MessageActionsPayload {
    */
   locale?: string;
   /**
+   * @member {string} [linkToMessage] Link back to the message.
+   */
+  linkToMessage?: string;
+  /**
    * @member {MessageActionsPayloadFrom} [from] Sender of the message.
    */
   from?: MessageActionsPayloadFrom;


### PR DESCRIPTION
Fixes #2381

## Description
- Add the **linkToMessage** property to the [MessageActionsPayload ](https://github.com/microsoft/botbuilder-js/blob/master/libraries/botframework-schema/src/teams/index.ts#L766)interface.
- Unit tests are not necessary for **MessageActionsPayload** properties since it is an interface.

## Testing
In the image below we can see the [TeamsMessagingExtensionsAction](https://github.com/microsoft/BotBuilder-Samples/tree/master/samples/javascript_nodejs/51.teams-messaging-extensions-action) sample displaying the new property's value in the action card.
![image](https://user-images.githubusercontent.com/62260472/85333535-24087800-b4b0-11ea-8664-5e723700bf83.jpg)