### PR TITLE
[PORT]Extend 'getProperty' builtin function to support accessing top memory

### DIFF
--- a/libraries/adaptive-expressions/tests/badExpression.test.js
+++ b/libraries/adaptive-expressions/tests/badExpression.test.js
@@ -371,6 +371,7 @@ const badExpressions =
 
         // Memory access test
         'getProperty(bag, 1)',// second param should be string
+        'getProperty(1)', // if getProperty contains only one parameter, the parameter should be string
         'Accessor(1)',// first param should be string
         'Accessor(bag, 1)', // second should be object
         'one[0]',  // one is not list

--- a/libraries/adaptive-expressions/tests/expressionParser.test.js
+++ b/libraries/adaptive-expressions/tests/expressionParser.test.js
@@ -640,6 +640,9 @@ const dataSource = [
 
     // Memory access tests
     ['getProperty(bag, concat(\'na\',\'me\'))', 'mybag'],
+    ['getProperty(\'bag\').index', 3],
+    ['getProperty(\'a:b\')', 'stringa:b'],
+    ['getProperty(concat(\'he\', \'llo\'))', 'hello'],
     ['items[2]', 'two', ['items[2]']],
     ['bag.list[bag.index - 2]', 'blue', ['bag.list', 'bag.index']],
     ['items[nestedItems[1].x]', 'two', ['items', 'nestedItems[1].x']],
@@ -708,6 +711,7 @@ const dataSource = [
 
 const scope = {
     '$index': 'index',
+    'a:b' : 'stringa:b',
     alist: [
         {
             Name: 'item1'


### PR DESCRIPTION
issue link: https://github.com/microsoft/botbuilder-dotnet/issues/4029
Fixes #2448

Originally, `getProperty` accepts two parameters, the first parameter is an instance, and the second parameter is the property name which user wants to access the value from. In this mode, the user can not access the top-level memory from dynamic/special string property.

After this change, `getProperty` accepts only one parameter, that presents the root property from the memory.

Example: 
Scope is :
```
{
"a:b": "value"
}
```
`getProperty('a:b')` would get string "value", 