### PR TITLE
Fix issue2134: add allowloop to repeat dialog and test

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-tests/resources/ActionTests/Action_RepeatDialogLoop.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-tests/resources/ActionTests/Action_RepeatDialogLoop.test.dialog
@@ -1,0 +1,69 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "testDialog",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SetProperties",
+                        "assignments": [
+                            {
+                                "property": "dialog.greeting",
+                                "value": "=coalesce($greeting, 'Hi')"
+                            }
+                        ]
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${$greeting}"
+                    },
+                    {
+                        "$kind": "Microsoft.IfCondition",
+                        "condition": "length($greeting) < 6",
+                        "actions": [
+                            {
+                                "$kind": "Microsoft.RepeatDialog",
+                                "allowLoop": true,
+                                "options": {
+                                    "greeting": "${$greeting + 'Hi'}"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Welcome!"
+                    }
+                ]
+            }
+        ],
+        "autoEndDialog": true,
+        "defaultResultProperty": "dialog.result"
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "HiHi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "HiHiHi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Welcome!"
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-tests/src/action.test.ts
+++ b/libraries/botbuilder-dialogs-adaptive-tests/src/action.test.ts
@@ -146,6 +146,10 @@ describe('ActionTests', function() {
         await testRunner.runTestScript('Action_RepeatDialog');
     });
 
+    it('RepeatDialogLoop', async () => {
+        await testRunner.runTestScript('Action_RepeatDialogLoop');
+    });
+
     it('ReplaceDialog', async () => {
         await testRunner.runTestScript('Action_ReplaceDialog');
     });

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialogComponentRegistration.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialogComponentRegistration.ts
@@ -170,7 +170,8 @@ export class AdaptiveDialogComponentRegistration implements ComponentRegistratio
         }));
         this.registerBuilder('Microsoft.RepeatDialog', new AdaptiveTypeBuilder(RepeatDialog, this._resourceExplorer,
             Object.assign(baseInvokeDialogConverters, {
-                'disabled': new BoolExpressionConverter()
+                'disabled': new BoolExpressionConverter(),
+                'allowLoop': new BoolExpressionConverter()
             })));
         this.registerBuilder('Microsoft.ReplaceDialog', new AdaptiveTypeBuilder(ReplaceDialog, this._resourceExplorer,
             Object.assign(baseInvokeDialogConverters, {


### PR DESCRIPTION
Fixes #2134 
# Description
add allowloop to repeat dialog and test

## Specific Changes

  - botbuilder-js/libraries/botbuilder-dialogs-adaptive
  - botbuilder-js/libraries/botbuilder-dialogs-adaptive-tests
