### PR TITLE
Move TelemetryClient property to DialogContainer

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
@@ -6,9 +6,7 @@
  * Licensed under the MIT License.
  */
 import {
-    TurnContext, BotTelemetryClient, NullTelemetryClient, ActivityTypes,
-    Activity, RecognizerResult, getTopScoringIntent
-} from 'botbuilder-core';
+    TurnContext, ActivityTypes, Activity, RecognizerResult, getTopScoringIntent } from 'botbuilder-core';
 import { Dialog, DialogInstance, DialogReason, DialogTurnResult, DialogTurnStatus, DialogEvent, DialogContext, DialogContainer, DialogDependencies, TurnPath, DialogPath, DialogState } from 'botbuilder-dialogs';
 import { OnCondition } from './conditions';
 import { Recognizer } from './recognizers';
@@ -88,11 +86,6 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
 
     public get schema(): object | undefined {
         return this.dialogSchema ? this.dialogSchema.schema : undefined;
-    }
-
-    public set telemetryClient(client: BotTelemetryClient) {
-        super.telemetryClient = client ? client : new NullTelemetryClient();
-        this.dialogs.telemetryClient = client;
     }
 
     protected ensureDependenciesInstalled(): void {

--- a/libraries/botbuilder-dialogs/src/componentDialog.ts
+++ b/libraries/botbuilder-dialogs/src/componentDialog.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { BotTelemetryClient, NullTelemetryClient, telemetryTrackDialogView, TurnContext } from 'botbuilder-core';
+import { telemetryTrackDialogView, TurnContext } from 'botbuilder-core';
 import { Dialog, DialogInstance, DialogReason, DialogTurnResult, DialogTurnStatus } from './dialog';
 import { DialogContext } from './dialogContext';
 import { DialogContainer } from './dialogContainer';
@@ -249,21 +249,5 @@ export class ComponentDialog<O extends object = {}> extends DialogContainer<O> {
         const innerDC: DialogContext = new DialogContext(this.dialogs, context, dialogState);
 
         return innerDC
-    }
-
-    /**
-     * Set the telemetry client, and also apply it to all child dialogs.
-     * Future dialogs added to the component will also inherit this client.
-     */
-    public set telemetryClient(client: BotTelemetryClient) {
-        this._telemetryClient = client ? client : new NullTelemetryClient();
-        this.dialogs.telemetryClient = client;
-    }
-
-    /**
-     * Get the current telemetry client.
-     */
-    public get telemetryClient(): BotTelemetryClient {
-        return this._telemetryClient;
     }
 }

--- a/libraries/botbuilder-dialogs/src/dialogContainer.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContainer.ts
@@ -5,6 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+import { BotTelemetryClient, NullTelemetryClient } from 'botbuilder-core';
 import { Dialog } from './dialog';
 import { DialogSet } from './dialogSet';
 import { DialogContext } from './dialogContext';
@@ -65,5 +66,21 @@ export abstract class DialogContainer<O extends object = {}> extends Dialog<O> {
             //   change again.
             await dc.emitEvent(DialogEvents.versionChanged, this.id, true, false);
         }
+    }
+    
+    /**
+     * Set the telemetry client, and also apply it to all child dialogs.
+     * Future dialogs added to the component will also inherit this client.
+     */
+    public set telemetryClient(client: BotTelemetryClient) {
+        this._telemetryClient = client ? client : new NullTelemetryClient();
+        this.dialogs.telemetryClient = client;
+    }
+
+    /**
+     * Get the current telemetry client.
+     */
+    public get telemetryClient(): BotTelemetryClient {
+        return this._telemetryClient;
     }
 }


### PR DESCRIPTION
Fixes #2454 

## Description
Move TelemetryClient onto DialogContainer (implementation the same in AdaptiveDialog and ComponentDialog).

## Specific Changes

  - Move TelemetryClient onto DialogContainer
  - remove TelemetryClient from AdaptiveDialog and ComponentDialog

## Testing
N/A