### PR TITLE
cherry-pick to 4.9: Open id metadata cache refresh if key is missing (#2466)

### DIFF
--- a/libraries/botframework-connector/src/auth/openIdMetadata.ts
+++ b/libraries/botframework-connector/src/auth/openIdMetadata.ts
@@ -24,8 +24,8 @@ export class OpenIdMetadata {
     }
 
     public async getKey(keyId: string): Promise<IOpenIdMetadataKey | null> {
-        // If keys are more than 5 days old, refresh them
-        if (this.lastUpdated < (Date.now() - 1000 * 60 * 60 * 24 * 5)) {
+        // If keys are more than 24 hours old, refresh them
+        if (this.lastUpdated < (Date.now() - 1000 * 60 * 60 * 24)) {
             try {
                 await this.refreshCache();
                 
@@ -40,6 +40,11 @@ export class OpenIdMetadata {
         } else {
             // Otherwise read from cache
             const key: IOpenIdMetadataKey = this.findKey(keyId);
+            // Refresh the cache if a key is not found (max once per hour)
+            if (!key && this.lastUpdated < (Date.now() - 1000 * 60 * 60)) {
+                await this.refreshCache();
+                return this.findKey(keyId);
+            }
             return key;
         }
     }

--- a/libraries/botframework-connector/tests/openIdMetadata.test.js
+++ b/libraries/botframework-connector/tests/openIdMetadata.test.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const assert = require('assert');
+const nock = require('nock');
+const { JwtTokenValidation } = require('../lib');
+const { StatusCodes } = require('botframework-schema');
+const { OpenIdMetadata } = require('../lib/auth/openIdMetadata');
+
+describe('OpenIdMetadata', function() {
+
+    describe('Cache Tests', function() {
+        this.timeout(20000);
+
+        const mockUrl = 'http://mockUrl';
+        const mockMetadataUrl = '/api/metadataUrl';
+        const jwks_uriUrl = '/api/jwks_uriUrl';
+
+        // the below key and parts were retrieved from an Emulator token
+        const e = 'AQAB';
+        const kid = 'SsZsBNhZcF3Q9S4trpQBTByNRRI';
+        const n = 'uHPewhg4WC3eLVPkEFlj7RDtaKYWXCI5G-LPVzsMKOuIu7qQQbeytIA6P6HT9_iIRt8zNQvuw4P9vbNjgUCpI6vfZGsjk3XuCVoB_bAIhvuBcQh9ePH2yEwS5reR-NrG1PsqzobnZZuigKCoDmuOb_UDx1DiVyNCbMBlEG7UzTQwLf5NP6HaRHx027URJeZvPAWY7zjHlSOuKoS_d1yUveaBFIgZqPWLCg44ck4gvik45HsNVWT9zYfT74dvUSSrMSR-SHFT7Hy1XjbVXpHJHNNAXpPoGoWXTuc0BxMsB4cqjfJqoftFGOG4x32vEzakArLPxAKwGvkvu0jToAyvSQ';
+        const publicKey = `-----BEGIN RSA PUBLIC KEY-----
+MIIBCgKCAQEAuHPewhg4WC3eLVPkEFlj7RDtaKYWXCI5G+LPVzsMKOuIu7qQQbey
+tIA6P6HT9/iIRt8zNQvuw4P9vbNjgUCpI6vfZGsjk3XuCVoB/bAIhvuBcQh9ePH2
+yEwS5reR+NrG1PsqzobnZZuigKCoDmuOb/UDx1DiVyNCbMBlEG7UzTQwLf5NP6Ha
+RHx027URJeZvPAWY7zjHlSOuKoS/d1yUveaBFIgZqPWLCg44ck4gvik45HsNVWT9
+zYfT74dvUSSrMSR+SHFT7Hy1XjbVXpHJHNNAXpPoGoWXTuc0BxMsB4cqjfJqoftF
+GOG4x32vEzakArLPxAKwGvkvu0jToAyvSQIDAQAB
+-----END RSA PUBLIC KEY-----\n`;
+
+        describe('getKey', function() {
+
+            it('retrieves cached key on subsequent call', async () => {
+                var nockScope = setupNockCalls();
+
+                var openIdMetadata = new OpenIdMetadata(mockUrl + mockMetadataUrl);
+                var foundKey = await openIdMetadata.getKey(kid);
+                assert(nockScope.isDone(), 'nock calls not completed');
+
+                assert.equal(foundKey.key, publicKey);
+
+                var foundKey = await openIdMetadata.getKey(kid);
+                assert.equal(foundKey.key, publicKey);
+            });
+
+            it('returns null key if key missing and lastUpdated > (Date.now() - 1000 * 60 * 60)', async () => {
+                var nockScope = setupNockCalls();
+
+                var openIdMetadata = new OpenIdMetadata(mockUrl + mockMetadataUrl);
+                var foundKey = await openIdMetadata.getKey(kid);
+                assert(nockScope.isDone(), 'nock calls not completed');
+
+                assert.equal(foundKey.key, publicKey);
+
+                // remove the key, so it is not found
+                openIdMetadata.keys.splice(openIdMetadata.keys.indexOf(kid), 1);
+                var foundKey = await openIdMetadata.getKey(kid);
+                assert.equal(foundKey, null);
+            });
+
+            it('calls refreshCache if key missing and lastUpdated < (Date.now() - 1000 * 60 * 60)', async () => {
+                var nockScope = setupNockCalls();
+
+                var openIdMetadata = new OpenIdMetadata(mockUrl + mockMetadataUrl);
+                var foundKey = await openIdMetadata.getKey(kid);
+                assert(nockScope.isDone(), 'nock calls not completed');
+                
+                assert.equal(foundKey.key, publicKey);
+
+                // remove the key, so it is not found
+                openIdMetadata.keys.splice(openIdMetadata.keys.indexOf(kid), 1);
+                openIdMetadata.lastUpdated = (Date.now() - 1000 * 60 * 60) - 10000;
+                
+                nockScope = setupNockCalls();
+                var foundKey = await openIdMetadata.getKey(kid);
+                assert(nockScope.isDone(), 'nock calls not completed');
+                assert.equal(foundKey.key, publicKey);
+            });
+
+            it('calls refreshCache if lastUpdated < (1000 * 60 * 60 * 24)', async () => {
+                var nockScope = setupNockCalls();
+
+                var openIdMetadata = new OpenIdMetadata(mockUrl + mockMetadataUrl);
+                var foundKey = await openIdMetadata.getKey(kid);
+                assert(nockScope.isDone(), 'nock calls not completed');
+
+                assert.equal(foundKey.key, publicKey);
+                openIdMetadata.lastUpdated = (Date.now() - 1000 * 60 * 60 * 24) - 10000;
+                
+                nockScope = setupNockCalls();
+                var foundKey = await openIdMetadata.getKey(kid);
+                assert(nockScope.isDone(), 'nock calls not completed');
+                assert.equal(foundKey.key, publicKey);
+            });
+        });
+
+        function setupNockCalls(){
+            return nock(mockUrl)
+                .get(mockMetadataUrl)
+                .reply(StatusCodes.OK, { jwks_uri: mockUrl + jwks_uriUrl })
+                .get(jwks_uriUrl)
+                .reply(StatusCodes.OK, { keys : [{ kid : kid, e : e, n : n}] });
+        }
+    });
+});
+


### PR DESCRIPTION
* openIdMetadata cache updates and tests

* revert whitespace change

* copyright header for openIdMetadata.test.js
