### PR TITLE
add readableFlowing property to INodeSocket

### DIFF
--- a/libraries/botframework-streaming/src/interfaces/INodeSocket.ts
+++ b/libraries/botframework-streaming/src/interfaces/INodeSocket.ts
@@ -28,6 +28,7 @@ export interface INodeSocket {
     readonly writableLength: number;
     readonly readableHighWaterMark: number;
     readonly readableLength: number;
+    readonly readableFlowing: boolean | null;
 
     address(): AddressInfo | string;
 


### PR DESCRIPTION
All JS builds are breaking I believe due to a linting or pipeline update(?); I didn't really see any other relevant recent commits. INodeSocket needs to implement `readableFlowing` so I added it as a property that does nothing. It can't be optional or the build will still break. It uses the same typing and scope as `Socket` defined in Node globals:

![image](https://user-images.githubusercontent.com/40401643/87180089-b83a5380-c294-11ea-935f-10e851d3dc48.png)


[Here's the failure](https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=145306&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=df8dc50d-985d-501e-ee67-7f805e7e444c&l=49):

```cmd
src/webSocket/nodeWebSocket.ts(39,69): error TS2345: Argument of type 'INodeSocket' is not assignable to parameter of type 'Socket'.
> botframework-config@4.4.0-preview.145306 build /Users/runner/work/1/s/libraries/botframework-config
  Property 'readableFlowing' is missing in type 'INodeSocket' but required in type 'Socket'.
```

[The reference for the change](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45997) doesn't amount to much more than "it was missing, so we added it".