### PR TITLE
[Teams] Fix onSelectedItem in Teams Search Extension Bot

### DIFF
--- a/libraries/teams-scenarios/searchBasedMessagingExtension/src/index.ts
+++ b/libraries/teams-scenarios/searchBasedMessagingExtension/src/index.ts
@@ -7,7 +7,7 @@ import * as restify from 'restify';
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-import { BotFrameworkAdapter, MemoryStorage, UserState } from 'botbuilder';
+import { BotFrameworkAdapter, MemoryStorage, UserState } from '../../../botbuilder';
 
 // This bot's main dialog.
 import { TeamsSearchExtensionBot } from './teamsSearchExtensionBot';

--- a/libraries/teams-scenarios/searchBasedMessagingExtension/src/index.ts
+++ b/libraries/teams-scenarios/searchBasedMessagingExtension/src/index.ts
@@ -7,7 +7,7 @@ import * as restify from 'restify';
 
 // Import required bot services.
 // See https://aka.ms/bot-services to learn more about the different parts of a bot.
-import { BotFrameworkAdapter, MemoryStorage, UserState } from '../../../botbuilder';
+import { BotFrameworkAdapter, MemoryStorage, UserState } from 'botbuilder';
 
 // This bot's main dialog.
 import { TeamsSearchExtensionBot } from './teamsSearchExtensionBot';

--- a/libraries/teams-scenarios/searchBasedMessagingExtension/src/teamsSearchExtensionBot.ts
+++ b/libraries/teams-scenarios/searchBasedMessagingExtension/src/teamsSearchExtensionBot.ts
@@ -13,7 +13,7 @@ import {
     MessagingExtensionResult,
     TeamsActivityHandler,
     TurnContext
-} from '../../../botbuilder';
+} from 'botbuilder';
 
 export class TeamsSearchExtensionBot extends TeamsActivityHandler {
 

--- a/libraries/teams-scenarios/searchBasedMessagingExtension/src/teamsSearchExtensionBot.ts
+++ b/libraries/teams-scenarios/searchBasedMessagingExtension/src/teamsSearchExtensionBot.ts
@@ -13,7 +13,7 @@ import {
     MessagingExtensionResult,
     TeamsActivityHandler,
     TurnContext
-} from 'botbuilder';
+} from '../../../botbuilder';
 
 export class TeamsSearchExtensionBot extends TeamsActivityHandler {
 
@@ -52,7 +52,7 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
         const searchQuery = query.parameters[0].value;
         const composeExtension = this.createMessagingExtensionResult([
             this.createSearchResultAttachment(searchQuery), 
-            this.createDummySearchResultAttachment(), 
+            this.createDummySearchResultAttachment(searchQuery), 
             this.createSelectItemsResultAttachment(searchQuery)
         ]);
 
@@ -71,7 +71,7 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
         };
     }
 
-    private createMessagingExtensionResult(attachments: Attachment[]) : MessagingExtensionResult {   
+    private createMessagingExtensionResult(attachments: Attachment[]) : MessagingExtensionResult {
         return <MessagingExtensionResult> {
             type: "result",
             attachmentLayout: "list",
@@ -91,6 +91,7 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
 
         const heroCard = CardFactory.heroCard("You searched for:", cardText, [bfLogo], [button]);
         const preview = CardFactory.heroCard("You searched for:", cardText, [bfLogo]);
+        preview.content.tap = { type: 'invoke', value: { query: searchQuery } };
 
         return <MessagingExtensionAttachment> {
             contentType: CardFactory.contentTypes.heroCard,
@@ -99,7 +100,7 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
         };
     }
 
-    private createDummySearchResultAttachment() : MessagingExtensionAttachment {
+    private createDummySearchResultAttachment(searchQuery: string) : MessagingExtensionAttachment {
         const cardText = "https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/bots/bots-overview";
         const bfLogo = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQtB3AwMUeNoq4gUBGe6Ocj8kyh3bXa9ZbV7u1fVKQoyKFHdkqU";
 
@@ -111,6 +112,7 @@ export class TeamsSearchExtensionBot extends TeamsActivityHandler {
 
         const heroCard = CardFactory.heroCard("Learn more about Teams:", cardText, [bfLogo], [button]);
         const preview = CardFactory.heroCard("Learn more about Teams:", cardText, [bfLogo]);
+        preview.content.tap = { type: 'invoke', value: { query: searchQuery } };
 
         return <MessagingExtensionAttachment> {
             contentType: CardFactory.contentTypes.heroCard,


### PR DESCRIPTION
Addresses #1314

## Description
This PR fixes how the [teamsSearchExtensionBot](https://github.com/microsoft/botbuilder-js/blob/master/libraries/teams-scenarios/searchBasedMessagingExtension/src/teamsSearchExtensionBot.ts) handles the _onSelectedItem_ event so it returns a hero card for every result selected by the user.

### Detailed changes
- Updated [teamsSearchExtensionBot.ts](https://github.com/microsoft/botbuilder-js/blob/master/libraries/teams-scenarios/searchBasedMessagingExtension/src/teamsSearchExtensionBot.ts) file adding a tap event to all the result card' previews.

## Testing
The images below show the bot running on Teams.

![image](https://user-images.githubusercontent.com/44245136/87688408-5464ce80-c75d-11ea-8638-b2b82e0ad652.png)