### PR TITLE
Restore and activate nock

### DIFF
--- a/libraries/botframework-connector/tests/openIdMetadata.test.js
+++ b/libraries/botframework-connector/tests/openIdMetadata.test.js
@@ -98,6 +98,8 @@ GOG4x32vEzakArLPxAKwGvkvu0jToAyvSQIDAQAB
         });
 
         function setupNockCalls(){
+            nock.restore();
+            nock.activate();
             return nock(mockUrl)
                 .get(mockMetadataUrl)
                 .reply(StatusCodes.OK, { jwks_uri: mockUrl + jwks_uriUrl })


### PR DESCRIPTION
Related to: https://github.com/microsoft/botbuilder-js/issues/2563

Core issue is that the `-connector` metadata tests break after running `npm run test` multiple times. This is band-aid fix that addresses the symptom but not the real problem, which I believe is nock cross-pollution between tests. Tracking that in the issue above to fix tomorrow.