### PR TITLE
Fix intermittent expressions test error due to hour change

### DIFF
--- a/libraries/adaptive-expressions/tests/expressionParser.test.js
+++ b/libraries/adaptive-expressions/tests/expressionParser.test.js
@@ -464,7 +464,7 @@ const dataSource = [
     ['date(timestamp)', '3/15/2018'],//Default. TODO
     ['year(timestamp)', 2018],
     ['length(utcNow())', 24],
-    ['utcNow(\'MM-DD-YY HH\')', moment(new Date().toISOString()).utc().format('MM-DD-YY HH')],
+    ['utcNow(\'MM-DD-YY HH\')', 'getNowTime'],
     ['formatDateTime(notISOTimestamp)', '2018-03-15T13:00:00.000Z'],
     ['formatDateTime(notISOTimestamp, \'MM-dd-yy\')', '03-15-18'],
     ['formatDateTime(notISOTimestamp, \'ddd\')', 'Thu'],
@@ -843,7 +843,14 @@ describe('expression parser functional test', () => {
             var {value: actual, error} = parsed.tryEvaluate(scope);
             assert(error === undefined, `input: ${input}, Has error: ${error}`);
 
-            const expected = data[1];
+            let expected = data[1];
+
+            // There's an issue when running this test near the end of an hour,
+            // where expected 'HH' doesn't always match up. This ensures it's synced with the current hour.
+            if (input === 'utcNow(\'MM-DD-YY HH\')' && expected === 'getNowTime') {
+                expected = moment(new Date().toISOString()).utc().format('MM-DD-YY HH');
+            }
+
             assertObjectEquals(actual, expected);
 
             //Assert ExpectedRefs


### PR DESCRIPTION
## Description

Occasionally, one of the `adaptive-expressions` tests would fail with something like:

```cmd
 AssertionError [ERR_ASSERTION]: actual is: 07-27-20 17, expected is 07-27-20 16
      + expected - actual

      -07-27-20 17
      +07-27-20 16
```

I believe this is because:

* Test loads at say, 9:58am which [would give expected data of `07-27-20 09'](https://github.com/microsoft/botbuilder-js/blob/master/libraries/adaptive-expressions/tests/expressionParser.test.js#L467)
* Test actually runs two minutes later at 10:00, so the actual data would be `07-27-20 10'. 

## Specific Changes

Have the test refresh the expected time based off of the current time.