### PR TITLE
[Port] properly escape slashes in constant strings with StringExpression/ValueExpression

### DIFF
--- a/libraries/adaptive-expressions/src/expressionProperties/stringExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/stringExpression.ts
@@ -50,7 +50,7 @@ export class StringExpression extends ExpressionProperty<string> {
             }
 
             // Initialize value
-            this.expressionText = `=\`${ value }\``;
+            this.expressionText = `=\`${ value.replace(/\\/g, '\\\\') }\``;
             return;
         }
     }

--- a/libraries/adaptive-expressions/src/expressionProperties/valueExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/valueExpression.ts
@@ -44,7 +44,7 @@ export class ValueExpression extends ExpressionProperty<any> {
             }
 
             // keep the string as quoted expression, which will be literal unless string interpolation is used.
-            this.expressionText = `=\`${ value }\``;
+            this.expressionText = `=\`${ value.replace(/\\/g, '\\\\') }\``;
             return;
         }
 

--- a/libraries/adaptive-expressions/tests/expressionProperty.test.ts
+++ b/libraries/adaptive-expressions/tests/expressionProperty.test.ts
@@ -163,14 +163,14 @@ describe('expressionProperty tests', () => {
         assert.equal(str.toExpression().toString(), 'test');
 
         // slashes are the chars
-        str = new StringExpression('c:\\test\\test\\test')
-        result = str.getValue(data)
-        assert.equal(result, 'c:\\test\\test\\test')
+        str = new StringExpression('c:\\test\\test\\test');
+        result = str.getValue(data);
+        assert.equal(result, 'c:\\test\\test\\test');
 
         // tabs are the chars
-        str = new StringExpression('c:\test\test\test')
-        result = str.getValue(data)
-        assert.equal(result, 'c:\test\test\test')
+        str = new StringExpression('c:\test\test\test');
+        result = str.getValue(data);
+        assert.equal(result, 'c:\test\test\test');
     });
 
     it('ValueExpression', () => {
@@ -207,13 +207,13 @@ describe('expressionProperty tests', () => {
         assert.equal(val.toExpression().toString(), 'null');
 
         // slashes are the chars
-        val = new ValueExpression('c:\\test\\test\\test')
-        result = val.getValue(data)
-        assert.equal(result, 'c:\\test\\test\\test')
+        val = new ValueExpression('c:\\test\\test\\test');
+        result = val.getValue(data);
+        assert.equal(result, 'c:\\test\\test\\test');
 
         // tabs are the chars
-        val = new ValueExpression('c:\test\test\test')
-        result = val.getValue(data)
-        assert.equal(result, 'c:\test\test\test')
+        val = new ValueExpression('c:\test\test\test');
+        result = val.getValue(data);
+        assert.equal(result, 'c:\test\test\test');
     });
 });

--- a/libraries/adaptive-expressions/tests/expressionProperty.test.ts
+++ b/libraries/adaptive-expressions/tests/expressionProperty.test.ts
@@ -161,6 +161,16 @@ describe('expressionProperty tests', () => {
         result = str.getValue(data);
         assert.equal(result, 'joe');
         assert.equal(str.toExpression().toString(), 'test');
+
+        // slashes are the chars
+        str = new StringExpression('c:\\test\\test\\test')
+        result = str.getValue(data)
+        assert.equal(result, 'c:\\test\\test\\test')
+
+        // tabs are the chars
+        str = new StringExpression('c:\test\test\test')
+        result = str.getValue(data)
+        assert.equal(result, 'c:\test\test\test')
     });
 
     it('ValueExpression', () => {
@@ -195,5 +205,15 @@ describe('expressionProperty tests', () => {
         result = val.getValue(data);
         assert.equal(result, undefined);
         assert.equal(val.toExpression().toString(), 'null');
+
+        // slashes are the chars
+        val = new ValueExpression('c:\\test\\test\\test')
+        result = val.getValue(data)
+        assert.equal(result, 'c:\\test\\test\\test')
+
+        // tabs are the chars
+        val = new ValueExpression('c:\test\test\test')
+        result = val.getValue(data)
+        assert.equal(result, 'c:\test\test\test')
     });
 });


### PR DESCRIPTION
Fixes #2443 

## Description
When encoding a string as an expression we need to properly handle slash.

## Specific Changes
* AdaptiveExpressions
* AdaptiveExpressions.Tests

## Testing
tests updated to validate round-trip slashes