### PR TITLE
BeginSkillDialog: store DialogOptions in state and regen for methods

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
@@ -5,9 +5,9 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { SkillDialog, SkillDialogOptions, DialogContext, DialogTurnResult, BeginSkillDialogOptions } from 'botbuilder-dialogs';
+import { SkillDialog, SkillDialogOptions, DialogContext, DialogTurnResult, BeginSkillDialogOptions, DialogInstance, DialogReason } from 'botbuilder-dialogs';
 import { BoolExpression, StringExpression } from 'adaptive-expressions';
-import { Activity, ActivityTypes, StringUtils } from 'botbuilder-core';
+import { Activity, ActivityTypes, StringUtils, TurnContext } from 'botbuilder-core';
 import { TemplateInterface } from '../template';
 import { skillClientKey, skillConversationIdFactoryKey } from '../skillExtensions';
 import { ActivityTemplate } from '../templates';
@@ -69,6 +69,9 @@ export class BeginSkill extends SkillDialog {
      */
     public connectionName: StringExpression;
 
+    // Used to cache DialogOptions for multi-turn calls across servers.
+    private _dialogOptionsStateKey: string = `${ this.constructor.name }.dialogOptionsData`;
+
     /**
      * Creates a new `BeginSkillDialog instance.
      * @param options Optional options used to configure the skill dialog.
@@ -95,6 +98,9 @@ export class BeginSkill extends SkillDialog {
         if (!this.dialogOptions.skillClient) { this.dialogOptions.skillClient = dc.context.turnState.get(skillClientKey); }
         if (!this.dialogOptions.conversationIdFactory) { this.dialogOptions.conversationIdFactory = dc.context.turnState.get(skillConversationIdFactoryKey); }
 
+        // Store the initialized dialogOptions in state so we can restore these values when the dialog is resumed.
+        dc.activeDialog.state[this._dialogOptionsStateKey] = this.dialogOptions;
+
         // Get the activity to send to the skill.
         options = {} as BeginSkillDialogOptions;
         if (this.activityProcessed.getValue(dcState) && this.activity) {
@@ -120,6 +126,7 @@ export class BeginSkill extends SkillDialog {
     }
 
     public async continueDialog(dc: DialogContext): Promise<DialogTurnResult> {
+        this.loadDialogOptions(dc.context, dc.activeDialog);
         const activity = dc.context.activity;
         if (activity.type == ActivityTypes.EndOfConversation) {
             // Capture the result of the dialog if the property is set
@@ -132,11 +139,48 @@ export class BeginSkill extends SkillDialog {
         return await super.continueDialog(dc);
     }
 
+    public async repromptDialog(turnContext: TurnContext, instance: DialogInstance): Promise<void> {
+        this.loadDialogOptions(turnContext, instance);
+        return await super.repromptDialog(turnContext, instance);
+    }
+
+    public async resumeDialog(dc: DialogContext, reason: DialogReason, result?: any): Promise<DialogTurnResult<any>> {
+        this.loadDialogOptions(dc.context, dc.activeDialog);
+        return await super.resumeDialog(dc, reason, result);
+    }
+
+    public async endDialog(turnContext: TurnContext, instance: DialogInstance, reason: DialogReason): Promise<void> {
+        this.loadDialogOptions(turnContext, instance);
+        return await super.endDialog(turnContext, instance, reason);
+    }
+
     protected onComputeId(): string {
         const appId = this.skillAppId ? this.skillAppId.toString() : '';
         if (this.activity instanceof ActivityTemplate) {
             return `BeginSkill['${ appId }','${ StringUtils.ellipsis(this.activity.template.trim(), 30) }']`;
         }
         return `BeginSkill['${ appId }','${ StringUtils.ellipsis(this.activity && this.activity.toString().trim(), 30) }']`;
+    }
+
+    private loadDialogOptions(context: TurnContext, instance: DialogInstance): void {
+        const dialogOptions = <SkillDialogOptions>instance.state[this._dialogOptionsStateKey];
+
+        this.dialogOptions.botId = dialogOptions.botId;
+        this.dialogOptions.skillHostEndpoint = dialogOptions.skillHostEndpoint;
+        
+        this.dialogOptions.conversationIdFactory = context.turnState.get(skillConversationIdFactoryKey);
+        if (this.dialogOptions.conversationIdFactory == null) { 
+            throw new ReferenceError('Unable to locate skillConversationIdFactoryBase in HostContext.');
+        };
+        
+        this.dialogOptions.skillClient = context.turnState.get(skillClientKey);
+        if (this.dialogOptions.skillClient == null) { 
+            throw new ReferenceError('Unable to get an instance of conversationState from turnState.');
+        };
+
+        this.dialogOptions.connectionName = dialogOptions.connectionName;
+
+        // Set the skill to call.
+        this.dialogOptions.skill = dialogOptions.skill;
     }
 }


### PR DESCRIPTION
Fixes #2672 

## Description

* Added code to BeginSkill.BeginDialog() that stores DialogOptions in state.
* Added overrides for ContinueDialogAsync, RepromptDialogAsync, ResumeDialogAsync and EndDialogAsync that pull the stored DialogOptions from the dialog state and regenerate the property .

## Notes

Unit tests will be added after they're added in Dotnet as part of [#3879](https://github.com/microsoft/botbuilder-dotnet/issues/3879), I am just trying to fix the P0 issue for R10 right now.