### PR TITLE
Empty recognizer support in crosstrained recognizer set

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/crossTrainedRecognizerSet.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/crossTrainedRecognizerSet.test.js
@@ -21,6 +21,10 @@ describe('CrossTrainedRecognizerSetTests', function() {
         await testRunner.runTestScript('CrossTrainedRecognizerSetTests_DoubleIntent');
     });
 
+    it('Empty', async () => {
+        await testRunner.runTestScript('CrossTrainedRecognizerSetTests_Empty');
+    });
+
     it('NoneWithIntent', async () => {
         await testRunner.runTestScript('CrossTrainedRecognizerSetTests_NoneWithIntent');
     });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/CrossTrainedRecognizerSetTests/CrossTrainedRecognizerSetTests_Empty.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/CrossTrainedRecognizerSetTests/CrossTrainedRecognizerSetTests_Empty.test.dialog
@@ -1,0 +1,52 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "recognizer": {
+            "$schema": "../../../tests.schema",
+            "$kind": "Microsoft.CrossTrainedRecognizerSet",
+            "recognizers": [
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "UnknownIntent:${turn.recognized.intent}"
+                    }
+                ]
+            }
+        ],
+        "defaultResultProperty": "dialog.result"
+    },
+    "locale": "",
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "UnknownIntent:None"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "x"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "UnknownIntent:None"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "y"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "UnknownIntent:None"
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts
@@ -17,6 +17,12 @@ export class CrossTrainedRecognizerSet extends Recognizer {
     public recognizers: Recognizer[] = [];
 
     public async recognize(dialogContext: DialogContext, activity: Activity, telemetryProperties?: { [key: string]: string }, telemetryMetrics?: { [key: string]: number }): Promise<RecognizerResult> {
+        if (!this.recognizers.length) {
+            return {
+                text: '',
+                intents: { 'None': { score: 1.0 } }
+            };
+        }
         for (let i = 0; i < this.recognizers.length; i++) {
             if (!this.recognizers[i].id) {
                 throw new Error('This recognizer requires that each recognizer in the set have an id.');

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts
@@ -10,12 +10,24 @@ import { RecognizerResult, Activity, getTopScoringIntent } from 'botbuilder-core
 import { DialogContext } from 'botbuilder-dialogs';
 import { Recognizer } from './recognizer';
 
+/**
+ * Standard cross trained intent name prefix.
+ */
 const deferPrefix = 'DeferToRecognizer_';
 
+/**
+ * Recognizer for selecting between cross trained recognizers.
+ */
 export class CrossTrainedRecognizerSet extends Recognizer {
 
+    /**
+     * Gets or sets the input recognizers.
+     */
     public recognizers: Recognizer[] = [];
 
+    /**
+     * To recognize intents and entities in a users utterance.
+     */
     public async recognize(dialogContext: DialogContext, activity: Activity, telemetryProperties?: { [key: string]: string }, telemetryMetrics?: { [key: string]: number }): Promise<RecognizerResult> {
         if (!this.recognizers.length) {
             return {
@@ -39,6 +51,13 @@ export class CrossTrainedRecognizerSet extends Recognizer {
         
     }
 
+    /**
+     * Process a list of raw results from recognizers.
+     * If there is consensus among the cross trained recognizers, the recognizerResult structure from
+     * the consensus recognizer is returned.
+     * 
+     * @param results A list of recognizer results to be processed.
+     */
     private processResults(results: RecognizerResult[]): RecognizerResult {
         const recognizerResults = {};
         const intents = {};
@@ -109,6 +128,10 @@ export class CrossTrainedRecognizerSet extends Recognizer {
         return recognizerResult;
     }
 
+    /**
+     * Creates choose intent result in the case that there is conflicting or ambigious signals from the recognizers.
+     * @param recognizerResults A group of recognizer results.
+     */
     private createChooseIntentResult(recognizerResults: { [name: string]: RecognizerResult }): RecognizerResult {
         let text: string;
         const candidates: object[] = [];
@@ -143,10 +166,18 @@ export class CrossTrainedRecognizerSet extends Recognizer {
         return recognizerResult;
     }
 
+    /**
+     * Check if an intent is triggering redirects.
+     * @param intent 
+     */
     private isRedirect(intent: string): boolean {
         return intent.startsWith(deferPrefix);
     }
 
+    /**
+     * Extracts the redirect id from an intent.
+     * @param intent Intent string contains redirect id.
+     */
     private getRedirectId(intent: string): string {
         return intent.substr(deferPrefix.length);
     }


### PR DESCRIPTION
Fixes #2438 

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Added empty recognizer support in crosstrained recognizer set.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - If recognizers are empty, return none intent in cross trained recognizer set.
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
Added corresponding test.