### PR TITLE
Add "jsonStringify" builtin function

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/index.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/index.ts
@@ -91,6 +91,7 @@ export * from './isTimeRange';
 export * from './join';
 export * from './jPath';
 export * from './json';
+export * from './jsonStringify';
 export * from './last';
 export * from './lastIndexOf';
 export * from './length';

--- a/libraries/adaptive-expressions/src/builtinFunctions/jsonStringify.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/jsonStringify.ts
@@ -1,0 +1,27 @@
+/**
+ * @module adaptive-expressions
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { EvaluateExpressionDelegate, ExpressionEvaluator } from '../expressionEvaluator';
+import { ExpressionType } from '../expressionType';
+import { FunctionUtils } from '../functionUtils';
+import { ReturnType } from '../returnType';
+
+/**
+ * Return the string version of a value.
+ */
+export class JsonStringify extends ExpressionEvaluator {
+    public constructor() {
+        super(ExpressionType.JsonStringify, JsonStringify.evaluator(), ReturnType.String, FunctionUtils.validateUnary);
+    }
+
+    private static evaluator(): EvaluateExpressionDelegate {
+        return FunctionUtils.apply((args: any[]): string => {
+            return JSON.stringify(args[0]);
+        });
+    }
+}

--- a/libraries/adaptive-expressions/src/constant.ts
+++ b/libraries/adaptive-expressions/src/constant.ts
@@ -61,6 +61,8 @@ export class Constant extends Expression {
     public toString(): string {
         
         if (this.value === undefined) {
+            return 'undefined';
+        } else if (this.value === null) {
             return 'null';
         } else if (typeof this.value === 'string') {
             let result = this.value;

--- a/libraries/adaptive-expressions/src/expressionFunctions.ts
+++ b/libraries/adaptive-expressions/src/expressionFunctions.ts
@@ -116,6 +116,7 @@ export class ExpressionFunctions {
             new BuiltinFunctions.Join(),
             new BuiltinFunctions.JPath(),
             new BuiltinFunctions.Json(),
+            new BuiltinFunctions.JsonStringify(),
             new BuiltinFunctions.Last(),
             new BuiltinFunctions.LastIndexOf(),
             new BuiltinFunctions.Length(),

--- a/libraries/adaptive-expressions/src/expressionType.ts
+++ b/libraries/adaptive-expressions/src/expressionType.ts
@@ -124,6 +124,7 @@ export class ExpressionType {
     public static readonly UriComponent: string = 'uriComponent';
     public static readonly UriComponentToString: string = 'uriComponentToString';
     public static readonly FormatNumber: string = 'formatNumber';
+    public static readonly JsonStringify: string = 'jsonStringify';
 
     // Memory
     public static readonly Accessor: string = 'Accessor';

--- a/libraries/adaptive-expressions/src/parser/expressionParser.ts
+++ b/libraries/adaptive-expressions/src/parser/expressionParser.ts
@@ -77,7 +77,9 @@ export class ExpressionParser implements ExpressionParserInterface {
                 result = new Constant(false);
             } else if (symbol === 'true') {
                 result = new Constant(true);
-            } else if (symbol === 'null' || symbol === 'undefined') {
+            } else if (symbol === 'null') {
+                result = new Constant(null);
+            } else if (symbol === 'undefined') {
                 result = new Constant(undefined);
             } else {
                 result = this.makeExpression(ExpressionType.Accessor, new Constant(symbol));

--- a/libraries/adaptive-expressions/tests/badExpression.test.js
+++ b/libraries/adaptive-expressions/tests/badExpression.test.js
@@ -139,6 +139,7 @@ const badExpressions =
         'uriComponent()', // should have 1 param
         'uriComponent(hello, world)', // should have 1 param
         'uriComponent(false)', // param should be string
+        'jsonStringify(hello, 12)', // should have 1 param
 
         // Math functions test
         'max(hello, one)', // param should be number

--- a/libraries/adaptive-expressions/tests/expressionParser.test.js
+++ b/libraries/adaptive-expressions/tests/expressionParser.test.js
@@ -402,6 +402,11 @@ const dataSource = [
     ['formatNumber(12.123, 2)', '12.12'],
     ['formatNumber(1.555, 2)', '1.56'],
     ['formatNumber(12.123, 4)', '12.1230'],
+    ['jsonStringify(json(\'{\"a\":\"b\"}\'))', '{"a":"b"}'],
+    ['jsonStringify(\'a\')', '"a"'],
+    ['jsonStringify(null)', 'null'],
+    ['jsonStringify(undefined)', undefined],
+    ['jsonStringify({a:"b"})', '{"a":"b"}'],
 
     // TODO: This should actually be the below, but toLocaleString does not work.
     // ['formatNumber(12000.3, 4, "fr-FR")', '12\u00a0000,3000'],
@@ -714,7 +719,7 @@ const dataSource = [
     ['setPathToValue(path.simple, 5) + path.simple', 10],
     ['setPathToValue(path.array[0], 7) + path.array[0]', 14],
     ['setPathToValue(path.array[1], 9) + path.array[1]', 18],
-    ['setPathToValue(path.x, null)', undefined],
+    ['setPathToValue(path.x, null)', null],
 ];
 
 const scope = {


### PR DESCRIPTION
issue ref: https://github.com/microsoft/botbuilder-dotnet/issues/4528

## Description
Add function `jsonStringify` to convert objects into json string.

Cases:
jsonStringify({a:'b'}) =>  '{"a":"b"}'
jsonStringify('a') => '"a"'
jsonStringify(null) => 'null'
jsonStringify(undefined) => undefined
