### PR TITLE
Allow calling an event driven dialog

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
@@ -174,6 +174,12 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
         // Install dependencies on first access
         this.ensureDependenciesInstalled();
 
+        // Initialize dialog state
+        if (options) {
+            // Replace initial activeDialog.State with clone of options
+            dc.activeDialog.state = JSON.parse(JSON.stringify(options));
+        }
+
         // Initialize event counter
         const dcState = dc.state;
         if (dcState.getValue(DialogPath.eventCounter) == undefined) {
@@ -199,11 +205,6 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> {
             });
         }
 
-        // Initialize dialog state
-        if (options) {
-            // Replace initial activeDialog.State with clone of options
-            dc.activeDialog.state = JSON.parse(JSON.stringify(options));
-        }
         dc.activeDialog.state[this.adaptiveKey] = {};
 
         const properties: { [key: string]: string } = {


### PR DESCRIPTION
Fixes #2307 

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Calling an event driven dialog did not work because passed in options would override the initial setup of dialog memory.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Adjusted beginDialog() in AdaptiveDialog
  -
  -