### PR TITLE
[PORT] Allow the activity only with channelData property in sendActivity action

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_SendActivity.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_SendActivity.test.dialog
@@ -26,6 +26,28 @@
                     {
                         "$kind": "Microsoft.SendActivity",
                         "activity": "done"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": {
+                            "type": "message",
+                            "channelData": {
+                                "attachment": {
+                                    "type": "template",
+                                    "payload": {
+                                        "template_type": "button",
+                                        "text": "What do you want to do next?",
+                                        "buttons": [
+                                            {
+                                                "type": "web_url",
+                                                "url": "https://www.messenger.com",
+                                                "title": "Visit Messenger"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
                     }
                 ]
             }
@@ -42,6 +64,14 @@
         {
             "$kind": "Microsoft.Test.AssertReply",
             "text": "done"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+            "assertions": [
+                "type == 'message'",
+                "text == undefined",
+                "channelData != undefined"
+            ]
         }
     ]
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/sendActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/sendActivity.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 import { DialogTurnResult, DialogContext, Dialog } from 'botbuilder-dialogs';
-import { Activity, StringUtils } from 'botbuilder-core';
+import { Activity, StringUtils, MessageFactory, ActivityTypes, ResourceResponse } from 'botbuilder-core';
 import { TemplateInterface } from '../template';
 import { ActivityTemplate } from '../templates/activityTemplate';
 import { StaticActivityTemplate } from '../templates/staticActivityTemplate';
@@ -64,7 +64,16 @@ export class SendActivity<O extends object = {}> extends Dialog<O> {
             }
         });
 
-        const result = await dc.context.sendActivity(activityResult);
+        let result: ResourceResponse;
+        if (activityResult.type !== ActivityTypes.Message
+             || activityResult.text
+             || activityResult.speak
+             || (activityResult.attachments && activityResult.attachments.length > 0)
+             || activityResult.suggestedActions
+             || activityResult.channelData) {
+                result = await dc.context.sendActivity(activityResult);
+        }
+
         return await dc.endDialog(result);
     }
 

--- a/libraries/botbuilder-dialogs-adaptive/src/converters/activityTemplateConverter.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/converters/activityTemplateConverter.ts
@@ -7,10 +7,14 @@
  */
 
 import { Converter } from 'botbuilder-dialogs-declarative';
-import { ActivityTemplate } from '../templates';
+import { ActivityTemplate, StaticActivityTemplate, TextTemplate } from '../templates';
 
 export class ActivityTemplateConverter implements Converter {
-    public convert(value: string): ActivityTemplate {
-        return new ActivityTemplate(value);
+    public convert(value: string): ActivityTemplate | StaticActivityTemplate | TextTemplate {
+        if (typeof value === 'string') { 
+            return new ActivityTemplate(value);
+        } else {
+            return new StaticActivityTemplate(value);
+        }
     }
 }


### PR DESCRIPTION
Fixes #2346

```
{
     "$kind": "Microsoft.SendActivity",
     "activity": {
       "$kind": "Microsoft.StaticActivityTemplate",
       "activity": {
           "type": "message",
           // only channel data property, no text and speak.
           // This one should be valid and be sent to the channel.
          "channelData": {xxxx}
   }
}
}
```