### PR TITLE
Catch errors in ShowTypingMiddleware

### DIFF
--- a/libraries/botbuilder-core/src/showTypingMiddleware.ts
+++ b/libraries/botbuilder-core/src/showTypingMiddleware.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Activity, ActivityTypes, ConversationReference } from 'botframework-schema';
+import { ActivityTypes } from 'botframework-schema';
 import { Middleware } from './middlewareSet';
 import { TurnContext } from './turnContext';
 
@@ -20,17 +20,12 @@ import { TurnContext } from './turnContext';
   * will continue to be sent until your bot sends another message back to the user
   */
 export class ShowTypingMiddleware implements Middleware {
-    private readonly delay: number;
-    private readonly period: number;
-    private interval: any;
-    private finished: boolean;
-
     /**
          * Create the SendTypingIndicator middleware
          * @param delay {number} Number of milliseconds to wait before sending the first typing indicator.
          * @param period {number} Number of milliseconds to wait before sending each following indicator.
          */
-    constructor(delay: number = 500, period: number = 2000) {
+    constructor(private readonly delay: number = 500, private readonly period: number = 2000) {
         if (delay < 0) {
             throw new Error('Delay must be greater than or equal to zero');
         }
@@ -38,86 +33,52 @@ export class ShowTypingMiddleware implements Middleware {
         if (period <= 0) {
             throw new Error('Repeat period must be greater than zero');
         }
-
-        this.delay = delay;
-        this.period = period;
     }
 
     /** Implement middleware signature
          * @param context {TurnContext} An incoming TurnContext object.
          * @param next {function} The next delegate function.
          */
-    public async onTurn(context: TurnContext, next: () => Promise<void>): Promise<void> {
-
+    public async onTurn(context: TurnContext, next: () => Promise<void>) {
         let finished = false;
-        let hTimeout: any = undefined;
+        let timeout: ReturnType<typeof setTimeout>;
 
-        /**
-             * @param context TurnContext object representing incoming message.
-             * @param delay The initial delay before sending the first indicator.
-             * @param period How often to send the indicator after the first.
-             */
-        function startInterval(context: TurnContext, delay: number, period: number): void {
-            hTimeout = setTimeout(
-                async () => {
-                    if (!finished) {
-                        let typingActivity: Partial<Activity> = {
-                            type: ActivityTypes.Typing,
-                            relatesTo: context.activity.relatesTo
-                        };
-
-                        // Sending the Activity directly via the Adapter avoids other middleware and avoids setting the
-                        // responded flag. However this also requires that the conversation reference details are explicitly added.
-                        const conversationReference: Partial<ConversationReference> =
-                                TurnContext.getConversationReference(context.activity);
-                        typingActivity = TurnContext.applyConversationReference(typingActivity, conversationReference);
-
-                        await context.adapter.sendActivities(context, [typingActivity]);
-
-                        // Pass in period as the delay to repeat at an interval.
-                        startInterval(context, period, period);
-                    } else {
-                        // Do nothing! This turn is done and we don't want to continue sending typing indicators.
+        const scheduleIndicator = (delay = this.delay) => {
+            timeout = setTimeout(async () => {
+                if (!finished) {
+                    try {
+                        await this.sendTypingActivity(context);
+                    } catch (err) {
+                        await context.adapter.onTurnError(context, err);
                     }
-                },
-                delay
-            );
+
+                    scheduleIndicator(this.period);
+                }
+            }, delay);
         }
 
         if (context.activity.type === ActivityTypes.Message) {
-            // Set a property to track whether or not the turn is finished.
-            // When it flips to true, we won't send anymore typing indicators.
             finished = false;
-            startInterval(context, this.delay, this.period);
+            scheduleIndicator();
         }
 
-        // Let the rest of the process run.
-        // After everything has run, stop the indicator!
-        try {
-            return await next();
-        }
-        finally
-        {
-            finished = true;
-            if (hTimeout) {
-                clearTimeout(hTimeout);
-            }
-        }
+        // Execute remaining middleware, then clear scheduled indicators
+        await next();
+
+        finished = true;
+        if (timeout) clearTimeout(timeout);
     }
-    private async sendTypingActivity(context: TurnContext): Promise<void> {
 
-        let typingActivity: Partial<Activity> = {
-            type: ActivityTypes.Typing,
-            relatesTo: context.activity.relatesTo
-        };
-
+    private async sendTypingActivity(context: TurnContext) {
         // Sending the Activity directly via the Adapter avoids other middleware and avoids setting the
         // responded flag. However this also requires that the conversation reference details are explicitly added.
-        const conversationReference: Partial<ConversationReference> = TurnContext.getConversationReference(context.activity);
-        typingActivity = TurnContext.applyConversationReference(typingActivity, conversationReference);
+        const conversationReference = TurnContext.getConversationReference(context.activity);
+
+        const typingActivity = TurnContext.applyConversationReference({
+            type: ActivityTypes.Typing,
+            relatesTo: context.activity.relatesTo
+        }, conversationReference);
 
         await context.adapter.sendActivities(context, [typingActivity]);
-
     }
-
 }

--- a/libraries/botbuilder-core/src/showTypingMiddleware.ts
+++ b/libraries/botbuilder-core/src/showTypingMiddleware.ts
@@ -49,7 +49,11 @@ export class ShowTypingMiddleware implements Middleware {
                     try {
                         await this.sendTypingActivity(context);
                     } catch (err) {
-                        await context.adapter.onTurnError(context, err);
+                        if (context.adapter && context.adapter.onTurnError) {
+                            await context.adapter.onTurnError(context, err);
+                        } else {
+                            throw err;
+                        }
                     }
 
                     scheduleIndicator(this.period);

--- a/libraries/botbuilder-core/tests/showTypingMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/showTypingMiddleware.test.js
@@ -1,51 +1,70 @@
 const assert = require('assert');
 const { ActivityTypes, ShowTypingMiddleware, TestAdapter } = require('../lib');
 
-function sleep(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-}
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-describe(`ShowTypingMiddleware`, function() {
+describe(`ShowTypingMiddleware`, function () {
     this.timeout(10000);
 
-    var adapter = new TestAdapter(async (context) => {
+    const adapter = new TestAdapter(async (context) => {
         await sleep(600);
-        await context.sendActivity(`echo:${ context.activity.text }`);
+        await context.sendActivity(`echo:${context.activity.text}`);
     }).use(new ShowTypingMiddleware());
 
-    it('should automatically send a typing indicator', function(done) {
+    it('should automatically send a typing indicator', function (done) {
         adapter
             .send('foo')
-            .assertReply(activity => assert.equal(activity.type, ActivityTypes.Typing))
+            .assertReply(activity => assert.strictEqual(activity.type, ActivityTypes.Typing))
             .assertReply('echo:foo')
             .send('bar')
-            .assertReply(activity => assert.equal(activity.type, ActivityTypes.Typing))
+            .assertReply(activity => assert.strictEqual(activity.type, ActivityTypes.Typing))
             .assertReply('echo:bar')
             .then(done);
     });
 
-    var adapter2 = new TestAdapter(async (context) => {
-        await context.sendActivity(`echo:${ context.activity.text }`);
+    const noMiddlewareAdapter = new TestAdapter(async (context) => {
+        await context.sendActivity(`echo:${context.activity.text}`);
     });
 
-    it('should NOT automatically send a typing indicator if middleware not applied', function(done) {
-        adapter2
+    it('should NOT automatically send a typing indicator if middleware not applied', function (done) {
+        noMiddlewareAdapter
             .send('foo')
             .assertReply('echo:foo')
             .then(done);
     });
 
-    it('should not immediately respond with a message (rather get a typing indicator)', function(done) {
+    it('should not immediately respond with a message (rather get a typing indicator)', function (done) {
         adapter
             .send('foo')
-            .assertReply(activity => assert.notEqual(activity.type, ActivityTypes.Message))
+            .assertReply(activity => assert.notStrictEqual(activity.type, ActivityTypes.Message))
             .then(done);
     });
 
-    it('should immediately respond with a message (rather get a typing indicator) if middleware not applied', function(done) {
-        adapter2
+    it('should immediately respond with a message (rather get a typing indicator) if middleware not applied', function (done) {
+        noMiddlewareAdapter
             .send('foo')
-            .assertReply(activity => assert.equal(activity.type, ActivityTypes.Message))
+            .assertReply(activity => assert.strictEqual(activity.type, ActivityTypes.Message))
             .then(done);
+    });
+
+    it('should not emit an uncaught exception when a promise is rejected', function (done) {
+        class ShowTypingErrorMiddleware extends ShowTypingMiddleware {
+            async sendTypingActivity() {
+                throw new Error('uh oh');
+            }
+        }
+
+        const adapter = new TestAdapter(async (context) => {
+            await sleep(100);
+            await context.sendActivity(`echo:${context.activity.text}`);
+        }).use(new ShowTypingErrorMiddleware(1, 1000));
+
+        adapter.onTurnError = (context, error) => {
+            assert.strictEqual(error != null, true);
+            assert.strictEqual(error.message, 'uh oh');
+            done();
+        }
+
+        adapter.send('foo').assertReply(activity => assert.strictEqual(activity.type, ActivityTypes.Message))
     });
 });


### PR DESCRIPTION
Fixes #2527

## Description
This fixes the bug described in the linked issue. In particular, errors are now caught and passed to the error handler registered on the adapter, if it exists.

## Specific Changes
* Small refactoring to leverage more idiomatic Typescript and Javascript (inline class constructor params, leverage inferred types, use proper `setTimeout` type, arrow functions for `this` propagation, etc)
* Catch errors in ShowTypingMiddleware `setTimeout` function
* Add a test to verify this behavior

## Testing
* Added a test to verify behavior.