### PR TITLE
shx for cross platform compatible shell commands

### DIFF
--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -41,6 +41,7 @@
     "nock": "^11.9.1",
     "nyc": "^15.1.0",
     "should": "^13.2.3",
+    "shx": "^0.3.2",
     "sponge": "^0.1.0",
     "source-map-support": "^0.5.3",
     "ts-node": "^4.1.0",
@@ -48,7 +49,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "postbuild": "cp lib/index.js lib/browser.js | browserify --debug lib/browser.js | exorcist lib/browser.map.js | sponge lib/browser.js",
+    "postbuild": "shx cp lib/index.js lib/browser.js | browserify --debug lib/browser.js | exorcist lib/browser.map.js | sponge lib/browser.js",
     "clean": "erase /q /s .\\lib",
     "set-version": "npm version --allow-same-version ${Version}",
     "test": "tsc && nyc mocha tests/ --timeout 60000 --inspect"


### PR DESCRIPTION
Fixes builds in non-Unix environments (i.e. Windows does not have the `cp` builtin).