### PR TITLE
[JSDoc] Add missing documentation for adaptive-expressions/expressionProperties

### DIFF
--- a/libraries/adaptive-expressions/src/expressionProperties/arrayExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/arrayExpression.ts
@@ -16,10 +16,9 @@ import { Expression } from '../expression';
  * @param T Type of object in the array.
  */
 export class ArrayExpression<T> extends ExpressionProperty<T[]> {
-    
     /**
-     * Initializes a new instance of the ArrayExpression<T> class.
-     * @param value Value of array of T or a string expression to bind to an array of T.
+     * Initializes a new instance of the `ArrayExpression<T>` class.
+     * @param value Value of `T[]` or a `string` expression to bind to an `T[]`.
      */
     public constructor(value?: T[] | string | Expression) {
         super(value);

--- a/libraries/adaptive-expressions/src/expressionProperties/arrayExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/arrayExpression.ts
@@ -16,6 +16,11 @@ import { Expression } from '../expression';
  * @param T Type of object in the array.
  */
 export class ArrayExpression<T> extends ExpressionProperty<T[]> {
+    
+    /**
+     * Initializes a new instance of the ArrayExpression<T> class.
+     * @param value Value of array of T or a string expression to bind to an array of T.
+     */
     public constructor(value?: T[] | string | Expression) {
         super(value);
     }

--- a/libraries/adaptive-expressions/src/expressionProperties/boolExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/boolExpression.ts
@@ -14,6 +14,11 @@ import { Expression } from '../expression';
  * String values are always interpreted as an expression, whether it has '=' prefix or not.
  */
 export class BoolExpression extends ExpressionProperty<boolean> {
+    
+    /**
+     * Initializes a new instance of the ArrayExpression<T> class.
+     * @param value A boolean or a string expression which resolves to a boolean.
+     */
     public constructor(value?: boolean | string | Expression) {
         super(value, false);
     }

--- a/libraries/adaptive-expressions/src/expressionProperties/boolExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/boolExpression.ts
@@ -16,8 +16,8 @@ import { Expression } from '../expression';
 export class BoolExpression extends ExpressionProperty<boolean> {
     
     /**
-     * Initializes a new instance of the ArrayExpression<T> class.
-     * @param value A boolean or a string expression which resolves to a boolean.
+     * Initializes a new instance of the `ArrayExpression<T>` class.
+     * @param value A `boolean` or a `string` expression which resolves to a `boolean`.
      */
     public constructor(value?: boolean | string | Expression) {
         super(value, false);

--- a/libraries/adaptive-expressions/src/expressionProperties/enumExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/enumExpression.ts
@@ -15,6 +15,11 @@ import { ExpressionProperty } from './expressionProperty';
  * String values are always interpreted as an expression whether it has '=' prefix or not, as string values cannot be parsed to enum values.
  */
 export class EnumExpression<T> extends ExpressionProperty<T> {
+    
+    /**
+     * Initializes a new instance of the ArrayExpression<T> class.
+     * @param value An enum of T or a string expression which resolves to an enum.
+     */
     public constructor(value: T | string | Expression) {
         super(value);
     }

--- a/libraries/adaptive-expressions/src/expressionProperties/enumExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/enumExpression.ts
@@ -15,10 +15,9 @@ import { ExpressionProperty } from './expressionProperty';
  * String values are always interpreted as an expression whether it has '=' prefix or not, as string values cannot be parsed to enum values.
  */
 export class EnumExpression<T> extends ExpressionProperty<T> {
-    
     /**
-     * Initializes a new instance of the ArrayExpression<T> class.
-     * @param value An enum of T or a string expression which resolves to an enum.
+     * Initializes a new instance of the `ArrayExpression<T>` class.
+     * @param value An enum of `T` or a `string` expression which resolves to an `enum`.
      */
     public constructor(value: T | string | Expression) {
         super(value);

--- a/libraries/adaptive-expressions/src/expressionProperties/expressionProperty.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/expressionProperty.ts
@@ -9,12 +9,18 @@ import { Expression } from '../expression';
 
 
 /**
- * Base class which defines a Expression or value for a property.
+ * Base class which defines an Expression or value for a property.
+ * @typeparam T Type of value of the expression property.
  */
 export class ExpressionProperty<T> {
     private defaultValue: T;
     private expression: Expression;
 
+    /**
+     * Initializes a new instance of the ExpressionProperty<T> class.
+     * @param value Optional. Raw value of the expression property.
+     * @param defaultValue Optional. Default value for the property.
+     */
     public constructor(value?: T | string | Expression, defaultValue?: T) {
         this.defaultValue = defaultValue;
         this.setValue(value);

--- a/libraries/adaptive-expressions/src/expressionProperties/expressionProperty.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/expressionProperty.ts
@@ -17,7 +17,7 @@ export class ExpressionProperty<T> {
     private expression: Expression;
 
     /**
-     * Initializes a new instance of the ExpressionProperty<T> class.
+     * Initializes a new instance of the `ExpressionProperty<T>` class.
      * @param value Optional. Raw value of the expression property.
      * @param defaultValue Optional. Default value for the property.
      */

--- a/libraries/adaptive-expressions/src/expressionProperties/intExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/intExpression.ts
@@ -14,10 +14,9 @@ import { Expression } from '../expression';
  * String values are always interpreted as an expression, whether it has '=' prefix or not.
  */
 export class IntExpression extends ExpressionProperty<number> {
-    
     /**
-     * Initializes a new instance of the ArrayExpression<T> class.
-     * @param value An int or string expression which resolves to a int.
+     * Initializes a new instance of the `ArrayExpression<T>` class.
+     * @param value An `int` or `string` expression which resolves to a `int`.
      */
     public constructor(value?: number | string | Expression) {
         super(value, 0);

--- a/libraries/adaptive-expressions/src/expressionProperties/intExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/intExpression.ts
@@ -14,6 +14,11 @@ import { Expression } from '../expression';
  * String values are always interpreted as an expression, whether it has '=' prefix or not.
  */
 export class IntExpression extends ExpressionProperty<number> {
+    
+    /**
+     * Initializes a new instance of the ArrayExpression<T> class.
+     * @param value An int or string expression which resolves to a int.
+     */
     public constructor(value?: number | string | Expression) {
         super(value, 0);
     }

--- a/libraries/adaptive-expressions/src/expressionProperties/numberExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/numberExpression.ts
@@ -14,6 +14,11 @@ import { Expression } from '../expression';
  * String values are always interpreted as an expression, whether it has '=' prefix or not.
  */
 export class NumberExpression extends ExpressionProperty<number> {
+    
+    /**
+     * Initializes a new instance of the ArrayExpression<T> class.
+     * @param value A float or string expression which resolves to a float.
+     */
     public constructor(value?: number | string | Expression) {
         super(value, 0);
     }

--- a/libraries/adaptive-expressions/src/expressionProperties/numberExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/numberExpression.ts
@@ -14,10 +14,9 @@ import { Expression } from '../expression';
  * String values are always interpreted as an expression, whether it has '=' prefix or not.
  */
 export class NumberExpression extends ExpressionProperty<number> {
-    
     /**
-     * Initializes a new instance of the ArrayExpression<T> class.
-     * @param value A float or string expression which resolves to a float.
+     * Initializes a new instance of the `ArrayExpression<T>` class.
+     * @param value A `float` or `string` expression which resolves to a `float`.
      */
     public constructor(value?: number | string | Expression) {
         super(value, 0);

--- a/libraries/adaptive-expressions/src/expressionProperties/objectExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/objectExpression.ts
@@ -16,10 +16,9 @@ import { Expression } from '../expression';
  * @param T The type of object.
  */
 export class ObjectExpression<T> extends ExpressionProperty<T> {
-    
     /**
-     * Initializes a new instance of the ArrayExpression<T> class.
-     * @param value An object of type T or a string expression which resolves to a object of type T.
+     * Initializes a new instance of the `ArrayExpression<T>` class.
+     * @param value An object of type `T` or a `string` expression which resolves to a object of type `T`.
      */
     public constructor(value?: T | string | Expression) {
         super(value);

--- a/libraries/adaptive-expressions/src/expressionProperties/objectExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/objectExpression.ts
@@ -16,6 +16,11 @@ import { Expression } from '../expression';
  * @param T The type of object.
  */
 export class ObjectExpression<T> extends ExpressionProperty<T> {
+    
+    /**
+     * Initializes a new instance of the ArrayExpression<T> class.
+     * @param value An object of type T or a string expression which resolves to a object of type T.
+     */
     public constructor(value?: T | string | Expression) {
         super(value);
     }

--- a/libraries/adaptive-expressions/src/expressionProperties/stringExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/stringExpression.ts
@@ -22,10 +22,9 @@ import { Expression } from '../expression';
  *     prop = "\=user" => "=user".
  */
 export class StringExpression extends ExpressionProperty<string> {
-    
     /**
-     * Initializes a new instance of the ArrayExpression<T> class.
-     * @param value A string value or a string expression.
+     * Initializes a new instance of the `ArrayExpression<T>` class.
+     * @param value A `string` value or a `string` expression.
      */
     public constructor(value?: string | Expression) {
         super(value);

--- a/libraries/adaptive-expressions/src/expressionProperties/stringExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/stringExpression.ts
@@ -22,7 +22,11 @@ import { Expression } from '../expression';
  *     prop = "\=user" => "=user".
  */
 export class StringExpression extends ExpressionProperty<string> {
-
+    
+    /**
+     * Initializes a new instance of the ArrayExpression<T> class.
+     * @param value A string value or a string expression.
+     */
     public constructor(value?: string | Expression) {
         super(value);
     }

--- a/libraries/adaptive-expressions/src/expressionProperties/valueExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/valueExpression.ts
@@ -22,10 +22,9 @@ import { Expression } from '../expression';
  *     prop = "\=user" => "=user".
  */
 export class ValueExpression extends ExpressionProperty<any> {
-    
     /**
-     * Initializes a new instance of the ArrayExpression<T> class.
-     * @param value An object of any kind or a string expression.
+     * Initializes a new instance of the `ArrayExpression<T>` class.
+     * @param value An object of `any` kind or a `string` expression.
      */
     public constructor(value?: any | string | Expression) {
         super(value);

--- a/libraries/adaptive-expressions/src/expressionProperties/valueExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/valueExpression.ts
@@ -22,7 +22,11 @@ import { Expression } from '../expression';
  *     prop = "\=user" => "=user".
  */
 export class ValueExpression extends ExpressionProperty<any> {
-
+    
+    /**
+     * Initializes a new instance of the ArrayExpression<T> class.
+     * @param value An object of any kind or a string expression.
+     */
     public constructor(value?: any | string | Expression) {
         super(value);
     }


### PR DESCRIPTION
Addresses # 2602

## Description
This PR adds the missing documentation in [adaptive-expressions/expressionProperties/](https://github.com/microsoft/botbuilder-js/tree/main/libraries/adaptive-expressions/src/expressionProperties) files.
Some documentation is ported and adapted from [botbuilder-dotnet](https://github.com/microsoft/botbuilder-dotnet)

## Specific Changes
- Added JSDoc comments in all public methods.

## Testing
The following image shows the ESLint Report with no JSDoc errors.
![image](https://user-images.githubusercontent.com/64803884/94727957-d9f82380-0335-11eb-89eb-16c1d9921a4a.png)
