### PR TITLE
[PORT][LG] Redo the default fallback of namespace

### DIFF
--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -27,7 +27,7 @@ import { AnalyzerResult } from './analyzerResult';
 import { TemplateErrors } from './templateErrors';
 import { TemplateExtensions } from './templateExtensions';
 import { EvaluationOptions, LGLineBreakStyle } from './evaluationOptions';
-import { isAbsolute, basename } from 'path';
+import { basename } from 'path';
 import { StaticChecker } from './staticChecker';
 import { LGResource } from './lgResource';
 import { CustomizedMemory } from './customizedMemory';
@@ -549,7 +549,10 @@ export class Templates implements Iterable<Template> {
             const globalFuncs = curTemplates.getGlobalFunctionTable(curTemplates.options);
             for (const templateName of globalFuncs) {
                 if (curTemplates.items.find((u) => u.name === templateName) !== undefined) {
-                    const newGlobalName = `${curTemplates.namespace}.${templateName}`;
+                    const prefix =
+                        !curTemplates.namespace || !curTemplates.namespace.trim() ? '' : curTemplates.namespace + '.';
+
+                    const newGlobalName = prefix + templateName;
                     Expression.functions.add(
                         newGlobalName,
                         new ExpressionEvaluator(
@@ -606,11 +609,7 @@ export class Templates implements Iterable<Template> {
     private extractNamespace(options: string[]): string {
         let result = this.extractOptionByKey(this.namespaceKey, options);
         if (!result) {
-            if (isAbsolute(this.source)) {
-                result = basename(this.source).split('.')[0];
-            } else {
-                throw new Error('namespace is required or the id should be an absoulte path!"');
-            }
+            result = basename(this.id || '').split('.')[0];
         }
 
         return result;

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -57,6 +57,7 @@ describe('LG', function() {
         MemoryAccess: Templates.parseFile(GetExampleFilePath('MemoryAccess.lg')),
         ReExecute: Templates.parseFile(GetExampleFilePath('ReExecute.lg')),
         inject: Templates.parseFile(GetExampleFilePath('./injectionTest/inject.lg')),
+        injectWithoutNamespace: Templates.parseFile(GetExampleFilePath('./injectionTest/injectWithoutNamespace.lg')),
         StrictModeTrue: Templates.parseFile(GetExampleFilePath('./EvaluationOptions/StrictModeTrue.lg')),
         a1: Templates.parseFile(GetExampleFilePath('./EvaluationOptions/a1.lg')),
         a2: Templates.parseFile(GetExampleFilePath('./EvaluationOptions/a2.lg')),
@@ -1412,5 +1413,31 @@ describe('LG', function() {
         var scope2 = { i: 1, j: 2, k: 3, l: 4 };
         var {value: evaled, error} = Expression.parse('common.sumFourNumbers(i, j, k, l)').tryEvaluate(scope2);
         assert.strictEqual(10, evaled);
+    });
+
+    it('TestInjectLGWithoutNamespace', function() {
+        const lgPath = GetExampleFilePath('./injectionTest/injectWithoutNamespace.lg');
+        let resource = new LGResource('myId', lgPath, fs.readFileSync(lgPath, 'utf-8'));
+        Templates.parseResource(resource);
+
+        var { value: evaled, error } = Expression.parse('myId.greeting()').tryEvaluate({ name: 'Alice' });
+        assert(error === undefined);
+        assert.strictEqual('hi Alice', evaled);
+
+        // using the fuileName parsed from Id as the namespace
+        resource = new LGResource('./path/myNewId.lg', lgPath, fs.readFileSync(lgPath, 'utf-8'));
+        Templates.parseResource(resource);
+
+        var { value: evaled, error } = Expression.parse('myNewId.greeting()').tryEvaluate({ name: 'Alice' });
+        assert(error === undefined);
+        assert.strictEqual('hi Alice', evaled);
+
+        // With empty id
+        resource = new LGResource('', lgPath, fs.readFileSync(lgPath, 'utf-8'));
+        Templates.parseResource(resource);
+
+        var { value: evaled, error } = Expression.parse('greeting()').tryEvaluate({ name: 'Alice' });
+        assert(error === undefined);
+        assert.strictEqual('hi Alice', evaled);
     });
 });

--- a/libraries/botbuilder-lg/tests/testData/examples/injectionTest/injectWithoutNamespace.lg
+++ b/libraries/botbuilder-lg/tests/testData/examples/injectionTest/injectWithoutNamespace.lg
@@ -1,0 +1,4 @@
+﻿> !# @Exports = greeting
+
+# greeting
+- hi ${name}


### PR DESCRIPTION
Issue: https://github.com/microsoft/BotFramework-Composer/issues/3982
C# pr: https://github.com/microsoft/botbuilder-dotnet/pull/4724


## Description
Originally, the injection of LG function into Expression require a namespace option. If there is no namespace option, a absolute path is require. It is too strict.


## Specific Changes
Loose the namespace fallback policy. The priority order is:
1. If there is a namespace option, use it
2. If there is an un-empty id, parse the file name from the id, and get the namespace
3. If the Id is empty, just drop the namespace and use the template name as the expression name directly.

For example:
If there is an option in LG file, like:
```
> !# @Namespace = general
```

`general` is the namespace, the export function could be presented as `general.xxx`

If there does not exist a namespace option, use the name of Id by default, for example:
If the id is: `./a.lg` -> `a` is the namespace, `a.xxx` is the expression name
if the id is: `abc` -> `abc` is the namespace, `abc.xxx` is the expression name
If the is is empty string, just drop the namespace, and use template name directly, `xxx` is the final expression name
