### PR TITLE
Bump @azure/ms-rest-js to 1.9.0

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -21,7 +21,7 @@
   "typings": "./lib/index.d.ts",
   "dependencies": {
     "@azure/cognitiveservices-luis-runtime": "2.0.0",
-    "@azure/ms-rest-js": "1.8.15",
+    "@azure/ms-rest-js": "1.9.0",
     "@microsoft/recognizers-text-date-time": "1.1.4",
     "@types/node": "^10.17.27",
     "botbuilder-core": "4.1.6",

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -20,7 +20,7 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "dependencies": {
-    "@azure/ms-rest-js": "1.8.15",
+    "@azure/ms-rest-js": "1.9.0",
     "@types/node": "^10.17.27",
     "axios": "^0.19.0",
     "botbuilder-core": "4.1.6",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -20,7 +20,7 @@
   "browser": "lib/browser.js",
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@azure/ms-rest-js": "1.8.15",
+    "@azure/ms-rest-js": "1.9.0",
     "adal-node": "0.2.1",
     "base64url": "^3.0.0",
     "botframework-schema": "4.1.6",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "update-versions": "lerna run set-version && npm run set-dependency-versions"
   },
   "dependencies": {
-    "@azure/ms-rest-js": "1.8.15",
+    "@azure/ms-rest-js": "1.9.0",
     "@microsoft/api-extractor": "^7.7.12",
     "@types/jsonwebtoken": "7.2.8",
     "@types/lodash": "^4.14.134",


### PR DESCRIPTION
Supports the following adapter configuration:

```typescript
const httpAgent = new Agent({ maxSockets: 10 });
const httpsAgent = new HttpsAgent({ maxSockets: 10 });

const adapter = new BotFrameworkAdapter({
  appId: process.env.MicrosoftAppId,
  appPassword: process.env.MicrosoftAppPassword,
  clientOptions: {
    agentSettings: {
      http: httpAgent,
      https: httpsAgent,
    },
  },
});
```

Fixes #183