### PR TITLE
dialogs: fall back to defaultLocale Globalize parser if locale is not found

### DIFF
--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.12",
+    "@types/globalize": "^1.5.0",
     "@types/mocha": "^5.2.7",
     "codelyzer": "^4.1.0",
     "line-reader": "^0.4.0",

--- a/libraries/botbuilder-dialogs/src/i18n.ts
+++ b/libraries/botbuilder-dialogs/src/i18n.ts
@@ -5,6 +5,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+
+/* eslint-disable @typescript-eslint/no-var-requires */
 const Chinese = require('../vendor/cldr-data/main/zh/numbers.json');
 const English = require('../vendor/cldr-data/main/en/numbers.json');
 const French = require('../vendor/cldr-data/main/fr/numbers.json');

--- a/libraries/botbuilder-dialogs/tests/numberPrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/numberPrompt.test.js
@@ -1,195 +1,144 @@
+const assert = require('assert');
 const { ActivityTypes, ConversationState, MemoryStorage, TestAdapter } = require('botbuilder-core');
 const { DialogSet, NumberPrompt, DialogTurnStatus } = require('../');
-const assert = require('assert');
 
 describe('NumberPrompt', function () {
     this.timeout(5000);
-    it('should call NumberPrompt using dc.prompt().', async function () {
-        const adapter = new TestAdapter(async (turnContext) => {
-            const dc = await dialogs.createContext(turnContext);
 
-            const results = await dc.continueDialog();
-            if (results.status === DialogTurnStatus.empty) {
-                await dc.prompt('prompt', 'Please send a number.');
-            } else if (results.status === DialogTurnStatus.complete) {
-                const reply = results.result.toString();
-                await turnContext.sendActivity(reply);
-            }
-            await convoState.saveChanges(turnContext);
-        });
-        // Create new ConversationState with MemoryStorage and register the state as middleware.
+    const createAdapter = (onEmpty, onComplete, validator, defaultLocale) => {
         const convoState = new ConversationState(new MemoryStorage());
 
-        // Create a DialogState property, DialogSet and NumberPrompt.
         const dialogState = convoState.createProperty('dialogState');
+
         const dialogs = new DialogSet(dialogState);
-        dialogs.add(new NumberPrompt('prompt'));
 
-        await adapter.send('Hello')
-            .assertReply('Please send a number.')
-            .send('35')
-            .assertReply('35');
+        const prompt = new NumberPrompt('prompt', validator, defaultLocale);
+        dialogs.add(prompt);
 
+        const adapter = new TestAdapter(async (turnContext) => {
+            const dialogContext = await dialogs.createContext(turnContext);
+
+            const results = await dialogContext.continueDialog();
+            if (results.status === DialogTurnStatus.empty) {
+                await onEmpty(dialogContext);
+            } else if (results.status === DialogTurnStatus.complete) {
+                await onComplete(turnContext, results.result);
+            }
+
+            await convoState.saveChanges(turnContext);
+        });
+
+        return adapter;
+    };
+
+    it('should call NumberPrompt using dc.prompt().', async function () {
+        const adapter = createAdapter(
+            (dialogContext) => dialogContext.prompt('prompt', 'Please send a number.'),
+            (turnContext, result) => turnContext.sendActivity(result.toString())
+        );
+
+        await adapter.send('Hello').assertReply('Please send a number.').send('35').assertReply('35');
     });
 
     it('should call NumberPrompt with custom validator.', async function () {
-        const adapter = new TestAdapter(async (turnContext) => {
-            const dc = await dialogs.createContext(turnContext);
-
-            const results = await dc.continueDialog();
-            if (results.status === DialogTurnStatus.empty) {
-                await dc.prompt('prompt', 'Please send a number.');
-            } else if (results.status === DialogTurnStatus.complete) {
-                const reply = results.result.toString();
-                await turnContext.sendActivity(reply);
+        const adapter = createAdapter(
+            (dialogContext) => dialogContext.prompt('prompt', 'Please send a number.'),
+            (turnContext, result) => turnContext.sendActivity(result.toString()),
+            (prompt) => {
+                assert(prompt);
+                let value = prompt.recognized.value;
+                return value !== undefined && value >= 1 && value <= 100;
             }
-            await convoState.saveChanges(turnContext);
-        });
+        );
 
-        const convoState = new ConversationState(new MemoryStorage());
-
-        const dialogState = convoState.createProperty('dialogState');
-        const dialogs = new DialogSet(dialogState);
-        dialogs.add(new NumberPrompt('prompt', async (prompt) => {
-            assert(prompt);
-            let value = prompt.recognized.value;
-            return value !== undefined && value >= 1 && value <= 100;
-        }));
-
-        await adapter.send('Hello')
+        await adapter
+            .send('Hello')
             .assertReply('Please send a number.')
             .send('0')
             .assertReply('Please send a number.')
             .send('25')
             .assertReply('25');
-
     });
 
     it('should send custom retryPrompt.', async function () {
-        const adapter = new TestAdapter(async (turnContext) => {
-            const dc = await dialogs.createContext(turnContext);
-
-            const results = await dc.continueDialog();
-            if (results.status === DialogTurnStatus.empty) {
-                await dc.prompt('prompt', { prompt: 'Please send a number.', retryPrompt: 'Please send a number between 1 and 100.' });
-            } else if (results.status === DialogTurnStatus.complete) {
-                const reply = results.result.toString();
-                await turnContext.sendActivity(reply);
+        const adapter = createAdapter(
+            (dialogContext) =>
+                dialogContext.prompt('prompt', {
+                    prompt: 'Please send a number.',
+                    retryPrompt: 'Please send a number between 1 and 100.',
+                }),
+            (turnContext, result) => turnContext.sendActivity(result.toString()),
+            (prompt) => {
+                assert(prompt);
+                let value = prompt.recognized.value;
+                return value !== undefined && value >= 1 && value <= 100;
             }
-            await convoState.saveChanges(turnContext);
-        });
+        );
 
-        const convoState = new ConversationState(new MemoryStorage());
-
-        const dialogState = convoState.createProperty('dialogState');
-        const dialogs = new DialogSet(dialogState);
-        dialogs.add(new NumberPrompt('prompt', async (prompt) => {
-            assert(prompt);
-            let value = prompt.recognized.value;
-            return value !== undefined && value >= 1 && value <= 100;
-        }));
-
-        await adapter.send('Hello')
+        await adapter
+            .send('Hello')
             .assertReply('Please send a number.')
             .send('0')
             .assertReply('Please send a number between 1 and 100.')
             .send('42')
-            .assertReply('42')
-
+            .assertReply('42');
     });
 
     it('should send ignore retryPrompt if validator replies.', async function () {
-        const adapter = new TestAdapter(async (turnContext) => {
-            const dc = await dialogs.createContext(turnContext);
-
-            const results = await dc.continueDialog();
-            if (results.status === DialogTurnStatus.empty) {
-                await dc.prompt('prompt', { prompt: 'Please send a number.', retryPrompt: 'Please send a number between 1 and 100.' });
-            } else if (results.status === DialogTurnStatus.complete) {
-                const reply = results.result.toString();
-                await turnContext.sendActivity(reply);
+        const adapter = createAdapter(
+            (dialogContext) =>
+                dialogContext.prompt('prompt', {
+                    prompt: 'Please send a number.',
+                    retryPrompt: 'Please send a number between 1 and 100.',
+                }),
+            (turnContext, result) => turnContext.sendActivity(result.toString()),
+            async (prompt) => {
+                assert(prompt);
+                let value = prompt.recognized.value;
+                const valid = value !== undefined && value >= 1 && value <= 100;
+                if (!valid) {
+                    await prompt.context.sendActivity('out of range');
+                }
+                return valid;
             }
-            await convoState.saveChanges(turnContext);
-        });
+        );
 
-        const convoState = new ConversationState(new MemoryStorage());
-
-        const dialogState = convoState.createProperty('dialogState');
-        const dialogs = new DialogSet(dialogState);
-        dialogs.add(new NumberPrompt('prompt', async (prompt) => {
-            assert(prompt);
-            let value = prompt.recognized.value;
-            const valid = value !== undefined && value >= 1 && value <= 100;
-            if (!valid) {
-                await prompt.context.sendActivity('out of range');
-            }
-            return valid;
-        }));
-
-        await adapter.send('Hello')
+        await adapter
+            .send('Hello')
             .assertReply('Please send a number.')
             .send('-1')
             .assertReply('out of range')
             .send('67')
-            .assertReply('67')
-
+            .assertReply('67');
     });
 
     it('should not send any retryPrompt no prompt specified.', async function () {
-        const adapter = new TestAdapter(async (turnContext) => {
-            const dc = await dialogs.createContext(turnContext);
-
-            const results = await dc.continueDialog();
-            if (results.status === DialogTurnStatus.empty) {
-                await dc.beginDialog('prompt');
-            } else if (results.status === DialogTurnStatus.complete) {
-                const reply = results.result.toString();
-                await turnContext.sendActivity(reply);
+        const adapter = createAdapter(
+            (dialogContext) => dialogContext.beginDialog('prompt'),
+            (turnContext, result) => turnContext.sendActivity(result.toString()),
+            (prompt) => {
+                assert(prompt);
+                let value = prompt.recognized.value;
+                return value !== undefined && value >= 1 && value <= 100;
             }
-            await convoState.saveChanges(turnContext);
-        });
+        );
 
-        const convoState = new ConversationState(new MemoryStorage());
-
-        const dialogState = convoState.createProperty('dialogState');
-        const dialogs = new DialogSet(dialogState);
-        dialogs.add(new NumberPrompt('prompt', async (prompt) => {
-            assert(prompt);
-            let value = prompt.recognized.value;
-            return value !== undefined && value >= 1 && value <= 100;
-        }));
-
-        await adapter.send('Hello')
-            .send('0')
-            .send('25')
-            .assertReply('25')
-
+        await adapter.send('Hello').send('0').send('25').assertReply('25');
     });
 
-    it ('should recognize 0 and zero as valid values', async function() {
-        const adapter = new TestAdapter(async (turnContext) => {
-            const dc = await dialogs.createContext(turnContext);
-
-            const results = await dc.continueDialog();
-            if (results.status === DialogTurnStatus.empty) {
-                await dc.prompt('prompt',{prompt: 'Send me a zero', retryPrompt: 'Send 0 or zero'});
-            } else if (results.status === DialogTurnStatus.complete) {
-                const reply = results.result.toString();
-                await turnContext.sendActivity(reply);
+    it('should recognize 0 and zero as valid values', async function () {
+        const adapter = createAdapter(
+            (dialogContext) =>
+                dialogContext.prompt('prompt', { prompt: 'Send me a zero', retryPrompt: 'Send 0 or zero' }),
+            (turnContext, result) => turnContext.sendActivity(result.toString()),
+            (prompt) => {
+                assert(prompt);
+                return prompt.recognized.value === 0;
             }
-            await convoState.saveChanges(turnContext);
-        });
+        );
 
-        const convoState = new ConversationState(new MemoryStorage());
-
-        const dialogState = convoState.createProperty('dialogState');
-        const dialogs = new DialogSet(dialogState);
-        dialogs.add(new NumberPrompt('prompt', async (prompt) => {
-            assert(prompt);
-            return prompt.recognized.value === 0;
-        }));
-
-        await adapter.send('Hello')
+        await adapter
+            .send('Hello')
             .assertReply('Send me a zero')
             .send('100')
             .assertReply('Send 0 or zero')
@@ -198,36 +147,26 @@ describe('NumberPrompt', function () {
             .send('Another!')
             .assertReply('Send me a zero')
             .send('zero')
-            .assertReply('0')
+            .assertReply('0');
     });
 
-    it ('should see attemptCount increment', async function() {
-        const adapter = new TestAdapter(async (turnContext) => {
-            const dc = await dialogs.createContext(turnContext);
+    it('should see attemptCount increment', async function () {
+        const adapter = createAdapter(
+            (dialogContext) =>
+                dialogContext.prompt('prompt', { prompt: 'Send me a zero', retryPrompt: 'Send 0 or zero' }),
+            (turnContext) => turnContext.sendActivity('ok'),
+            (prompt) => {
+                if (prompt.recognized.value !== 0) {
+                    prompt.context.sendActivity(`attemptCount ${prompt.attemptCount}`);
+                    return false;
+                }
 
-            const results = await dc.continueDialog();
-            if (results.status === DialogTurnStatus.empty) {
-                await dc.prompt('prompt',{prompt: 'Send me a zero', retryPrompt: 'Send 0 or zero'});
-            } else if (results.status === DialogTurnStatus.complete) {
-                await turnContext.sendActivity('ok');
+                return true;
             }
-            await convoState.saveChanges(turnContext);
-        });
+        );
 
-        const convoState = new ConversationState(new MemoryStorage());
-
-        const dialogState = convoState.createProperty('dialogState');
-        const dialogs = new DialogSet(dialogState);
-
-        dialogs.add(new NumberPrompt('prompt', async (prompt) => {
-            if (prompt.recognized.value !== 0) {
-                prompt.context.sendActivity(`attemptCount ${prompt.attemptCount}`);
-                return false;
-            }
-            return true;
-        }));
-
-        await adapter.send('Hello')
+        await adapter
+            .send('Hello')
             .assertReply('Send me a zero')
             .send('100')
             .assertReply('attemptCount 1')
@@ -246,91 +185,64 @@ describe('NumberPrompt', function () {
             .send('300')
             .assertReply('attemptCount 3')
             .send('0')
-            .assertReply('ok')
+            .assertReply('ok');
     });
 
     it('should consider culture specified in constructor', async function () {
-        const adapter = new TestAdapter(async (turnContext) => {
-            const dc = await dialogs.createContext(turnContext);
-
-            const results = await dc.continueDialog();
-            if (results.status === DialogTurnStatus.empty) {
-                await dc.prompt('prompt', 'Please send a number.');
-            } else if (results.status === DialogTurnStatus.complete) {
-                const reply = results.result;
+        const adapter = createAdapter(
+            (dialogContext) => dialogContext.prompt('prompt', 'Please send a number.'),
+            (turnContext, reply) => {
                 assert.strictEqual(reply, 3.14);
-                
-                await turnContext.sendActivity(reply);
-            }
-            await convoState.saveChanges(turnContext);
-        });
-        // Create new ConversationState with MemoryStorage and register the state as middleware.
-        const convoState = new ConversationState(new MemoryStorage());
+                return turnContext.sendActivity(reply);
+            },
+            undefined,
+            'es-es'
+        );
 
-        // Create a DialogState property, DialogSet and NumberPrompt.
-        const dialogState = convoState.createProperty('dialogState');
-        const dialogs = new DialogSet(dialogState);
-        dialogs.add(new NumberPrompt('prompt', undefined, 'es-es'));
-
-        await adapter.send('Hello')
-            .assertReply('Please send a number.')
-            .send('3,14')
+        await adapter.send('Hello').assertReply('Please send a number.').send('3,14');
     });
 
     it('should consider culture specified in activity', async function () {
-        const adapter = new TestAdapter(async (turnContext) => {
-            const dc = await dialogs.createContext(turnContext);
-
-            const results = await dc.continueDialog();
-            if (results.status === DialogTurnStatus.empty) {
-                await dc.prompt('prompt', 'Please send a number.');
-            } else if (results.status === DialogTurnStatus.complete) {
-                const reply = results.result;
+        const adapter = createAdapter(
+            (dialogContext) => dialogContext.prompt('prompt', 'Please send a number.'),
+            (turnContext, reply) => {
                 assert.strictEqual(reply, 3.14);
-                
-                await turnContext.sendActivity(reply);
-            }
-            await convoState.saveChanges(turnContext);
-        });
-        // Create new ConversationState with MemoryStorage and register the state as middleware.
-        const convoState = new ConversationState(new MemoryStorage());
+                return turnContext.sendActivity(reply);
+            },
+            undefined,
+            'en-us'
+        );
 
-        // Create a DialogState property, DialogSet and NumberPrompt.
-        const dialogState = convoState.createProperty('dialogState');
-        const dialogs = new DialogSet(dialogState);
-        dialogs.add(new NumberPrompt('prompt', undefined, 'en-us'));
-
-        await adapter.send('Hello')
+        await adapter
+            .send('Hello')
             .assertReply('Please send a number.')
-            .send({ type: ActivityTypes.Message, text: "3,14", locale: 'es-es'})
+            .send({ type: ActivityTypes.Message, text: '3,14', locale: 'es-es' });
     });
 
     it('should consider default to en-us culture when no culture is specified', async function () {
-        const adapter = new TestAdapter(async (turnContext) => {
-            const dc = await dialogs.createContext(turnContext);
-
-            const results = await dc.continueDialog();
-            if (results.status === DialogTurnStatus.empty) {
-                await dc.prompt('prompt', 'Please send a number.');
-            } else if (results.status === DialogTurnStatus.complete) {
-                const reply = results.result;
+        const adapter = createAdapter(
+            (dialogContext) => dialogContext.prompt('prompt', 'Please send a number.'),
+            (turnContext, reply) => {
                 assert.strictEqual(reply, 1500.25);
-                
-                await turnContext.sendActivity(reply);
+                return turnContext.sendActivity(reply);
             }
-            await convoState.saveChanges(turnContext);
-        });
-        // Create new ConversationState with MemoryStorage and register the state as middleware.
-        const convoState = new ConversationState(new MemoryStorage());
+        );
 
-        // Create a DialogState property, DialogSet and NumberPrompt.
-        const dialogState = convoState.createProperty('dialogState');
-        const dialogs = new DialogSet(dialogState);
-        dialogs.add(new NumberPrompt('prompt', undefined));
-
-        await adapter.send('Hello')
-            .assertReply('Please send a number.')
-            .send('1,500.25')
+        await adapter.send('Hello').assertReply('Please send a number.').send('1,500.25');
     });
 
+    it('should fall back to default locale if culture is not registered', async function () {
+        const adapter = createAdapter(
+            (dialogContext) => dialogContext.prompt('prompt', 'Please send a number.'),
+            (turnContext, reply) => {
+                assert.strictEqual(reply, 3.14);
+                return turnContext.sendActivity(reply);
+            }
+        );
+
+        await adapter
+            .send('Hello')
+            .assertReply('Please send a number.')
+            .send({ type: ActivityTypes.Message, text: '3,14', locale: 'it-it' });
+    });
 });


### PR DESCRIPTION
This fixes a case where looking up a locale not registered in Globalize
throws a module not found exception.

Also refactors the test slightly, installs and uses @types/globalize,
and fixes locale registration.

Fixes #2911