### PR TITLE
Revert "Change vmImage to ubuntu for all JS pipelines (#2931)"

### DIFF
--- a/build/yaml/botbuilder-js-api-check.yaml
+++ b/build/yaml/botbuilder-js-api-check.yaml
@@ -3,7 +3,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  vmImage: 'macOS-10.15'
 
 variables:
   version: 4.0.0-0
@@ -51,25 +51,27 @@ steps:
     customCommand: 'install coveralls --save-dev'
   enabled: false
 
-- script: |
-   sed -i 's/${Version}/$(version)/g' package.json
-   sed -i 's/${Version}/$(version)/g' libraries/adaptive-expressions/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/bot-integration-tests/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botbuilder/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botbuilder-ai/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botbuilder-applicationinsights/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botbuilder-azure/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botbuilder-core/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botbuilder-dialogs/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botbuilder-dialogs-adaptive/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botbuilder-dialogs-adaptive-tests/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botbuilder-dialogs-declarative/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botbuilder-lg/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botbuilder-testing/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botframework-config/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botframework-connector/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botframework-schema/package.json
-   sed -i 's/${Version}/$(version)/g' libraries/botframework-streaming/package.json
+- bash: |
+   sed -i '' 's/${Version}/$(version)/g' package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/adaptive-expressions/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/bot-integration-tests/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-ai/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-applicationinsights/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-azure/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-core/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-dialogs/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-dialogs-adaptive/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-dialogs-adaptive-tests/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-dialogs-declarative/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-lg/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botbuilder-testing/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botframework-config/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botframework-connector/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botframework-schema/package.json
+   sed -i '' 's/${Version}/$(version)/g' libraries/botframework-streaming/package.json
+   
+  failOnStderr: true
   displayName: 'Replace version number in package.json files'
   continueOnError: true
   env:

--- a/build/yaml/botbuilder-js-ci-node12.yml
+++ b/build/yaml/botbuilder-js-ci-node12.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  vmImage: 'macOS-10.15'
 
 variables:
   NodeVersion: 12.x

--- a/build/yaml/botbuilder-js-ci.yml
+++ b/build/yaml/botbuilder-js-ci.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  vmImage: 'macOS-10.15'
 
 variables:
   PackageVersion: 4.4.0-preview.$(Build.BuildNumber)

--- a/build/yaml/botbuilder-js-daily.yml
+++ b/build/yaml/botbuilder-js-daily.yml
@@ -6,7 +6,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  vmImage: 'macOS-10.15'
 
 variables:
   NodeVersion: 12.x
@@ -36,7 +36,7 @@ steps:
   displayName: 'lerna exec --no-private npm pack'
 
 - task: CopyFiles@2
-  displayName: 'Copy packages to staging'
+  displayName: 'Copy TGZ files to staging'
   inputs:
     SourceFolder: libraries
     Contents: '*/*.tgz'
@@ -44,7 +44,7 @@ steps:
     flattenFolders: true
 
 - task: PublishBuildArtifacts@1
-  displayName: 'Publish packages to Build Artifacts'
+  displayName: 'Publish staging to Build Artifacts'
 
 - powershell: |
    [string[]]$outvar = (Get-ChildItem *.tgz -Path $(Build.ArtifactStagingDirectory) ).Name;

--- a/build/yaml/js-build-steps.yml
+++ b/build/yaml/js-build-steps.yml
@@ -31,31 +31,31 @@ steps:
     workingDir: tools
     verbose: false
 
-- script: |
+- bash: |
    set -o xtrace
-   sed -i 's/${Version}/$(PackageVersion)/g' package.json 
-   sed -i 's/${Version}/$(PackageVersion)/g' libraries/adaptive-expressions/package.json
-   sed -i 's/${Version}/$(PackageVersion)/g' libraries/bot-integration-tests/package.json
-   sed -i 's/${Version}/$(PackageVersion)/g' libraries/botbuilder/package.json
-   sed -i 's/${Version}/$(PackageVersion)/g' libraries/botbuilder-ai/package.json
-   sed -i 's/${Version}/$(PreviewPackageVersion)/g' libraries/botbuilder-ai-orchestrator/package.json
-   sed -i 's/${Version}/$(PackageVersion)/g' libraries/botbuilder-applicationinsights/package.json
-   sed -i 's/${Version}/$(PackageVersion)/g' libraries/botbuilder-azure/package.json
-   sed -i 's/${Version}/$(PackageVersion)/g' libraries/botbuilder-core/package.json
-   sed -i 's/${Version}/$(PackageVersion)/g' libraries/botbuilder-dialogs/package.json
-   sed -i 's/${Version}/$(PreviewPackageVersion)/g' libraries/botbuilder-dialogs-adaptive/package.json
-   sed -i 's/${Version}/$(PreviewPackageVersion)/g' libraries/botbuilder-dialogs-adaptive-testing/package.json
-   sed -i 's/${Version}/$(PreviewPackageVersion)/g' libraries/botbuilder-dialogs-declarative/package.json
-   sed -i 's/${Version}/$(PackageVersion)/g' libraries/botbuilder-lg/package.json
-   sed -i 's/${Version}/$(PackageVersion)/g' libraries/botbuilder-testing/package.json
-   sed -i 's/${Version}/$(PackageVersion)/g' libraries/botframework-config/package.json
-   sed -i 's/${Version}/$(PackageVersion)/g' libraries/botframework-connector/package.json
-   sed -i 's/${Version}/$(PackageVersion)/g' libraries/botframework-schema/package.json
-   sed -i 's/${Version}/$(PackageVersion)/g' libraries/botframework-streaming/package.json
+   sed -i '' 's/${Version}/$(PackageVersion)/g' package.json 
+   sed -i '' 's/${Version}/$(PackageVersion)/g' libraries/adaptive-expressions/package.json
+   sed -i '' 's/${Version}/$(PackageVersion)/g' libraries/bot-integration-tests/package.json
+   sed -i '' 's/${Version}/$(PackageVersion)/g' libraries/botbuilder/package.json
+   sed -i '' 's/${Version}/$(PackageVersion)/g' libraries/botbuilder-ai/package.json
+   sed -i '' 's/${Version}/$(PreviewPackageVersion)/g' libraries/botbuilder-ai-orchestrator/package.json
+   sed -i '' 's/${Version}/$(PackageVersion)/g' libraries/botbuilder-applicationinsights/package.json
+   sed -i '' 's/${Version}/$(PackageVersion)/g' libraries/botbuilder-azure/package.json
+   sed -i '' 's/${Version}/$(PackageVersion)/g' libraries/botbuilder-core/package.json
+   sed -i '' 's/${Version}/$(PackageVersion)/g' libraries/botbuilder-dialogs/package.json
+   sed -i '' 's/${Version}/$(PreviewPackageVersion)/g' libraries/botbuilder-dialogs-adaptive/package.json
+   sed -i '' 's/${Version}/$(PreviewPackageVersion)/g' libraries/botbuilder-dialogs-adaptive-testing/package.json
+   sed -i '' 's/${Version}/$(PreviewPackageVersion)/g' libraries/botbuilder-dialogs-declarative/package.json
+   sed -i '' 's/${Version}/$(PackageVersion)/g' libraries/botbuilder-lg/package.json
+   sed -i '' 's/${Version}/$(PackageVersion)/g' libraries/botbuilder-testing/package.json
+   sed -i '' 's/${Version}/$(PackageVersion)/g' libraries/botframework-config/package.json
+   sed -i '' 's/${Version}/$(PackageVersion)/g' libraries/botframework-connector/package.json
+   sed -i '' 's/${Version}/$(PackageVersion)/g' libraries/botframework-schema/package.json
+   sed -i '' 's/${Version}/$(PackageVersion)/g' libraries/botframework-streaming/package.json
   displayName: 'Replace version number in package.json files'
   continueOnError: true
 
-- script: |
+- bash: |
    npm run update-versions
   displayName: 'npm run update-versions'
   env:


### PR DESCRIPTION
Reverting to vmImage macOS-10.15.

OrchestratorAdaptiveRecognizer tests were failing when running in ubuntu-18.04 and in ubuntu-20.04.

This reverts commit ac08692132e0cf3ce21661f5626591b3af312c4f.

