### PR TITLE
Add type check for ExpressionProperty

### DIFF
--- a/libraries/adaptive-expressions/src/expressionProperties/arrayExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/arrayExpression.ts
@@ -23,4 +23,20 @@ export class ArrayExpression<T> extends ExpressionProperty<T[]> {
     public constructor(value?: T[] | string | Expression) {
         super(value);
     }
+
+        /**
+     * Set an array value.
+     * @param value Value to set.
+     */
+    public setValue(value: T[] | string | Expression): void {
+        if (value !== undefined 
+            && value !== null 
+            && !Array.isArray(value)
+            && typeof value !== 'string' 
+            && !(value instanceof Expression)) {
+            throw new Error("ArrayExpression accepts string, array or Expression as the value.");
+        }
+
+        super.setValue(value);
+    }
 }

--- a/libraries/adaptive-expressions/src/expressionProperties/boolExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/boolExpression.ts
@@ -22,4 +22,20 @@ export class BoolExpression extends ExpressionProperty<boolean> {
     public constructor(value?: boolean | string | Expression) {
         super(value, false);
     }
+
+    /**
+     * Set a boolean value.
+     * @param value Value to set.
+     */
+    public setValue(value: boolean | string | Expression): void {
+        if (value !== undefined 
+            && value !== null 
+            && typeof value !== 'boolean' 
+            && typeof value !== 'string' 
+            && !(value instanceof Expression)) {
+            throw new Error("BoolExpression accepts string, boolean or Expression as the value.");
+        }
+
+        super.setValue(value);
+    }
 }

--- a/libraries/adaptive-expressions/src/expressionProperties/intExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/intExpression.ts
@@ -36,4 +36,20 @@ export class IntExpression extends ExpressionProperty<number> {
 
         return result;
     }
+
+    /**
+     * Set an integer value.
+     * @param value Value to set.
+     */
+    public setValue(value: number | string | Expression): void {
+        if (value !== undefined 
+            && value !== null 
+            && typeof value !== 'number' 
+            && typeof value !== 'string' 
+            && !(value instanceof Expression)) {
+            throw new Error("IntExpression accepts string, number or Expression as the value.");
+        }
+
+        super.setValue(value);
+    }
 }

--- a/libraries/adaptive-expressions/src/expressionProperties/numberExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/numberExpression.ts
@@ -21,4 +21,20 @@ export class NumberExpression extends ExpressionProperty<number> {
     public constructor(value?: number | string | Expression) {
         super(value, 0);
     }
+
+    /**
+     * Set a number value.
+     * @param value Value to set.
+     */
+    public setValue(value: number | string | Expression): void {
+        if (value !== undefined 
+            && value !== null 
+            && typeof value !== 'number' 
+            && typeof value !== 'string' 
+            && !(value instanceof Expression)) {
+            throw new Error("NumberExpression accepts string, number or Expression as the value.");
+        }
+
+        super.setValue(value);
+    }
 }

--- a/libraries/adaptive-expressions/src/expressionProperties/stringExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/stringExpression.ts
@@ -43,7 +43,7 @@ export class StringExpression extends ExpressionProperty<string> {
             return;
         }
 
-        if (typeof value == 'string') {
+        if (typeof value === 'string') {
             if (value.startsWith('=')) {
                 this.expressionText = value;
                 return;
@@ -55,6 +55,10 @@ export class StringExpression extends ExpressionProperty<string> {
             // Initialize value
             this.expressionText = `=\`${value.replace(/\\/g, '\\\\')}\``;
             return;
+        }
+
+        if (value !== undefined && value !== null) {
+            throw new Error("StringExpression accepts string or Expression as the value.");
         }
     }
 }

--- a/libraries/adaptive-expressions/tests/ExpressionPropertyType.test.js
+++ b/libraries/adaptive-expressions/tests/ExpressionPropertyType.test.js
@@ -1,0 +1,40 @@
+const { ArrayExpression, BoolExpression, IntExpression, NumberExpression, StringExpression } = require('../lib');
+const assert = require('assert');
+
+describe('expressionProperty type exception tests', () => {
+    it('array expression with error type', function () {
+        const errorMsg = 'ArrayExpression accepts string, array or Expression as the value.';
+        assert.throws(() => new ArrayExpression(1), Error(errorMsg));
+        assert.throws(() => new ArrayExpression(false), Error(errorMsg));
+        assert.throws(() => new ArrayExpression({ key: 'value' }), Error(errorMsg));
+    });
+
+    it('bool expression with error type', function () {
+        const errorMsg = 'BoolExpression accepts string, boolean or Expression as the value.';
+        assert.throws(() => new BoolExpression(1), Error(errorMsg));
+        assert.throws(() => new BoolExpression(['v1', 'v2']), Error(errorMsg));
+        assert.throws(() => new BoolExpression({ key: 'value' }), Error(errorMsg));
+    });
+
+    it('int expression with error type', function () {
+        const errorMsg = 'IntExpression accepts string, number or Expression as the value.';
+        assert.throws(() => new IntExpression(['v1', 'v2']), Error(errorMsg));
+        assert.throws(() => new IntExpression(false), Error(errorMsg));
+        assert.throws(() => new IntExpression({ key: 'value' }), Error(errorMsg));
+    });
+
+    it('number expression with error type', function () {
+        const errorMsg = 'NumberExpression accepts string, number or Expression as the value.';
+        assert.throws(() => new NumberExpression(['v1', 'v2']), Error(errorMsg));
+        assert.throws(() => new NumberExpression(false), Error(errorMsg));
+        assert.throws(() => new NumberExpression({ key: 'value' }), Error(errorMsg));
+    });
+
+    it('string expression with error type', function () {
+        const errorMsg = 'StringExpression accepts string or Expression as the value.';
+        assert.throws(() => new StringExpression(['v1', 'v2']), Error(errorMsg));
+        assert.throws(() => new StringExpression(false), Error(errorMsg));
+        assert.throws(() => new StringExpression(1), Error(errorMsg));
+        assert.throws(() => new StringExpression({ key: 'value' }), Error(errorMsg));
+    });
+});


### PR DESCRIPTION
Fixes #2568

## Description
Add type checking for the implements of ExpressionProperty. Including `NumberExpression`, `IntExpression`, `BoolExpression`, `ArrayExpression`, `StringExpression`