### PR TITLE
fix: luis recognizer tests

### DIFF
--- a/libraries/botbuilder-ai/tests/luisRecognizer.test.js
+++ b/libraries/botbuilder-ai/tests/luisRecognizer.test.js
@@ -24,13 +24,17 @@ class TestContext extends TurnContext {
 
 class ThrowErrorRecognizer extends LuisRecognizer {
     constructor() {
-        super({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true, includeInstanceData: true }, true);
+        super(
+            { applicationId: luisAppId, endpointKey: endpointKey },
+            { includeAllIntents: true, includeInstanceData: true },
+            true
+        );
     }
 
     recognize() {
         return new Promise((resolve, reject) => {
             reject(new Error('Test'));
-        }).catch(error => {
+        }).catch((error) => {
             this.prepareErrorMessage(error);
             throw error;
         });
@@ -39,13 +43,13 @@ class ThrowErrorRecognizer extends LuisRecognizer {
 
 class TelemetryOverrideRecognizer extends LuisRecognizer {
     async onRecognizerResults(recognizerResult, turnContext, properties, metrics) {
-        if (!('\'MyImportantProperty' in properties)) {
+        if (!("'MyImportantProperty" in properties)) {
             properties['MyImportantProperty'] = 'myImportantValue';
         }
         this.telemetryClient.trackEvent({
             name: 'LuisResult',
             properties: properties,
-            metrics: metrics
+            metrics: metrics,
         });
 
         // Create second event
@@ -54,7 +58,7 @@ class TelemetryOverrideRecognizer extends LuisRecognizer {
 
         this.telemetryClient.trackEvent({
             name: 'MySecondEvent',
-            properties: secondProperties
+            properties: secondProperties,
         });
     }
 }
@@ -69,7 +73,7 @@ class OverrideFillRecognizer extends LuisRecognizer {
         this.telemetryClient.trackEvent({
             name: 'LuisResult',
             properties: props,
-            metrics: metrics
+            metrics: metrics,
         });
 
         // Create second event
@@ -78,7 +82,7 @@ class OverrideFillRecognizer extends LuisRecognizer {
 
         this.telemetryClient.trackEvent({
             name: 'MySecondEvent',
-            properties: secondProperties
+            properties: secondProperties,
         });
     }
 }
@@ -96,30 +100,25 @@ function WithinDelta(token1, token2, delta, compare) {
     var within = true;
     if (token1 == null || token2 == null) {
         within = token1 == token2;
-    }
-    else if (Array.isArray(token1) && Array.isArray(token2)) {
+    } else if (Array.isArray(token1) && Array.isArray(token2)) {
         within = token1.length == token2.length;
         for (var i = 0; within && i < token1.length; ++i) {
             within = WithinDelta(token1[i], token2[i], delta, compare);
         }
-    }
-    else if (typeof token1 === 'object' && typeof token2 === 'object') {
-        Object.keys(token2).forEach(k => token2[k] === undefined && delete token2[k]);
+    } else if (typeof token1 === 'object' && typeof token2 === 'object') {
+        Object.keys(token2).forEach((k) => token2[k] === undefined && delete token2[k]);
         within = Object.keys(token1).length === Object.keys(token2).length;
-        Object.keys(token1).forEach(function(key) {
+        Object.keys(token1).forEach(function (key) {
             if (!within) return;
             within = WithinDelta(token1[key], token2[key], delta, compare || key === 'score' || key === 'intents');
         });
-    }
-    else if (token1 !== token2) {
+    } else if (token1 !== token2) {
         if (token1 !== undefined && token2 != undefined && token1.Type == token2.Type) {
             within = false;
-            if (compare &&
-                typeof token1 === 'number' && typeof token2 === 'number') {
+            if (compare && typeof token1 === 'number' && typeof token2 === 'number') {
                 within = Math.abs(token1 - token2) < delta;
             }
-        }
-        else {
+        } else {
             within = false;
         }
     }
@@ -134,16 +133,16 @@ function GetExpected(oracle) {
     var expected = fs.readJSONSync(oracle);
 
     var query = 'verbose=(true|false)&staging=false&spellCheck=false&log=true';
-    var path = `/luis/v2\\.0/apps/${ luisAppId }`;
-    var pattern = `${ path }\\?${ query }`;
+    var path = `/luis/v2\\.0/apps/${luisAppId}`;
+    var pattern = `${path}\\?${query}`;
     var uri = new RegExp(pattern);
-    var requestContent = expected.text != undefined ? `"${ expected.text }"` : undefined;
+    var requestContent = expected.text != undefined ? `"${expected.text}"` : undefined;
     var responseBody = expected.v2;
 
     if (mockLuis) {
         nock('https://westus.api.cognitive.microsoft.com')
             .matchHeader('Ocp-Apim-Subscription-Key', endpointKey)
-            .matchHeader('authorization', `Bearer ${ endpointKey }`)
+            .matchHeader('authorization', `Bearer ${endpointKey}`)
             .post(uri, requestContent)
             .reply(200, responseBody);
     }
@@ -151,16 +150,23 @@ function GetExpected(oracle) {
 }
 
 function ReturnErrorStatusCode(code) {
-    nock('https://westus.api.cognitive.microsoft.com')
-        .post(/apps/)
-        .reply(code);
+    nock('https://westus.api.cognitive.microsoft.com').post(/apps/).reply(code);
 }
 
 // To create a file to test:
 // 1) Create a <name>.json file with an object { text:<query> } in it.
 // 2) Run this test sith mockLuis = false which will fail and generate a <name>.json.new file.
 // 3) Check the .new file and if correct, replace the original .json file with it.
-function TestJson(file, done, includeAllIntents, includeInstance, telemetryClient, telemetryProperties, telemetryMetrics, logPersonalInformation) {
+function TestJson(
+    file,
+    done,
+    includeAllIntents,
+    includeInstance,
+    telemetryClient,
+    telemetryProperties,
+    telemetryMetrics,
+    logPersonalInformation
+) {
     if (includeAllIntents === undefined) includeAllIntents = true;
     if (includeInstance === undefined) includeInstance = true;
     if (logPersonalInformation === undefined) logPersonalInformation = true;
@@ -169,227 +175,279 @@ function TestJson(file, done, includeAllIntents, includeInstance, telemetryClien
     var expected = GetExpected(expectedPath);
     var newPath = expectedPath + '.new';
     var context = new TestContext({ text: expected.text });
-    var recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey },
-        { includeAllIntents: includeAllIntents, includeInstanceData: includeInstance, telemetryClient: telemetryClient, logPersonalInformation: logPersonalInformation }, true);
-    recognizer.recognize(context, telemetryProperties, telemetryMetrics).then(res => {
+    var recognizer = new LuisRecognizer(
+        { applicationId: luisAppId, endpointKey: endpointKey },
+        {
+            includeAllIntents: includeAllIntents,
+            includeInstanceData: includeInstance,
+            telemetryClient: telemetryClient,
+            logPersonalInformation: logPersonalInformation,
+        },
+        true
+    );
+    recognizer.recognize(context, telemetryProperties, telemetryMetrics).then((res) => {
         res.v2 = res.luisResult;
         delete res.luisResult;
         if (!WithinDelta(expected, res, 0.1, false)) {
             fs.outputJSONSync(newPath, res, { spaces: 2 });
             assert(false, '\nReturned JSON\n  ' + newPath + '\n!= expected JSON\n  ' + expectedPath);
-        }
-        else if (fs.existsSync(newPath)) {
+        } else if (fs.existsSync(newPath)) {
             fs.unlinkSync(newPath);
         }
         done(res);
     });
 }
 
-describe('LuisRecognizer', function() {
+describe('LuisRecognizer', function () {
     this.timeout(15000);
 
-    const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true }, true);
+    const recognizer = new LuisRecognizer(
+        { applicationId: luisAppId, endpointKey: endpointKey },
+        { includeAllIntents: true },
+        true
+    );
 
     if (!mockLuis && endpointKey === 'MockedKey') {
-        console.warn('WARNING: skipping LuisRecognizer test suite because the LUISAPPKEY environment variable is not defined');
+        console.warn(
+            'WARNING: skipping LuisRecognizer test suite because the LUISAPPKEY environment variable is not defined'
+        );
         return;
     }
 
-    it('test built-ins composite1', done => TestJson('Composite1.json', () => throttle(done)));
-    it('test built-ins composite2', done => TestJson('Composite2.json', () => throttle(done)));
-    it('test built-ins composite3', done => TestJson('Composite3.json', () => throttle(done)));
-    it('test built-ins prebuilt', done => TestJson('Prebuilt.json', () => throttle(done)));
-    it('test patterns', done => TestJson('Patterns.json', () => throttle(done)));
-    it('test roles', done => TestJson('roles.json', () => throttle(done)));
-    it('should return single intent and a simple entity', done => {
-        TestJson('SingleIntent_SimplyEntity.json', (res) => {
-            assert(res);
-            assert(res.text == 'My name is Emad');
-            assert(Object.keys(res.intents).length == 1);
-            assert(res.intents.SpecifyName);
-            assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
-            assert(res.entities);
-            assert(res.entities.Name);
-            assert(res.entities.Name[0] === 'emad');
-            assert(res.entities.$instance);
-            assert(res.entities.$instance.Name);
-            assert(res.entities.$instance.Name[0].startIndex === 11);
-            assert(res.entities.$instance.Name[0].endIndex === 15);
-            assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
-            throttle(done);
-        }, false);
-    });
-
-    it('should return multiple intents and prebuilt entities with a single value', done => {
-        TestJson('MultipleIntents_PrebuiltEntity.json', res => {
-            assert(res);
-            assert(res.text == 'Please deliver February 2nd 2001');
-            assert(res.intents);
-            assert(res.intents.Delivery);
-            assert(res.intents.Delivery.score > 0 && res.intents.Delivery.score <= 1);
-            assert(LuisRecognizer.topIntent(res) === 'Delivery');
-            assert(res.entities);
-            assert(res.entities.number);
-            assert(res.entities.number[0] === 2001);
-            assert(res.entities.datetime);
-            assert(res.entities.datetime[0].timex[0] === '2001-02-02');
-            assert(res.entities.$instance);
-            assert(res.entities.$instance.number);
-            assert(res.entities.$instance.number[0].startIndex === 28);
-            assert(res.entities.$instance.number[0].endIndex === 32);
-            assert(res.entities.$instance.number[0].text);
-            assert(res.entities.$instance.number[0].text === '2001');
-            assert(res.entities.$instance.datetime);
-            assert(res.entities.$instance.datetime[0].startIndex === 15);
-            assert(res.entities.$instance.datetime[0].endIndex === 32);
-            assert(res.entities.$instance.datetime[0].text);
-            assert(res.entities.$instance.datetime[0].text === 'february 2nd 2001');
-            throttle(done);
-        }, false);
-    });
-
-    it('should return multiple intents and prebuilt entities with multiple values', done => {
-        TestJson('MultipleIntents_PrebuiltEntitiesWithMultiValues.json', res => {
-            assert(res);
-            assert(res.text == 'Please deliver February 2nd 2001 in room 201');
-            assert(res.intents);
-            assert(res.intents.Delivery);
-            assert(res.intents.Delivery.score > 0 && res.intents.Delivery.score <= 1);
-            assert(res.entities);
-            assert(res.entities.number);
-            assert(res.entities.number.length == 2);
-            assert(res.entities.number.indexOf(2001) > -1);
-            assert(res.entities.number.indexOf(201) > -1);
-            assert(res.entities.datetime);
-            assert(res.entities.datetime[0].timex[0] === '2001-02-02');
-            throttle(done);
-        }, false);
-    });
-
-    it('should return multiple intents and a list entity with a single value', done => {
-        TestJson('MultipleIntents_ListEntityWithSingleValue.json', res => {
-            assert(res);
-            assert(res.text == 'I want to travel on united');
-            assert(res.intents);
-            assert(res.intents.Travel);
-            assert(res.intents.Travel.score > 0 && res.intents.Travel.score <= 1);
-            assert(res.entities);
-            assert(res.entities.Airline);
-            assert(res.entities.Airline[0][0] === 'United');
-            assert(res.entities.$instance);
-            assert(res.entities.$instance.Airline);
-            assert(res.entities.$instance.Airline[0].startIndex);
-            assert(res.entities.$instance.Airline[0].startIndex === 20);
-            assert(res.entities.$instance.Airline[0].endIndex);
-            assert(res.entities.$instance.Airline[0].endIndex === 26);
-            assert(res.entities.$instance.Airline[0].text);
-            assert(res.entities.$instance.Airline[0].text === 'united');
-            throttle(done);
-        }, false);
-    });
-
-    it('should return multiple intents and a list entity with multiple values', done => {
-        TestJson('MultipleIntents_ListEntityWithMultiValues.json', res => {
-            assert(res);
-            assert(res.text == 'I want to travel on DL');
-            assert(res.intents);
-            assert(res.intents.Travel);
-            assert(res.intents.Travel.score > 0 && res.intents.Travel.score <= 1);
-            assert(res.entities);
-            assert(res.entities.Airline[0]);
-            assert(res.entities.Airline[0].length == 2);
-            assert(res.entities.Airline[0].indexOf('Delta') > -1);
-            assert(res.entities.Airline[0].indexOf('Virgin') > -1);
-            assert(res.entities.$instance);
-            assert(res.entities.$instance.Airline);
-            assert(res.entities.$instance.Airline[0].startIndex);
-            assert(res.entities.$instance.Airline[0].startIndex === 20);
-            assert(res.entities.$instance.Airline[0].endIndex);
-            assert(res.entities.$instance.Airline[0].endIndex === 22);
-            assert(res.entities.$instance.Airline[0].text);
-            assert(res.entities.$instance.Airline[0].text === 'dl');
-            throttle(done);
-        }, false);
-    });
-
-    it('should return multiple intents and a single composite entity', done => {
-        TestJson('MultipleIntents_CompositeEntityModel.json', res => {
-            assert(res);
-            assert(res.text == 'Please deliver it to 98033 WA');
-            assert(res.intents);
-            assert(res.intents.Delivery);
-            assert(res.intents.Delivery.score > 0 && res.intents.Delivery.score <= 1);
-            assert(res.entities);
-            assert(res.entities.number === undefined);
-            assert(res.entities.State === undefined);
-            assert(res.entities.Address);
-            assert(res.entities.Address[0].number[0] === 98033);
-            assert(res.entities.Address[0].State);
-            assert(res.entities.Address[0].State[0] === 'wa');
-            assert(res.entities.$instance);
-            assert(res.entities.$instance.number === undefined);
-            assert(res.entities.$instance.State === undefined);
-            assert(res.entities.$instance.Address);
-            assert(res.entities.$instance.Address[0].startIndex);
-            assert(res.entities.$instance.Address[0].startIndex === 21);
-            assert(res.entities.$instance.Address[0].endIndex);
-            assert(res.entities.$instance.Address[0].endIndex === 29);
-            assert(res.entities.$instance.Address[0].score);
-            assert(res.entities.$instance.Address[0].score > 0 && res.entities.$instance.Address[0].score <= 1);
-            assert(res.entities.Address[0].$instance.number);
-            assert(res.entities.Address[0].$instance.number[0].startIndex);
-            assert(res.entities.Address[0].$instance.number[0].startIndex === 21);
-            assert(res.entities.Address[0].$instance.number[0].endIndex);
-            assert(res.entities.Address[0].$instance.number[0].endIndex === 26);
-            assert(res.entities.Address[0].$instance.number[0].text);
-            assert(res.entities.Address[0].$instance.number[0].text === '98033');
-            assert(res.entities.Address[0].$instance.State);
-            assert(res.entities.Address[0].$instance.State[0].startIndex);
-            assert(res.entities.Address[0].$instance.State[0].startIndex === 27);
-            assert(res.entities.Address[0].$instance.State[0].endIndex);
-            assert(res.entities.Address[0].$instance.State[0].endIndex === 29);
-            assert(res.entities.Address[0].$instance.State[0].score);
-            assert(res.entities.Address[0].$instance.State[0].score > 0 && res.entities.Address[0].$instance.State[0].score <= 1);
-            throttle(done);
-        }, false);
-    });
-
-    it('should cache multiple calls to recognize()', done => {
-        var expected = GetExpected(ExpectedPath('SingleIntent_SimplyEntity.json'));
-        var recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, { includeAllIntents: true, apiVersion: 'v2', includeAPIResults: true });
-        var context = new TestContext({ text: expected.text });
-        recognizer.recognize(context)
-            .then(res => {
+    it('test built-ins composite1', (done) => TestJson('Composite1.json', () => throttle(done)));
+    it('test built-ins composite2', (done) => TestJson('Composite2.json', () => throttle(done)));
+    it('test built-ins composite3', (done) => TestJson('Composite3.json', () => throttle(done)));
+    it('test built-ins prebuilt', (done) => TestJson('Prebuilt.json', () => throttle(done)));
+    it('test patterns', (done) => TestJson('Patterns.json', () => throttle(done)));
+    it('test roles', (done) => TestJson('roles.json', () => throttle(done)));
+    it('should return single intent and a simple entity', (done) => {
+        TestJson(
+            'SingleIntent_SimplyEntity.json',
+            (res) => {
                 assert(res);
-                res.text = 'cached';
-                recognizer.recognize(context).then(res => {
-                    assert(res);
-                    assert(res.text === 'cached');
-                    throttle(done);
-                });
-            }, false);
+                assert(res.text == 'My name is Emad');
+                assert(Object.keys(res.intents).length == 1);
+                assert(res.intents.SpecifyName);
+                assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
+                assert(res.entities);
+                assert(res.entities.Name);
+                assert(res.entities.Name[0] === 'emad');
+                assert(res.entities.$instance);
+                assert(res.entities.$instance.Name);
+                assert(res.entities.$instance.Name[0].startIndex === 11);
+                assert(res.entities.$instance.Name[0].endIndex === 15);
+                assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
+                throttle(done);
+            },
+            false
+        );
     });
 
-    it('should only return $instance metadata for entities if verbose flag set', done => {
-        TestJson('NoInstanceSimple.json', res => {
+    it('should return multiple intents and prebuilt entities with a single value', (done) => {
+        TestJson(
+            'MultipleIntents_PrebuiltEntity.json',
+            (res) => {
+                assert(res);
+                assert(res.text == 'Please deliver February 2nd 2001');
+                assert(res.intents);
+                assert(res.intents.Delivery);
+                assert(res.intents.Delivery.score > 0 && res.intents.Delivery.score <= 1);
+                assert(LuisRecognizer.topIntent(res) === 'Delivery');
+                assert(res.entities);
+                assert(res.entities.number);
+                assert(res.entities.number[0] === 2001);
+                assert(res.entities.datetime);
+                assert(res.entities.datetime[0].timex[0] === '2001-02-02');
+                assert(res.entities.$instance);
+                assert(res.entities.$instance.number);
+                assert(res.entities.$instance.number[0].startIndex === 28);
+                assert(res.entities.$instance.number[0].endIndex === 32);
+                assert(res.entities.$instance.number[0].text);
+                assert(res.entities.$instance.number[0].text === '2001');
+                assert(res.entities.$instance.datetime);
+                assert(res.entities.$instance.datetime[0].startIndex === 15);
+                assert(res.entities.$instance.datetime[0].endIndex === 32);
+                assert(res.entities.$instance.datetime[0].text);
+                assert(res.entities.$instance.datetime[0].text === 'february 2nd 2001');
+                throttle(done);
+            },
+            false
+        );
+    });
+
+    it('should return multiple intents and prebuilt entities with multiple values', (done) => {
+        TestJson(
+            'MultipleIntents_PrebuiltEntitiesWithMultiValues.json',
+            (res) => {
+                assert(res);
+                assert(res.text == 'Please deliver February 2nd 2001 in room 201');
+                assert(res.intents);
+                assert(res.intents.Delivery);
+                assert(res.intents.Delivery.score > 0 && res.intents.Delivery.score <= 1);
+                assert(res.entities);
+                assert(res.entities.number);
+                assert(res.entities.number.length == 2);
+                assert(res.entities.number.indexOf(2001) > -1);
+                assert(res.entities.number.indexOf(201) > -1);
+                assert(res.entities.datetime);
+                assert(res.entities.datetime[0].timex[0] === '2001-02-02');
+                throttle(done);
+            },
+            false
+        );
+    });
+
+    it('should return multiple intents and a list entity with a single value', (done) => {
+        TestJson(
+            'MultipleIntents_ListEntityWithSingleValue.json',
+            (res) => {
+                assert(res);
+                assert(res.text == 'I want to travel on united');
+                assert(res.intents);
+                assert(res.intents.Travel);
+                assert(res.intents.Travel.score > 0 && res.intents.Travel.score <= 1);
+                assert(res.entities);
+                assert(res.entities.Airline);
+                assert(res.entities.Airline[0][0] === 'United');
+                assert(res.entities.$instance);
+                assert(res.entities.$instance.Airline);
+                assert(res.entities.$instance.Airline[0].startIndex);
+                assert(res.entities.$instance.Airline[0].startIndex === 20);
+                assert(res.entities.$instance.Airline[0].endIndex);
+                assert(res.entities.$instance.Airline[0].endIndex === 26);
+                assert(res.entities.$instance.Airline[0].text);
+                assert(res.entities.$instance.Airline[0].text === 'united');
+                throttle(done);
+            },
+            false
+        );
+    });
+
+    it('should return multiple intents and a list entity with multiple values', (done) => {
+        TestJson(
+            'MultipleIntents_ListEntityWithMultiValues.json',
+            (res) => {
+                assert(res);
+                assert(res.text == 'I want to travel on DL');
+                assert(res.intents);
+                assert(res.intents.Travel);
+                assert(res.intents.Travel.score > 0 && res.intents.Travel.score <= 1);
+                assert(res.entities);
+                assert(res.entities.Airline[0]);
+                assert(res.entities.Airline[0].length == 2);
+                assert(res.entities.Airline[0].indexOf('Delta') > -1);
+                assert(res.entities.Airline[0].indexOf('Virgin') > -1);
+                assert(res.entities.$instance);
+                assert(res.entities.$instance.Airline);
+                assert(res.entities.$instance.Airline[0].startIndex);
+                assert(res.entities.$instance.Airline[0].startIndex === 20);
+                assert(res.entities.$instance.Airline[0].endIndex);
+                assert(res.entities.$instance.Airline[0].endIndex === 22);
+                assert(res.entities.$instance.Airline[0].text);
+                assert(res.entities.$instance.Airline[0].text === 'dl');
+                throttle(done);
+            },
+            false
+        );
+    });
+
+    it('should return multiple intents and a single composite entity', (done) => {
+        TestJson(
+            'MultipleIntents_CompositeEntityModel.json',
+            (res) => {
+                assert(res);
+                assert(res.text == 'Please deliver it to 98033 WA');
+                assert(res.intents);
+                assert(res.intents.Delivery);
+                assert(res.intents.Delivery.score > 0 && res.intents.Delivery.score <= 1);
+                assert(res.entities);
+                assert(res.entities.number === undefined);
+                assert(res.entities.State === undefined);
+                assert(res.entities.Address);
+                assert(res.entities.Address[0].number[0] === 98033);
+                assert(res.entities.Address[0].State);
+                assert(res.entities.Address[0].State[0] === 'wa');
+                assert(res.entities.$instance);
+                assert(res.entities.$instance.number === undefined);
+                assert(res.entities.$instance.State === undefined);
+                assert(res.entities.$instance.Address);
+                assert(res.entities.$instance.Address[0].startIndex);
+                assert(res.entities.$instance.Address[0].startIndex === 21);
+                assert(res.entities.$instance.Address[0].endIndex);
+                assert(res.entities.$instance.Address[0].endIndex === 29);
+                assert(res.entities.$instance.Address[0].score);
+                assert(res.entities.$instance.Address[0].score > 0 && res.entities.$instance.Address[0].score <= 1);
+                assert(res.entities.Address[0].$instance.number);
+                assert(res.entities.Address[0].$instance.number[0].startIndex);
+                assert(res.entities.Address[0].$instance.number[0].startIndex === 21);
+                assert(res.entities.Address[0].$instance.number[0].endIndex);
+                assert(res.entities.Address[0].$instance.number[0].endIndex === 26);
+                assert(res.entities.Address[0].$instance.number[0].text);
+                assert(res.entities.Address[0].$instance.number[0].text === '98033');
+                assert(res.entities.Address[0].$instance.State);
+                assert(res.entities.Address[0].$instance.State[0].startIndex);
+                assert(res.entities.Address[0].$instance.State[0].startIndex === 27);
+                assert(res.entities.Address[0].$instance.State[0].endIndex);
+                assert(res.entities.Address[0].$instance.State[0].endIndex === 29);
+                assert(res.entities.Address[0].$instance.State[0].score);
+                assert(
+                    res.entities.Address[0].$instance.State[0].score > 0 &&
+                        res.entities.Address[0].$instance.State[0].score <= 1
+                );
+                throttle(done);
+            },
+            false
+        );
+    });
+
+    it('should cache multiple calls to recognize()', (done) => {
+        var expected = GetExpected(ExpectedPath('SingleIntent_SimplyEntity.json'));
+        var recognizer = new LuisRecognizer(
+            { applicationId: luisAppId, endpointKey: endpointKey },
+            { includeAllIntents: true, apiVersion: 'v2', includeAPIResults: true }
+        );
+        var context = new TestContext({ text: expected.text });
+        recognizer.recognize(context).then((res) => {
             assert(res);
-            assert(res.entities);
-            assert(res.entities.$instance === undefined);
-            throttle(done);
-        }, false, false);
+            res.text = 'cached';
+            recognizer.recognize(context).then((res) => {
+                assert(res);
+                assert(res.text === 'cached');
+                throttle(done);
+            });
+        }, false);
     });
 
-    it('should only return $instance metadata for composite entities if verbose flag set', done => {
-        TestJson('NoInstanceComposite.json', res => {
-            assert(res);
-            assert(res.entities);
-            assert(res.entities.$instance === undefined);
-            throttle(done);
-        }, true, false);
+    it('should only return $instance metadata for entities if verbose flag set', (done) => {
+        TestJson(
+            'NoInstanceSimple.json',
+            (res) => {
+                assert(res);
+                assert(res.entities);
+                assert(res.entities.$instance === undefined);
+                throttle(done);
+            },
+            false,
+            false
+        );
     });
 
-    it('should only return empty intent for empty text', done => {
-        TestJson('EmptyText.json', res => {
+    it('should only return $instance metadata for composite entities if verbose flag set', (done) => {
+        TestJson(
+            'NoInstanceComposite.json',
+            (res) => {
+                assert(res);
+                assert(res.entities);
+                assert(res.entities.$instance === undefined);
+                throttle(done);
+            },
+            true,
+            false
+        );
+    });
+
+    it('should only return empty intent for empty text', (done) => {
+        TestJson('EmptyText.json', (res) => {
             const top = LuisRecognizer.topIntent(res);
             assert(top === 'None'); // topIntent() converts '' to 'None'
             assert(Object.keys(res.intents).length == 1);
@@ -398,50 +456,55 @@ describe('LuisRecognizer', function() {
         });
     });
 
-    it('should return defaultIntent from topIntent() if results undefined', done => {
+    it('should return defaultIntent from topIntent() if results undefined', (done) => {
         const top = LuisRecognizer.topIntent(undefined);
         assert(top === 'None');
         throttle(done);
     });
 
-    it('should return defaultIntent from topIntent() if intent scores below threshold', done => {
+    it('should return defaultIntent from topIntent() if intent scores below threshold', (done) => {
         const top = LuisRecognizer.topIntent({ intents: { TestIntent: 0.49 } }, 'None', 0.5);
         assert(top === 'None');
         throttle(done);
     });
 
-    it('should emit trace info once per call to recognize', done => {
+    it('should emit trace info once per call to recognize', (done) => {
         var expected = GetExpected(ExpectedPath('SingleIntent_SimplyEntity.json'));
         var context = new TestContext({ text: expected.text });
-        recognizer.recognize(context).then(() => {
-            return recognizer.recognize(context);
-        }).then(() => {
-            return recognizer.recognize(context);
-        }).then(res => {
-            assert(res);
-            assert(res.text == expected.text);
-        }).then(() => {
-            let luisTraceActivities = context.sent.filter(s => s.type === 'trace' && s.name === 'LuisRecognizer');
-            assert(luisTraceActivities.length === 1);
-            let traceActivity = luisTraceActivities[0];
-            assert(traceActivity.type === 'trace');
-            assert(traceActivity.name === 'LuisRecognizer');
-            assert(traceActivity.label === 'Luis Trace');
-            assert(traceActivity.valueType === 'https://www.luis.ai/schemas/trace');
-            assert(traceActivity.value);
-            assert(traceActivity.value.luisResult);
-            assert(traceActivity.value.recognizerResult);
-            assert(traceActivity.value.luisOptions);
-            assert(traceActivity.value.luisModel);
-            throttle(done);
-        });
+        recognizer
+            .recognize(context)
+            .then(() => {
+                return recognizer.recognize(context);
+            })
+            .then(() => {
+                return recognizer.recognize(context);
+            })
+            .then((res) => {
+                assert(res);
+                assert(res.text == expected.text);
+            })
+            .then(() => {
+                let luisTraceActivities = context.sent.filter((s) => s.type === 'trace' && s.name === 'LuisRecognizer');
+                assert(luisTraceActivities.length === 1);
+                let traceActivity = luisTraceActivities[0];
+                assert(traceActivity.type === 'trace');
+                assert(traceActivity.name === 'LuisRecognizer');
+                assert(traceActivity.label === 'Luis Trace');
+                assert(traceActivity.valueType === 'https://www.luis.ai/schemas/trace');
+                assert(traceActivity.value);
+                assert(traceActivity.value.luisResult);
+                assert(traceActivity.value.recognizerResult);
+                assert(traceActivity.value.luisOptions);
+                assert(traceActivity.value.luisModel);
+                throttle(done);
+            });
     });
 
-    it('should call prepareErrorMessage when a non-200 status code is received.', done => {
+    it('should call prepareErrorMessage when a non-200 status code is received.', (done) => {
         nock.cleanAll();
         ReturnErrorStatusCode(400);
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch(error => {
+        recognizer.recognize(context).catch((error) => {
             const expectedError = `Response 400: The request's body or parameters are incorrect, meaning they are missing, malformed, or too large.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
@@ -449,11 +512,11 @@ describe('LuisRecognizer', function() {
         });
     });
 
-    it('should throw expected 401 error message.', done => {
+    it('should throw expected 401 error message.', (done) => {
         nock.cleanAll();
         ReturnErrorStatusCode(401);
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch(error => {
+        recognizer.recognize(context).catch((error) => {
             const expectedError = `Response 401: The key used is invalid, malformed, empty, or doesn't match the region.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
@@ -461,11 +524,11 @@ describe('LuisRecognizer', function() {
         });
     });
 
-    it('should throw expected 403 error message.', done => {
+    it('should throw expected 403 error message.', (done) => {
         nock.cleanAll();
         ReturnErrorStatusCode(403);
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch(error => {
+        recognizer.recognize(context).catch((error) => {
             const expectedError = `Response 403: Total monthly key quota limit exceeded.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
@@ -473,11 +536,11 @@ describe('LuisRecognizer', function() {
         });
     });
 
-    it('should throw expected 409 error message.', done => {
+    it('should throw expected 409 error message.', (done) => {
         nock.cleanAll();
         ReturnErrorStatusCode(409);
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch(error => {
+        recognizer.recognize(context).catch((error) => {
             const expectedError = `Response 409: Application loading in progress, please try again.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
@@ -485,11 +548,11 @@ describe('LuisRecognizer', function() {
         });
     });
 
-    it('should throw expected 410 error message.', done => {
+    it('should throw expected 410 error message.', (done) => {
         nock.cleanAll();
         ReturnErrorStatusCode(410);
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch(error => {
+        recognizer.recognize(context).catch((error) => {
             const expectedError = `Response 410: Please retrain and republish your application.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
@@ -497,11 +560,11 @@ describe('LuisRecognizer', function() {
         });
     });
 
-    it('should throw expected 414 error message.', done => {
+    it('should throw expected 414 error message.', (done) => {
         nock.cleanAll();
         ReturnErrorStatusCode(414);
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch(error => {
+        recognizer.recognize(context).catch((error) => {
             const expectedError = `Response 414: The query is too long. Please reduce the query length to 500 or less characters.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
@@ -509,11 +572,11 @@ describe('LuisRecognizer', function() {
         });
     });
 
-    it('should throw expected 429 error message.', done => {
+    it('should throw expected 429 error message.', (done) => {
         nock.cleanAll();
         ReturnErrorStatusCode(429);
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch(error => {
+        recognizer.recognize(context).catch((error) => {
             const expectedError = `Response 429: Too many requests.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
@@ -521,31 +584,30 @@ describe('LuisRecognizer', function() {
         });
     });
 
-    it('should throw unexpected error message with correct status code.', done => {
+    it('should throw unexpected error message with correct status code.', (done) => {
         nock.cleanAll();
         const statusCode = 404;
         ReturnErrorStatusCode(statusCode);
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch(error => {
-            const expectedError = `Response ${ statusCode }: Unexpected status code received. Please verify that your LUIS application is properly setup.`;
+        recognizer.recognize(context).catch((error) => {
+            const expectedError = `Response ${statusCode}: Unexpected status code received. Please verify that your LUIS application is properly setup.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
             nock.cleanAll();
             throttle(done);
         });
     });
 
-    it('.prepareErrorMessage() should not change `error.message` if `error.response.statusCode` does not exist.',
-        done => {
-            const recognizer = new ThrowErrorRecognizer();
-            const context = new TestContext({ text: 'Hello world!' });
-            recognizer.recognize(context).catch(error => {
-                const expectedError = 'Test';
-                assert(error.message === expectedError, `unexpected error message thrown.`);
-                throttle(done);
-            });
+    it('.prepareErrorMessage() should not change `error.message` if `error.response.statusCode` does not exist.', (done) => {
+        const recognizer = new ThrowErrorRecognizer();
+        const context = new TestContext({ text: 'Hello world!' });
+        recognizer.recognize(context).catch((error) => {
+            const expectedError = 'Test';
+            assert(error.message === expectedError, `unexpected error message thrown.`);
+            throttle(done);
         });
+    });
 
-    it('should send user-agent header.', done => {
+    it('should send user-agent header.', (done) => {
         nock.cleanAll();
         nock('https://westus.api.cognitive.microsoft.com')
             .matchHeader('User-Agent', /botbuilder-ai\/4.*/)
@@ -561,7 +623,8 @@ describe('LuisRecognizer', function() {
     it('should successfully construct with valid endpoint.', () => {
         // Note this is NOT a real LUIS application ID nor a real LUIS subscription-key.
         // These are GUIDs edited to look right to the parsing and validation code.
-        const mockedEndpoint = 'https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=';
+        const mockedEndpoint =
+            'https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=';
 
         const recognizer = new LuisRecognizer(mockedEndpoint);
 
@@ -571,24 +634,32 @@ describe('LuisRecognizer', function() {
     });
 
     it('should throw an error when parsing application endpoint with no subscription-key.', () => {
-        const endpointWithNoSubscriptionKey = 'https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&q=';
+        const endpointWithNoSubscriptionKey =
+            'https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&q=';
         const expectedSubscriptionKey = undefined;
         try {
             new LuisRecognizer(endpointWithNoSubscriptionKey);
             assert(false, 'should have thrown an error.');
         } catch (e) {
-            assert(e.message === `Invalid \`endpointKey\` value detected: ${ expectedSubscriptionKey }\nPlease make sure your endpointKey is a valid LUIS Endpoint Key, e.g. "048ec46dc58e495482b0c447cfdbd291".`);
+            assert(
+                e.message ===
+                    `Invalid \`endpointKey\` value detected: ${expectedSubscriptionKey}\nPlease make sure your endpointKey is a valid LUIS Endpoint Key, e.g. "048ec46dc58e495482b0c447cfdbd291".`
+            );
         }
     });
 
     const expectedApplicationId = undefined;
     it('should throw an error when parsing application endpoint with no application ID.', () => {
-        const endpointWithNoAppId = 'https://westus.api.cognitive.microsoft.com?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=';
+        const endpointWithNoAppId =
+            'https://westus.api.cognitive.microsoft.com?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=';
         try {
             new LuisRecognizer(endpointWithNoAppId);
             assert(false, 'should have thrown an error.');
         } catch (e) {
-            assert(e.message === `Invalid \`applicationId\` value detected: ${ expectedApplicationId }\nPlease make sure your applicationId is a valid LUIS Application Id, e.g. "b31aeaf3-3511-495b-a07f-571fc873214b".`);
+            assert(
+                e.message ===
+                    `Invalid \`applicationId\` value detected: ${expectedApplicationId}\nPlease make sure your applicationId is a valid LUIS Application Id, e.g. "b31aeaf3-3511-495b-a07f-571fc873214b".`
+            );
         }
     });
 
@@ -597,7 +668,10 @@ describe('LuisRecognizer', function() {
             new LuisRecognizer('this.is.not.a.url');
             assert(false, 'should have thrown an error.');
         } catch (e) {
-            assert(e.message === `Invalid \`applicationId\` value detected: ${ expectedApplicationId }\nPlease make sure your applicationId is a valid LUIS Application Id, e.g. "b31aeaf3-3511-495b-a07f-571fc873214b".`);
+            assert(
+                e.message ===
+                    `Invalid \`applicationId\` value detected: ${expectedApplicationId}\nPlease make sure your applicationId is a valid LUIS Application Id, e.g. "b31aeaf3-3511-495b-a07f-571fc873214b".`
+            );
         }
     });
 
@@ -608,21 +682,29 @@ describe('LuisRecognizer', function() {
         const nullTelemetryProperties = null;
         const logPersonalInformation = true;
 
-        TestJson('SingleIntent_SimplyEntityTelemetry.json', (res) => {
-            assert(res);
-            assert(res.text == 'My name is Emad');
-            assert(Object.keys(res.intents).length == 1);
-            assert(res.intents.SpecifyName);
-            assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
-            assert(res.entities);
-            assert(res.entities.Name);
-            assert(res.entities.Name[0] === 'emad');
-            assert(res.entities.$instance);
-            assert(res.entities.$instance.Name);
-            assert(res.entities.$instance.Name[0].startIndex === 11);
-            assert(res.entities.$instance.Name[0].endIndex === 15);
-            assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
-        }, includeAllIntents, includeInstance, nullTelemetryClient, nullTelemetryProperties, logPersonalInformation);
+        TestJson(
+            'SingleIntent_SimplyEntityTelemetry.json',
+            (res) => {
+                assert(res);
+                assert(res.text == 'My name is Emad');
+                assert(Object.keys(res.intents).length == 1);
+                assert(res.intents.SpecifyName);
+                assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
+                assert(res.entities);
+                assert(res.entities.Name);
+                assert(res.entities.Name[0] === 'emad');
+                assert(res.entities.$instance);
+                assert(res.entities.$instance.Name);
+                assert(res.entities.$instance.Name[0].startIndex === 11);
+                assert(res.entities.$instance.Name[0].endIndex === 15);
+                assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
+            },
+            includeAllIntents,
+            includeInstance,
+            nullTelemetryClient,
+            nullTelemetryProperties,
+            logPersonalInformation
+        );
     });
 
     it('basic telemetry test.', () => {
@@ -652,7 +734,7 @@ describe('LuisRecognizer', function() {
                         assert(false);
                         break;
                 }
-            }
+            },
         };
 
         const includeAllIntents = false;
@@ -660,21 +742,29 @@ describe('LuisRecognizer', function() {
         const nullTelemetryProperties = null;
         const logPersonalInformation = true;
 
-        TestJson('SingleIntent_SimplyEntityTelemetry.json', (res) => {
-            assert(res);
-            assert(res.text == 'My name is Emad');
-            assert(Object.keys(res.intents).length == 1);
-            assert(res.intents.SpecifyName);
-            assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
-            assert(res.entities);
-            assert(res.entities.Name);
-            assert(res.entities.Name[0] === 'emad');
-            assert(res.entities.$instance);
-            assert(res.entities.$instance.Name);
-            assert(res.entities.$instance.Name[0].startIndex === 11);
-            assert(res.entities.$instance.Name[0].endIndex === 15);
-            assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
-        }, includeAllIntents, includeInstance, telemetryClient, nullTelemetryProperties, logPersonalInformation);
+        TestJson(
+            'SingleIntent_SimplyEntityTelemetry.json',
+            (res) => {
+                assert(res);
+                assert(res.text == 'My name is Emad');
+                assert(Object.keys(res.intents).length == 1);
+                assert(res.intents.SpecifyName);
+                assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
+                assert(res.entities);
+                assert(res.entities.Name);
+                assert(res.entities.Name[0] === 'emad');
+                assert(res.entities.$instance);
+                assert(res.entities.$instance.Name);
+                assert(res.entities.$instance.Name[0].startIndex === 11);
+                assert(res.entities.$instance.Name[0].endIndex === 15);
+                assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
+            },
+            includeAllIntents,
+            includeInstance,
+            telemetryClient,
+            nullTelemetryProperties,
+            logPersonalInformation
+        );
     });
 
     it('telemetry with multiple entity names returned.', () => {
@@ -704,7 +794,7 @@ describe('LuisRecognizer', function() {
                         assert(false);
                         break;
                 }
-            }
+            },
         };
 
         const includeAllIntents = true;
@@ -712,26 +802,34 @@ describe('LuisRecognizer', function() {
         const nullTelemetryProperties = null;
         const logPersonalInformation = true;
 
-        TestJson('MultipleIntents_ListEntityWithMultiValuesTelemetry.json', (res) => {
-            assert(res);
-            assert(res.text == 'I want to travel on DL');
-            assert(res.intents);
-            assert(res.intents.Travel);
-            assert(res.intents.Travel.score > 0 && res.intents.Travel.score <= 1);
-            assert(res.entities);
-            assert(res.entities.Airline[0]);
-            assert(res.entities.Airline[0].length == 2);
-            assert(res.entities.Airline[0].indexOf('Delta') > -1);
-            assert(res.entities.Airline[0].indexOf('Virgin') > -1);
-            assert(res.entities.$instance);
-            assert(res.entities.$instance.Airline);
-            assert(res.entities.$instance.Airline[0].startIndex);
-            assert(res.entities.$instance.Airline[0].startIndex === 20);
-            assert(res.entities.$instance.Airline[0].endIndex);
-            assert(res.entities.$instance.Airline[0].endIndex === 22);
-            assert(res.entities.$instance.Airline[0].text);
-            assert(res.entities.$instance.Airline[0].text === 'dl');
-        }, includeAllIntents, includeInstance, telemetryClient, nullTelemetryProperties, logPersonalInformation);
+        TestJson(
+            'MultipleIntents_ListEntityWithMultiValuesTelemetry.json',
+            (res) => {
+                assert(res);
+                assert(res.text == 'I want to travel on DL');
+                assert(res.intents);
+                assert(res.intents.Travel);
+                assert(res.intents.Travel.score > 0 && res.intents.Travel.score <= 1);
+                assert(res.entities);
+                assert(res.entities.Airline[0]);
+                assert(res.entities.Airline[0].length == 2);
+                assert(res.entities.Airline[0].indexOf('Delta') > -1);
+                assert(res.entities.Airline[0].indexOf('Virgin') > -1);
+                assert(res.entities.$instance);
+                assert(res.entities.$instance.Airline);
+                assert(res.entities.$instance.Airline[0].startIndex);
+                assert(res.entities.$instance.Airline[0].startIndex === 20);
+                assert(res.entities.$instance.Airline[0].endIndex);
+                assert(res.entities.$instance.Airline[0].endIndex === 22);
+                assert(res.entities.$instance.Airline[0].text);
+                assert(res.entities.$instance.Airline[0].text === 'dl');
+            },
+            includeAllIntents,
+            includeInstance,
+            telemetryClient,
+            nullTelemetryProperties,
+            logPersonalInformation
+        );
     });
 
     it('override telemetry properties on logging.', () => {
@@ -766,7 +864,7 @@ describe('LuisRecognizer', function() {
                         assert(false);
                         break;
                 }
-            }
+            },
         };
 
         const properties = {};
@@ -778,21 +876,29 @@ describe('LuisRecognizer', function() {
         const includeInstance = true;
         const logPersonalInformation = true;
 
-        TestJson('SingleIntent_SimplyEntityTelemetry.json', (res) => {
-            assert(res);
-            assert(res.text == 'My name is Emad');
-            assert(Object.keys(res.intents).length == 1);
-            assert(res.intents.SpecifyName);
-            assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
-            assert(res.entities);
-            assert(res.entities.Name);
-            assert(res.entities.Name[0] === 'emad');
-            assert(res.entities.$instance);
-            assert(res.entities.$instance.Name);
-            assert(res.entities.$instance.Name[0].startIndex === 11);
-            assert(res.entities.$instance.Name[0].endIndex === 15);
-            assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
-        }, includeAllIntents, includeInstance, telemetryClient, properties, logPersonalInformation);
+        TestJson(
+            'SingleIntent_SimplyEntityTelemetry.json',
+            (res) => {
+                assert(res);
+                assert(res.text == 'My name is Emad');
+                assert(Object.keys(res.intents).length == 1);
+                assert(res.intents.SpecifyName);
+                assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
+                assert(res.entities);
+                assert(res.entities.Name);
+                assert(res.entities.Name[0] === 'emad');
+                assert(res.entities.$instance);
+                assert(res.entities.$instance.Name);
+                assert(res.entities.$instance.Name[0].startIndex === 11);
+                assert(res.entities.$instance.Name[0].endIndex === 15);
+                assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
+            },
+            includeAllIntents,
+            includeInstance,
+            telemetryClient,
+            properties,
+            logPersonalInformation
+        );
     });
 
     it('override telemetry by deriving LuisRecognizer.', () => {
@@ -830,7 +936,7 @@ describe('LuisRecognizer', function() {
                         assert(false);
                         break;
                 }
-            }
+            },
         };
 
         const properties = {};
@@ -844,9 +950,17 @@ describe('LuisRecognizer', function() {
         var expected = GetExpected(expectedPath);
         var newPath = expectedPath + '.new';
         var context = new TestContext({ text: expected.text });
-        var recognizer = new TelemetryOverrideRecognizer({ applicationId: luisAppId, endpointKey: endpointKey },
-            { includeAllIntents: false, includeInstanceData: true, telemetryClient: telemetryClient, logPersonalInformation: true }, true);
-        recognizer.recognize(context, properties, metrics).then(res => {
+        var recognizer = new TelemetryOverrideRecognizer(
+            { applicationId: luisAppId, endpointKey: endpointKey },
+            {
+                includeAllIntents: false,
+                includeInstanceData: true,
+                telemetryClient: telemetryClient,
+                logPersonalInformation: true,
+            },
+            true
+        );
+        recognizer.recognize(context, properties, metrics).then((res) => {
             res.v2 = res.luisResult;
             delete res.luisResult;
             if (!WithinDelta(expected, res, 0.1, false)) {
@@ -854,7 +968,6 @@ describe('LuisRecognizer', function() {
                 assert(false, '\nReturned JSON\n  ' + newPath + '\n!= expected JSON\n  ' + expectedPath);
             }
         });
-
     });
 
     it('override telemetry by deriving LuisRecognizer and using fill.', () => {
@@ -895,7 +1008,7 @@ describe('LuisRecognizer', function() {
                         assert(false);
                         break;
                 }
-            }
+            },
         };
 
         var properties = {};
@@ -909,9 +1022,17 @@ describe('LuisRecognizer', function() {
         var expected = GetExpected(expectedPath);
         var newPath = expectedPath + '.new';
         var context = new TestContext({ text: expected.text });
-        var recognizer = new OverrideFillRecognizer({ applicationId: luisAppId, endpointKey: endpointKey },
-            { includeAllIntents: false, includeInstanceData: true, telemetryClient: telemetryClient, logPersonalInformation: true }, true);
-        recognizer.recognize(context, properties, metrics).then(res => {
+        var recognizer = new OverrideFillRecognizer(
+            { applicationId: luisAppId, endpointKey: endpointKey },
+            {
+                includeAllIntents: false,
+                includeInstanceData: true,
+                telemetryClient: telemetryClient,
+                logPersonalInformation: true,
+            },
+            true
+        );
+        recognizer.recognize(context, properties, metrics).then((res) => {
             res.v2 = res.luisResult;
             delete res.luisResult;
             if (!WithinDelta(expected, res, 0.1, false)) {
@@ -933,66 +1054,86 @@ describe('LuisRecognizer', function() {
         });
     });
 
-    it('should accept LuisPredictionOptions passed into recognizer "recognize" method', done => {
+    it('should accept LuisPredictionOptions passed into recognizer "recognize" method', (done) => {
         const luisPredictionDefaultOptions = {
             includeAllIntents: true,
-            includeInstanceData: true
+            includeInstanceData: true,
         };
         const luisPredictionUserOptions = {
             includeAllIntents: false,
-            includeInstanceData: false
+            includeInstanceData: false,
         };
-        const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, luisPredictionDefaultOptions, true);
-        const mergedOptions = luisPredictionUserOptions ? recognizer.setLuisPredictionOptions(recognizer.options, luisPredictionUserOptions) : recognizer.options;
+        const recognizer = new LuisRecognizer(
+            { applicationId: luisAppId, endpointKey: endpointKey },
+            luisPredictionDefaultOptions,
+            true
+        );
+        const mergedOptions = luisPredictionUserOptions
+            ? recognizer.setLuisPredictionOptions(recognizer.options, luisPredictionUserOptions)
+            : recognizer.options;
         assert(mergedOptions.includeAllIntents === false);
         assert(mergedOptions.includeInstanceData === false);
         throttle(done);
     });
 
-    it('should accept LuisRecognizerOptions passed into recognizer "recognize" method', done => {
+    it('should accept LuisRecognizerOptions passed into recognizer "recognize" method', (done) => {
         const luisPredictionDefaultOptions = {
             includeAllIntents: true,
             includeInstanceData: true,
-            apiVersion: 'v3'
+            apiVersion: 'v3',
         };
         const luisPredictionUserOptions = {
             includeAllIntents: false,
             includeInstanceData: false,
-            apiVersion: 'v3'
+            apiVersion: 'v3',
         };
-        const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, luisPredictionDefaultOptions, true);
+        const recognizer = new LuisRecognizer(
+            { applicationId: luisAppId, endpointKey: endpointKey },
+            luisPredictionDefaultOptions,
+            true
+        );
         const mergedOptions = recognizer.buildRecognizer(luisPredictionUserOptions);
         assert(mergedOptions.predictionOptions.includeAllIntents === false);
         assert(mergedOptions.predictionOptions.includeInstanceData === false);
         throttle(done);
     });
 
-    it('should accept LuisRecognizerOptions passed into recognizer "recognize" method. v3 to v2', done => {
+    it('should accept LuisRecognizerOptions passed into recognizer "recognize" method. v3 to v2', (done) => {
         const luisPredictionDefaultOptions = {
             includeAllIntents: true,
             includeInstanceData: true,
-            apiVersion: 'v3'
+            apiVersion: 'v3',
         };
         const luisPredictionUserOptions = {
             includeAllIntents: false,
             includeInstanceData: false,
-            apiVersion: 'v2'
+            apiVersion: 'v2',
         };
-        const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, luisPredictionDefaultOptions, true);
+        const recognizer = new LuisRecognizer(
+            { applicationId: luisAppId, endpointKey: endpointKey },
+            luisPredictionDefaultOptions,
+            true
+        );
         const mergedOptions = recognizer.buildRecognizer(luisPredictionUserOptions);
         assert(mergedOptions.options.includeAllIntents === false);
         assert(mergedOptions.options.includeInstanceData === false);
         throttle(done);
     });
 
-    it('should use default Luis prediction options if no user options passed in', done => {
+    it('should use default Luis prediction options if no user options passed in', (done) => {
         const luisPredictionDefaultOptions = {
             includeAllIntents: true,
-            includeInstanceData: true
+            includeInstanceData: true,
         };
         const luisPredictionUserOptions = null;
-        const recognizer = new LuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, luisPredictionDefaultOptions, true);
-        const mergedOptions = luisPredictionUserOptions ? recognizer.setLuisPredictionOptions(recognizer.options, luisPredictionUserOptions) : recognizer.options;
+        const recognizer = new LuisRecognizer(
+            { applicationId: luisAppId, endpointKey: endpointKey },
+            luisPredictionDefaultOptions,
+            true
+        );
+        const mergedOptions = luisPredictionUserOptions
+            ? recognizer.setLuisPredictionOptions(recognizer.options, luisPredictionUserOptions)
+            : recognizer.options;
         assert(mergedOptions.includeAllIntents === true);
         assert(mergedOptions.includeInstanceData === true);
         throttle(done);

--- a/libraries/botbuilder-ai/tests/luisRecognizer.test.js
+++ b/libraries/botbuilder-ai/tests/luisRecognizer.test.js
@@ -1,8 +1,11 @@
+/* eslint-disable security/detect-non-literal-fs-filename */
 const assert = require('assert');
 const fs = require('fs-extra');
 const nock = require('nock');
-const { TestAdapter, TurnContext } = require('botbuilder-core');
+const path = require('path');
 const { LuisRecognizer } = require('../');
+const { TestAdapter, TurnContext } = require('botbuilder-core');
+
 const luisAppId = '38330cad-f768-4619-96f9-69ea333e594b';
 
 // This can be any endpoint key for calling LUIS
@@ -44,8 +47,9 @@ class ThrowErrorRecognizer extends LuisRecognizer {
 class TelemetryOverrideRecognizer extends LuisRecognizer {
     async onRecognizerResults(recognizerResult, turnContext, properties, metrics) {
         if (!("'MyImportantProperty" in properties)) {
-            properties['MyImportantProperty'] = 'myImportantValue';
+            properties.MyImportantProperty = 'myImportantValue';
         }
+
         this.telemetryClient.trackEvent({
             name: 'LuisResult',
             properties: properties,
@@ -67,7 +71,7 @@ class OverrideFillRecognizer extends LuisRecognizer {
     async onRecognizerResults(recognizerResult, turnContext, properties, metrics) {
         var props = await this.fillTelemetryProperties(recognizerResult, turnContext, properties);
         if (!('MyImportantProperty' in props)) {
-            props['MyImportantProperty'] = 'myImportantValue';
+            props.MyImportantProperty = 'myImportantValue';
         }
 
         this.telemetryClient.trackEvent({
@@ -77,8 +81,9 @@ class OverrideFillRecognizer extends LuisRecognizer {
         });
 
         // Create second event
-        const secondProperties = {};
-        secondProperties['MyImportantProperty2'] = 'myImportantValue2';
+        const secondProperties = {
+            MyImportantProperty2: 'myImportantValue2',
+        };
 
         this.telemetryClient.trackEvent({
             name: 'MySecondEvent',
@@ -87,57 +92,59 @@ class OverrideFillRecognizer extends LuisRecognizer {
     }
 }
 
-function throttle(callback) {
-    if (mockLuis) {
-        callback();
-    } else {
-        // If actually calling LUIS, need to throttle our requests
-        setTimeout(callback, 1000);
-    }
+async function throttle() {
+    return new Promise((resolve) => {
+        return mockLuis ? resolve() : setTimeout(resolve, 1000);
+    });
 }
 
-function WithinDelta(token1, token2, delta, compare) {
-    var within = true;
-    if (token1 == null || token2 == null) {
-        within = token1 == token2;
-    } else if (Array.isArray(token1) && Array.isArray(token2)) {
-        within = token1.length == token2.length;
-        for (var i = 0; within && i < token1.length; ++i) {
-            within = WithinDelta(token1[i], token2[i], delta, compare);
+function isWithinDelta(left, right, delta, compare) {
+    let within = true;
+
+    if (left == null || right == null) {
+        within = left === right;
+    } else if (Array.isArray(left) && Array.isArray(right)) {
+        within = left.length === right.length;
+        for (let i = 0; within && i < left.length; i++) {
+            // eslint-disable-next-line security/detect-object-injection
+            within = isWithinDelta(left[i], right[i], delta, compare);
         }
-    } else if (typeof token1 === 'object' && typeof token2 === 'object') {
-        Object.keys(token2).forEach((k) => token2[k] === undefined && delete token2[k]);
-        within = Object.keys(token1).length === Object.keys(token2).length;
-        Object.keys(token1).forEach(function (key) {
-            if (!within) return;
-            within = WithinDelta(token1[key], token2[key], delta, compare || key === 'score' || key === 'intents');
+    } else if (typeof left === 'object' && typeof right === 'object') {
+        // eslint-disable-next-line security/detect-object-injection
+        within = Object.keys(left).length === Object.keys(right).length;
+
+        Object.keys(left).forEach((key) => {
+            // eslint-disable-next-line security/detect-object-injection
+            within = isWithinDelta(left[key], right[key], delta, compare || key === 'score' || key === 'intents');
         });
-    } else if (token1 !== token2) {
-        if (token1 !== undefined && token2 != undefined && token1.Type == token2.Type) {
+    } else if (left !== right) {
+        if (left && right && left.Type == right.Type) {
             within = false;
-            if (compare && typeof token1 === 'number' && typeof token2 === 'number') {
-                within = Math.abs(token1 - token2) < delta;
+            if (compare && typeof left === 'number' && typeof right === 'number') {
+                within = Math.abs(left - right) < delta;
             }
         } else {
             within = false;
         }
     }
+
     return within;
 }
 
-function ExpectedPath(file) {
-    return __dirname + '/TestData/LuisRecognizer/' + file;
+function getExpectedPath(file) {
+    return path.join(__dirname, 'TestData', 'LuisRecognizer', file);
 }
 
-function GetExpected(oracle) {
-    var expected = fs.readJSONSync(oracle);
+function getExpectedData(oracle) {
+    const expectedData = fs.readJSONSync(oracle);
 
-    var query = 'verbose=(true|false)&staging=false&spellCheck=false&log=true';
-    var path = `/luis/v2\\.0/apps/${luisAppId}`;
-    var pattern = `${path}\\?${query}`;
-    var uri = new RegExp(pattern);
-    var requestContent = expected.text != undefined ? `"${expected.text}"` : undefined;
-    var responseBody = expected.v2;
+    const query = 'verbose=(true|false)&staging=false&spellCheck=false&log=true';
+    const path = `/luis/v2\\.0/apps/${luisAppId}`;
+    const pattern = `${path}\\?${query}`;
+    // eslint-disable-next-line security/detect-non-literal-regexp
+    const uri = new RegExp(pattern);
+    const requestContent = expectedData.text != undefined ? `"${expectedData.text}"` : undefined;
+    const responseBody = expectedData.v2;
 
     if (mockLuis) {
         nock('https://westus.api.cognitive.microsoft.com')
@@ -146,10 +153,11 @@ function GetExpected(oracle) {
             .post(uri, requestContent)
             .reply(200, responseBody);
     }
-    return expected;
+
+    return expectedData;
 }
 
-function ReturnErrorStatusCode(code) {
+function returnStatusCode(code) {
     nock('https://westus.api.cognitive.microsoft.com').post(/apps/).reply(code);
 }
 
@@ -157,470 +165,455 @@ function ReturnErrorStatusCode(code) {
 // 1) Create a <name>.json file with an object { text:<query> } in it.
 // 2) Run this test sith mockLuis = false which will fail and generate a <name>.json.new file.
 // 3) Check the .new file and if correct, replace the original .json file with it.
-function TestJson(
+async function testJson(
     file,
-    done,
-    includeAllIntents,
-    includeInstance,
-    telemetryClient,
-    telemetryProperties,
-    telemetryMetrics,
-    logPersonalInformation
+    {
+        includeAllIntents = true,
+        includeInstanceData = true,
+        logPersonalInformation = true,
+        telemetryClient,
+        telemetryMetrics,
+        telemetryProperties,
+    } = {}
 ) {
-    if (includeAllIntents === undefined) includeAllIntents = true;
-    if (includeInstance === undefined) includeInstance = true;
-    if (logPersonalInformation === undefined) logPersonalInformation = true;
-    if (telemetryProperties === undefined) telemetryProperties = null;
-    var expectedPath = ExpectedPath(file);
-    var expected = GetExpected(expectedPath);
-    var newPath = expectedPath + '.new';
-    var context = new TestContext({ text: expected.text });
-    var recognizer = new LuisRecognizer(
-        { applicationId: luisAppId, endpointKey: endpointKey },
+    const expectedPath = getExpectedPath(file);
+    const expectedData = getExpectedData(expectedPath);
+    const newPath = expectedPath + '.new';
+
+    const context = new TestContext({ text: expectedData.text });
+
+    const recognizer = new LuisRecognizer(
+        { applicationId: luisAppId, endpointKey },
         {
-            includeAllIntents: includeAllIntents,
-            includeInstanceData: includeInstance,
-            telemetryClient: telemetryClient,
-            logPersonalInformation: logPersonalInformation,
+            includeAllIntents,
+            includeInstanceData,
+            logPersonalInformation,
+            telemetryClient,
         },
         true
     );
-    recognizer.recognize(context, telemetryProperties, telemetryMetrics).then((res) => {
-        res.v2 = res.luisResult;
-        delete res.luisResult;
-        if (!WithinDelta(expected, res, 0.1, false)) {
-            fs.outputJSONSync(newPath, res, { spaces: 2 });
-            assert(false, '\nReturned JSON\n  ' + newPath + '\n!= expected JSON\n  ' + expectedPath);
-        } else if (fs.existsSync(newPath)) {
-            fs.unlinkSync(newPath);
-        }
-        done(res);
-    });
+
+    const result = await recognizer.recognize(context, telemetryProperties, telemetryMetrics);
+
+    result.v2 = result.luisResult;
+    delete result.luisResult;
+
+    if (!isWithinDelta(expectedData, result, 0.1, false)) {
+        fs.outputJSONSync(newPath, result, { spaces: 2 });
+        assert.fail('\nReturned JSON\n  ' + newPath + '\n!= expected JSON\n  ' + getExpectedPath);
+    } else if (fs.existsSync(newPath)) {
+        fs.unlinkSync(newPath);
+    }
+
+    return result;
 }
 
-describe('LuisRecognizer', function () {
-    this.timeout(15000);
-
+describe('LuisRecognizer', () => {
     const recognizer = new LuisRecognizer(
         { applicationId: luisAppId, endpointKey: endpointKey },
         { includeAllIntents: true },
         true
     );
 
-    if (!mockLuis && endpointKey === 'MockedKey') {
-        console.warn(
-            'WARNING: skipping LuisRecognizer test suite because the LUISAPPKEY environment variable is not defined'
-        );
-        return;
-    }
+    const maybeIt = !mockLuis && endpointKey === 'MockedKey' ? it.skip : it;
 
-    it('test built-ins composite1', (done) => TestJson('Composite1.json', () => throttle(done)));
-    it('test built-ins composite2', (done) => TestJson('Composite2.json', () => throttle(done)));
-    it('test built-ins composite3', (done) => TestJson('Composite3.json', () => throttle(done)));
-    it('test built-ins prebuilt', (done) => TestJson('Prebuilt.json', () => throttle(done)));
-    it('test patterns', (done) => TestJson('Patterns.json', () => throttle(done)));
-    it('test roles', (done) => TestJson('roles.json', () => throttle(done)));
-    it('should return single intent and a simple entity', (done) => {
-        TestJson(
-            'SingleIntent_SimplyEntity.json',
-            (res) => {
-                assert(res);
-                assert(res.text == 'My name is Emad');
-                assert(Object.keys(res.intents).length == 1);
-                assert(res.intents.SpecifyName);
-                assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
-                assert(res.entities);
-                assert(res.entities.Name);
-                assert(res.entities.Name[0] === 'emad');
-                assert(res.entities.$instance);
-                assert(res.entities.$instance.Name);
-                assert(res.entities.$instance.Name[0].startIndex === 11);
-                assert(res.entities.$instance.Name[0].endIndex === 15);
-                assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
-                throttle(done);
-            },
-            false
+    beforeEach(() => {
+        nock.cleanAll();
+    });
+
+    afterEach(async () => {
+        nock.cleanAll();
+        await throttle();
+    });
+
+    maybeIt('test built-ins composite1', async () => {
+        await testJson('Composite1.json');
+    });
+
+    maybeIt('test built-ins composite2', async () => {
+        await testJson('Composite2.json');
+    });
+
+    maybeIt('test built-ins composite3', async () => {
+        await testJson('Composite3.json');
+    });
+
+    maybeIt('test built-ins prebuilt', async () => {
+        await testJson('Prebuilt.json');
+    });
+
+    maybeIt('test patterns', async () => {
+        await testJson('Patterns.json');
+    });
+
+    maybeIt('test roles', async () => {
+        await testJson('roles.json');
+    });
+
+    maybeIt('should return single intent and a simple entity', async () => {
+        const res = await testJson('SingleIntent_SimplyEntity.json', { includeAllIntents: false });
+
+        assert(res);
+        assert(res.text == 'My name is Emad');
+        assert(Object.keys(res.intents).length == 1);
+        assert(res.intents.SpecifyName);
+        assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
+        assert(res.entities);
+        assert(res.entities.Name);
+        assert(res.entities.Name[0] === 'emad');
+        assert(res.entities.$instance);
+        assert(res.entities.$instance.Name);
+        assert(res.entities.$instance.Name[0].startIndex === 11);
+        assert(res.entities.$instance.Name[0].endIndex === 15);
+        assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
+    });
+
+    maybeIt('should return multiple intents and prebuilt entities with a single value', async () => {
+        const res = await testJson('MultipleIntents_PrebuiltEntity.json', { includeAllIntents: false });
+
+        assert(res);
+        assert(res.text == 'Please deliver February 2nd 2001');
+        assert(res.intents);
+        assert(res.intents.Delivery);
+        assert(res.intents.Delivery.score > 0 && res.intents.Delivery.score <= 1);
+        assert(LuisRecognizer.topIntent(res) === 'Delivery');
+        assert(res.entities);
+        assert(res.entities.number);
+        assert(res.entities.number[0] === 2001);
+        assert(res.entities.datetime);
+        assert(res.entities.datetime[0].timex[0] === '2001-02-02');
+        assert(res.entities.$instance);
+        assert(res.entities.$instance.number);
+        assert(res.entities.$instance.number[0].startIndex === 28);
+        assert(res.entities.$instance.number[0].endIndex === 32);
+        assert(res.entities.$instance.number[0].text);
+        assert(res.entities.$instance.number[0].text === '2001');
+        assert(res.entities.$instance.datetime);
+        assert(res.entities.$instance.datetime[0].startIndex === 15);
+        assert(res.entities.$instance.datetime[0].endIndex === 32);
+        assert(res.entities.$instance.datetime[0].text);
+        assert(res.entities.$instance.datetime[0].text === 'february 2nd 2001');
+    });
+
+    maybeIt('should return multiple intents and prebuilt entities with multiple values', async () => {
+        const res = await testJson('MultipleIntents_PrebuiltEntitiesWithMultiValues.json', {
+            includeAllIntents: false,
+        });
+
+        assert(res);
+        assert(res.text == 'Please deliver February 2nd 2001 in room 201');
+        assert(res.intents);
+        assert(res.intents.Delivery);
+        assert(res.intents.Delivery.score > 0 && res.intents.Delivery.score <= 1);
+        assert(res.entities);
+        assert(res.entities.number);
+        assert(res.entities.number.length == 2);
+        assert(res.entities.number.indexOf(2001) > -1);
+        assert(res.entities.number.indexOf(201) > -1);
+        assert(res.entities.datetime);
+        assert(res.entities.datetime[0].timex[0] === '2001-02-02');
+    });
+
+    maybeIt('should return multiple intents and a list entity with a single value', async () => {
+        const res = await testJson('MultipleIntents_ListEntityWithSingleValue.json', { includeAllIntents: false });
+
+        assert(res);
+        assert(res.text == 'I want to travel on united');
+        assert(res.intents);
+        assert(res.intents.Travel);
+        assert(res.intents.Travel.score > 0 && res.intents.Travel.score <= 1);
+        assert(res.entities);
+        assert(res.entities.Airline);
+        assert(res.entities.Airline[0][0] === 'United');
+        assert(res.entities.$instance);
+        assert(res.entities.$instance.Airline);
+        assert(res.entities.$instance.Airline[0].startIndex);
+        assert(res.entities.$instance.Airline[0].startIndex === 20);
+        assert(res.entities.$instance.Airline[0].endIndex);
+        assert(res.entities.$instance.Airline[0].endIndex === 26);
+        assert(res.entities.$instance.Airline[0].text);
+        assert(res.entities.$instance.Airline[0].text === 'united');
+    });
+
+    maybeIt('should return multiple intents and a list entity with multiple values', async () => {
+        const res = await testJson('MultipleIntents_ListEntityWithMultiValues.json', { includeAllIntents: false });
+
+        assert(res);
+        assert(res.text == 'I want to travel on DL');
+        assert(res.intents);
+        assert(res.intents.Travel);
+        assert(res.intents.Travel.score > 0 && res.intents.Travel.score <= 1);
+        assert(res.entities);
+        assert(res.entities.Airline[0]);
+        assert(res.entities.Airline[0].length == 2);
+        assert(res.entities.Airline[0].indexOf('Delta') > -1);
+        assert(res.entities.Airline[0].indexOf('Virgin') > -1);
+        assert(res.entities.$instance);
+        assert(res.entities.$instance.Airline);
+        assert(res.entities.$instance.Airline[0].startIndex);
+        assert(res.entities.$instance.Airline[0].startIndex === 20);
+        assert(res.entities.$instance.Airline[0].endIndex);
+        assert(res.entities.$instance.Airline[0].endIndex === 22);
+        assert(res.entities.$instance.Airline[0].text);
+        assert(res.entities.$instance.Airline[0].text === 'dl');
+    });
+
+    maybeIt('should return multiple intents and a single composite entity', async () => {
+        const res = await testJson('MultipleIntents_CompositeEntityModel.json', { includeAllIntents: false });
+
+        assert(res);
+        assert(res.text == 'Please deliver it to 98033 WA');
+        assert(res.intents);
+        assert(res.intents.Delivery);
+        assert(res.intents.Delivery.score > 0 && res.intents.Delivery.score <= 1);
+        assert(res.entities);
+        assert(res.entities.number === undefined);
+        assert(res.entities.State === undefined);
+        assert(res.entities.Address);
+        assert(res.entities.Address[0].number[0] === 98033);
+        assert(res.entities.Address[0].State);
+        assert(res.entities.Address[0].State[0] === 'wa');
+        assert(res.entities.$instance);
+        assert(res.entities.$instance.number === undefined);
+        assert(res.entities.$instance.State === undefined);
+        assert(res.entities.$instance.Address);
+        assert(res.entities.$instance.Address[0].startIndex);
+        assert(res.entities.$instance.Address[0].startIndex === 21);
+        assert(res.entities.$instance.Address[0].endIndex);
+        assert(res.entities.$instance.Address[0].endIndex === 29);
+        assert(res.entities.$instance.Address[0].score);
+        assert(res.entities.$instance.Address[0].score > 0 && res.entities.$instance.Address[0].score <= 1);
+        assert(res.entities.Address[0].$instance.number);
+        assert(res.entities.Address[0].$instance.number[0].startIndex);
+        assert(res.entities.Address[0].$instance.number[0].startIndex === 21);
+        assert(res.entities.Address[0].$instance.number[0].endIndex);
+        assert(res.entities.Address[0].$instance.number[0].endIndex === 26);
+        assert(res.entities.Address[0].$instance.number[0].text);
+        assert(res.entities.Address[0].$instance.number[0].text === '98033');
+        assert(res.entities.Address[0].$instance.State);
+        assert(res.entities.Address[0].$instance.State[0].startIndex);
+        assert(res.entities.Address[0].$instance.State[0].startIndex === 27);
+        assert(res.entities.Address[0].$instance.State[0].endIndex);
+        assert(res.entities.Address[0].$instance.State[0].endIndex === 29);
+        assert(res.entities.Address[0].$instance.State[0].score);
+        assert(
+            res.entities.Address[0].$instance.State[0].score > 0 &&
+                res.entities.Address[0].$instance.State[0].score <= 1
         );
     });
 
-    it('should return multiple intents and prebuilt entities with a single value', (done) => {
-        TestJson(
-            'MultipleIntents_PrebuiltEntity.json',
-            (res) => {
-                assert(res);
-                assert(res.text == 'Please deliver February 2nd 2001');
-                assert(res.intents);
-                assert(res.intents.Delivery);
-                assert(res.intents.Delivery.score > 0 && res.intents.Delivery.score <= 1);
-                assert(LuisRecognizer.topIntent(res) === 'Delivery');
-                assert(res.entities);
-                assert(res.entities.number);
-                assert(res.entities.number[0] === 2001);
-                assert(res.entities.datetime);
-                assert(res.entities.datetime[0].timex[0] === '2001-02-02');
-                assert(res.entities.$instance);
-                assert(res.entities.$instance.number);
-                assert(res.entities.$instance.number[0].startIndex === 28);
-                assert(res.entities.$instance.number[0].endIndex === 32);
-                assert(res.entities.$instance.number[0].text);
-                assert(res.entities.$instance.number[0].text === '2001');
-                assert(res.entities.$instance.datetime);
-                assert(res.entities.$instance.datetime[0].startIndex === 15);
-                assert(res.entities.$instance.datetime[0].endIndex === 32);
-                assert(res.entities.$instance.datetime[0].text);
-                assert(res.entities.$instance.datetime[0].text === 'february 2nd 2001');
-                throttle(done);
-            },
-            false
-        );
-    });
+    maybeIt('should cache multiple calls to recognize()', async () => {
+        const expectedData = getExpectedData(getExpectedPath('SingleIntent_SimplyEntity.json'));
 
-    it('should return multiple intents and prebuilt entities with multiple values', (done) => {
-        TestJson(
-            'MultipleIntents_PrebuiltEntitiesWithMultiValues.json',
-            (res) => {
-                assert(res);
-                assert(res.text == 'Please deliver February 2nd 2001 in room 201');
-                assert(res.intents);
-                assert(res.intents.Delivery);
-                assert(res.intents.Delivery.score > 0 && res.intents.Delivery.score <= 1);
-                assert(res.entities);
-                assert(res.entities.number);
-                assert(res.entities.number.length == 2);
-                assert(res.entities.number.indexOf(2001) > -1);
-                assert(res.entities.number.indexOf(201) > -1);
-                assert(res.entities.datetime);
-                assert(res.entities.datetime[0].timex[0] === '2001-02-02');
-                throttle(done);
-            },
-            false
-        );
-    });
-
-    it('should return multiple intents and a list entity with a single value', (done) => {
-        TestJson(
-            'MultipleIntents_ListEntityWithSingleValue.json',
-            (res) => {
-                assert(res);
-                assert(res.text == 'I want to travel on united');
-                assert(res.intents);
-                assert(res.intents.Travel);
-                assert(res.intents.Travel.score > 0 && res.intents.Travel.score <= 1);
-                assert(res.entities);
-                assert(res.entities.Airline);
-                assert(res.entities.Airline[0][0] === 'United');
-                assert(res.entities.$instance);
-                assert(res.entities.$instance.Airline);
-                assert(res.entities.$instance.Airline[0].startIndex);
-                assert(res.entities.$instance.Airline[0].startIndex === 20);
-                assert(res.entities.$instance.Airline[0].endIndex);
-                assert(res.entities.$instance.Airline[0].endIndex === 26);
-                assert(res.entities.$instance.Airline[0].text);
-                assert(res.entities.$instance.Airline[0].text === 'united');
-                throttle(done);
-            },
-            false
-        );
-    });
-
-    it('should return multiple intents and a list entity with multiple values', (done) => {
-        TestJson(
-            'MultipleIntents_ListEntityWithMultiValues.json',
-            (res) => {
-                assert(res);
-                assert(res.text == 'I want to travel on DL');
-                assert(res.intents);
-                assert(res.intents.Travel);
-                assert(res.intents.Travel.score > 0 && res.intents.Travel.score <= 1);
-                assert(res.entities);
-                assert(res.entities.Airline[0]);
-                assert(res.entities.Airline[0].length == 2);
-                assert(res.entities.Airline[0].indexOf('Delta') > -1);
-                assert(res.entities.Airline[0].indexOf('Virgin') > -1);
-                assert(res.entities.$instance);
-                assert(res.entities.$instance.Airline);
-                assert(res.entities.$instance.Airline[0].startIndex);
-                assert(res.entities.$instance.Airline[0].startIndex === 20);
-                assert(res.entities.$instance.Airline[0].endIndex);
-                assert(res.entities.$instance.Airline[0].endIndex === 22);
-                assert(res.entities.$instance.Airline[0].text);
-                assert(res.entities.$instance.Airline[0].text === 'dl');
-                throttle(done);
-            },
-            false
-        );
-    });
-
-    it('should return multiple intents and a single composite entity', (done) => {
-        TestJson(
-            'MultipleIntents_CompositeEntityModel.json',
-            (res) => {
-                assert(res);
-                assert(res.text == 'Please deliver it to 98033 WA');
-                assert(res.intents);
-                assert(res.intents.Delivery);
-                assert(res.intents.Delivery.score > 0 && res.intents.Delivery.score <= 1);
-                assert(res.entities);
-                assert(res.entities.number === undefined);
-                assert(res.entities.State === undefined);
-                assert(res.entities.Address);
-                assert(res.entities.Address[0].number[0] === 98033);
-                assert(res.entities.Address[0].State);
-                assert(res.entities.Address[0].State[0] === 'wa');
-                assert(res.entities.$instance);
-                assert(res.entities.$instance.number === undefined);
-                assert(res.entities.$instance.State === undefined);
-                assert(res.entities.$instance.Address);
-                assert(res.entities.$instance.Address[0].startIndex);
-                assert(res.entities.$instance.Address[0].startIndex === 21);
-                assert(res.entities.$instance.Address[0].endIndex);
-                assert(res.entities.$instance.Address[0].endIndex === 29);
-                assert(res.entities.$instance.Address[0].score);
-                assert(res.entities.$instance.Address[0].score > 0 && res.entities.$instance.Address[0].score <= 1);
-                assert(res.entities.Address[0].$instance.number);
-                assert(res.entities.Address[0].$instance.number[0].startIndex);
-                assert(res.entities.Address[0].$instance.number[0].startIndex === 21);
-                assert(res.entities.Address[0].$instance.number[0].endIndex);
-                assert(res.entities.Address[0].$instance.number[0].endIndex === 26);
-                assert(res.entities.Address[0].$instance.number[0].text);
-                assert(res.entities.Address[0].$instance.number[0].text === '98033');
-                assert(res.entities.Address[0].$instance.State);
-                assert(res.entities.Address[0].$instance.State[0].startIndex);
-                assert(res.entities.Address[0].$instance.State[0].startIndex === 27);
-                assert(res.entities.Address[0].$instance.State[0].endIndex);
-                assert(res.entities.Address[0].$instance.State[0].endIndex === 29);
-                assert(res.entities.Address[0].$instance.State[0].score);
-                assert(
-                    res.entities.Address[0].$instance.State[0].score > 0 &&
-                        res.entities.Address[0].$instance.State[0].score <= 1
-                );
-                throttle(done);
-            },
-            false
-        );
-    });
-
-    it('should cache multiple calls to recognize()', (done) => {
-        var expected = GetExpected(ExpectedPath('SingleIntent_SimplyEntity.json'));
-        var recognizer = new LuisRecognizer(
+        const recognizer = new LuisRecognizer(
             { applicationId: luisAppId, endpointKey: endpointKey },
             { includeAllIntents: true, apiVersion: 'v2', includeAPIResults: true }
         );
-        var context = new TestContext({ text: expected.text });
-        recognizer.recognize(context).then((res) => {
-            assert(res);
-            res.text = 'cached';
-            recognizer.recognize(context).then((res) => {
-                assert(res);
-                assert(res.text === 'cached');
-                throttle(done);
-            });
-        }, false);
+
+        const context = new TestContext({ text: expectedData.text });
+
+        let res = await recognizer.recognize(context);
+        assert(res);
+
+        res.text = 'cached';
+        res = await recognizer.recognize(context);
+        assert(res);
+        assert(res.text === 'cached');
     });
 
-    it('should only return $instance metadata for entities if verbose flag set', (done) => {
-        TestJson(
-            'NoInstanceSimple.json',
-            (res) => {
-                assert(res);
-                assert(res.entities);
-                assert(res.entities.$instance === undefined);
-                throttle(done);
-            },
-            false,
-            false
-        );
+    maybeIt('should only return $instance metadata for entities if verbose flag set', async () => {
+        const res = await testJson('NoInstanceSimple.json', { includeAllIntents: false, includeInstanceData: false });
+
+        assert(res);
+        assert(res.entities);
+        assert(res.entities.$instance === undefined);
     });
 
-    it('should only return $instance metadata for composite entities if verbose flag set', (done) => {
-        TestJson(
-            'NoInstanceComposite.json',
-            (res) => {
-                assert(res);
-                assert(res.entities);
-                assert(res.entities.$instance === undefined);
-                throttle(done);
-            },
-            true,
-            false
-        );
+    maybeIt('should only return $instance metadata for composite entities if verbose flag set', async () => {
+        const res = await testJson('NoInstanceComposite.json', { includeInstanceData: false });
+
+        assert(res);
+        assert(res.entities);
+        assert(res.entities.$instance === undefined);
     });
 
-    it('should only return empty intent for empty text', (done) => {
-        TestJson('EmptyText.json', (res) => {
-            const top = LuisRecognizer.topIntent(res);
-            assert(top === 'None'); // topIntent() converts '' to 'None'
-            assert(Object.keys(res.intents).length == 1);
-            assert('' in res.intents);
-            throttle(done);
-        });
+    maybeIt('should only return empty intent for empty text', async () => {
+        const res = await testJson('EmptyText.json');
+
+        const top = LuisRecognizer.topIntent(res);
+
+        assert(top === 'None'); // topIntent() converts '' to 'None'
+        assert(Object.keys(res.intents).length == 1);
+        assert('' in res.intents);
     });
 
-    it('should return defaultIntent from topIntent() if results undefined', (done) => {
+    maybeIt('should return defaultIntent from topIntent() if results undefined', () => {
         const top = LuisRecognizer.topIntent(undefined);
         assert(top === 'None');
-        throttle(done);
     });
 
-    it('should return defaultIntent from topIntent() if intent scores below threshold', (done) => {
+    maybeIt('should return defaultIntent from topIntent() if intent scores below threshold', () => {
         const top = LuisRecognizer.topIntent({ intents: { TestIntent: 0.49 } }, 'None', 0.5);
         assert(top === 'None');
-        throttle(done);
     });
 
-    it('should emit trace info once per call to recognize', (done) => {
-        var expected = GetExpected(ExpectedPath('SingleIntent_SimplyEntity.json'));
-        var context = new TestContext({ text: expected.text });
-        recognizer
-            .recognize(context)
-            .then(() => {
-                return recognizer.recognize(context);
-            })
-            .then(() => {
-                return recognizer.recognize(context);
-            })
-            .then((res) => {
-                assert(res);
-                assert(res.text == expected.text);
-            })
-            .then(() => {
-                let luisTraceActivities = context.sent.filter((s) => s.type === 'trace' && s.name === 'LuisRecognizer');
-                assert(luisTraceActivities.length === 1);
-                let traceActivity = luisTraceActivities[0];
-                assert(traceActivity.type === 'trace');
-                assert(traceActivity.name === 'LuisRecognizer');
-                assert(traceActivity.label === 'Luis Trace');
-                assert(traceActivity.valueType === 'https://www.luis.ai/schemas/trace');
-                assert(traceActivity.value);
-                assert(traceActivity.value.luisResult);
-                assert(traceActivity.value.recognizerResult);
-                assert(traceActivity.value.luisOptions);
-                assert(traceActivity.value.luisModel);
-                throttle(done);
-            });
+    maybeIt('should emit trace info once per call to recognize', async () => {
+        const expectedData = getExpectedData(getExpectedPath('SingleIntent_SimplyEntity.json'));
+
+        const context = new TestContext({ text: expectedData.text });
+
+        await recognizer.recognize(context);
+        await recognizer.recognize(context);
+
+        const res = await recognizer.recognize(context);
+        assert(res);
+        assert(res.text === expectedData.text);
+
+        const traceActivity = context.sent.find((s) => s.type === 'trace' && s.name === 'LuisRecognizer');
+        assert(traceActivity);
+
+        assert(traceActivity.type === 'trace');
+        assert(traceActivity.name === 'LuisRecognizer');
+        assert(traceActivity.label === 'Luis Trace');
+        assert(traceActivity.valueType === 'https://www.luis.ai/schemas/trace');
+        assert(traceActivity.value);
+        assert(traceActivity.value.luisResult);
+        assert(traceActivity.value.recognizerResult);
+        assert(traceActivity.value.luisOptions);
+        assert(traceActivity.value.luisModel);
     });
 
-    it('should call prepareErrorMessage when a non-200 status code is received.', (done) => {
-        nock.cleanAll();
-        ReturnErrorStatusCode(400);
+    maybeIt('should call prepareErrorMessage when a non-200 status code is received.', async () => {
+        returnStatusCode(400);
+
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        try {
+            await recognizer.recognize(context);
+            assert.fail('should have thrown');
+        } catch (error) {
             const expectedError = `Response 400: The request's body or parameters are incorrect, meaning they are missing, malformed, or too large.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
-            nock.cleanAll();
-            throttle(done);
-        });
+        }
     });
 
-    it('should throw expected 401 error message.', (done) => {
-        nock.cleanAll();
-        ReturnErrorStatusCode(401);
+    maybeIt('should throw expected 401 error message.', async () => {
+        returnStatusCode(401);
+
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        try {
+            await recognizer.recognize(context);
+            assert.fail('should have thrown');
+        } catch (error) {
             const expectedError = `Response 401: The key used is invalid, malformed, empty, or doesn't match the region.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
-            nock.cleanAll();
-            throttle(done);
-        });
+        }
     });
 
-    it('should throw expected 403 error message.', (done) => {
-        nock.cleanAll();
-        ReturnErrorStatusCode(403);
+    maybeIt('should throw expected 403 error message.', async () => {
+        returnStatusCode(403);
+
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        try {
+            await recognizer.recognize(context);
+            assert.fail('should have thrown');
+        } catch (error) {
             const expectedError = `Response 403: Total monthly key quota limit exceeded.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
-            nock.cleanAll();
-            throttle(done);
-        });
+        }
     });
 
-    it('should throw expected 409 error message.', (done) => {
-        nock.cleanAll();
-        ReturnErrorStatusCode(409);
+    maybeIt('should throw expected 409 error message.', async () => {
+        returnStatusCode(409);
+
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        try {
+            await recognizer.recognize(context);
+            assert.fail('should have thrown');
+        } catch (error) {
             const expectedError = `Response 409: Application loading in progress, please try again.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
-            nock.cleanAll();
-            throttle(done);
-        });
+        }
     });
 
-    it('should throw expected 410 error message.', (done) => {
-        nock.cleanAll();
-        ReturnErrorStatusCode(410);
+    maybeIt('should throw expected 410 error message.', async () => {
+        returnStatusCode(410);
+
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        try {
+            await recognizer.recognize(context);
+            assert.fail('should have thrown');
+        } catch (error) {
             const expectedError = `Response 410: Please retrain and republish your application.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
-            nock.cleanAll();
-            throttle(done);
-        });
+        }
     });
 
-    it('should throw expected 414 error message.', (done) => {
-        nock.cleanAll();
-        ReturnErrorStatusCode(414);
+    maybeIt('should throw expected 414 error message.', async () => {
+        returnStatusCode(414);
+
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        try {
+            await recognizer.recognize(context);
+            assert.fail('should have thrown');
+        } catch (error) {
             const expectedError = `Response 414: The query is too long. Please reduce the query length to 500 or less characters.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
-            nock.cleanAll();
-            throttle(done);
-        });
+        }
     });
 
-    it('should throw expected 429 error message.', (done) => {
-        nock.cleanAll();
-        ReturnErrorStatusCode(429);
+    maybeIt('should throw expected 429 error message.', async () => {
+        returnStatusCode(429);
+
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        try {
+            await recognizer.recognize(context);
+            assert.fail('should have thrown');
+        } catch (error) {
             const expectedError = `Response 429: Too many requests.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
-            nock.cleanAll();
-            throttle(done);
-        });
+        }
     });
 
-    it('should throw unexpected error message with correct status code.', (done) => {
-        nock.cleanAll();
+    maybeIt('should throw unexpected error message with correct status code.', async () => {
         const statusCode = 404;
-        ReturnErrorStatusCode(statusCode);
+        returnStatusCode(statusCode);
+
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
+        try {
+            await recognizer.recognize(context);
+            assert.fail('should have thrown');
+        } catch (error) {
             const expectedError = `Response ${statusCode}: Unexpected status code received. Please verify that your LUIS application is properly setup.`;
             assert(error.message === expectedError, `unexpected error message thrown.`);
-            nock.cleanAll();
-            throttle(done);
-        });
+        }
     });
 
-    it('.prepareErrorMessage() should not change `error.message` if `error.response.statusCode` does not exist.', (done) => {
-        const recognizer = new ThrowErrorRecognizer();
-        const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).catch((error) => {
-            const expectedError = 'Test';
-            assert(error.message === expectedError, `unexpected error message thrown.`);
-            throttle(done);
-        });
-    });
+    maybeIt(
+        '.prepareErrorMessage() should not change `error.message` if `error.response.statusCode` does not exist.',
+        async () => {
+            const recognizer = new ThrowErrorRecognizer();
+            const context = new TestContext({ text: 'Hello world!' });
+            try {
+                await recognizer.recognize(context);
+                assert.fail('should have thrown');
+            } catch (error) {
+                const expectedError = 'Test';
+                assert(error.message === expectedError, `unexpected error message thrown.`);
+            }
+        }
+    );
 
-    it('should send user-agent header.', (done) => {
-        nock.cleanAll();
+    maybeIt('should send user-agent header.', async () => {
         nock('https://westus.api.cognitive.microsoft.com')
             .matchHeader('User-Agent', /botbuilder-ai\/4.*/)
             .post(/apps/)
             .reply(200, { query: null, intents: [], entities: [] });
+
         const context = new TestContext({ text: 'Hello world!' });
-        recognizer.recognize(context).then(() => {
-            nock.cleanAll();
-            throttle(done);
-        });
+        await recognizer.recognize(context);
     });
 
-    it('should successfully construct with valid endpoint.', () => {
+    maybeIt('should successfully construct with valid endpoint.', () => {
         // Note this is NOT a real LUIS application ID nor a real LUIS subscription-key.
         // These are GUIDs edited to look right to the parsing and validation code.
         const mockedEndpoint =
@@ -633,23 +626,23 @@ describe('LuisRecognizer', function () {
         assert(recognizer.application.endpoint === 'https://westus.api.cognitive.microsoft.com');
     });
 
-    it('should throw an error when parsing application endpoint with no subscription-key.', () => {
+    maybeIt('should throw an error when parsing application endpoint with no subscription-key.', () => {
         const endpointWithNoSubscriptionKey =
             'https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/b31aeaf3-3511-495b-a07f-571fc873214b?verbose=true&timezoneOffset=-360&q=';
         const expectedSubscriptionKey = undefined;
         try {
             new LuisRecognizer(endpointWithNoSubscriptionKey);
-            assert(false, 'should have thrown an error.');
+            assert.fail('should have thrown');
         } catch (e) {
-            assert(
-                e.message ===
-                    `Invalid \`endpointKey\` value detected: ${expectedSubscriptionKey}\nPlease make sure your endpointKey is a valid LUIS Endpoint Key, e.g. "048ec46dc58e495482b0c447cfdbd291".`
+            assert.strictEqual(
+                e.message,
+                `Invalid \`endpointKey\` value detected: ${expectedSubscriptionKey}\nPlease make sure your endpointKey is a valid LUIS Endpoint Key, e.g. "048ec46dc58e495482b0c447cfdbd291".`
             );
         }
     });
 
     const expectedApplicationId = undefined;
-    it('should throw an error when parsing application endpoint with no application ID.', () => {
+    maybeIt('should throw an error when parsing application endpoint with no application ID.', () => {
         const endpointWithNoAppId =
             'https://westus.api.cognitive.microsoft.com?verbose=true&timezoneOffset=-360&subscription-key=048ec46dc58e495482b0c447cfdbd291&q=';
         try {
@@ -663,7 +656,7 @@ describe('LuisRecognizer', function () {
         }
     });
 
-    it('should throw an error when parsing non-URL value.', () => {
+    maybeIt('should throw an error when parsing non-URL value.', () => {
         try {
             new LuisRecognizer('this.is.not.a.url');
             assert(false, 'should have thrown an error.');
@@ -675,41 +668,29 @@ describe('LuisRecognizer', function () {
         }
     });
 
-    it('null telemetryClient should work.', () => {
-        const includeAllIntents = false;
-        const includeInstance = true;
-        const nullTelemetryClient = null;
-        const nullTelemetryProperties = null;
-        const logPersonalInformation = true;
+    maybeIt('null telemetryClient should work.', async () => {
+        const res = await testJson('SingleIntent_SimplyEntityTelemetry.json', {
+            includeAllIntents: false,
+        });
 
-        TestJson(
-            'SingleIntent_SimplyEntityTelemetry.json',
-            (res) => {
-                assert(res);
-                assert(res.text == 'My name is Emad');
-                assert(Object.keys(res.intents).length == 1);
-                assert(res.intents.SpecifyName);
-                assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
-                assert(res.entities);
-                assert(res.entities.Name);
-                assert(res.entities.Name[0] === 'emad');
-                assert(res.entities.$instance);
-                assert(res.entities.$instance.Name);
-                assert(res.entities.$instance.Name[0].startIndex === 11);
-                assert(res.entities.$instance.Name[0].endIndex === 15);
-                assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
-            },
-            includeAllIntents,
-            includeInstance,
-            nullTelemetryClient,
-            nullTelemetryProperties,
-            logPersonalInformation
-        );
+        assert(res);
+        assert(res.text == 'My name is Emad');
+        assert(Object.keys(res.intents).length == 1);
+        assert(res.intents.SpecifyName);
+        assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
+        assert(res.entities);
+        assert(res.entities.Name);
+        assert(res.entities.Name[0] === 'emad');
+        assert(res.entities.$instance);
+        assert(res.entities.$instance.Name);
+        assert(res.entities.$instance.Name[0].startIndex === 11);
+        assert(res.entities.$instance.Name[0].endIndex === 15);
+        assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
     });
 
-    it('basic telemetry test.', () => {
-        var callCount = 0;
-        var telemetryClient = {
+    maybeIt('basic telemetry test.', async () => {
+        let callCount = 0;
+        const telemetryClient = {
             trackEvent: (telemetry) => {
                 assert(telemetry, 'telemetry is null');
                 switch (++callCount) {
@@ -737,39 +718,29 @@ describe('LuisRecognizer', function () {
             },
         };
 
-        const includeAllIntents = false;
-        const includeInstance = false;
-        const nullTelemetryProperties = null;
-        const logPersonalInformation = true;
-
-        TestJson(
-            'SingleIntent_SimplyEntityTelemetry.json',
-            (res) => {
-                assert(res);
-                assert(res.text == 'My name is Emad');
-                assert(Object.keys(res.intents).length == 1);
-                assert(res.intents.SpecifyName);
-                assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
-                assert(res.entities);
-                assert(res.entities.Name);
-                assert(res.entities.Name[0] === 'emad');
-                assert(res.entities.$instance);
-                assert(res.entities.$instance.Name);
-                assert(res.entities.$instance.Name[0].startIndex === 11);
-                assert(res.entities.$instance.Name[0].endIndex === 15);
-                assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
-            },
-            includeAllIntents,
-            includeInstance,
+        const res = await testJson('SingleIntent_SimplyEntityTelemetry.json', {
+            includeAllIntents: false,
             telemetryClient,
-            nullTelemetryProperties,
-            logPersonalInformation
-        );
+        });
+
+        assert(res);
+        assert(res.text == 'My name is Emad');
+        assert(Object.keys(res.intents).length == 1);
+        assert(res.intents.SpecifyName);
+        assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
+        assert(res.entities);
+        assert(res.entities.Name);
+        assert(res.entities.Name[0] === 'emad');
+        assert(res.entities.$instance);
+        assert(res.entities.$instance.Name);
+        assert(res.entities.$instance.Name[0].startIndex === 11);
+        assert(res.entities.$instance.Name[0].endIndex === 15);
+        assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
     });
 
-    it('telemetry with multiple entity names returned.', () => {
-        var callCount = 0;
-        var telemetryClient = {
+    maybeIt('telemetry with multiple entity names returned.', async () => {
+        let callCount = 0;
+        const telemetryClient = {
             trackEvent: (telemetry) => {
                 assert(telemetry, 'telemetry is null');
                 switch (++callCount) {
@@ -797,44 +768,31 @@ describe('LuisRecognizer', function () {
             },
         };
 
-        const includeAllIntents = true;
-        const includeInstance = true;
-        const nullTelemetryProperties = null;
-        const logPersonalInformation = true;
+        const res = await testJson('MultipleIntents_ListEntityWithMultiValuesTelemetry.json', { telemetryClient });
 
-        TestJson(
-            'MultipleIntents_ListEntityWithMultiValuesTelemetry.json',
-            (res) => {
-                assert(res);
-                assert(res.text == 'I want to travel on DL');
-                assert(res.intents);
-                assert(res.intents.Travel);
-                assert(res.intents.Travel.score > 0 && res.intents.Travel.score <= 1);
-                assert(res.entities);
-                assert(res.entities.Airline[0]);
-                assert(res.entities.Airline[0].length == 2);
-                assert(res.entities.Airline[0].indexOf('Delta') > -1);
-                assert(res.entities.Airline[0].indexOf('Virgin') > -1);
-                assert(res.entities.$instance);
-                assert(res.entities.$instance.Airline);
-                assert(res.entities.$instance.Airline[0].startIndex);
-                assert(res.entities.$instance.Airline[0].startIndex === 20);
-                assert(res.entities.$instance.Airline[0].endIndex);
-                assert(res.entities.$instance.Airline[0].endIndex === 22);
-                assert(res.entities.$instance.Airline[0].text);
-                assert(res.entities.$instance.Airline[0].text === 'dl');
-            },
-            includeAllIntents,
-            includeInstance,
-            telemetryClient,
-            nullTelemetryProperties,
-            logPersonalInformation
-        );
+        assert(res);
+        assert(res.text == 'I want to travel on DL');
+        assert(res.intents);
+        assert(res.intents.Travel);
+        assert(res.intents.Travel.score > 0 && res.intents.Travel.score <= 1);
+        assert(res.entities);
+        assert(res.entities.Airline[0]);
+        assert(res.entities.Airline[0].length == 2);
+        assert(res.entities.Airline[0].indexOf('Delta') > -1);
+        assert(res.entities.Airline[0].indexOf('Virgin') > -1);
+        assert(res.entities.$instance);
+        assert(res.entities.$instance.Airline);
+        assert(res.entities.$instance.Airline[0].startIndex);
+        assert(res.entities.$instance.Airline[0].startIndex === 20);
+        assert(res.entities.$instance.Airline[0].endIndex);
+        assert(res.entities.$instance.Airline[0].endIndex === 22);
+        assert(res.entities.$instance.Airline[0].text);
+        assert(res.entities.$instance.Airline[0].text === 'dl');
     });
 
-    it('override telemetry properties on logging.', () => {
-        var callCount = 0;
-        var telemetryClient = {
+    maybeIt('override telemetry properties on logging.', async () => {
+        let callCount = 0;
+        const telemetryClient = {
             trackEvent: (telemetry) => {
                 assert(telemetry, 'telemetry is null');
                 switch (++callCount) {
@@ -867,43 +825,32 @@ describe('LuisRecognizer', function () {
             },
         };
 
-        const properties = {};
-        properties['test'] = 'testvalue';
-        properties['foo'] = 'foovalue';
-        properties['intent'] = 'MYINTENT';
+        const telemetryProperties = {
+            test: 'testvalue',
+            foo: 'foovalue',
+            intent: 'MYINTENT',
+        };
 
-        const includeAllIntents = true;
-        const includeInstance = true;
-        const logPersonalInformation = true;
+        const res = await testJson('SingleIntent_SimplyEntityTelemetry.json', { telemetryClient, telemetryProperties });
 
-        TestJson(
-            'SingleIntent_SimplyEntityTelemetry.json',
-            (res) => {
-                assert(res);
-                assert(res.text == 'My name is Emad');
-                assert(Object.keys(res.intents).length == 1);
-                assert(res.intents.SpecifyName);
-                assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
-                assert(res.entities);
-                assert(res.entities.Name);
-                assert(res.entities.Name[0] === 'emad');
-                assert(res.entities.$instance);
-                assert(res.entities.$instance.Name);
-                assert(res.entities.$instance.Name[0].startIndex === 11);
-                assert(res.entities.$instance.Name[0].endIndex === 15);
-                assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
-            },
-            includeAllIntents,
-            includeInstance,
-            telemetryClient,
-            properties,
-            logPersonalInformation
-        );
+        assert(res);
+        assert(res.text == 'My name is Emad');
+        assert(Object.keys(res.intents).length == 1);
+        assert(res.intents.SpecifyName);
+        assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
+        assert(res.entities);
+        assert(res.entities.Name);
+        assert(res.entities.Name[0] === 'emad');
+        assert(res.entities.$instance);
+        assert(res.entities.$instance.Name);
+        assert(res.entities.$instance.Name[0].startIndex === 11);
+        assert(res.entities.$instance.Name[0].endIndex === 15);
+        assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
     });
 
-    it('override telemetry by deriving LuisRecognizer.', () => {
-        var callCount = 0;
-        var telemetryClient = {
+    maybeIt('override telemetry by deriving LuisRecognizer.', async () => {
+        let callCount = 0;
+        const telemetryClient = {
             trackEvent: (telemetry) => {
                 assert(telemetry, 'telemetry is null');
                 switch (++callCount) {
@@ -917,7 +864,7 @@ describe('LuisRecognizer', function () {
                         assert('foo' in telemetry.properties);
                         assert(telemetry.properties['foo'] === 'foovalue');
                         assert('MyImportantProperty' in telemetry.properties);
-                        assert(telemetry.properties['MyImportantProperty'] === 'myImportantValue');
+                        assert(telemetry.properties.MyImportantProperty === 'myImportantValue');
 
                         break;
 
@@ -939,18 +886,23 @@ describe('LuisRecognizer', function () {
             },
         };
 
-        const properties = {};
-        properties['test'] = 'testvalue';
-        properties['foo'] = 'foovalue';
-        const metrics = {};
-        metrics['moo'] = 3.14159;
-        metrics['boo'] = 2.11;
+        const properties = {
+            test: 'testvalue',
+            foo: 'foovalue',
+        };
 
-        var expectedPath = ExpectedPath('SingleIntent_SimplyEntityTelemetry.json');
-        var expected = GetExpected(expectedPath);
-        var newPath = expectedPath + '.new';
-        var context = new TestContext({ text: expected.text });
-        var recognizer = new TelemetryOverrideRecognizer(
+        const metrics = {
+            moo: 3.14159,
+            boo: 2.11,
+        };
+
+        const expectedPath = getExpectedPath('SingleIntent_SimplyEntityTelemetry.json');
+        const expectedData = getExpectedData(expectedPath);
+        const newPath = expectedPath + '.new';
+
+        const context = new TestContext({ text: expectedData.text });
+
+        const recognizer = new TelemetryOverrideRecognizer(
             { applicationId: luisAppId, endpointKey: endpointKey },
             {
                 includeAllIntents: false,
@@ -960,19 +912,21 @@ describe('LuisRecognizer', function () {
             },
             true
         );
-        recognizer.recognize(context, properties, metrics).then((res) => {
-            res.v2 = res.luisResult;
-            delete res.luisResult;
-            if (!WithinDelta(expected, res, 0.1, false)) {
-                fs.outputJSONSync(newPath, res, { spaces: 2 });
-                assert(false, '\nReturned JSON\n  ' + newPath + '\n!= expected JSON\n  ' + expectedPath);
-            }
-        });
+
+        const res = await recognizer.recognize(context, properties, metrics);
+
+        res.v2 = res.luisResult;
+        delete res.luisResult;
+
+        if (!isWithinDelta(expectedData, res, 0.1, false)) {
+            fs.outputJSONSync(newPath, res, { spaces: 2 });
+            assert(false, '\nReturned JSON\n  ' + newPath + '\n!= expected JSON\n  ' + expectedPath);
+        }
     });
 
-    it('override telemetry by deriving LuisRecognizer and using fill.', () => {
-        var callCount = 0;
-        var telemetryClient = {
+    maybeIt('override telemetry by deriving LuisRecognizer and using fill.', async () => {
+        let callCount = 0;
+        const telemetryClient = {
             trackEvent: (telemetry) => {
                 assert(telemetry, 'telemetry is null');
                 switch (++callCount) {
@@ -982,7 +936,7 @@ describe('LuisRecognizer', function () {
                         assert(telemetry.name === 'LuisResult');
                         assert(telemetry.properties);
                         assert('MyImportantProperty' in telemetry.properties);
-                        assert(telemetry.properties['MyImportantProperty'] === 'myImportantValue');
+                        assert(telemetry.properties.MyImportantProperty === 'myImportantValue');
                         assert('test' in telemetry.properties);
                         assert(telemetry.properties['test'] === 'testvalue');
                         assert('foo' in telemetry.properties);
@@ -1011,18 +965,22 @@ describe('LuisRecognizer', function () {
             },
         };
 
-        var properties = {};
-        properties['test'] = 'testvalue';
-        properties['foo'] = 'foovalue';
-        var metrics = {};
-        metrics['moo'] = 3.14159;
-        metrics['boo'] = 2.11;
+        const properties = {
+            test: 'testvalue',
+            foo: 'foovalue',
+        };
 
-        var expectedPath = ExpectedPath('SingleIntent_SimplyEntityTelemetry.json');
-        var expected = GetExpected(expectedPath);
-        var newPath = expectedPath + '.new';
-        var context = new TestContext({ text: expected.text });
-        var recognizer = new OverrideFillRecognizer(
+        const metrics = {
+            moo: 3.14159,
+            boo: 2.11,
+        };
+
+        const expectedPath = getExpectedPath('SingleIntent_SimplyEntityTelemetry.json');
+        const expectedData = getExpectedData(expectedPath);
+        const newPath = expectedPath + '.new';
+
+        const context = new TestContext({ text: expectedData.text });
+        const recognizer = new OverrideFillRecognizer(
             { applicationId: luisAppId, endpointKey: endpointKey },
             {
                 includeAllIntents: false,
@@ -1032,29 +990,32 @@ describe('LuisRecognizer', function () {
             },
             true
         );
-        recognizer.recognize(context, properties, metrics).then((res) => {
-            res.v2 = res.luisResult;
-            delete res.luisResult;
-            if (!WithinDelta(expected, res, 0.1, false)) {
-                fs.outputJSONSync(newPath, res, { spaces: 2 });
-                assert(false, '\nReturned JSON\n  ' + newPath + '\n!= expected JSON\n  ' + expectedPath);
-            }
-            assert(res.text == 'My name is Emad');
-            assert(Object.keys(res.intents).length == 1);
-            assert(res.intents.SpecifyName);
-            assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
-            assert(res.entities);
-            assert(res.entities.Name);
-            assert(res.entities.Name[0] === 'emad');
-            assert(res.entities.$instance);
-            assert(res.entities.$instance.Name);
-            assert(res.entities.$instance.Name[0].startIndex === 11);
-            assert(res.entities.$instance.Name[0].endIndex === 15);
-            assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
-        });
+
+        const res = await recognizer.recognize(context, properties, metrics);
+
+        res.v2 = res.luisResult;
+        delete res.luisResult;
+
+        if (!isWithinDelta(expectedData, res, 0.1, false)) {
+            fs.outputJSONSync(newPath, res, { spaces: 2 });
+            assert(false, '\nReturned JSON\n  ' + newPath + '\n!= expected JSON\n  ' + expectedPath);
+        }
+
+        assert(res.text == 'My name is Emad');
+        assert(Object.keys(res.intents).length == 1);
+        assert(res.intents.SpecifyName);
+        assert(res.intents.SpecifyName.score > 0 && res.intents.SpecifyName.score <= 1);
+        assert(res.entities);
+        assert(res.entities.Name);
+        assert(res.entities.Name[0] === 'emad');
+        assert(res.entities.$instance);
+        assert(res.entities.$instance.Name);
+        assert(res.entities.$instance.Name[0].startIndex === 11);
+        assert(res.entities.$instance.Name[0].endIndex === 15);
+        assert(res.entities.$instance.Name[0].score > 0 && res.entities.$instance.Name[0].score <= 1);
     });
 
-    it('should accept LuisPredictionOptions passed into recognizer "recognize" method', (done) => {
+    maybeIt('should accept LuisPredictionOptions passed into recognizer "recognize" method', () => {
         const luisPredictionDefaultOptions = {
             includeAllIntents: true,
             includeInstanceData: true,
@@ -1073,10 +1034,9 @@ describe('LuisRecognizer', function () {
             : recognizer.options;
         assert(mergedOptions.includeAllIntents === false);
         assert(mergedOptions.includeInstanceData === false);
-        throttle(done);
     });
 
-    it('should accept LuisRecognizerOptions passed into recognizer "recognize" method', (done) => {
+    maybeIt('should accept LuisRecognizerOptions passed into recognizer "recognize" method', () => {
         const luisPredictionDefaultOptions = {
             includeAllIntents: true,
             includeInstanceData: true,
@@ -1095,10 +1055,9 @@ describe('LuisRecognizer', function () {
         const mergedOptions = recognizer.buildRecognizer(luisPredictionUserOptions);
         assert(mergedOptions.predictionOptions.includeAllIntents === false);
         assert(mergedOptions.predictionOptions.includeInstanceData === false);
-        throttle(done);
     });
 
-    it('should accept LuisRecognizerOptions passed into recognizer "recognize" method. v3 to v2', (done) => {
+    maybeIt('should accept LuisRecognizerOptions passed into recognizer "recognize" method. v3 to v2', () => {
         const luisPredictionDefaultOptions = {
             includeAllIntents: true,
             includeInstanceData: true,
@@ -1117,14 +1076,14 @@ describe('LuisRecognizer', function () {
         const mergedOptions = recognizer.buildRecognizer(luisPredictionUserOptions);
         assert(mergedOptions.options.includeAllIntents === false);
         assert(mergedOptions.options.includeInstanceData === false);
-        throttle(done);
     });
 
-    it('should use default Luis prediction options if no user options passed in', (done) => {
+    maybeIt('should use default Luis prediction options if no user options passed in', () => {
         const luisPredictionDefaultOptions = {
             includeAllIntents: true,
             includeInstanceData: true,
         };
+
         const luisPredictionUserOptions = null;
         const recognizer = new LuisRecognizer(
             { applicationId: luisAppId, endpointKey: endpointKey },
@@ -1134,8 +1093,8 @@ describe('LuisRecognizer', function () {
         const mergedOptions = luisPredictionUserOptions
             ? recognizer.setLuisPredictionOptions(recognizer.options, luisPredictionUserOptions)
             : recognizer.options;
+
         assert(mergedOptions.includeAllIntents === true);
         assert(mergedOptions.includeInstanceData === true);
-        throttle(done);
     });
 });


### PR DESCRIPTION
There were a few issues with this test -

1. Throttle code sprinkled unnecessarily throughout
2. Inconsistent promise rejection/async/done handling
3. Code style issues

This commit cleans up all these issues and ensures that TestJson
failures are properly logged as test failures rather than unhandled
promise rejections.

```
(node:2921) UnhandledPromiseRejectionWarning: AssertionError [ERR_ASSERTION]: 
Returned JSON
  /Users/runner/work/1/s/libraries/botbuilder-ai/tests/TestData/LuisRecognizer/SingleIntent_SimplyEntityTelemetry.json.new
!= expected JSON
  /Users/runner/work/1/s/libraries/botbuilder-ai/tests/TestData/LuisRecognizer/SingleIntent_SimplyEntityTelemetry.json
    at TestJson.recognizer.recognize.then.res (/Users/runner/work/1/s/libraries/botbuilder-ai/tests/luisRecognizer.test.js:179:13)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```