### PR TITLE
port: fix error caused by backtick in stringExpression and valueExpression

### DIFF
--- a/libraries/adaptive-expressions/src/expressionProperties/stringExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/stringExpression.ts
@@ -52,8 +52,8 @@ export class StringExpression extends ExpressionProperty<string> {
                 value = value.substr(1);
             }
 
-            // Initialize value
-            this.expressionText = `=\`${value.replace(/\\/g, '\\\\')}\``;
+            // keep the string as quoted expression, which will be literal unless string interpolation is used.
+            this.expressionText = `=\`${value.replace(/\\/g, '\\\\').replace('`', '\\`')}\``;
             return;
         }
     }

--- a/libraries/adaptive-expressions/src/expressionProperties/valueExpression.ts
+++ b/libraries/adaptive-expressions/src/expressionProperties/valueExpression.ts
@@ -47,7 +47,7 @@ export class ValueExpression extends ExpressionProperty<any> {
             }
 
             // keep the string as quoted expression, which will be literal unless string interpolation is used.
-            this.expressionText = `=\`${value.replace(/\\/g, '\\\\')}\``;
+            this.expressionText = `=\`${value.replace(/\\/g, '\\\\').replace('`', '\\`')}\``;
             return;
         }
 

--- a/libraries/adaptive-expressions/tests/expressionProperty.test.ts
+++ b/libraries/adaptive-expressions/tests/expressionProperty.test.ts
@@ -170,6 +170,15 @@ describe('expressionProperty tests', () => {
         str = new StringExpression('c:\test\test\test');
         result = str.getValue(data);
         assert.equal(result, 'c:\test\test\test');
+
+        // test backtick in stringExpression
+        str = new StringExpression('test `name');
+        result = str.getValue(data);
+        assert.strictEqual(result, 'test `name');
+
+        str = new StringExpression('test //`name');
+        result = str.getValue(data);
+        assert.strictEqual(result, 'test //`name');
     });
 
     it('ValueExpression', () => {
@@ -214,5 +223,14 @@ describe('expressionProperty tests', () => {
         val = new ValueExpression('c:\test\test\test');
         result = val.getValue(data);
         assert.equal(result, 'c:\test\test\test');
+
+        // test backtick in valueExpression
+        val = new ValueExpression('name `backtick');
+        result = val.getValue(data);
+        assert.strictEqual(result, 'name `backtick');
+
+        val = new ValueExpression('name \\`backtick');
+        result = val.getValue(data);
+        assert.strictEqual(result, 'name \\`backtick');
     });
 });

--- a/libraries/adaptive-expressions/tests/expressionProperty.test.ts
+++ b/libraries/adaptive-expressions/tests/expressionProperty.test.ts
@@ -179,6 +179,11 @@ describe('expressionProperty tests', () => {
         str = new StringExpression('test //`name');
         result = str.getValue(data);
         assert.strictEqual(result, 'test //`name');
+
+        // test new line
+        str = new StringExpression('[test](./test)\n*');
+        result = str.getValue(data);
+        assert.strictEqual(result, '[test](./test)\n*');
     });
 
     it('ValueExpression', () => {
@@ -232,5 +237,10 @@ describe('expressionProperty tests', () => {
         val = new ValueExpression('name \\`backtick');
         result = val.getValue(data);
         assert.strictEqual(result, 'name \\`backtick');
+
+        // test new line
+        val = new ValueExpression('[test](./test)\n*');
+        result = val.getValue(data);
+        assert.strictEqual(result, '[test](./test)\n*');
     });
 });


### PR DESCRIPTION
Fixes #2982 in `4.11`

Feature parity with .NET PR: https://github.com/microsoft/botbuilder-dotnet/pull/4847
