### PR TITLE
Cached lgm initialization in lg extension

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/src/languageGeneratorExtensions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languageGeneratorExtensions.ts
@@ -36,6 +36,11 @@ export const languagePolicyKey = Symbol('LanguagePolicy');
  * Extension methods for language generator.
  */
 export class LanguageGeneratorExtensions {
+    private static readonly _languageGeneratorManagers: Map<ResourceExplorer, LanguageGeneratorManager> = new Map<
+        ResourceExplorer,
+        LanguageGeneratorManager
+    >();
+
     /**
      * Register default LG file or a language generator as default language generator.
      * @param dialogManager The dialog manager to add language generator to.
@@ -56,7 +61,11 @@ export class LanguageGeneratorExtensions {
             }
         }
 
-        const languageGeneratorManager: LanguageGeneratorManager = new LanguageGeneratorManager(resourceExplorer);
+        let languageGeneratorManager: LanguageGeneratorManager = this._languageGeneratorManagers.get(resourceExplorer);
+        if (!languageGeneratorManager) {
+            languageGeneratorManager = new LanguageGeneratorManager(resourceExplorer);
+            this._languageGeneratorManagers.set(resourceExplorer, languageGeneratorManager);
+        }
 
         dialogManager.initialTurnState.set(languageGeneratorKey, languageGenerator);
         dialogManager.initialTurnState.set(languageGeneratorManagerKey, languageGeneratorManager);

--- a/libraries/botbuilder-dialogs-adaptive/src/languageGeneratorExtensions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languageGeneratorExtensions.ts
@@ -36,10 +36,7 @@ export const languagePolicyKey = Symbol('LanguagePolicy');
  * Extension methods for language generator.
  */
 export class LanguageGeneratorExtensions {
-    private static readonly _languageGeneratorManagers: Map<ResourceExplorer, LanguageGeneratorManager> = new Map<
-        ResourceExplorer,
-        LanguageGeneratorManager
-    >();
+    private static readonly _languageGeneratorManagers = new Map<ResourceExplorer, LanguageGeneratorManager>();
 
     /**
      * Register default LG file or a language generator as default language generator.
@@ -61,7 +58,7 @@ export class LanguageGeneratorExtensions {
             }
         }
 
-        let languageGeneratorManager: LanguageGeneratorManager = this._languageGeneratorManagers.get(resourceExplorer);
+        let languageGeneratorManager = this._languageGeneratorManagers.get(resourceExplorer);
         if (!languageGeneratorManager) {
             languageGeneratorManager = new LanguageGeneratorManager(resourceExplorer);
             this._languageGeneratorManagers.set(resourceExplorer, languageGeneratorManager);


### PR DESCRIPTION
Fixes #2988 

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Cached instances of `LanguageGeneratorManager` in `LanguageGeneratorExtensions` to avoid registering duplicated callbacks in resource explorer.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Cached lgm instance in LanguageGeneratorExtensions.useLanguageGenerator().
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->