### PR TITLE
fix: small execute script tweaks

### DIFF
--- a/libraries/botbuilder-repo-utils/src/execCmd.ts
+++ b/libraries/botbuilder-repo-utils/src/execCmd.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import * as R from 'remeda';
 import minimist from 'minimist';
 import path from 'path';
 import util from 'util';
-import { Package } from './package';
 import { DependencyResolver, collectWorkspacePackages } from './workspace';
+import { Package } from './package';
 import { exec } from 'child_process';
 import { failure, run, success } from './run';
 import { gitRoot } from './git';
@@ -15,6 +16,7 @@ const execp = util.promisify(exec);
 
 run(async () => {
     const { _: maybeCmd, ...flags } = minimist(process.argv.slice(2), {
+        '--': true,
         boolean: ['continue', 'noPrivate', 'silent'],
         default: { concurrency: '', npm: 'yarn' },
         string: ['concurrency', 'ignoreName', 'ignorePath', 'name', 'npm', 'script', 'path'],
@@ -23,10 +25,15 @@ run(async () => {
     // Resolve npm args from the command, `npm` requires the extra 'run' arg
     const npmArgs = flags.npm.trim() === 'npm' ? ['npm', 'run'] : [flags.npm.trim()];
 
-    // If we just have --script, simply invoke that with the npm program
-    const cmd = flags.script ? [...npmArgs, flags.script] : maybeCmd;
+    // To pass flags to the resolved command use '--' in the command line invocation
+    const maybeFlags: string[] = flags['--'] ?? [];
 
-    if (!cmd.length) {
+    // If we just have --script, simply invoke that with the npm program
+    const command = R.compact(
+        flags.script ? [...npmArgs, flags.script, ...maybeFlags] : [...maybeCmd, ...maybeFlags]
+    ).join(' ');
+
+    if (!command) {
         throw new Error('must provide a command to execute');
     }
 
@@ -64,18 +71,21 @@ run(async () => {
         await dependencyResolver.execute(async (workspace) => {
             console.log(`[${workspace.pkg.name}]: ${cmd.join(' ')}`);
 
-            const { stdout, stderr } = await execp(cmd.join(' '), {
+            let { stdout, stderr } = await execp(cmd.join(' '), {
                 cwd: path.dirname(workspace.absPath),
             });
 
+            stdout = stdout.trim();
+            stderr = stderr.trim();
+
             if (stderr) {
                 if (flags.continue) {
-                    console.error(`[${workspace.pkg.name}]: ${stderr.trim()}`);
+                    console.error(`[${workspace.pkg.name}]: ${stderr}`);
                 } else {
-                    throw new Error(`[${workspace.pkg.name}]: ${stderr.trim()}`);
+                    throw new Error(`[${workspace.pkg.name}]: ${stderr}`);
                 }
             } else if (!flags.silent) {
-                console.log(`[${workspace.pkg.name}]: ${stdout.trim()}`);
+                console.log(`[${workspace.pkg.name}]: ${stdout || 'done!'}`);
             }
         });
 

--- a/libraries/botbuilder-repo-utils/src/workspace.ts
+++ b/libraries/botbuilder-repo-utils/src/workspace.ts
@@ -30,7 +30,7 @@ export async function collectWorkspacePackages(
     workspaces: string[] = [],
     filters: Partial<Filters> = {}
 ): Promise<Array<Workspace>> {
-    let paths = await globby(workspaces.map((workspace) => path.join(repoRoot, workspace, 'package.json')));
+    const paths = await globby(workspaces.map((workspace) => path.join(repoRoot, workspace, 'package.json')));
 
     const maybeWorkspaces = await Promise.all(
         paths.map(


### PR DESCRIPTION
- Propagate flags to underlying command (i.e. `yarn execute lint -- --quiet`)
- Clean up error handling/logging and make `--continue` work
- Add `--stream` support