### PR TITLE
fix: add repoutils workflow script to glob pattern

### DIFF
--- a/.github/workflows/run-test-repoutils.yml
+++ b/.github/workflows/run-test-repoutils.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
     - 'libraries/botbuilder-repo-utils/**'
+    - '.github/workflows/run-test-repoutils.yml'
     branches: 
     - main
 


### PR DESCRIPTION
Missed this in https://github.com/microsoft/botbuilder-js/pull/3056