### PR TITLE
bug: Fix OrchestratorRecognizer null checks 

### DIFF
--- a/libraries/botbuilder-ai-orchestrator/package.json
+++ b/libraries/botbuilder-ai-orchestrator/package.json
@@ -34,6 +34,9 @@
     "botbuilder-dialogs-adaptive": "4.1.6",
     "read-text-file": "1.1.0"
   },
+  "devDependencies": {
+    "sinon": "^9.2.1"
+  },
   "scripts": {
     "build": "tsc -b",
     "build-docs": "typedoc --theme markdown --entryPoint botbuilder-ai-orchestrator --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\botbuilder-ai-orchestrator .\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK - Orchestrator\" --readme none",

--- a/libraries/botbuilder-ai-orchestrator/src/orchestratorAdaptiveRecognizer.ts
+++ b/libraries/botbuilder-ai-orchestrator/src/orchestratorAdaptiveRecognizer.ts
@@ -296,7 +296,7 @@ export class OrchestratorAdaptiveRecognizer extends Recognizer implements Orches
      * @private
      */
     private Initialize() {
-        if (OrchestratorAdaptiveRecognizer.orchestrator == null && this.resolver == null) {
+        if (OrchestratorAdaptiveRecognizer.orchestrator === null || this.resolver == null) {
             if (this._modelPath == null) {
                 throw new Error(`Missing "ModelPath" information.`);
             }

--- a/libraries/botbuilder-ai-orchestrator/tests/orchestratorAdaptiveRecognizer.test.js
+++ b/libraries/botbuilder-ai-orchestrator/tests/orchestratorAdaptiveRecognizer.test.js
@@ -13,9 +13,8 @@ const { NumberEntityRecognizer } = require('botbuilder-dialogs-adaptive');
 const sinon = require('sinon');
 
 describe('OrchestratorAdpativeRecognizer tests', function() {
-    it('Expect initialize is called when orchestrator obj is null', (done) => {
-        //if labelresolver is null, initialize() must be called
-        let result = [
+    it('Expect initialize is called when orchestrator obj is null', async () => {
+        const result = [
             {
                 score : 0.9,
                 label : {
@@ -23,44 +22,36 @@ describe('OrchestratorAdpativeRecognizer tests', function() {
                 }
             }
         ];
-        let mockResolver = new MockResolver(result);
-        let testPaths = "test";
+        const mockResolver = new MockResolver(result);
+        const testPaths = "test";
 
-        let rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, mockResolver);
+        const rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, mockResolver);
         OrchestratorAdaptiveRecognizer.orchestrator = null;
         rec.Initialize = sinon.fake();
 
-        let {dc, activity} = createTestDcAndActivity("hello");
-        rec.recognize(dc, activity)
-            .then(res => {
-                assert(res.text, "hello");
-                assert(res.intents.mockLabel.score, 0.9);
-                
-                done();
-            })
-            .catch(err => done(err))
+        const {dc, activity} = createTestDcAndActivity("hello");
+        const res = await rec.recognize(dc, activity);
 
+        assert(res.text, "hello");
+        assert(res.intents.mockLabel.score, 0.9);
         assert(rec.Initialize.calledOnce);
     });
 
-    it('Expect initialize is called when labelresolver is null', (done) => {
-        let testPaths = "test";
-        let rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, null);
+    it('Expect initialize is called when labelresolver is null', async () => {
+        const testPaths = "test";
+        const rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, null);
         OrchestratorAdaptiveRecognizer.orchestrator = null;
         
         rec.Initialize = sinon.fake();
         
-        let {dc, activity} = createTestDcAndActivity("hello");
-        rec.recognize(dc, activity)
-            .catch(err => {
-                done();
-            })
+        const {dc, activity} = createTestDcAndActivity("hello");
+        assert.rejects(async () => await rec.recognize(dc, activity));
         
         assert(rec.Initialize.calledOnce);
     });
 
-    it('Test intent recognition', (done) => {
-        let result = [
+    it('Test intent recognition', async () => {
+        const result = [
             {
                 score : 0.9,
                 label : {
@@ -68,24 +59,21 @@ describe('OrchestratorAdpativeRecognizer tests', function() {
                 }
             }
         ];
-        let mockResolver = new MockResolver(result);
-        let testPaths = "test";
-        let rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, mockResolver);
+        const mockResolver = new MockResolver(result);
+        const testPaths = "test";
+        const rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, mockResolver);
         OrchestratorAdaptiveRecognizer.orchestrator = "mock";
         rec.modelPath = new StringExpression(testPaths);
         rec.snapshotPath = new StringExpression(testPaths);
-        let {dc, activity} = createTestDcAndActivity("hello");
-        rec.recognize(dc, activity)
-            .then(res => {
-                assert(res.text, "hello");
-                assert(res.intents.mockLabel.score, 0.9);
-                done();
-            })
-            .catch(err => done(err))
+        const {dc, activity} = createTestDcAndActivity("hello");
+
+        const res = await rec.recognize(dc, activity)
+        assert(res.text, "hello");
+        assert(res.intents.mockLabel.score, 0.9);
     })
 
-    it('Test entity recognition', (done) => {
-        let result = [
+    it('Test entity recognition', async () => {
+        const result = [
             {
                 score : 0.9,
                 label : {
@@ -93,28 +81,25 @@ describe('OrchestratorAdpativeRecognizer tests', function() {
                 }
             }
         ];
-        let mockResolver = new MockResolver(result);
-        let testPaths = "test";
-        let rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, mockResolver);
+        const mockResolver = new MockResolver(result);
+        const testPaths = "test";
+        const rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, mockResolver);
         OrchestratorAdaptiveRecognizer.orchestrator = "mock";
         rec.modelPath = new StringExpression(testPaths);
         rec.snapshotPath = new StringExpression(testPaths);
         rec.entityRecognizers = [
             new NumberEntityRecognizer()
         ];
-        let {dc, activity} = createTestDcAndActivity("hello 123")
-        rec.recognize(dc, activity)
-            .then(res => {
-                assert(res.text, "hello 123");
-                assert(res.intents.mockLabel.score, 0.9);
-                assert(res.entities.number[0], "123");
-                done();
-            })
-            .catch(err => done(err))
+        const {dc, activity} = createTestDcAndActivity("hello 123")
+        
+        const res = await rec.recognize(dc, activity)
+        assert(res.text, "hello 123");
+        assert(res.intents.mockLabel.score, 0.9);
+        assert(res.entities.number[0], "123");
     })
 
-    it('Test ambiguous intent recognition', (done) => {
-        let result = [
+    it('Test ambiguous intent recognition', async () => {
+        const result = [
             {
                 score : 0.9,
                 label : {
@@ -134,32 +119,29 @@ describe('OrchestratorAdpativeRecognizer tests', function() {
                 }
             }
         ];
-        let mockResolver = new MockResolver(result);
-        let testPaths = "test";
-        let rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, mockResolver);
+        const mockResolver = new MockResolver(result);
+        const testPaths = "test";
+        const rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, mockResolver);
         rec.modelPath = new StringExpression(testPaths);
         rec.snapshotPath = new StringExpression(testPaths);
         rec.detectAmbiguousIntents = new BoolExpression(true);
         rec.disambiguationScoreThreshold = new NumberExpression(0.1);
-        let {dc, activity} = createTestDcAndActivity("hello")
-        rec.recognize(dc, activity)
-            .then(res => {
-                assert(res.intents.ChooseIntent.score, 1);
-                assert(res.candidates[0].intent, "mockLabel1");
-                assert(res.candidates[1].intent, "mockLabel2");
-                done();
-            })
-            .catch(err => done(err))
+        const {dc, activity} = createTestDcAndActivity("hello");
+
+        const res = await rec.recognize(dc, activity);
+        assert(res.intents.ChooseIntent.score, 1);
+        assert(res.candidates[0].intent, "mockLabel1");
+        assert(res.candidates[1].intent, "mockLabel2");
     })
 })
 
 const createTestDcAndActivity = function (message) {
-    let settings = new TestAdapterSettings('appId', 'password');
-    let adapter = new BotFrameworkAdapter(settings);
-    let activity = MessageFactory.text(message);
-    let turnContext = new TurnContext(adapter, activity);
+    const settings = new TestAdapterSettings('appId', 'password');
+    const adapter = new BotFrameworkAdapter(settings);
+    const activity = MessageFactory.text(message);
+    const turnContext = new TurnContext(adapter, activity);
     turnContext.sendTraceActivity = function() {}
-    let state = [{dialogStack: []}];
-    let dc = new DialogContext(new DialogSet(), turnContext, state);
+    const state = [{dialogStack: []}];
+    const dc = new DialogContext(new DialogSet(), turnContext, state);
     return {dc, activity};
 }

--- a/libraries/botbuilder-ai-orchestrator/tests/orchestratorAdaptiveRecognizer.test.js
+++ b/libraries/botbuilder-ai-orchestrator/tests/orchestratorAdaptiveRecognizer.test.js
@@ -44,7 +44,6 @@ describe('OrchestratorAdpativeRecognizer tests', function() {
     });
 
     it('Expect initialize is called when labelresolver is null', (done) => {
-        //if labelresolver is null, initialize() must be called        
         let testPaths = "test";
         let rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, null);
         OrchestratorAdaptiveRecognizer.orchestrator = null;

--- a/libraries/botbuilder-ai-orchestrator/tests/orchestratorAdaptiveRecognizer.test.js
+++ b/libraries/botbuilder-ai-orchestrator/tests/orchestratorAdaptiveRecognizer.test.js
@@ -10,8 +10,56 @@ const { TurnContext, MessageFactory } = require('botbuilder-core');
 const { BotFrameworkAdapter } = require('../../botbuilder/lib');
 const { StringExpression, BoolExpression, NumberExpression } = require('adaptive-expressions');
 const { NumberEntityRecognizer } = require('botbuilder-dialogs-adaptive');
+const sinon = require('sinon');
 
 describe('OrchestratorAdpativeRecognizer tests', function() {
+    it('Expect initialize is called when orchestrator obj is null', (done) => {
+        //if labelresolver is null, initialize() must be called
+        let result = [
+            {
+                score : 0.9,
+                label : {
+                    name : "mockLabel"
+                }
+            }
+        ];
+        let mockResolver = new MockResolver(result);
+        let testPaths = "test";
+
+        let rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, mockResolver);
+        OrchestratorAdaptiveRecognizer.orchestrator = null;
+        rec.Initialize = sinon.fake();
+
+        let {dc, activity} = createTestDcAndActivity("hello");
+        rec.recognize(dc, activity)
+            .then(res => {
+                assert(res.text, "hello");
+                assert(res.intents.mockLabel.score, 0.9);
+                
+                done();
+            })
+            .catch(err => done(err))
+
+        assert(rec.Initialize.calledOnce);
+    });
+
+    it('Expect initialize is called when labelresolver is null', (done) => {
+        //if labelresolver is null, initialize() must be called        
+        let testPaths = "test";
+        let rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, null);
+        OrchestratorAdaptiveRecognizer.orchestrator = null;
+        
+        rec.Initialize = sinon.fake();
+        
+        let {dc, activity} = createTestDcAndActivity("hello");
+        rec.recognize(dc, activity)
+            .catch(err => {
+                done();
+            })
+        
+        assert(rec.Initialize.calledOnce);
+    });
+
     it('Test intent recognition', (done) => {
         let result = [
             {
@@ -24,9 +72,10 @@ describe('OrchestratorAdpativeRecognizer tests', function() {
         let mockResolver = new MockResolver(result);
         let testPaths = "test";
         let rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, mockResolver);
+        OrchestratorAdaptiveRecognizer.orchestrator = "mock";
         rec.modelPath = new StringExpression(testPaths);
         rec.snapshotPath = new StringExpression(testPaths);
-        let {dc, activity} = createTestDcAndActivity("hello")
+        let {dc, activity} = createTestDcAndActivity("hello");
         rec.recognize(dc, activity)
             .then(res => {
                 assert(res.text, "hello");
@@ -48,6 +97,7 @@ describe('OrchestratorAdpativeRecognizer tests', function() {
         let mockResolver = new MockResolver(result);
         let testPaths = "test";
         let rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, mockResolver);
+        OrchestratorAdaptiveRecognizer.orchestrator = "mock";
         rec.modelPath = new StringExpression(testPaths);
         rec.snapshotPath = new StringExpression(testPaths);
         rec.entityRecognizers = [


### PR DESCRIPTION
Closes #3073 

## Description
Fix the Orchestrator null check on Initialize() to be consistent at lines 156 and 299

## Specific Changes
  - Change null check at line 299 to match line 156

## Testing
Unit tests added to catch cases where either the `orchestrator` or `labelResolver` objects are not initialized before `score` is called (would have failed this test before). 