### PR TITLE
Compute LG SourceRange based on content instead of parsed token

### DIFF
--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -409,6 +409,10 @@ export class Templates implements Iterable<Template> {
         if (updatedTemplates.toArray().length > 0) {
             const newTemplate = this.adjustSingleTemplateRange(updatedTemplates.toArray()[0], content);
             this.adjustRangeForAddTemplate(newTemplate, originalStartLine);
+
+            // adjust the previous range
+            this.items[this.items.length - 1].sourceRange.range.end.line = newTemplate.sourceRange.range.start.line - 1;
+
             this.items.push(newTemplate);
             new StaticChecker(this).check().forEach((u): number => this.diagnostics.push(u));
         }

--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -576,7 +576,7 @@ export class Templates implements Iterable<Template> {
 
     /**
      * @private
-     * Use content range replace the range from lexer.
+     * Compute LG SourceRange based on content instead of parsed token.
      * */
     private recomputeSourceRange(template: Template, content: string): Template {
         if (content != null) {

--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -366,7 +366,8 @@ export class Templates implements Iterable<Template> {
             this.appendDiagnosticWithOffset(updatedTemplates.diagnostics, originalStartLine);
 
             if (updatedTemplates.toArray().length > 0) {
-                const newTemplate = updatedTemplates.toArray()[0];
+                const newTemplate = this.adjustSingleTemplateRange(updatedTemplates.toArray()[0], content);
+
                 this.adjustRangeForUpdateTemplate(template, newTemplate);
                 new StaticChecker(this).check().forEach((u): number => this.diagnostics.push(u));
             }
@@ -406,7 +407,7 @@ export class Templates implements Iterable<Template> {
         this.appendDiagnosticWithOffset(updatedTemplates.diagnostics, originalStartLine);
 
         if (updatedTemplates.toArray().length > 0) {
-            const newTemplate = updatedTemplates.toArray()[0];
+            const newTemplate = this.adjustSingleTemplateRange(updatedTemplates.toArray()[0], content);
             this.adjustRangeForAddTemplate(newTemplate, originalStartLine);
             this.items.push(newTemplate);
             new StaticChecker(this).check().forEach((u): number => this.diagnostics.push(u));
@@ -565,6 +566,19 @@ export class Templates implements Iterable<Template> {
         });
 
         return destList.join(this.newLine);
+    }
+
+    /**
+     * @private
+     */
+    private adjustSingleTemplateRange(template: Template, content: string): Template {
+        if (content != null) {
+            const contentList: string[] = TemplateExtensions.readLine(content);
+            template.sourceRange.range.start.line = 1;
+            template.sourceRange.range.end.line = contentList.length;
+        }
+
+        return template;
     }
 
     /**

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -939,7 +939,7 @@ describe('LG', function () {
         assert.strictEqual(templates.diagnostics.length, 0);
         newTemplate = templates.toArray()[1];
         assert.strictEqual(newTemplate.sourceRange.range.start.line, 9);
-        assert.strictEqual(newTemplate.sourceRange.range.end.line, 12);
+        assert.strictEqual(newTemplate.sourceRange.range.end.line, 13);
     });
 
     it('TemplateCRUD_RepeatAdd', function () {

--- a/libraries/botbuilder-lg/tests/lg.test.js
+++ b/libraries/botbuilder-lg/tests/lg.test.js
@@ -923,7 +923,7 @@ describe('LG', function () {
         assert.strictEqual(newTemplate.parameters.length, 2);
         assert.strictEqual(newTemplate.body.replace(/\r\n/g, '\n'), '- new hi\n- #hi2\n');
         assert.strictEqual(newTemplate.sourceRange.range.start.line, 17);
-        assert.strictEqual(newTemplate.sourceRange.range.end.line, 19);
+        assert.strictEqual(newTemplate.sourceRange.range.end.line, 20);
 
         // delete a middle template
         templates.deleteTemplate('newtemplateName');
@@ -931,7 +931,7 @@ describe('LG', function () {
         assert.strictEqual(templates.diagnostics.length, 0);
         newTemplate = templates.toArray()[2];
         assert.strictEqual(newTemplate.sourceRange.range.start.line, 14);
-        assert.strictEqual(newTemplate.sourceRange.range.end.line, 16);
+        assert.strictEqual(newTemplate.sourceRange.range.end.line, 17);
 
         // delete a tailing template
         templates.deleteTemplate('newtemplateName2');
@@ -1043,6 +1043,30 @@ describe('LG', function () {
         // delete error message
         templates.deleteTemplate('newtemplateName');
         assert.strictEqual(templates.diagnostics.length, 0);
+    });
+
+    it('TemplateUpdate_With_Trailing_Newline', function () {
+        var filePath = GetExampleFilePath('CrudInit.lg');
+        const resource = new LGResource(filePath, filePath, fs.readFileSync(filePath, 'utf-8'));
+        var templates = Templates.parseResource(resource);
+
+        templates = templates.updateTemplate('template1', 'template1', undefined, '-Hi\r\n-Hello\r\n');
+        let firstTemplateRange = templates.toArray()[0].sourceRange.range;
+        assert.strictEqual(firstTemplateRange.start.line, 3);
+        assert.strictEqual(firstTemplateRange.end.line, 6);
+
+        let secondTemplateRange = templates.toArray()[1].sourceRange.range;
+        assert.strictEqual(secondTemplateRange.start.line, 7);
+        assert.strictEqual(secondTemplateRange.end.line, 10);
+
+        templates = templates.updateTemplate('template2', 'template2', undefined, '-Hi');
+        firstTemplateRange = templates.toArray()[0].sourceRange.range;
+        assert.strictEqual(firstTemplateRange.start.line, 3);
+        assert.strictEqual(firstTemplateRange.end.line, 6);
+
+        secondTemplateRange = templates.toArray()[1].sourceRange.range;
+        assert.strictEqual(secondTemplateRange.start.line, 7);
+        assert.strictEqual(secondTemplateRange.end.line, 8);
     });
 
     it('TestMemoryScope', function () {


### PR DESCRIPTION
Fixes #3076

### Root cause
Previously, the sourceRange(start and end line position) of a LG template is calculated based on the parsed token. But in certain scenarios that, when there are extra empty character (line breaks) at the end of a template, will cause this calculation not correct, and thus causing the further update on this lg file misplaced in the wrong position, causing potential data loss. 

### Fix
Use the real content received to calculate start\end line.  Content is the golden truth, more trustworthy than parsed tokens. 

### Impact
Composer