### PR TITLE
feat: create parity issue workflow

### DIFF
--- a/.github/workflows/create-parity-issue.yml
+++ b/.github/workflows/create-parity-issue.yml
@@ -1,0 +1,41 @@
+name: create-parity-issue.yml
+
+on:
+  workflow_dispatch:
+    inputs:
+      prDescription:
+        description: PR description
+        default: 'No description provided'
+        required: true
+      prNumber:
+        description: PR number
+        required: true
+      prTitle:
+        description: PR title
+        required: true
+      sourceRepo:
+        description: repository PR is sourced from
+        required: true
+
+jobs:
+  createIssue:
+    name: create issue
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: joshgummersall/create-issue@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: |
+            port: ${{ github.event.inputs.prTitle }} (#${{ github.event.inputs.prNumber }})
+          labels: |
+            ["parity"]
+          body: |
+             The changes in [${{ github.event.inputs.prTitle }} (#${{ github.event.inputs.prNumber }})](https://github.com/${{ github.event.inputs.sourceRepo }}/pull/${{ github.event.inputs.prNumber }}) may need to be ported to maintain parity with `${{ github.event.inputs.sourceRepo }}`.
+
+             > ${{ github.event.inputs.prDescription }}
+
+             Please review and, if necessary, port the changes.


### PR DESCRIPTION
This workflow will create a parity issue that includes a short summary
and a link to a pull request, along with the parity label, to keep us
honest!

It will trigger on manual dispatch - actions will need to be added to
other repos to trigger this workflow.
