### PR TITLE
fix package relative path

### DIFF
--- a/libraries/adaptive-expressions-ie11/babel.config.js
+++ b/libraries/adaptive-expressions-ie11/babel.config.js
@@ -25,5 +25,6 @@ module.exports = function (api) {
     return {
         presets,
         plugins,
+        compact: false,
     };
 };

--- a/libraries/adaptive-expressions-ie11/package.json
+++ b/libraries/adaptive-expressions-ie11/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "build:webpack": "webpack",
-    "build:copyfiles": "copyfiles -u 3 node_modules/adaptive-expressions/lib/**/*.d.ts dist",
+    "build:copyfiles": "copyfiles -u 3 ../adaptive-expressions/lib/**/*.d.ts dist",
     "build": "npm-run-all -p build:webpack build:copyfiles",
     "clean": "rimraf dist",
     "lint": "eslint . --ext .js,.ts"

--- a/libraries/adaptive-expressions-ie11/webpack.config.js
+++ b/libraries/adaptive-expressions-ie11/webpack.config.js
@@ -33,14 +33,14 @@ module.exports = () => {
                         },
                     ],
                     include: [
-                        path.resolve(__dirname, './node_modules/adaptive-expressions'),
+                        path.resolve(__dirname, '../adaptive-expressions'),
                         path.resolve(
                             __dirname,
-                            './node_modules/@microsoft/recognizers-text-data-types-timex-expression'
+                            '../../node_modules/@microsoft/recognizers-text-data-types-timex-expression'
                         ),
-                        path.resolve(__dirname, './node_modules/antlr4ts'),
-                        path.resolve(__dirname, './node_modules/lru-cache'),
-                        path.resolve(__dirname, './node_modules/yallist'),
+                        path.resolve(__dirname, '../../node_modules/antlr4ts'),
+                        path.resolve(__dirname, '../../node_modules/lru-cache'),
+                        path.resolve(__dirname, '../../node_modules/yallist'),
                     ],
                 },
             ],


### PR DESCRIPTION
Fixes 
The adaptive expression library was not passing through babel .

## Description
Fix the relative path of all libraries for it to be compiled with babel.

## Testing
Tested with adaptive card library by replacing the minfied bundle