### PR TITLE
Fix typo in botframework-connector README

### DIFF
--- a/libraries/botframework-connector/README.md
+++ b/libraries/botframework-connector/README.md
@@ -41,14 +41,14 @@ async function connectToSlack() {
         isGroup: false
     });
 
-    var acivityResponse = await client.conversations.sendToConversation(conversationResponse.id, {
+    var activityResponse = await client.conversations.sendToConversation(conversationResponse.id, {
         type: 'message',
         from: { id: botId },
         recipient: { id: recipientId },
         text: 'This a message from Bot Connector Client (NodeJS)'
     });
 
-    console.log('Sent reply with ActivityId:', acivityResponse.id);
+    console.log('Sent reply with ActivityId:', activityResponse.id);
 }
 ````
 


### PR DESCRIPTION
## Description
Noticed a spelling mistake in the README of the `botframework-connector`.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Updates variable `acivityResponse` to `activityResponse` in the example code. 

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->