### PR TITLE
feat: bump moment-related dependencies

### DIFF
--- a/libraries/adaptive-expressions/package.json
+++ b/libraries/adaptive-expressions/package.json
@@ -23,17 +23,16 @@
     "@microsoft/recognizers-text-data-types-timex-expression": "1.3.0",
     "@types/atob-lite": "^2.0.0",
     "@types/lru-cache": "^5.1.0",
-    "@types/moment-timezone": "^0.5.13",
     "@types/xmldom": "^0.1.29",
     "antlr4ts": "0.5.0-alpha.3",
     "atob-lite": "^2.0.0",
     "big-integer": "^1.6.48",
+    "d3-format": "^1.4.4",
     "jspath": "^0.4.0",
     "lodash": "^4.17.19",
     "lru-cache": "^5.1.1",
-    "moment": "^2.25.1",
-    "moment-timezone": "^0.5.28",
-    "d3-format": "^1.4.4"
+    "moment": "^2.29.1",
+    "moment-timezone": "^0.5.32"
   },
   "devDependencies": {
     "@types/jspath": "^0.4.0",

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -34,10 +34,9 @@
     "botframework-streaming": "4.1.6",
     "filenamify": "^4.1.0",
     "fs-extra": "^7.0.1",
-    "moment-timezone": "^0.5.28"
+    "moment-timezone": "^0.5.32"
   },
   "devDependencies": {
-    "@types/moment-timezone": "^0.5.13",
     "assert": "^1.4.1",
     "chatdown": "^1.0.2",
     "nock": "^11.9.1",

--- a/tools/package.json
+++ b/tools/package.json
@@ -33,7 +33,7 @@
     "botframework-connector": "4.1.6",
     "dotenv": "^4.0.0",
     "mime": "^1.4.1",
-    "moment": "^2.22.2",
+    "moment": "^2.29.1",
     "ms-rest": "^2.3.6",
     "ms-rest-azure": "^2.5.7",
     "request": "^2.88.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1498,13 +1498,6 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
 
-"@types/moment-timezone@^0.5.13":
-  version "0.5.30"
-  resolved "https://registry.yarnpkg.com/@types/moment-timezone/-/moment-timezone-0.5.30.tgz#340ed45fe3e715f4a011f5cfceb7cb52aad46fc7"
-  integrity sha512-aDVfCsjYnAQaV/E9Qc24C5Njx1CoDjXsEgkxtp9NyXDpYu4CCbmclb6QhWloS9UTU/8YROUEEdEkWI0D7DxnKg==
-  dependencies:
-    moment-timezone "*"
-
 "@types/node-fetch@^2.5.0", "@types/node-fetch@^2.5.3", "@types/node-fetch@^2.5.7":
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
@@ -8005,14 +7998,14 @@ mold-source-map@~0.4.0:
     convert-source-map "^1.1.0"
     through "~2.2.7"
 
-moment-timezone@*, moment-timezone@^0.5.28:
-  version "0.5.31"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.31.tgz#9c40d8c5026f0c7ab46eda3d63e49c155148de05"
-  integrity sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==
+moment-timezone@^0.5.32:
+  version "0.5.32"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.32.tgz#db7677cc3cc680fd30303ebd90b0da1ca0dfecc2"
+  integrity sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@^2.19.3, moment@^2.21.0, moment@^2.22.2, moment@^2.25.1, moment@^2.29.1:
+"moment@>= 2.9.0", moment@^2.19.3, moment@^2.21.0, moment@^2.22.2, moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
- bump `moment` and `moment-timezone` dependencies to latest.
- remove unnecessary `@types/moment-timezone`. (See https://www.npmjs.com/package/@types/moment-timezone)