### PR TITLE
fix: add tags to browser CI resource groups

### DIFF
--- a/libraries/browser-functional-tests/browser-tests-build-ci.yml
+++ b/libraries/browser-functional-tests/browser-tests-build-ci.yml
@@ -20,6 +20,13 @@ variables:
 
 steps:
 
+- powershell: |
+   # Create DateTimeTag for Resource Group
+   $DateTimeTag=Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ"
+   "##vso[task.setvariable variable=DateTimeTag]$DateTimeTag";
+  displayName: 'Create DateTimeTag for Resource Group'
+  # Get-Date on Azure DevOps returns a datetime relative to UTC-0, so "Z" is being used instead of the dynamic "K".
+
 - task: NodeTool@0
   displayName: use node 12.x
   inputs:
@@ -44,7 +51,7 @@ steps:
     scriptLocation: inlineScript
     inlineScript: |
      echo "# Create resource group"
-     call az group create -l westus -n "$(TestResourceGroup)"
+     call az group create -l westus -n "$(TestResourceGroup)" --tags buildName="$(Build.DefinitionName)" cause=automation date="$(DateTimeTag)" product="$(Build.Repository.Name)" sourceBranch="$(Build.SourceBranch)"
      
      echo "# Create app service plan"
      call az appservice plan create -g "$(TestResourceGroup)" -n "$(TestAppServicePlan)" --number-of-workers 4 --sku S1


### PR DESCRIPTION
## Description
Adds tags to the provisioned Azure Resource Group for automated management of RGs.

These tags indicate when and why the Resource Group was created. They also provide pointers to the repository, the source branch and name of the pipeline that was run to better assist other team members with figuring out who to contact.

## Specific Changes
- Add tags to `az group create` step
- Create `$DateTimeTag` runtime variable in Azure DevOps
  - A REST call is required to get the actual pipeline queue time, which didn't seem necessary for the goals of this PR.