### PR TITLE
feat: cycle references support

### DIFF
--- a/libraries/botbuilder-dialogs-declarative/tests/resources/CycleDetection/child.dialog
+++ b/libraries/botbuilder-dialogs-declarative/tests/resources/CycleDetection/child.dialog
@@ -1,0 +1,19 @@
+{
+    "$schema": "../../testbot.schema",
+    "$kind": "Microsoft.AdaptiveDialog",
+    "triggers": [
+        {
+            "$kind": "Microsoft.OnBeginDialog",
+            "actions": [
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "World"
+                },
+                {
+                    "$kind": "Microsoft.EndTurn"
+                },
+                "root"
+            ]
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-declarative/tests/resources/CycleDetection/root.dialog
+++ b/libraries/botbuilder-dialogs-declarative/tests/resources/CycleDetection/root.dialog
@@ -1,0 +1,19 @@
+{
+    "$schema": "../../testbot.schema",
+    "$kind": "Microsoft.AdaptiveDialog",
+    "triggers": [
+        {
+            "$kind": "Microsoft.OnBeginDialog",
+            "actions": [
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "Hello"
+                },
+                {
+                    "$kind": "Microsoft.EndTurn"
+                },
+                "child"
+            ]
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs/src/dialogContainer.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContainer.ts
@@ -96,8 +96,10 @@ export abstract class DialogContainer<O extends object = {}> extends Dialog<O> {
      * Future dialogs added to the component will also inherit this client.
      */
     public set telemetryClient(client: BotTelemetryClient) {
-        this._telemetryClient = client ? client : new NullTelemetryClient();
-        this.dialogs.telemetryClient = client;
+        this._telemetryClient = client ?? new NullTelemetryClient();
+        if (this.dialogs.telemetryClient !== this._telemetryClient) {
+            this.dialogs.telemetryClient = this._telemetryClient;
+        }
     }
 
     /**

--- a/libraries/botbuilder-dialogs/src/dialogManager.ts
+++ b/libraries/botbuilder-dialogs/src/dialogManager.ts
@@ -339,15 +339,20 @@ export class DialogManager extends Configurable {
     // Recursively traverses the dialog tree and registers intances of `DialogContainer` in the `DialogSet`
     // for this `DialogManager` instance.
     private registerContainerDialogs(dialog: Dialog, registerRoot = true): void {
-        if (dialog instanceof DialogContainer) {
-            if (registerRoot) {
-                this.dialogs.add(dialog);
-            }
-
-            dialog.dialogs.getDialogs().forEach((inner) => {
-                this.registerContainerDialogs(inner);
-            });
+        if (!(dialog instanceof DialogContainer)) {
+            return;
         }
+        const container = dialog;
+        if (registerRoot) {
+            if (this.dialogs.getDialogs().find((dlg) => dlg === container)) {
+                return;
+            }
+            this.dialogs.add(container);
+        }
+
+        container.dialogs.getDialogs().forEach((inner) => {
+            this.registerContainerDialogs(inner);
+        });
     }
 
     /**


### PR DESCRIPTION
Fixes #2640 

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Allow `ResourceExplorer` to preload types into cache to support cycle references between dialog files.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - allow `ResourceExplorer` to preload types
  - updated container registration in `DialogManager` to avoid infinite loops
  - updated telemetry client configuration in `DialogContainer` to avoid infinite loops

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
Added tests to cover cycle references.