### PR TITLE
feat: cloud adapter

### DIFF
--- a/libraries/botbuilder-core/src/invokeResponse.ts
+++ b/libraries/botbuilder-core/src/invokeResponse.ts
@@ -6,6 +6,8 @@
  * Licensed under the MIT License.
  */
 
+import { assert, Assertion, Nil } from 'botbuilder-stdlib';
+
 /**
  * Represents a response returned by a bot when it receives an `invoke` activity.
  *
@@ -22,3 +24,16 @@ export interface InvokeResponse<T = any> {
      */
     body?: T;
 }
+
+export const makeAssertInvokeResponse = <T>(bodyAssertion: Assertion<T>): Assertion<InvokeResponse<T>> => (
+    val,
+    path
+) => {
+    assert.unsafe.castObjectAs<InvokeResponse<unknown>>(val, path);
+    assert.number(val.status, path.concat('status'));
+
+    const assertMaybeBody: Assertion<T | Nil> = assert.makeMaybe(bodyAssertion);
+    assertMaybeBody(val.body, path.concat('body'));
+};
+
+export const assertInvokeResponse = makeAssertInvokeResponse(assert.unknown);

--- a/libraries/botbuilder-core/src/turnContext.ts
+++ b/libraries/botbuilder-core/src/turnContext.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+import { assert, Assertion } from 'botbuilder-stdlib';
 import {
     Activity,
     ActivityTypes,
@@ -130,6 +131,9 @@ export interface TurnContext {}
  * created by a [BotAdapter](xref:botbuilder-core.BotAdapter) and persists for the length of the turn.
  */
 export class TurnContext {
+    static assert: Assertion<TurnContext> = assert.instanceOf('TurnContext', TurnContext);
+    static isType = assert.toTest(TurnContext.assert);
+
     private _adapter: BotAdapter | undefined;
     private _activity: Activity | undefined;
     private _respondedRef: { responded: boolean } = { responded: false };

--- a/libraries/botbuilder-stdlib/package.json
+++ b/libraries/botbuilder-stdlib/package.json
@@ -13,6 +13,9 @@
     "type": "git",
     "url": "https://github.com/Microsoft/botbuilder-js.git"
   },
+  "devDependencies": {
+    "sinon": "^9.2.2"
+  },
   "scripts": {
     "build": "tsc -b",
     "clean": "rimraf _ts3.4 lib tsconfig.tsbuildinfo",

--- a/libraries/botbuilder-stdlib/src/delay.ts
+++ b/libraries/botbuilder-stdlib/src/delay.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Delay resolution of a promise.
+ *
+ * @template T type that promise will yield, defaults to `void`
+ * @param {number} milliseconds how long to delay
+ * @param {Promise<T>} promise an optional promise to delay
+ * @returns {Promise<T>} a promise that will resolve to the result of `promise`, delayed by `milliseconds`.
+ */
+export function delay<T = void>(milliseconds: number, promise?: Promise<T>): Promise<T> {
+    return new Promise((resolve) => setTimeout(() => resolve(promise), milliseconds));
+}

--- a/libraries/botbuilder-stdlib/src/index.ts
+++ b/libraries/botbuilder-stdlib/src/index.ts
@@ -3,4 +3,5 @@
 
 export * as assertExt from './assertExt';
 export * from './types';
+export { delay } from './delay';
 export { maybeCast } from './maybeCast';

--- a/libraries/botbuilder-stdlib/src/types.ts
+++ b/libraries/botbuilder-stdlib/src/types.ts
@@ -325,7 +325,7 @@ function undefinedError(val: unknown, path: string[]): asserts val is UndefinedE
 }
 
 // Represents a generic function
-export type Func<T extends unknown[] = unknown[], R = unknown> = (...args: T) => R;
+export type Func<T extends unknown[] = unknown[], U = unknown> = (...args: T) => U;
 
 /**
  * Test if `val` is of type `Func`.

--- a/libraries/botbuilder-stdlib/tests/delay.test.js
+++ b/libraries/botbuilder-stdlib/tests/delay.test.js
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const assert = require('assert');
+const sinon = require('sinon');
+const { delay } = require('../');
+
+describe('delay', () => {
+    let sandbox;
+    beforeEach(() => {
+        sandbox = sinon.createSandbox({ useFakeTimers: true });
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    it('works with a promise arg', async () => {
+        const promise = Promise.resolve(10);
+
+        let result = delay(250, promise);
+        sandbox.clock.tick(251);
+
+        result = await result;
+        assert.strictEqual(result, 10);
+    });
+
+    it('works without a promise arg', async () => {
+        const promise = delay(250);
+        sandbox.clock.tick(251);
+
+        const result = await promise;
+        assert.strictEqual(result, undefined);
+    });
+});

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -30,6 +30,7 @@
     "@azure/ms-rest-js": "1.9.1",
     "axios": "^0.21.1",
     "botbuilder-core": "4.1.6",
+    "botbuilder-stdlib": "4.1.6",
     "botframework-connector": "4.1.6",
     "botframework-streaming": "4.1.6",
     "filenamify": "^4.1.0",

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -33,15 +33,18 @@
     "botbuilder-stdlib": "4.1.6",
     "botframework-connector": "4.1.6",
     "botframework-streaming": "4.1.6",
+    "dayjs": "^1.10.3",
     "filenamify": "^4.1.0",
     "fs-extra": "^7.0.1",
-    "dayjs": "^1.10.3",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "assert": "^1.4.1",
+    "botbuilder-test-utils": "0.0.0",
     "chatdown": "^1.0.2",
-    "nock": "^11.9.1"
+    "nock": "^11.9.1",
+    "sinon": "^9.2.2",
+    "supertest": "^6.1.2"
   },
   "scripts": {
     "build": "tsc -b",
@@ -50,8 +53,9 @@
     "clean": "rimraf _ts3.4 lib tsconfig.tsbuildinfo",
     "lint": "eslint . --ext .js,.ts",
     "postbuild": "downlevel-dts lib _ts3.4/lib --checksum",
-    "test": "yarn build && nyc mocha --recursive \"tests/**/*.test.js\"",
-    "test:compat": "api-extractor run --verbose"
+    "test": "npm-run-all build test:mocha",
+    "test:compat": "api-extractor run --verbose",
+    "test:mocha": "nyc mocha tests"
   },
   "files": [
     "_ts3.4",

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -34,6 +34,7 @@ import {
     HealthResults,
     ActivityEventNames,
 } from 'botbuilder-core';
+
 import {
     AuthenticationConfiguration,
     AuthenticationConstants,
@@ -73,7 +74,6 @@ import {
     WebSocketServer,
 } from 'botframework-streaming';
 
-import { ConnectorClientBuilder, WebRequest, WebResponse } from './interfaces';
 import {
     defaultPipeName,
     GET,
@@ -84,8 +84,10 @@ import {
     VERSION_PATH,
 } from './streaming';
 
-import { validateAndFixActivity } from './activityValidator';
+import { ConnectorClientBuilder, WebRequest, WebResponse } from './interfaces';
+import { delay } from 'botbuilder-stdlib';
 import { userAgentPolicy } from '@azure/ms-rest-js';
+import { validateAndFixActivity } from './activityValidator';
 
 /**
  * Contains settings used to configure a [BotFrameworkAdapter](xref:botbuilder.BotFrameworkAdapter) instance.
@@ -1318,11 +1320,11 @@ export class BotFrameworkAdapter
         for (let i = 0; i < activities.length; i++) {
             const activity: Partial<Activity> = activities[i];
             switch (activity.type) {
-                case 'delay':
+                case ActivityTypes.Delay:
                     await delay(typeof activity.value === 'number' ? activity.value : 1000);
                     responses.push({} as ResourceResponse);
                     break;
-                case 'invokeResponse':
+                case ActivityTypes.InvokeResponse:
                     // Cache response to context object. This will be retrieved when turn completes.
                     context.turnState.set(INVOKE_RESPONSE_KEY, activity);
                     responses.push({} as ResourceResponse);
@@ -2030,12 +2032,6 @@ function parseRequest(req: WebRequest): Promise<Activity> {
                 }
             });
         }
-    });
-}
-
-function delay(timeout: number): Promise<void> {
-    return new Promise((resolve): void => {
-        setTimeout(resolve, timeout);
     });
 }
 

--- a/libraries/botbuilder/src/botFrameworkHttpAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkHttpAdapter.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { BotLogic, Emitter, Request, Response } from './interfaces';
+
+export interface BotFrameworkHttpAdapter {
+    process(req: Request & Emitter, res: Response, logic: BotLogic): Promise<void>;
+}

--- a/libraries/botbuilder/src/cloudAdapter.ts
+++ b/libraries/botbuilder/src/cloudAdapter.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * @module botbuilder
+ */
+
+import { BotFrameworkAuthentication } from 'botframework-connector';
+import { BotFrameworkHttpAdapter } from './botFrameworkHttpAdapter';
+import { CloudAdapterBase } from './cloudAdapterBase';
+import { StatusCodes } from 'botbuilder-core';
+import { readRequest, writeResponse } from './httpHelper';
+import { assert, tests } from 'botbuilder-stdlib';
+
+import {
+    BotLogic,
+    Emitter,
+    Request,
+    Response,
+    assertBotLogic,
+    assertEmitter,
+    assertRequest,
+    assertResponse,
+} from './interfaces';
+
+export class CloudAdapter extends CloudAdapterBase implements BotFrameworkHttpAdapter {
+    /**
+     * Construct a CloudAdapter.
+     *
+     * @param {BotFrameworkAuthentication} botFrameworkAuthentication the bot framework authentication, optional
+     */
+    constructor(botFrameworkAuthentication: BotFrameworkAuthentication, appId: string);
+    constructor(botFrameworkAuthentication: unknown, appId: unknown) {
+        BotFrameworkAuthentication.assert(botFrameworkAuthentication, ['botFrameworkAuthentication']);
+        assert.string(appId, ['appId']);
+        super(botFrameworkAuthentication, appId);
+    }
+
+    /**
+     * Process an incoming HTTP request
+     *
+     * @param {Request & Emitter} req an HTTP request
+     * @param {Response} res an HTTP response
+     * @param {BotLogic} logic the bot logic
+     * @returns {Promise<void>} a promise representing the asynchronous handling of the request/response lifecycle
+     */
+    async process(req: Request & Emitter, res: Response, logic: BotLogic): Promise<void>;
+    async process(req: unknown, res: unknown, logic: unknown): Promise<void> {
+        assertRequest(req, ['req']);
+        assertEmitter(req, ['req']);
+        assertResponse(res, ['res']);
+        assertBotLogic(logic, ['logic']);
+
+        const activity = await readRequest(req);
+        if (!activity) {
+            res.status(StatusCodes.BAD_REQUEST);
+            res.end();
+            return;
+        }
+
+        try {
+            const maybeAuthHeaders = req.headers.Authorization ?? req.headers.authorization ?? [];
+            const authHeader = tests.isString(maybeAuthHeaders) ? maybeAuthHeaders : maybeAuthHeaders[0] ?? '';
+            const invokeResponse = await this.processActivity(authHeader, activity, logic);
+            writeResponse(res, invokeResponse);
+        } catch (err) {
+            res.status(err.statusCode ?? StatusCodes.INTERNAL_SERVER_ERROR);
+            res.end();
+        }
+    }
+}

--- a/libraries/botbuilder/src/cloudAdapterBase.ts
+++ b/libraries/botbuilder/src/cloudAdapterBase.ts
@@ -1,0 +1,323 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * @module botbuilder
+ */
+
+import { Assertion, assert, delay, tests } from 'botbuilder-stdlib';
+import { BotLogic, assertBotLogic } from './interfaces';
+import { ServiceClientCredentials } from '@azure/ms-rest-js';
+
+import {
+    AuthenticationConstants,
+    BotFrameworkAuthentication,
+    ClaimsIdentity,
+    ConnectorClient,
+} from 'botframework-connector';
+
+import {
+    Activity,
+    ActivityEventNames,
+    ActivityTypes,
+    BotAdapter,
+    Channels,
+    ConversationReference,
+    DeliveryModes,
+    InvokeResponse,
+    ResourceResponse,
+    StatusCodes,
+    TurnContext,
+    assertActivity,
+    assertConversationReference,
+    assertInvokeResponse,
+} from 'botbuilder-core';
+
+const assertPartialActivity: Assertion<Partial<Activity>> = assert.makePartial(assertActivity);
+
+const assertPartialConversationReference: Assertion<Partial<ConversationReference>> = assert.makePartial(
+    assertConversationReference
+);
+
+// CloudAdapterBase holds logic common to all cloud-based Bot adapters.
+export abstract class CloudAdapterBase extends BotAdapter {
+    public readonly InvokeResponseKey = Symbol('BotFrameworkAdapter.InvokeResponse');
+    public readonly ConnectorClientKey = Symbol('CloudAdapterBase.ConnectorClient');
+    public readonly BotLogicKey = Symbol('CloudAdapterBase.BotLogic');
+
+    private readonly _botFrameworkAuthentication: BotFrameworkAuthentication;
+    private readonly _appId: string;
+
+    /**
+     * Constructs an instance of CloudAdapterBase. Note that this is an abstract
+     * class, so the constructor should only be invoked with `super`.
+     *
+     * @param {BotFrameworkAuthentication} botFrameworkAuthentication a delegate to handle authentication
+     */
+    constructor(botFrameworkAuthentication: BotFrameworkAuthentication, appId: string);
+    constructor(botFrameworkAuthentication: unknown, appId: unknown) {
+        super();
+
+        BotFrameworkAuthentication.assert(botFrameworkAuthentication, ['botFrameworkAuthentication']);
+        this._botFrameworkAuthentication = botFrameworkAuthentication;
+
+        assert.string(appId, ['appId']);
+        this._appId = appId;
+    }
+
+    /**
+     * Send a set of activities via a connector client.
+     *
+     * @param {TurnContext} turnContext the turn context
+     * @param {Array<Partial<Activity>>} activities the activities to send
+     * @returns {Promise<Array<ResourceResponse>>} a promise that resolves to the resource responses obtained by sending activities
+     */
+    sendActivities(turnContext: TurnContext, activities: Array<Partial<Activity>>): Promise<Array<ResourceResponse>>;
+    async sendActivities(turnContext: unknown, activities: unknown): Promise<Array<ResourceResponse>> {
+        TurnContext.assert(turnContext, ['turnContext']);
+
+        const assertPartialActivityArray: Assertion<Array<Partial<Activity>>> = assert.arrayOf(assertPartialActivity);
+        assertPartialActivityArray(activities, ['activities']);
+
+        const connectorClient = this.turnContextConnectorClient(turnContext);
+
+        return Promise.all(
+            activities.map<Promise<ResourceResponse>>(async (activity) => {
+                delete activity.id;
+
+                if (activity.type === ActivityTypes.Delay) {
+                    const milliseconds = tests.isNumber(activity.value) ? activity.value : 1000;
+                    await delay(milliseconds);
+                } else if (activity.type === ActivityTypes.InvokeResponse) {
+                    turnContext.turnState.set(this.InvokeResponseKey, activity);
+                } else if (activity.type === ActivityTypes.Trace && activity.channelId !== Channels.Emulator) {
+                    // no-op
+                } else {
+                    if (activity.replyToId) {
+                        return connectorClient.conversations.replyToActivity(
+                            activity.conversation.id,
+                            activity.replyToId,
+                            activity
+                        );
+                    } else {
+                        return connectorClient.conversations.sendToConversation(activity.conversation.id, activity);
+                    }
+                }
+
+                return { id: '' };
+            })
+        );
+    }
+
+    /**
+     * Update an activity
+     *
+     * @param {TurnContext} turnContext turn context
+     * @param {Activity} activity an activity to update
+     * @returns {Promise<ResourceResponse>} a promise resolving to a resource response
+     */
+    updateActivity(turnContext: TurnContext, activity: Partial<Activity>): Promise<ResourceResponse>;
+    async updateActivity(turnContext: unknown, activity: unknown): Promise<ResourceResponse> {
+        TurnContext.assert(turnContext, ['turnContext']);
+        assertPartialActivity(activity, ['activity']);
+
+        const connectorClient = this.turnContextConnectorClient(turnContext);
+
+        const conversationId = activity.conversation?.id;
+        assert.string(conversationId, ['activity', 'conversation', 'id']);
+
+        const activityId = activity.id;
+        assert.string(activityId, ['activity']);
+
+        return connectorClient.conversations.updateActivity(conversationId, activityId, activity);
+    }
+
+    /**
+     * Delete an activity
+     *
+     * @param {TurnContext} turnContext turn context
+     * @param {ConversationReference} reference a conversation reference to delete
+     * @returns {Promise<void>} a promise representing the async operation
+     */
+    deleteActivity(turnContext: TurnContext, reference: Partial<ConversationReference>): Promise<void>;
+    async deleteActivity(turnContext: unknown, reference: unknown): Promise<void> {
+        TurnContext.assert(turnContext, ['turnContext']);
+        assertPartialConversationReference(reference, ['reference']);
+
+        const connectorClient = this.turnContextConnectorClient(turnContext);
+
+        const conversationId = reference.conversation?.id;
+        assert.string(conversationId, ['reference', 'conversation', 'id']);
+
+        const activityId = reference.activityId;
+        assert.string(activityId, ['reference', 'activityId']);
+
+        await connectorClient.conversations.deleteActivity(reference.conversation.id, reference.activityId);
+    }
+
+    /**
+     * Continue a conversation
+     *
+     * @param {Partial<ConversationReference>} reference a conversation reference
+     * @param {BotLogic} logic the bot's logic
+     * @returns {Promise<void>} a promise representing the async operation
+     */
+    continueConversation(reference: Partial<ConversationReference>, logic: BotLogic): Promise<void>;
+    async continueConversation(reference: unknown, logic: unknown): Promise<void> {
+        assertPartialConversationReference(reference, ['reference']);
+        assertBotLogic(logic, ['logic']);
+
+        const claimsIdentity = new ClaimsIdentity(
+            [
+                {
+                    type: AuthenticationConstants.AppIdClaim,
+                    value: this._appId,
+                },
+            ],
+            true
+        );
+
+        return this.processProactive(claimsIdentity, reference, undefined, logic);
+    }
+
+    private createConnectorClient(credentials: ServiceClientCredentials, baseUri?: string): ConnectorClient {
+        return new ConnectorClient(credentials, {
+            baseUri,
+        });
+    }
+
+    /**
+     * Handles a proactive operation, useful for `continueConversation` invocations.
+     *
+     * @param {ClaimsIdentity} claimsIdentity a set of claims
+     * @param {Partial<ConversationReference>} reference a conversation reference
+     * @param {string} audience the audience
+     * @param {BotLogic} logic the bot's actual logic
+     * @returns {Promise<void>} a promise representing the async operation
+     */
+    protected processProactive(
+        claimsIdentity: ClaimsIdentity,
+        reference: Partial<ConversationReference>,
+        audience: string | undefined,
+        logic: BotLogic
+    ): Promise<void>;
+    protected async processProactive(
+        claimsIdentity: unknown,
+        reference: unknown,
+        audience: unknown,
+        logic: unknown
+    ): Promise<void> {
+        ClaimsIdentity.assert(claimsIdentity, ['claimsIdentity']);
+        assertPartialConversationReference(reference, ['reference']);
+        assert.maybeString(audience, ['audience']);
+        assertBotLogic(logic, ['logic']);
+
+        const activity = TurnContext.applyConversationReference(
+            { type: ActivityTypes.Event, name: ActivityEventNames.ContinueConversation },
+            reference,
+            true
+        );
+
+        const proactiveCredentials = await this._botFrameworkAuthentication.getProactiveCredentials(
+            claimsIdentity,
+            audience
+        );
+
+        const connectorClient = this.createConnectorClient(proactiveCredentials.credentials, activity.serviceUrl);
+
+        const turnContext = this.createTurnContext(
+            activity,
+            claimsIdentity,
+            proactiveCredentials.scope,
+            connectorClient,
+            logic
+        );
+
+        try {
+            await this.runMiddleware(turnContext, logic);
+        } finally {
+            this.disposeTurnContext(turnContext);
+        }
+    }
+
+    /**
+     * Handles an activity
+     *
+     * @param {string} authHeader an HTTP auth header
+     * @param {Activity} activity the activity
+     * @param {BotLogic} botLogic the bot's logic
+     * @returns {Promise<void>} a promise that resolves to an invoke response
+     */
+    processActivity(authHeader: string | undefined, activity: Activity, logic: BotLogic): Promise<InvokeResponse>;
+    async processActivity(authHeader: unknown, activity: unknown, logic: unknown): Promise<InvokeResponse> {
+        assert.maybeString(authHeader, ['authHeader']);
+        assertPartialActivity(activity, ['activity']);
+        assertBotLogic(logic, ['logic']);
+
+        const authenticateResult = await this._botFrameworkAuthentication.authenticateRequest(activity, authHeader);
+        activity.callerId = authenticateResult.callerId;
+
+        const connectorClient = this.createConnectorClient(authenticateResult.credentials, activity.serviceUrl);
+
+        const turnContext = this.createTurnContext(
+            activity,
+            authenticateResult.claimsIdentity,
+            authenticateResult.scope,
+            connectorClient,
+            logic
+        );
+
+        try {
+            await this.runMiddleware(turnContext, logic);
+            return this.processTurnResults(turnContext);
+        } finally {
+            this.disposeTurnContext(turnContext);
+        }
+    }
+
+    private createTurnContext(
+        activity: Partial<Activity>,
+        claimsIdentity: ClaimsIdentity,
+        oauthScope: string,
+        connectorClient: ConnectorClient,
+        logic: BotLogic
+    ): TurnContext {
+        const turnContext = new TurnContext(this, activity);
+        turnContext.turnState.set(this.BotIdentityKey, claimsIdentity);
+        turnContext.turnState.set(this.OAuthScopeKey, oauthScope);
+        turnContext.turnState.set(this.ConnectorClientKey, connectorClient);
+        turnContext.turnState.set(this.BotLogicKey, logic);
+        return turnContext;
+    }
+
+    private disposeTurnContext(turnContext: TurnContext) {
+        turnContext.turnState.set(this.ConnectorClientKey, null);
+    }
+
+    private turnContextConnectorClient(turnContext: TurnContext): ConnectorClient {
+        const connectorClient = turnContext.turnState.get(this.ConnectorClientKey);
+        ConnectorClient.assert(connectorClient, ['turnContext', 'turnState', 'get', 'ConnectorClientKey']);
+
+        return connectorClient;
+    }
+
+    private processTurnResults(turnContext: TurnContext): InvokeResponse | null {
+        const activity = turnContext.activity;
+
+        if (activity.deliveryMode === DeliveryModes.ExpectReplies) {
+            return { status: StatusCodes.OK, body: turnContext.bufferedReplyActivities };
+        }
+
+        if (activity.type === ActivityTypes.Invoke) {
+            const invokeResponse = turnContext.turnState.get(this.InvokeResponseKey);
+            if (!invokeResponse) {
+                return { status: StatusCodes.NOT_IMPLEMENTED };
+            } else {
+                assertInvokeResponse(invokeResponse, ['turnContext', 'turnState', 'get', 'InvokeResponseKey']);
+                return invokeResponse;
+            }
+        }
+
+        return null;
+    }
+}

--- a/libraries/botbuilder/src/httpHelper.ts
+++ b/libraries/botbuilder/src/httpHelper.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import getStream = require('get-stream');
+import { Activity, InvokeResponse, StatusCodes } from 'botbuilder-core';
+import { Emitter, Request, Response } from './interfaces';
+import { validateAndFixActivity } from './activityValidator';
+import { tests } from 'botbuilder-stdlib';
+
+/**
+ * Returns the activity in a web request, or null.
+ *
+ * @param {Request} req request to read
+ * @returns {Promise<Activity | null>} a promise that resolves to the request activity
+ */
+export async function readRequest(req: Request & Emitter): Promise<Activity | null> {
+    const body = req.body ?? (await getStream(req));
+    const parsed = tests.isDictionary(body) ? body : JSON.parse(body);
+    return tests.isDictionary(parsed) ? validateAndFixActivity((parsed as unknown) as Activity) : null;
+}
+
+/**
+ * Write invokeResponse to HTTP response
+ *
+ * @param {Response} res a response
+ * @param {InvokeResponse} invokeResponse an invoke response
+ */
+export function writeResponse(res: Response, invokeResponse?: InvokeResponse): void {
+    if (!invokeResponse) {
+        res.status(StatusCodes.OK);
+    } else {
+        const { body, status } = invokeResponse;
+
+        res.status(status);
+
+        if (body) {
+            res.header('Content-Type', 'application/json');
+            res.send(JSON.stringify(body));
+        }
+    }
+
+    res.end();
+}

--- a/libraries/botbuilder/src/index.ts
+++ b/libraries/botbuilder/src/index.ts
@@ -6,19 +6,21 @@
  * Licensed under the MIT License.
  */
 
-export { BotFrameworkAdapter, BotFrameworkAdapterSettings } from './botFrameworkAdapter';
-export { BotFrameworkHttpClient } from './botFrameworkHttpClient';
-export { ChannelServiceHandler } from './channelServiceHandler';
-export { ChannelServiceRoutes, RouteHandler, WebServer } from './channelServiceRoutes';
 export * from './fileTranscriptStore';
-export { HandoffEventNames } from './handoffEventNames';
-export { EventFactory } from './eventFactory';
 export * from './inspectionMiddleware';
-export { WebRequest, WebResponse } from './interfaces';
 export * from './skills';
-export { StatusCodeError } from './statusCodeError';
-export { StreamingHttpClient, TokenResolver } from './streaming';
 export * from './teamsActivityHandler';
 export * from './teamsActivityHelpers';
 export * from './teamsInfo';
 export * from 'botbuilder-core';
+export { BotFrameworkAdapter, BotFrameworkAdapterSettings } from './botFrameworkAdapter';
+export { BotFrameworkHttpClient } from './botFrameworkHttpClient';
+export { ChannelServiceHandler } from './channelServiceHandler';
+export { ChannelServiceRoutes, RouteHandler, WebServer } from './channelServiceRoutes';
+export { CloudAdapter } from './cloudAdapter';
+export { CloudAdapterBase } from './cloudAdapterBase';
+export { EventFactory } from './eventFactory';
+export { HandoffEventNames } from './handoffEventNames';
+export { StatusCodeError } from './statusCodeError';
+export { StreamingHttpClient, TokenResolver } from './streaming';
+export { WebRequest, WebResponse } from './interfaces';

--- a/libraries/botbuilder/src/interfaces/botLogic.ts
+++ b/libraries/botbuilder/src/interfaces/botLogic.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { TurnContext } from 'botbuilder-core';
+import { Assertion, Func, assert } from 'botbuilder-stdlib';
+
+export type BotLogic<T = void> = Func<[TurnContext], Promise<T>>;
+
+export const assertBotLogic: Assertion<BotLogic> = (val, path) => {
+    assert.func(val, path);
+};
+
+export const isBotLogic = assert.toTest(assertBotLogic);

--- a/libraries/botbuilder/src/interfaces/emitter.ts
+++ b/libraries/botbuilder/src/interfaces/emitter.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { assert, Assertion } from 'botbuilder-stdlib';
+
+/**
+ * Represents a Node.js emitter. Template arg should restrict the set of events supported
+ * by a given emitter. Defaults to 'data' | 'end' | 'error'.
+ */
+export type Emitter<Events extends string = 'data' | 'end' | 'error'> = {
+    emit(event: Events, data: unknown): void;
+    on(event: Events, callback: (...args: unknown[]) => void): void;
+};
+
+export const assertEmitter: Assertion<Emitter> = (val, path) => {
+    assert.unsafe.castObjectAs<Emitter>(val, path);
+    assert.func(val.emit, path.concat('emit'));
+    assert.func(val.on, path.concat('on'));
+};
+
+export const isEmitter = assert.toTest(assertEmitter);

--- a/libraries/botbuilder/src/interfaces/index.ts
+++ b/libraries/botbuilder/src/interfaces/index.ts
@@ -6,6 +6,10 @@
  * Licensed under the MIT License.
  */
 
+export * from './botLogic';
+export * from './emitter';
+export * from './request';
+export * from './response';
 export { ConnectorClientBuilder } from './connectorClientBuilder';
 export { WebRequest } from './webRequest';
 export { WebResponse } from './webResponse';

--- a/libraries/botbuilder/src/interfaces/request.ts
+++ b/libraries/botbuilder/src/interfaces/request.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Assertion, assert } from 'botbuilder-stdlib';
+
+/**
+ * Represents a Node.js HTTP Request, including the minimal set of use properties.
+ * Compatible with Restify, Express, and Node.js core http.
+ */
+export interface Request<
+    Body extends Record<string, unknown> = Record<string, unknown>,
+    Headers extends Record<string, string[] | string | undefined> = Record<string, string[] | string | undefined>
+> {
+    body?: Body;
+    headers: Headers;
+    method?: string;
+}
+
+export const assertRequest: Assertion<Request> = (val, path) => {
+    assert.unsafe.castObjectAs<Request>(val, path);
+    assert.maybeDictionary(val.body, path.concat('body'));
+    assert.dictionary(val.headers, path.concat('headers'));
+    assert.maybeString(val.method, path.concat('method'));
+};
+
+export const isRequest = assert.toTest(assertRequest);

--- a/libraries/botbuilder/src/interfaces/response.ts
+++ b/libraries/botbuilder/src/interfaces/response.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { assert, Assertion } from 'botbuilder-stdlib';
+
+/**
+ * Represents a Node.js HTTP Response, including the minimal set of use properties and methods.
+ * Compatible with Restify, Express, and Node.js core http.
+ */
+export interface Response {
+    socket: unknown;
+
+    end(...args: unknown[]): unknown;
+    header(name: string, value: unknown): unknown;
+    send(...args: unknown[]): unknown;
+    status(code: number): unknown;
+}
+
+export const assertResponse: Assertion<Response> = (val, path) => {
+    assert.unsafe.castObjectAs<Response>(val, path);
+    assert.unknown(val.socket, path.concat('socket'));
+    assert.func(val.end, path.concat('end'));
+    assert.func(val.header, path.concat('header'));
+    assert.func(val.send, path.concat('send'));
+    assert.func(val.status, path.concat('status'));
+};
+
+export const isResponse = assert.toTest(assertResponse);

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -1,0 +1,284 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const assert = require('assert');
+const nock = require('nock');
+const restify = require('restify');
+const sinon = require('sinon');
+const supertest = require('supertest');
+const { CloudAdapter, TurnContext, StatusCodes, ActivityTypes, DeliveryModes } = require('..');
+const { jwt, oauth, sinonExt } = require('botbuilder-test-utils');
+
+const {
+    AuthenticationConfiguration,
+    EmulatorValidation,
+    ParameterizedBotFrameworkAuthentication,
+    PasswordServiceClientCredentialFactory,
+    SkillValidation,
+    makeAuthValidator,
+} = require('botframework-connector');
+
+const reference = {
+    activityId: '1234',
+    channelId: 'test',
+    serviceUrl: 'https://service.url',
+    user: { id: 'user', name: 'User Name' },
+    bot: { id: 'bot', name: 'Bot Name' },
+    conversation: {
+        id: 'convo1',
+        properties: {
+            foo: 'bar',
+        },
+    },
+};
+
+const incoming = TurnContext.applyConversationReference({ text: 'test', type: ActivityTypes.Message }, reference, true);
+
+const outgoing = TurnContext.applyConversationReference({ text: 'test', type: ActivityTypes.Message }, reference);
+
+const invoke = TurnContext.applyConversationReference({ type: ActivityTypes.Invoke }, reference, true);
+
+const expectReplies = TurnContext.applyConversationReference(
+    { deliveryMode: DeliveryModes.ExpectReplies, text: 'test', type: ActivityTypes.Message },
+    reference,
+    true
+);
+
+describe.only('CloudAdapter', () => {
+    jwt.mocha();
+    oauth.mocha();
+    const sandbox = sinonExt.mocha();
+
+    const makeAdapter = async ({
+        appId = 'appId',
+        appPassword = 'password',
+        callerId = 'caller:id',
+        connectorClientNock = undefined,
+        expectReplies = false,
+        invokeResponse = null,
+        loginUrl = 'login.url',
+        nockMatcher = null,
+        oauthScope = 'oauth:scope',
+        skipJwtVerify = false,
+    } = {}) => {
+        const { issuer, metadata, sign, verify } = jwt.stub();
+
+        const credentialFactory = new PasswordServiceClientCredentialFactory(appId, appPassword);
+        const authConfig = new AuthenticationConfiguration();
+
+        const authValidator = (expectedClaim) =>
+            makeAuthValidator(
+                {
+                    issuer,
+                },
+                metadata,
+                async (_, identity) => {
+                    assert(
+                        identity.claims.find((c) => c.type === expectedClaim.type && c.value === expectedClaim.value),
+                        'could not locate expected claim'
+                    );
+                }
+            );
+
+        const auth = new ParameterizedBotFrameworkAuthentication(
+            credentialFactory,
+            authConfig,
+            true,
+            loginUrl,
+            oauthScope,
+            callerId,
+            authValidator({ type: 'test', value: 'general' }),
+            authValidator({ type: 'test', value: 'emulator' }),
+            authValidator({ type: 'test', value: 'skill' })
+        );
+
+        const adapter = new CloudAdapter(auth, appId);
+
+        connectorClientNock =
+            connectorClientNock ||
+            nock(reference.serviceUrl)
+                .post(`/v3/conversations/${reference.conversation.id}/activities/${reference.activityId}`)
+                .reply(200, {});
+
+        if (nockMatcher) {
+            connectorClientNock = nockMatcher(connectorClientNock);
+        }
+
+        const app = restify.createServer();
+
+        app.post('/api/messages', async (req, res) => {
+            await adapter.process(req, res, async (turnContext) => {
+                sinon.assert.match(turnContext, sinon.match.instanceOf(TurnContext));
+
+                if (invokeResponse) {
+                    turnContext.turnState.set(adapter.InvokeResponseKey, {
+                        status: StatusCodes.OK,
+                        body: invokeResponse,
+                    });
+                }
+
+                if (!expectReplies) {
+                    await turnContext.sendActivity(outgoing);
+                }
+            });
+        });
+
+        return {
+            adapter,
+            app: supertest(app),
+            sign,
+            verify: () => {
+                if (!skipJwtVerify) verify();
+                if (!expectReplies) connectorClientNock.done();
+                sandbox().verify();
+            },
+        };
+    };
+
+    describe('process', () => {
+        beforeEach(() => {
+            nock.enableNetConnect('127.0.0.1');
+        });
+
+        it('works with general auth', async () => {
+            const { app, sign, verify } = await makeAdapter();
+
+            await app
+                .post('/api/messages')
+                .set('Authorization', `Bearer ${sign({ test: 'general' })}`)
+                .send(incoming)
+                .expect(200);
+
+            verify();
+        });
+
+        it('works with expectReplies', async () => {
+            const { app, sign, verify } = await makeAdapter({ expectReplies: true });
+
+            const res = await app
+                .post('/api/messages')
+                .set('Authorization', `Bearer ${sign({ test: 'general' })}`)
+                .send(expectReplies)
+                .expect(200);
+
+            assert.ok(res.body.length);
+
+            verify();
+        });
+
+        it('works with emulator auth', async () => {
+            const { app, sign, verify } = await makeAdapter();
+
+            const authHeader = `Bearer ${sign({ test: 'emulator' })}`;
+            sandbox()
+                .mock(EmulatorValidation)
+                .expects('isTokenFromEmulator')
+                .withArgs(authHeader)
+                .once()
+                .resolves(true);
+
+            await app.post('/api/messages').set('Authorization', authHeader).send(incoming).expect(200);
+            verify();
+        });
+
+        it('works with skills auth', async () => {
+            const { app, sign, verify } = await makeAdapter();
+
+            const authHeader = `Bearer ${sign({ test: 'skill' })}`;
+            sandbox().mock(SkillValidation).expects('isSkillToken').withArgs(authHeader).once().resolves(true);
+
+            await app.post('/api/messages').set('Authorization', authHeader).send(incoming).expect(200);
+            verify();
+        });
+
+        it('yields 401 for unauthenticated request', async () => {
+            const { app } = await makeAdapter();
+            await app.post('/api/messages').set('Authorization', `Bearer malformed`).send(incoming).expect(401);
+        });
+
+        it('yields a 501 for invoke with no response', async () => {
+            const { app, sign, verify } = await makeAdapter();
+
+            await app
+                .post('/api/messages')
+                .set('Authorization', `Bearer ${sign({ test: 'general' })}`)
+                .send(invoke)
+                .expect(501);
+
+            verify();
+        });
+
+        it('returns invoke response', async () => {
+            const invokeResponse = { hello: 'world' };
+            const { app, sign, verify } = await makeAdapter({ invokeResponse });
+
+            const res = await app
+                .post('/api/messages')
+                .set('Authorization', `Bearer ${sign({ test: 'general' })}`)
+                .send(invoke)
+                .expect(200);
+
+            assert.deepStrictEqual(JSON.parse(res.body), invokeResponse);
+
+            verify();
+        });
+    });
+
+    describe('CloudAdapterBase', () => {
+        describe('continueConversation', () => {
+            it('works', async () => {
+                const appId = 'proactiveAppId';
+                const oauthScope = 'oauth:scope';
+
+                const { match: nockMatcher, verify: verifyOauth } = oauth.stub({ clientId: appId, scope: oauthScope });
+
+                const { adapter, verify } = await makeAdapter({
+                    appId,
+                    nockMatcher,
+                    oauthScope,
+                    skipJwtVerify: true,
+                });
+
+                await adapter.continueConversation(reference, async (turnContext) => {
+                    sinon.assert.match(turnContext, sinon.match.instanceOf(TurnContext));
+                    await turnContext.sendActivity(outgoing);
+                });
+
+                verify();
+                verifyOauth();
+            });
+        });
+
+        describe('updateActivity', () => {
+            it('works', async () => {
+                const connectorClientNock = nock(reference.serviceUrl)
+                    .put(`/v3/conversations/${reference.conversation.id}/activities/${reference.activityId}`)
+                    .reply(200);
+
+                const { adapter, sign, verify } = await makeAdapter({ connectorClientNock });
+
+                await adapter.processActivity(`Bearer ${sign({ test: 'general' })}`, incoming, async (turnContext) => {
+                    await adapter.updateActivity(turnContext, incoming);
+                });
+
+                verify();
+            });
+        });
+
+        describe('deleteActivity', () => {
+            it('works', async () => {
+                const connectorClientNock = nock(reference.serviceUrl)
+                    .delete(`/v3/conversations/${reference.conversation.id}/activities/${reference.activityId}`)
+                    .reply(200);
+
+                const { adapter, sign, verify } = await makeAdapter({ connectorClientNock });
+
+                await adapter.processActivity(`Bearer ${sign({ test: 'general' })}`, incoming, async (turnContext) => {
+                    await adapter.deleteActivity(turnContext, reference);
+                });
+
+                verify();
+            });
+        });
+    });
+});

--- a/libraries/botbuilder/tests/mocha.opts
+++ b/libraries/botbuilder/tests/mocha.opts
@@ -1,4 +1,2 @@
---require ts-node/register
 --require source-map-support/register
 --recursive
-**/*.js

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -32,6 +32,7 @@
     "@types/node": "^10.17.27",
     "adal-node": "0.2.1",
     "base64url": "^3.0.0",
+    "botbuilder-stdlib": "4.1.6",
     "botframework-schema": "4.1.6",
     "cross-fetch": "^3.0.5",
     "jsonwebtoken": "8.0.1",

--- a/libraries/botframework-connector/src/auth/authValidator.ts
+++ b/libraries/botframework-connector/src/auth/authValidator.ts
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Activity, Channels, RoleTypes, StatusCodes } from 'botframework-schema';
+import { AuthenticationConfiguration } from './authenticationConfiguration';
+import { AuthenticationConstants } from './authenticationConstants';
+import { AuthenticationError } from './authenticationError';
+import { ClaimsIdentity } from './claimsIdentity';
+import { ICredentialProvider } from './credentialProvider';
+import { JwtTokenExtractor } from './jwtTokenExtractor';
+import { VerifyOptions } from 'jsonwebtoken';
+
+// AuthValidator is a function signature for logic that validates an HTTP auth header
+export type AuthValidator = (
+    credentials: ICredentialProvider,
+    authConfig: AuthenticationConfiguration,
+    authHeader: string,
+    activity: Partial<Activity>
+) => Promise<ClaimsIdentity>;
+
+// IdentityValidator is a function signature for logic that validates a set of JWT identity claims
+export type IdentityValidator = (
+    credentials: ICredentialProvider,
+    claimsIdentity: ClaimsIdentity,
+    activity: Partial<Activity>
+) => Promise<void>;
+
+/**
+ * Make an auth validator
+ *
+ * @param {VerifyOptions} verifyOptions options for verifying JWTs
+ * @param {string} openIdMetadata url to fetch open ID metadata
+ * @param {IdentityValidator} identityValidator the identity validator logic
+ * @returns {AuthValidator} an auth validator function
+ */
+export function makeAuthValidator(
+    verifyOptions: VerifyOptions,
+    openIdMetadata: string,
+    identityValidator: IdentityValidator
+): AuthValidator {
+    return async (credentials, authConfig, authHeader, activity) => {
+        if (!authHeader.trim()) {
+            const isAuthDisabled = await credentials.isAuthenticationDisabled();
+            if (!isAuthDisabled) {
+                throw new AuthenticationError(
+                    'Unauthorized Access. Request is not authorized',
+                    StatusCodes.UNAUTHORIZED
+                );
+            }
+
+            // Represents an anonymous skill claim
+            if (activity.channelId === Channels.Emulator && activity.recipient?.role === RoleTypes.Skill) {
+                return new ClaimsIdentity(
+                    [
+                        {
+                            type: AuthenticationConstants.AppIdClaim,
+                            value: AuthenticationConstants.AnonymousSkillAppId,
+                        },
+                    ],
+                    AuthenticationConstants.AnonymousAuthType
+                );
+            }
+
+            // Represents an anonymous claim
+            return new ClaimsIdentity([], AuthenticationConstants.AnonymousAuthType);
+        }
+
+        const tokenExtractor = new JwtTokenExtractor(
+            verifyOptions,
+            openIdMetadata,
+            AuthenticationConstants.AllowedSigningAlgorithms
+        );
+
+        const claimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(
+            authHeader.trim(),
+            activity.channelId,
+            authConfig.requiredEndorsements
+        );
+
+        if (!claimsIdentity) {
+            throw new AuthenticationError('Unauthorized. Is not authenticated', StatusCodes.UNAUTHORIZED);
+        }
+
+        if (!claimsIdentity.isAuthenticated) {
+            throw new AuthenticationError('Unauthorized. Is not authenticated', StatusCodes.UNAUTHORIZED);
+        }
+
+        await identityValidator(credentials, claimsIdentity, activity);
+
+        return claimsIdentity;
+    };
+}

--- a/libraries/botframework-connector/src/auth/botFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/botFrameworkAuthentication.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Activity, CallerIdConstants } from 'botframework-schema';
+import { AuthenticationConstants } from './authenticationConstants';
+import { ClaimsIdentity } from './claimsIdentity';
+import { ServiceClientCredentials } from '@azure/ms-rest-js';
+import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
+import { SkillValidation } from './skillValidation';
+import { assert, Assertion } from 'botbuilder-stdlib';
+
+export interface ProactiveCredentialsResult {
+    credentials: ServiceClientCredentials;
+    scope: string;
+}
+
+export interface AuthenticateRequestResult extends ProactiveCredentialsResult {
+    claimsIdentity: ClaimsIdentity;
+    callerId: string;
+}
+
+export abstract class BotFrameworkAuthentication {
+    static assert: Assertion<BotFrameworkAuthentication> = assert.instanceOf(
+        'BotFrameworkAuthentication',
+        BotFrameworkAuthentication
+    );
+
+    static isType = assert.toTest(BotFrameworkAuthentication.assert);
+
+    /**
+     * Extract app ID from claims identity.
+     *
+     * @param {ClaimsIdentity} claimsIdentity claims identity from which app ID is extracted
+     * @returns {string} the app ID
+     */
+    protected getAppId(claimsIdentity: ClaimsIdentity): string {
+        let botAppIdClaim = claimsIdentity.claims.find((claim) => claim.type === AuthenticationConstants.AudienceClaim);
+
+        if (!botAppIdClaim) {
+            botAppIdClaim = claimsIdentity.claims.find((claim) => claim.type === AuthenticationConstants.AppIdClaim);
+        }
+
+        return botAppIdClaim?.value;
+    }
+
+    /**
+     * Generate caller ID value.
+     *
+     * @param {ServiceClientCredentialsFactory} credentialFactory credential factory
+     * @param {ClaimsIdentity} claimsIdentity claims ID from which to generate caller ID
+     * @param {string | undefined} callerId fallback caller ID
+     * @returns {string} the caller ID value
+     */
+    protected async generateCallerId(
+        credentialFactory: ServiceClientCredentialsFactory,
+        claimsIdentity: ClaimsIdentity,
+        callerId?: string
+    ): Promise<string> {
+        if (await credentialFactory.isAuthenticationDisabled()) {
+            return null;
+        }
+
+        if (SkillValidation.isSkillClaim(claimsIdentity.claims)) {
+            return `${CallerIdConstants.BotToBotPrefix}${this.getAppId(claimsIdentity)}`;
+        }
+
+        return callerId;
+    }
+
+    abstract authenticateRequest(
+        activity: Partial<Activity>,
+        authHeader: string | undefined
+    ): Promise<AuthenticateRequestResult>;
+
+    abstract getProactiveCredentials(
+        claimsIdentity: ClaimsIdentity,
+        audience: string | undefined
+    ): Promise<ProactiveCredentialsResult>;
+}

--- a/libraries/botframework-connector/src/auth/botFrameworkAuthenticationFactory.ts
+++ b/libraries/botframework-connector/src/auth/botFrameworkAuthenticationFactory.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AuthenticationConfiguration } from './authenticationConfiguration';
+import { AuthenticationConstants } from './authenticationConstants';
+import { BotFrameworkAuthentication } from './botFrameworkAuthentication';
+import { ChannelValidation } from './channelValidation';
+import { GovernmentCloudBotFrameworkAuthentication } from './governmentCloudBotFrameworkAuthentication';
+import { GovernmentConstants } from './governmentConstants';
+import { JwtTokenExtractor } from './jwtTokenExtractor';
+import { ParameterizedBotFrameworkAuthentication } from './parameterizedBotFrameworkAuthentication';
+import { PublicCloudBotFrameworkAuthentication } from './publicCloudBotFrameworkAuthentication';
+import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
+import { AuthValidator, makeAuthValidator } from './authValidator';
+import { EmulatorValidation } from './emulatorValidation';
+import { makeSkillAuthValidator } from './skillValidation';
+
+// A helper class for creating BotFrameworkAuthentication instances.
+export class BotFrameworkAuthenticationFactory {
+    /**
+     * Create a BotFrameworkAuthentication instance that is appropriate based on the
+     * passed in arguments.
+     *
+     * @param {ServiceClientCredentialsFactory} credentialFactory the credential factory to use
+     * @param {AuthenticationConfiguration} authConfiguration the auth configuration to use
+     * @param {boolean} validateAuthority whether or not validate the authority
+     * @param {string} callerId caller ID
+     * @param {string} channelService the channel service
+     * @param {string} toChannelFromBotLoginUrl login url for messages from bot to channel
+     * @param {string} toChannelFromBotOAuthScope oauth scope for messages from bot to channel
+     * @param {AuthValidator} authValidator auth validator for general requests
+     * @param {AuthValidator} emulatorAuthValidator auth validator for emulator requests
+     * @param {AuthValidator} skillAuthValidator auth validator for skill requests
+     * @returns {BotFrameworkAuthentication} the appropriate BotFrameworkAuthentication instance
+     */
+    static create(
+        channelService?: string,
+        validateAuthority?: boolean,
+        callerId?: string,
+        toChannelFromBotLoginUrl?: string,
+        toChannelFromBotOAuthScope?: string,
+        authValidator?: AuthValidator,
+        emulatorAuthValidator?: AuthValidator,
+        skillAuthValidator?: AuthValidator,
+        credentialFactory?: ServiceClientCredentialsFactory,
+        authConfiguration?: AuthenticationConfiguration
+    ): BotFrameworkAuthentication {
+        if (
+            validateAuthority ||
+            callerId ||
+            toChannelFromBotLoginUrl ||
+            toChannelFromBotOAuthScope ||
+            authValidator ||
+            emulatorAuthValidator ||
+            skillAuthValidator
+        ) {
+            return new ParameterizedBotFrameworkAuthentication(
+                credentialFactory,
+                authConfiguration,
+                validateAuthority,
+                toChannelFromBotLoginUrl,
+                toChannelFromBotOAuthScope,
+                callerId,
+                authValidator,
+                emulatorAuthValidator,
+                skillAuthValidator
+            );
+        } else {
+            if (!channelService) {
+                return new PublicCloudBotFrameworkAuthentication(credentialFactory, authConfiguration);
+            } else if (channelService === GovernmentConstants.ChannelService) {
+                return new GovernmentCloudBotFrameworkAuthentication(credentialFactory, authConfiguration);
+            } else {
+                throw new TypeError('The provided ChannelService value is not supported');
+            }
+        }
+    }
+}

--- a/libraries/botframework-connector/src/auth/botFrameworkAuthenticationFactory.ts
+++ b/libraries/botframework-connector/src/auth/botFrameworkAuthenticationFactory.ts
@@ -1,19 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { AuthHeaderValidator } from './authHeaderValidator';
 import { AuthenticationConfiguration } from './authenticationConfiguration';
-import { AuthenticationConstants } from './authenticationConstants';
 import { BotFrameworkAuthentication } from './botFrameworkAuthentication';
-import { ChannelValidation } from './channelValidation';
 import { GovernmentCloudBotFrameworkAuthentication } from './governmentCloudBotFrameworkAuthentication';
 import { GovernmentConstants } from './governmentConstants';
-import { JwtTokenExtractor } from './jwtTokenExtractor';
 import { ParameterizedBotFrameworkAuthentication } from './parameterizedBotFrameworkAuthentication';
 import { PublicCloudBotFrameworkAuthentication } from './publicCloudBotFrameworkAuthentication';
 import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
-import { AuthValidator, makeAuthValidator } from './authValidator';
-import { EmulatorValidation } from './emulatorValidation';
-import { makeSkillAuthValidator } from './skillValidation';
 
 // A helper class for creating BotFrameworkAuthentication instances.
 export class BotFrameworkAuthenticationFactory {
@@ -21,16 +16,16 @@ export class BotFrameworkAuthenticationFactory {
      * Create a BotFrameworkAuthentication instance that is appropriate based on the
      * passed in arguments.
      *
-     * @param {ServiceClientCredentialsFactory} credentialFactory the credential factory to use
-     * @param {AuthenticationConfiguration} authConfiguration the auth configuration to use
+     * @param {string} channelService the channel service
      * @param {boolean} validateAuthority whether or not validate the authority
      * @param {string} callerId caller ID
-     * @param {string} channelService the channel service
      * @param {string} toChannelFromBotLoginUrl login url for messages from bot to channel
      * @param {string} toChannelFromBotOAuthScope oauth scope for messages from bot to channel
-     * @param {AuthValidator} authValidator auth validator for general requests
-     * @param {AuthValidator} emulatorAuthValidator auth validator for emulator requests
-     * @param {AuthValidator} skillAuthValidator auth validator for skill requests
+     * @param {AuthHeaderValidator} authHeaderValidator auth validator for general requests
+     * @param {AuthHeaderValidator} emulatorAuthHeaderValidator auth validator for emulator requests
+     * @param {AuthHeaderValidator} skillAuthHeaderValidator auth validator for skill requests
+     * @param {ServiceClientCredentialsFactory} credentialFactory the credential factory to use
+     * @param {AuthenticationConfiguration} authConfiguration the auth configuration to use
      * @returns {BotFrameworkAuthentication} the appropriate BotFrameworkAuthentication instance
      */
     static create(
@@ -39,9 +34,9 @@ export class BotFrameworkAuthenticationFactory {
         callerId?: string,
         toChannelFromBotLoginUrl?: string,
         toChannelFromBotOAuthScope?: string,
-        authValidator?: AuthValidator,
-        emulatorAuthValidator?: AuthValidator,
-        skillAuthValidator?: AuthValidator,
+        authHeaderValidator?: AuthHeaderValidator,
+        emulatorAuthHeaderValidator?: AuthHeaderValidator,
+        skillAuthHeaderValidator?: AuthHeaderValidator,
         credentialFactory?: ServiceClientCredentialsFactory,
         authConfiguration?: AuthenticationConfiguration
     ): BotFrameworkAuthentication {
@@ -50,9 +45,9 @@ export class BotFrameworkAuthenticationFactory {
             callerId ||
             toChannelFromBotLoginUrl ||
             toChannelFromBotOAuthScope ||
-            authValidator ||
-            emulatorAuthValidator ||
-            skillAuthValidator
+            authHeaderValidator ||
+            emulatorAuthHeaderValidator ||
+            skillAuthHeaderValidator
         ) {
             return new ParameterizedBotFrameworkAuthentication(
                 credentialFactory,
@@ -61,9 +56,9 @@ export class BotFrameworkAuthenticationFactory {
                 toChannelFromBotLoginUrl,
                 toChannelFromBotOAuthScope,
                 callerId,
-                authValidator,
-                emulatorAuthValidator,
-                skillAuthValidator
+                authHeaderValidator,
+                emulatorAuthHeaderValidator,
+                skillAuthHeaderValidator
             );
         } else {
             if (!channelService) {

--- a/libraries/botframework-connector/src/auth/claimsIdentity.ts
+++ b/libraries/botframework-connector/src/auth/claimsIdentity.ts
@@ -6,6 +6,8 @@
  * Licensed under the MIT License.
  */
 
+import { assert, Assertion } from 'botbuilder-stdlib';
+
 /**
  * Represents a claim.
  */
@@ -18,6 +20,9 @@ export interface Claim {
  * Represents a claims-based identity.
  */
 export class ClaimsIdentity {
+    static assert: Assertion<ClaimsIdentity> = assert.instanceOf('ClaimsIdentity', ClaimsIdentity);
+    static isType = assert.toTest(ClaimsIdentity.assert);
+
     /**
      * Initializes a new instance of the [ClaimsIdentity](xref:botframework-connector.ClaimsIdentity) class.
      *

--- a/libraries/botframework-connector/src/auth/claimsIdentityValidator.ts
+++ b/libraries/botframework-connector/src/auth/claimsIdentityValidator.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Activity } from 'botframework-schema';
+import { ClaimsIdentity } from './claimsIdentity';
+import { ICredentialProvider } from './credentialProvider';
+
+export interface ClaimsIdentityValidator {
+    validate(
+        credentials: ICredentialProvider,
+        claimsIdentity: ClaimsIdentity,
+        activity: Partial<Activity>
+    ): Promise<void>;
+}

--- a/libraries/botframework-connector/src/auth/credentialProvider.ts
+++ b/libraries/botframework-connector/src/auth/credentialProvider.ts
@@ -6,6 +6,8 @@
  * Licensed under the MIT License.
  */
 
+import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
+
 /**
  * CredentialProvider interface. This interface allows Bots to provide their own
  * implementation of what is, and what is not, a valid appId and password. This is
@@ -106,5 +108,38 @@ export class SimpleCredentialProvider implements ICredentialProvider {
      */
     public isAuthenticationDisabled(): Promise<boolean> {
         return Promise.resolve(!this.appId);
+    }
+}
+
+// Delegate credential provider implementation to a credential factory.
+export class DelegatingCredentialProvider implements ICredentialProvider {
+    constructor(private readonly credentialFactory: ServiceClientCredentialsFactory) {}
+
+    /**
+     * Not implemented for this provider.
+     *
+     * @returns {Promise<string>} a promise that resolves to an app password
+     */
+    async getAppPassword(): Promise<string> {
+        return Promise.reject(new Error('Method not implemented.'));
+    }
+
+    /**
+     * Check if an app ID is valid.
+     *
+     * @param {string} appId the app ID to check
+     * @returns {Promise<boolean>} a promise that resolves to true if the app ID is valid
+     */
+    isValidAppId(appId: string): Promise<boolean> {
+        return this.credentialFactory.isValidAppId(appId);
+    }
+
+    /**
+     * Check if authentication is disabled.
+     *
+     * @returns {Promise<boolean>} a promise that resolves to true if authentication is disabled
+     */
+    isAuthenticationDisabled(): Promise<boolean> {
+        return this.credentialFactory.isAuthenticationDisabled();
     }
 }

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -8,16 +8,109 @@
 
 /* eslint-disable @typescript-eslint/no-namespace */
 
-import { decode, VerifyOptions } from 'jsonwebtoken';
-import { ClaimsIdentity } from './claimsIdentity';
-import { AuthenticationConstants } from './authenticationConstants';
+import { AuthValidator, IdentityValidator, makeAuthValidator } from './authValidator';
 import { AuthenticationConfiguration } from './authenticationConfiguration';
+import { AuthenticationConstants } from './authenticationConstants';
+import { AuthenticationError } from './authenticationError';
+import { ClaimsIdentity } from './claimsIdentity';
 import { GovernmentConstants } from './governmentConstants';
 import { ICredentialProvider } from './credentialProvider';
-import { JwtTokenExtractor } from './jwtTokenExtractor';
 import { JwtTokenValidation } from './jwtTokenValidation';
-import { AuthenticationError } from './authenticationError';
 import { StatusCodes } from 'botframework-schema';
+import { decode, VerifyOptions } from 'jsonwebtoken';
+
+const verifyOptions: VerifyOptions = {
+    issuer: [
+        'https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/', // Auth v3.1, 1.0 token
+        'https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0', // Auth v3.1, 2.0 token
+        'https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/', // Auth v3.2, 1.0 token
+        'https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0', // Auth v3.2, 2.0 token
+        'https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/', // ???
+        'https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/', // US Gov Auth, 1.0 token
+        'https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0', // US Gov Auth, 2.0 token
+        'https://login.microsoftonline.us/f8cdef31-a31e-4b4a-93e4-5f571e91255a/', // Auth for US Gov, 1.0 token
+        'https://login.microsoftonline.us/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0', // Auth for US Gov, 2.0 token
+    ],
+    audience: undefined, // Audience validation takes place manually in code.
+    clockTolerance: 5 * 60,
+    ignoreExpiration: false,
+};
+
+const validateIdentity: IdentityValidator = async (credentials, identity) => {
+    // Now check that the AppID in the claimset matches
+    // what we're looking for. Note that in a multi-tenant bot, this value
+    // comes from developer code that may be reaching out to a service, hence the
+    // Async validation.
+    const versionClaim: string = identity.getClaimValue(AuthenticationConstants.VersionClaim);
+    if (versionClaim === null) {
+        throw new AuthenticationError(
+            'Unauthorized. "ver" claim is required on Emulator Tokens.',
+            StatusCodes.UNAUTHORIZED
+        );
+    }
+
+    let appId = '';
+
+    // The Emulator, depending on Version, sends the AppId via either the
+    // appid claim (Version 1) or the Authorized Party claim (Version 2).
+    if (!versionClaim || versionClaim === '1.0') {
+        // either no Version or a version of "1.0" means we should look for
+        // the claim in the "appid" claim.
+        const appIdClaim: string = identity.getClaimValue(AuthenticationConstants.AppIdClaim);
+        if (!appIdClaim) {
+            // No claim around AppID. Not Authorized.
+            throw new AuthenticationError(
+                'Unauthorized. "appid" claim is required on Emulator Token version "1.0".',
+                StatusCodes.UNAUTHORIZED
+            );
+        }
+
+        appId = appIdClaim;
+    } else if (versionClaim === '2.0') {
+        // Emulator, "2.0" puts the AppId in the "azp" claim.
+        const appZClaim: string = identity.getClaimValue(AuthenticationConstants.AuthorizedParty);
+        if (!appZClaim) {
+            // No claim around AppID. Not Authorized.
+            throw new AuthenticationError(
+                'Unauthorized. "azp" claim is required on Emulator Token version "2.0".',
+                StatusCodes.UNAUTHORIZED
+            );
+        }
+
+        appId = appZClaim;
+    } else {
+        // Unknown Version. Not Authorized.
+        throw new AuthenticationError(
+            `Unauthorized. Unknown Emulator Token version "${versionClaim}".`,
+            StatusCodes.UNAUTHORIZED
+        );
+    }
+
+    if (!(await credentials.isValidAppId(appId))) {
+        throw new AuthenticationError(
+            `Unauthorized. Invalid AppId passed on token: ${appId}`,
+            StatusCodes.UNAUTHORIZED
+        );
+    }
+};
+
+/**
+ * Construct an emulator auth validator using a specific open ID metadata url
+ *
+ * @param {string} openIdMetadataUrl url to fetch open ID metadata
+ * @returns {AuthValidator} an emulator auth validator
+ */
+export function makeEmulatorAuthValidator(openIdMetadataUrl: string): AuthValidator {
+    return makeAuthValidator(verifyOptions, openIdMetadataUrl, validateIdentity);
+}
+
+export const emulatorAuthValidator = makeEmulatorAuthValidator(
+    AuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl
+);
+
+export const governmentEmulatorAuthValidator = makeEmulatorAuthValidator(
+    GovernmentConstants.ToBotFromEmulatorOpenIdMetadataUrl
+);
 
 /**
  * Validates and Examines JWT tokens from the Bot Framework Emulator
@@ -26,22 +119,7 @@ export namespace EmulatorValidation {
     /**
      * TO BOT FROM EMULATOR: Token validation parameters when connecting to a channel.
      */
-    export const ToBotFromEmulatorTokenValidationParameters: VerifyOptions = {
-        issuer: [
-            'https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/', // Auth v3.1, 1.0 token
-            'https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0', // Auth v3.1, 2.0 token
-            'https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/', // Auth v3.2, 1.0 token
-            'https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0', // Auth v3.2, 2.0 token
-            'https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/', // ???
-            'https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/', // US Gov Auth, 1.0 token
-            'https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0', // US Gov Auth, 2.0 token
-            'https://login.microsoftonline.us/f8cdef31-a31e-4b4a-93e4-5f571e91255a/', // Auth for US Gov, 1.0 token
-            'https://login.microsoftonline.us/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0', // Auth for US Gov, 2.0 token
-        ],
-        audience: undefined, // Audience validation takes place manually in code.
-        clockTolerance: 5 * 60,
-        ignoreExpiration: false,
-    };
+    export const ToBotFromEmulatorTokenValidationParameters = verifyOptions;
 
     /**
      * Determines if a given Auth header is from the Bot Framework Emulator
@@ -116,88 +194,10 @@ export namespace EmulatorValidation {
         channelId: string,
         authConfig: AuthenticationConfiguration = new AuthenticationConfiguration()
     ): Promise<ClaimsIdentity> {
-        const openIdMetadataUrl =
-            channelService !== undefined && JwtTokenValidation.isGovernment(channelService)
-                ? GovernmentConstants.ToBotFromEmulatorOpenIdMetadataUrl
-                : AuthenticationConstants.ToBotFromEmulatorOpenIdMetadataUrl;
-
-        const tokenExtractor: JwtTokenExtractor = new JwtTokenExtractor(
-            ToBotFromEmulatorTokenValidationParameters,
-            openIdMetadataUrl,
-            AuthenticationConstants.AllowedSigningAlgorithms
-        );
-
-        const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(
-            authHeader,
-            channelId,
-            authConfig.requiredEndorsements
-        );
-        if (!identity) {
-            // No valid identity. Not Authorized.
-            throw new AuthenticationError('Unauthorized. No valid identity.', StatusCodes.UNAUTHORIZED);
-        }
-
-        if (!identity.isAuthenticated) {
-            // The token is in some way invalid. Not Authorized.
-            throw new AuthenticationError('Unauthorized. Is not authenticated', StatusCodes.UNAUTHORIZED);
-        }
-
-        // Now check that the AppID in the claimset matches
-        // what we're looking for. Note that in a multi-tenant bot, this value
-        // comes from developer code that may be reaching out to a service, hence the
-        // Async validation.
-        const versionClaim: string = identity.getClaimValue(AuthenticationConstants.VersionClaim);
-        if (versionClaim === null) {
-            throw new AuthenticationError(
-                'Unauthorized. "ver" claim is required on Emulator Tokens.',
-                StatusCodes.UNAUTHORIZED
-            );
-        }
-
-        let appId = '';
-
-        // The Emulator, depending on Version, sends the AppId via either the
-        // appid claim (Version 1) or the Authorized Party claim (Version 2).
-        if (!versionClaim || versionClaim === '1.0') {
-            // either no Version or a version of "1.0" means we should look for
-            // the claim in the "appid" claim.
-            const appIdClaim: string = identity.getClaimValue(AuthenticationConstants.AppIdClaim);
-            if (!appIdClaim) {
-                // No claim around AppID. Not Authorized.
-                throw new AuthenticationError(
-                    'Unauthorized. "appid" claim is required on Emulator Token version "1.0".',
-                    StatusCodes.UNAUTHORIZED
-                );
-            }
-
-            appId = appIdClaim;
-        } else if (versionClaim === '2.0') {
-            // Emulator, "2.0" puts the AppId in the "azp" claim.
-            const appZClaim: string = identity.getClaimValue(AuthenticationConstants.AuthorizedParty);
-            if (!appZClaim) {
-                // No claim around AppID. Not Authorized.
-                throw new AuthenticationError(
-                    'Unauthorized. "azp" claim is required on Emulator Token version "2.0".',
-                    StatusCodes.UNAUTHORIZED
-                );
-            }
-
-            appId = appZClaim;
+        if (JwtTokenValidation.isGovernment(channelService)) {
+            return governmentEmulatorAuthValidator(credentials, authConfig, authHeader, { channelId });
         } else {
-            // Unknown Version. Not Authorized.
-            throw new AuthenticationError(
-                `Unauthorized. Unknown Emulator Token version "${versionClaim}".`,
-                StatusCodes.UNAUTHORIZED
-            );
+            return emulatorAuthValidator(credentials, authConfig, authHeader, { channelId });
         }
-
-        if (!(await credentials.isValidAppId(appId))) {
-            throw new AuthenticationError(
-                `Unauthorized. Invalid AppId passed on token: ${appId}`,
-                StatusCodes.UNAUTHORIZED
-            );
-        }
-
-        return identity;
     }
 }

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -8,15 +8,16 @@
 
 /* eslint-disable @typescript-eslint/no-namespace */
 
-import { AuthValidator, IdentityValidator, makeAuthValidator } from './authValidator';
+import { Activity, StatusCodes } from 'botframework-schema';
+import { AuthHeaderValidator } from './authHeaderValidator';
 import { AuthenticationConfiguration } from './authenticationConfiguration';
 import { AuthenticationConstants } from './authenticationConstants';
 import { AuthenticationError } from './authenticationError';
 import { ClaimsIdentity } from './claimsIdentity';
+import { ClaimsIdentityValidator } from './claimsIdentityValidator';
 import { GovernmentConstants } from './governmentConstants';
 import { ICredentialProvider } from './credentialProvider';
 import { JwtTokenValidation } from './jwtTokenValidation';
-import { StatusCodes } from 'botframework-schema';
 import { decode, VerifyOptions } from 'jsonwebtoken';
 
 const verifyOptions: VerifyOptions = {
@@ -36,72 +37,78 @@ const verifyOptions: VerifyOptions = {
     ignoreExpiration: false,
 };
 
-const validateIdentity: IdentityValidator = async (credentials, identity) => {
-    // Now check that the AppID in the claimset matches
-    // what we're looking for. Note that in a multi-tenant bot, this value
-    // comes from developer code that may be reaching out to a service, hence the
-    // Async validation.
-    const versionClaim: string = identity.getClaimValue(AuthenticationConstants.VersionClaim);
-    if (versionClaim === null) {
-        throw new AuthenticationError(
-            'Unauthorized. "ver" claim is required on Emulator Tokens.',
-            StatusCodes.UNAUTHORIZED
-        );
-    }
-
-    let appId = '';
-
-    // The Emulator, depending on Version, sends the AppId via either the
-    // appid claim (Version 1) or the Authorized Party claim (Version 2).
-    if (!versionClaim || versionClaim === '1.0') {
-        // either no Version or a version of "1.0" means we should look for
-        // the claim in the "appid" claim.
-        const appIdClaim: string = identity.getClaimValue(AuthenticationConstants.AppIdClaim);
-        if (!appIdClaim) {
-            // No claim around AppID. Not Authorized.
+class EmulatorClaimsIdentityValidator implements ClaimsIdentityValidator {
+    async validate(
+        credentials: ICredentialProvider,
+        claimsIdentity: ClaimsIdentity,
+        _activity: Partial<Activity>
+    ): Promise<void> {
+        // Now check that the AppID in the claimset matches
+        // what we're looking for. Note that in a multi-tenant bot, this value
+        // comes from developer code that may be reaching out to a service, hence the
+        // Async validation.
+        const versionClaim: string = claimsIdentity.getClaimValue(AuthenticationConstants.VersionClaim);
+        if (versionClaim === null) {
             throw new AuthenticationError(
-                'Unauthorized. "appid" claim is required on Emulator Token version "1.0".',
+                'Unauthorized. "ver" claim is required on Emulator Tokens.',
                 StatusCodes.UNAUTHORIZED
             );
         }
 
-        appId = appIdClaim;
-    } else if (versionClaim === '2.0') {
-        // Emulator, "2.0" puts the AppId in the "azp" claim.
-        const appZClaim: string = identity.getClaimValue(AuthenticationConstants.AuthorizedParty);
-        if (!appZClaim) {
-            // No claim around AppID. Not Authorized.
+        let appId = '';
+
+        // The Emulator, depending on Version, sends the AppId via either the
+        // appid claim (Version 1) or the Authorized Party claim (Version 2).
+        if (!versionClaim || versionClaim === '1.0') {
+            // either no Version or a version of "1.0" means we should look for
+            // the claim in the "appid" claim.
+            const appIdClaim: string = claimsIdentity.getClaimValue(AuthenticationConstants.AppIdClaim);
+            if (!appIdClaim) {
+                // No claim around AppID. Not Authorized.
+                throw new AuthenticationError(
+                    'Unauthorized. "appid" claim is required on Emulator Token version "1.0".',
+                    StatusCodes.UNAUTHORIZED
+                );
+            }
+
+            appId = appIdClaim;
+        } else if (versionClaim === '2.0') {
+            // Emulator, "2.0" puts the AppId in the "azp" claim.
+            const appZClaim: string = claimsIdentity.getClaimValue(AuthenticationConstants.AuthorizedParty);
+            if (!appZClaim) {
+                // No claim around AppID. Not Authorized.
+                throw new AuthenticationError(
+                    'Unauthorized. "azp" claim is required on Emulator Token version "2.0".',
+                    StatusCodes.UNAUTHORIZED
+                );
+            }
+
+            appId = appZClaim;
+        } else {
+            // Unknown Version. Not Authorized.
             throw new AuthenticationError(
-                'Unauthorized. "azp" claim is required on Emulator Token version "2.0".',
+                `Unauthorized. Unknown Emulator Token version "${versionClaim}".`,
                 StatusCodes.UNAUTHORIZED
             );
         }
 
-        appId = appZClaim;
-    } else {
-        // Unknown Version. Not Authorized.
-        throw new AuthenticationError(
-            `Unauthorized. Unknown Emulator Token version "${versionClaim}".`,
-            StatusCodes.UNAUTHORIZED
-        );
+        if (!(await credentials.isValidAppId(appId))) {
+            throw new AuthenticationError(
+                `Unauthorized. Invalid AppId passed on token: ${appId}`,
+                StatusCodes.UNAUTHORIZED
+            );
+        }
     }
-
-    if (!(await credentials.isValidAppId(appId))) {
-        throw new AuthenticationError(
-            `Unauthorized. Invalid AppId passed on token: ${appId}`,
-            StatusCodes.UNAUTHORIZED
-        );
-    }
-};
+}
 
 /**
  * Construct an emulator auth validator using a specific open ID metadata url
  *
  * @param {string} openIdMetadataUrl url to fetch open ID metadata
- * @returns {AuthValidator} an emulator auth validator
+ * @returns {AuthHeaderValidator} an emulator auth validator
  */
-export function makeEmulatorAuthValidator(openIdMetadataUrl: string): AuthValidator {
-    return makeAuthValidator(verifyOptions, openIdMetadataUrl, validateIdentity);
+export function makeEmulatorAuthValidator(openIdMetadataUrl: string): AuthHeaderValidator {
+    return new AuthHeaderValidator(verifyOptions, openIdMetadataUrl, new EmulatorClaimsIdentityValidator());
 }
 
 export const emulatorAuthValidator = makeEmulatorAuthValidator(
@@ -180,11 +187,12 @@ export namespace EmulatorValidation {
     /**
      * Validate the incoming Auth Header as a token sent from the Bot Framework Emulator.
      * A token issued by the Bot Framework will FAIL this check. Only Emulator tokens will pass.
+     *
      * @param  {string} authHeader The raw HTTP header in the format: "Bearer [longString]"
      * @param  {ICredentialProvider} credentials The user defined set of valid credentials, such as the AppId.
      * @param  {string} channelService The channelService value that distinguishes public Azure from US Government Azure.
-     * @param  {string} channelId
-     * @param  {AuthenticationConfiguration} authConfig
+     * @param  {string} channelId The channel ID
+     * @param  {AuthenticationConfiguration} authConfig the auth config
      * @returns {Promise<ClaimsIdentity>} A valid ClaimsIdentity.
      */
     export async function authenticateEmulatorToken(
@@ -195,9 +203,9 @@ export namespace EmulatorValidation {
         authConfig: AuthenticationConfiguration = new AuthenticationConfiguration()
     ): Promise<ClaimsIdentity> {
         if (JwtTokenValidation.isGovernment(channelService)) {
-            return governmentEmulatorAuthValidator(credentials, authConfig, authHeader, { channelId });
+            return governmentEmulatorAuthValidator.validate(credentials, authConfig, authHeader, { channelId });
         } else {
-            return emulatorAuthValidator(credentials, authConfig, authHeader, { channelId });
+            return emulatorAuthValidator.validate(credentials, authConfig, authHeader, { channelId });
         }
     }
 }

--- a/libraries/botframework-connector/src/auth/governmentCloudBotFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/governmentCloudBotFrameworkAuthentication.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AuthenticationConfiguration } from './authenticationConfiguration';
+import { CallerIdConstants } from 'botframework-schema';
+import { GovernmentChannelValidation } from './governmentChannelValidation';
+import { GovernmentConstants } from './governmentConstants';
+import { ParameterizedBotFrameworkAuthentication } from './parameterizedBotFrameworkAuthentication';
+import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
+import { VerifyOptions } from 'jsonwebtoken';
+import { governmentEmulatorAuthValidator } from './emulatorValidation';
+import { governmentSkillAuthValidator } from './skillValidation';
+import { makeAuthValidator } from './authValidator';
+
+export class GovernmentCloudBotFrameworkAuthentication extends ParameterizedBotFrameworkAuthentication {
+    constructor(
+        credentialFactory: ServiceClientCredentialsFactory,
+        authConfiguration: AuthenticationConfiguration,
+        verifyOptions?: Partial<VerifyOptions>
+    ) {
+        const authValidator = makeAuthValidator(
+            Object.assign(
+                {},
+                GovernmentChannelValidation.ToBotFromGovernmentChannelTokenValidationParameters,
+                verifyOptions
+            ),
+            GovernmentConstants.ToBotFromChannelOpenIdMetadataUrl, // TODO: configurable
+            async (credentials, identity) => {
+                await GovernmentChannelValidation.validateIdentity(identity, credentials);
+            }
+        );
+
+        super(
+            credentialFactory,
+            authConfiguration,
+            true,
+            GovernmentConstants.ToChannelFromBotLoginUrl,
+            GovernmentConstants.ToChannelFromBotOAuthScope,
+            CallerIdConstants.USGovChannel,
+            authValidator,
+            governmentEmulatorAuthValidator,
+            governmentSkillAuthValidator
+        );
+    }
+}

--- a/libraries/botframework-connector/src/auth/governmentCloudBotFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/governmentCloudBotFrameworkAuthentication.ts
@@ -16,7 +16,8 @@ export class GovernmentCloudBotFrameworkAuthentication extends ParameterizedBotF
     constructor(
         credentialFactory: ServiceClientCredentialsFactory,
         authConfiguration: AuthenticationConfiguration,
-        verifyOptions?: Partial<VerifyOptions>
+        verifyOptions?: Partial<VerifyOptions>,
+        openIdMetadataUrl?: string
     ) {
         const authValidator = makeAuthValidator(
             Object.assign(
@@ -24,7 +25,7 @@ export class GovernmentCloudBotFrameworkAuthentication extends ParameterizedBotF
                 GovernmentChannelValidation.ToBotFromGovernmentChannelTokenValidationParameters,
                 verifyOptions
             ),
-            GovernmentConstants.ToBotFromChannelOpenIdMetadataUrl, // TODO: configurable
+            openIdMetadataUrl ?? GovernmentConstants.ToBotFromChannelOpenIdMetadataUrl,
             async (credentials, identity) => {
                 await GovernmentChannelValidation.validateIdentity(identity, credentials);
             }

--- a/libraries/botframework-connector/src/auth/governmentCloudBotFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/governmentCloudBotFrameworkAuthentication.ts
@@ -3,14 +3,13 @@
 
 import { AuthenticationConfiguration } from './authenticationConfiguration';
 import { CallerIdConstants } from 'botframework-schema';
-import { GovernmentChannelValidation } from './governmentChannelValidation';
 import { GovernmentConstants } from './governmentConstants';
 import { ParameterizedBotFrameworkAuthentication } from './parameterizedBotFrameworkAuthentication';
 import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
 import { VerifyOptions } from 'jsonwebtoken';
 import { governmentEmulatorAuthValidator } from './emulatorValidation';
 import { governmentSkillAuthValidator } from './skillValidation';
-import { makeAuthValidator } from './authValidator';
+import { makeGovernmentAuthValidator } from './governmentChannelValidation';
 
 export class GovernmentCloudBotFrameworkAuthentication extends ParameterizedBotFrameworkAuthentication {
     constructor(
@@ -19,16 +18,9 @@ export class GovernmentCloudBotFrameworkAuthentication extends ParameterizedBotF
         verifyOptions?: Partial<VerifyOptions>,
         openIdMetadataUrl?: string
     ) {
-        const authValidator = makeAuthValidator(
-            Object.assign(
-                {},
-                GovernmentChannelValidation.ToBotFromGovernmentChannelTokenValidationParameters,
-                verifyOptions
-            ),
+        const authHeaderValidator = makeGovernmentAuthValidator(
             openIdMetadataUrl ?? GovernmentConstants.ToBotFromChannelOpenIdMetadataUrl,
-            async (credentials, identity) => {
-                await GovernmentChannelValidation.validateIdentity(identity, credentials);
-            }
+            verifyOptions
         );
 
         super(
@@ -38,7 +30,7 @@ export class GovernmentCloudBotFrameworkAuthentication extends ParameterizedBotF
             GovernmentConstants.ToChannelFromBotLoginUrl,
             GovernmentConstants.ToChannelFromBotOAuthScope,
             CallerIdConstants.USGovChannel,
-            authValidator,
+            authHeaderValidator,
             governmentEmulatorAuthValidator,
             governmentSkillAuthValidator
         );

--- a/libraries/botframework-connector/src/auth/index.ts
+++ b/libraries/botframework-connector/src/auth/index.ts
@@ -7,6 +7,7 @@
  */
 
 export * from './appCredentials';
+export * from './authValidator';
 export * from './authenticationConfiguration';
 export * from './authenticationConstants';
 export * from './authenticationError';
@@ -22,6 +23,7 @@ export * from './enterpriseChannelValidation';
 export * from './governmentChannelValidation';
 export * from './governmentCloudBotFrameworkAuthentication';
 export * from './governmentConstants';
+export * from './jwtTokenExtractor';
 export * from './jwtTokenValidation';
 export * from './microsoftAppCredentials';
 export * from './parameterizedBotFrameworkAuthentication';

--- a/libraries/botframework-connector/src/auth/index.ts
+++ b/libraries/botframework-connector/src/auth/index.ts
@@ -7,7 +7,7 @@
  */
 
 export * from './appCredentials';
-export * from './authValidator';
+export * from './authHeaderValidator';
 export * from './authenticationConfiguration';
 export * from './authenticationConstants';
 export * from './authenticationError';
@@ -16,6 +16,7 @@ export * from './botFrameworkAuthenticationFactory';
 export * from './certificateAppCredentials';
 export * from './channelValidation';
 export * from './claimsIdentity';
+export * from './claimsIdentityValidator';
 export * from './credentialProvider';
 export * from './emulatorValidation';
 export * from './endorsementsValidator';

--- a/libraries/botframework-connector/src/auth/index.ts
+++ b/libraries/botframework-connector/src/auth/index.ts
@@ -6,19 +6,26 @@
  * Licensed under the MIT License.
  */
 
-export * from './credentialProvider';
-export * from './microsoftAppCredentials';
 export * from './appCredentials';
-export * from './certificateAppCredentials';
-export * from './jwtTokenValidation';
-export * from './channelValidation';
-export * from './governmentChannelValidation';
-export * from './governmentConstants';
-export * from './enterpriseChannelValidation';
-export * from './emulatorValidation';
-export * from './endorsementsValidator';
-export * from './claimsIdentity';
 export * from './authenticationConfiguration';
 export * from './authenticationConstants';
 export * from './authenticationError';
+export * from './botFrameworkAuthentication';
+export * from './botFrameworkAuthenticationFactory';
+export * from './certificateAppCredentials';
+export * from './channelValidation';
+export * from './claimsIdentity';
+export * from './credentialProvider';
+export * from './emulatorValidation';
+export * from './endorsementsValidator';
+export * from './enterpriseChannelValidation';
+export * from './governmentChannelValidation';
+export * from './governmentCloudBotFrameworkAuthentication';
+export * from './governmentConstants';
+export * from './jwtTokenValidation';
+export * from './microsoftAppCredentials';
+export * from './parameterizedBotFrameworkAuthentication';
+export * from './passwordServiceClientCredentialFactory';
+export * from './publicCloudBotFrameworkAuthentication';
+export * from './serviceClientCredentialsFactory';
 export * from './skillValidation';

--- a/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
@@ -23,6 +23,7 @@ function isErrorResponse(value: unknown): value is adal.ErrorResponse {
  * MicrosoftAppCredentials auth implementation
  */
 export class MicrosoftAppCredentials extends AppCredentials {
+    static Empty = new MicrosoftAppCredentials(undefined, undefined);
 
     /**
      * Initializes a new instance of the [MicrosoftAppCredentials](xref:botframework-connector.MicrosoftAppCredentials) class.

--- a/libraries/botframework-connector/src/auth/microsoftGovernmentAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/microsoftGovernmentAppCredentials.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { GovernmentConstants } from './governmentConstants';
+import { MicrosoftAppCredentials } from './microsoftAppCredentials';
+
+export class MicrosoftGovernmentAppCredentials extends MicrosoftAppCredentials {
+    static Empty = new MicrosoftGovernmentAppCredentials(undefined, undefined, undefined);
+
+    /**
+     * Initializes a new instance of the [MicrosoftGovernmentAppCredentials](xref:botframework-connector.MicrosoftGovernmentAppCredentials) class.
+     *
+     * @param {string} appId The Microsoft app ID.
+     * @param {string} appPassword The Microsoft app password.
+     * @param {string} oAuthScope Optional. The scope for the token.
+     */
+    public constructor(appId: string, appPassword: string, oAuthScope?: string) {
+        super(appId, appPassword, undefined, oAuthScope ?? GovernmentConstants.ToChannelFromBotOAuthScope);
+    }
+}

--- a/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Activity } from 'botframework-schema';
+import { AuthValidator } from './authValidator';
+import { AuthenticationConfiguration } from './authenticationConfiguration';
+import { ClaimsIdentity } from './claimsIdentity';
+import { DelegatingCredentialProvider, ICredentialProvider } from './credentialProvider';
+import { EmulatorValidation } from './emulatorValidation';
+import { JwtTokenValidation } from './jwtTokenValidation';
+import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
+import { SkillValidation } from './skillValidation';
+
+import {
+    AuthenticateRequestResult,
+    BotFrameworkAuthentication,
+    ProactiveCredentialsResult,
+} from './botFrameworkAuthentication';
+
+// Create a fully parameterized BotFrameworkAuthentication instance. Useful for scenarios
+// like tests or other non-standard deployments.
+export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthentication {
+    private readonly credentials: ICredentialProvider;
+
+    /**
+     * Construct a ParameterizedBotFrameworkAuthentication instance
+     *
+     * @param {ServiceClientCredentialsFactory} credentialFactory the credential factory to use
+     * @param {AuthenticationConfiguration} authConfiguration the auth configuration to use
+     * @param {boolean} validateAuthority whether or not validate the authority
+     * @param {string} toChannelFromBotLoginUrl login url for messages from bot to channel
+     * @param {string} toChannelFromBotOAuthScope oauth scope for messages from bot to channel
+     * @param {string} callerId caller ID
+     * @param {AuthValidator} authValidator general auth validator
+     * @param {AuthValidator} emulatorAuthValidator emulator auth validator
+     * @param {AuthValidator} skillAuthValidator skill auth validator
+     */
+    constructor(
+        private readonly credentialFactory: ServiceClientCredentialsFactory,
+        private readonly authConfiguration: AuthenticationConfiguration,
+        private readonly validateAuthority: boolean,
+        private readonly toChannelFromBotLoginUrl: string,
+        private readonly toChannelFromBotOAuthScope: string,
+        private readonly callerId: string | undefined,
+        private readonly authValidator: AuthValidator,
+        private readonly emulatorAuthValidator: AuthValidator,
+        private readonly skillAuthValidator: AuthValidator
+    ) {
+        super();
+        this.credentials = new DelegatingCredentialProvider(credentialFactory);
+    }
+
+    private async getClaimsIdentity(activity: Partial<Activity>, authHeader: string): Promise<ClaimsIdentity> {
+        let authValidator = this.authValidator;
+
+        if (SkillValidation.isSkillToken(authHeader)) {
+            authValidator = this.skillAuthValidator;
+        } else if (EmulatorValidation.isTokenFromEmulator(authHeader)) {
+            authValidator = this.emulatorAuthValidator;
+        }
+
+        return authValidator(this.credentials, this.authConfiguration, authHeader, activity);
+    }
+
+    async authenticateRequest(activity: Partial<Activity>, authHeader: string): Promise<AuthenticateRequestResult> {
+        const claimsIdentity = await this.getClaimsIdentity(activity, authHeader.trim());
+
+        const scope = SkillValidation.isSkillClaim(claimsIdentity.claims)
+            ? JwtTokenValidation.getAppIdFromClaims(claimsIdentity.claims)
+            : this.toChannelFromBotOAuthScope;
+
+        const callerId = await this.generateCallerId(this.credentialFactory, claimsIdentity, this.callerId);
+
+        const appId = this.getAppId(claimsIdentity);
+
+        const credentials = await this.credentialFactory.createCredentials(
+            appId,
+            scope,
+            this.toChannelFromBotLoginUrl,
+            this.validateAuthority
+        );
+
+        return { callerId, claimsIdentity, credentials, scope };
+    }
+
+    async getProactiveCredentials(
+        claimsIdentity: ClaimsIdentity,
+        audience: string
+    ): Promise<ProactiveCredentialsResult> {
+        const scope = audience ?? this.toChannelFromBotOAuthScope;
+
+        const appId = this.getAppId(claimsIdentity);
+
+        const credentials = await this.credentialFactory.createCredentials(
+            appId,
+            scope,
+            this.toChannelFromBotLoginUrl,
+            true
+        );
+
+        return { credentials, scope };
+    }
+}

--- a/libraries/botframework-connector/src/auth/passwordServiceClientCredentialFactory.ts
+++ b/libraries/botframework-connector/src/auth/passwordServiceClientCredentialFactory.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AuthenticationConstants } from './authenticationConstants';
+import { GovernmentConstants } from './governmentConstants';
+import { MicrosoftAppCredentials } from './microsoftAppCredentials';
+import { MicrosoftGovernmentAppCredentials } from './microsoftGovernmentAppCredentials';
+import { ServiceClientCredentials } from '@azure/ms-rest-js';
+import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
+
+class PrivateCloudAppCredentials extends MicrosoftAppCredentials {
+    constructor(
+        appId: string,
+        password: string,
+        oauthScope: string,
+        private readonly oauthEndpoint: string,
+        private readonly validateAuthority: boolean
+    ) {
+        super(appId, password, undefined, oauthScope);
+    }
+}
+
+export class PasswordServiceClientCredentialFactory extends ServiceClientCredentialsFactory {
+    constructor(private readonly appId?: string, private readonly password?: string) {
+        super();
+    }
+
+    isValidAppId(appId: string): Promise<boolean> {
+        return Promise.resolve(appId === this.appId);
+    }
+
+    isAuthenticationDisabled(): Promise<boolean> {
+        return Promise.resolve(this.appId == null);
+    }
+
+    createCredentials(
+        appId: string,
+        oauthScope: string,
+        loginEndpoint: string,
+        validateAuthority: boolean
+    ): Promise<ServiceClientCredentials> {
+        if (loginEndpoint.startsWith(AuthenticationConstants.ToChannelFromBotLoginUrlPrefix)) {
+            return Promise.resolve(
+                this.appId == null
+                    ? MicrosoftAppCredentials.Empty
+                    : new MicrosoftAppCredentials(appId, this.password, undefined, oauthScope)
+            );
+        } else if (loginEndpoint === GovernmentConstants.ToChannelFromBotLoginUrl) {
+            return Promise.resolve(
+                this.appId == null
+                    ? MicrosoftGovernmentAppCredentials.Empty
+                    : new MicrosoftAppCredentials(appId, this.appId, oauthScope)
+            );
+        } else {
+            return Promise.resolve(
+                this.appId == null
+                    ? new PrivateCloudAppCredentials(null, null, null, loginEndpoint, validateAuthority)
+                    : new PrivateCloudAppCredentials(appId, this.password, oauthScope, loginEndpoint, validateAuthority)
+            );
+        }
+    }
+}

--- a/libraries/botframework-connector/src/auth/publicCloudBotFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/publicCloudBotFrameworkAuthentication.ts
@@ -16,11 +16,12 @@ export class PublicCloudBotFrameworkAuthentication extends ParameterizedBotFrame
     constructor(
         credentialFactory: ServiceClientCredentialsFactory,
         authConfiguration: AuthenticationConfiguration,
-        verifyOptions?: Partial<VerifyOptions>
+        verifyOptions?: Partial<VerifyOptions>,
+        openIdMetadataUrl?: string
     ) {
         const authValidator = makeAuthValidator(
             Object.assign({}, ChannelValidation.ToBotFromChannelTokenValidationParameters, verifyOptions),
-            AuthenticationConstants.ToBotFromChannelOpenIdMetadataUrl, // TODO: configurable
+            openIdMetadataUrl ?? AuthenticationConstants.ToBotFromChannelOpenIdMetadataUrl,
             async (credentials, identity) => {
                 await ChannelValidation.validateIdentity(identity, credentials);
             }

--- a/libraries/botframework-connector/src/auth/publicCloudBotFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/publicCloudBotFrameworkAuthentication.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AuthenticationConfiguration } from './authenticationConfiguration';
+import { AuthenticationConstants } from './authenticationConstants';
+import { CallerIdConstants } from 'botframework-schema';
+import { ChannelValidation } from './channelValidation';
+import { ParameterizedBotFrameworkAuthentication } from './parameterizedBotFrameworkAuthentication';
+import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
+import { VerifyOptions } from 'jsonwebtoken';
+import { emulatorAuthValidator } from './emulatorValidation';
+import { emulatorSkillAuthValidator } from './skillValidation';
+import { makeAuthValidator } from './authValidator';
+
+export class PublicCloudBotFrameworkAuthentication extends ParameterizedBotFrameworkAuthentication {
+    constructor(
+        credentialFactory: ServiceClientCredentialsFactory,
+        authConfiguration: AuthenticationConfiguration,
+        verifyOptions?: Partial<VerifyOptions>
+    ) {
+        const authValidator = makeAuthValidator(
+            Object.assign({}, ChannelValidation.ToBotFromChannelTokenValidationParameters, verifyOptions),
+            AuthenticationConstants.ToBotFromChannelOpenIdMetadataUrl, // TODO: configurable
+            async (credentials, identity) => {
+                await ChannelValidation.validateIdentity(identity, credentials);
+            }
+        );
+
+        super(
+            credentialFactory,
+            authConfiguration,
+            true,
+            AuthenticationConstants.ToChannelFromBotLoginUrl,
+            AuthenticationConstants.ToChannelFromBotOAuthScope,
+            CallerIdConstants.PublicAzureChannel,
+            authValidator,
+            emulatorAuthValidator,
+            emulatorSkillAuthValidator
+        );
+    }
+}

--- a/libraries/botframework-connector/src/auth/publicCloudBotFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/publicCloudBotFrameworkAuthentication.ts
@@ -4,13 +4,12 @@
 import { AuthenticationConfiguration } from './authenticationConfiguration';
 import { AuthenticationConstants } from './authenticationConstants';
 import { CallerIdConstants } from 'botframework-schema';
-import { ChannelValidation } from './channelValidation';
 import { ParameterizedBotFrameworkAuthentication } from './parameterizedBotFrameworkAuthentication';
 import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
 import { VerifyOptions } from 'jsonwebtoken';
 import { emulatorAuthValidator } from './emulatorValidation';
 import { emulatorSkillAuthValidator } from './skillValidation';
-import { makeAuthValidator } from './authValidator';
+import { makeChannelAuthValidator } from './channelValidation';
 
 export class PublicCloudBotFrameworkAuthentication extends ParameterizedBotFrameworkAuthentication {
     constructor(
@@ -19,12 +18,9 @@ export class PublicCloudBotFrameworkAuthentication extends ParameterizedBotFrame
         verifyOptions?: Partial<VerifyOptions>,
         openIdMetadataUrl?: string
     ) {
-        const authValidator = makeAuthValidator(
-            Object.assign({}, ChannelValidation.ToBotFromChannelTokenValidationParameters, verifyOptions),
+        const authHeaderValidator = makeChannelAuthValidator(
             openIdMetadataUrl ?? AuthenticationConstants.ToBotFromChannelOpenIdMetadataUrl,
-            async (credentials, identity) => {
-                await ChannelValidation.validateIdentity(identity, credentials);
-            }
+            verifyOptions,
         );
 
         super(
@@ -34,7 +30,7 @@ export class PublicCloudBotFrameworkAuthentication extends ParameterizedBotFrame
             AuthenticationConstants.ToChannelFromBotLoginUrl,
             AuthenticationConstants.ToChannelFromBotOAuthScope,
             CallerIdConstants.PublicAzureChannel,
-            authValidator,
+            authHeaderValidator,
             emulatorAuthValidator,
             emulatorSkillAuthValidator
         );

--- a/libraries/botframework-connector/src/auth/serviceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/serviceClientCredentialsFactory.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ServiceClientCredentials } from '@azure/ms-rest-js';
+
+export abstract class ServiceClientCredentialsFactory {
+    abstract isValidAppId(appId: string): Promise<boolean>;
+
+    abstract isAuthenticationDisabled(): Promise<boolean>;
+
+    abstract createCredentials(
+        appId: string,
+        oauthScope: string,
+        loginEndpoint: string,
+        validateAuthority: boolean
+    ): Promise<ServiceClientCredentials>;
+}

--- a/libraries/botframework-connector/src/connectorApi/connectorClient.ts
+++ b/libraries/botframework-connector/src/connectorApi/connectorClient.ts
@@ -7,9 +7,12 @@ import * as Mappers from './models/mappers';
 import * as Models from './models';
 import * as msRest from '@azure/ms-rest-js';
 import * as operations from './operations';
+import { assert, Assertion } from 'botbuilder-stdlib';
 import { ConnectorClientContext } from './connectorClientContext';
 
 class ConnectorClient extends ConnectorClientContext {
+    static assert: Assertion<ConnectorClient> = assert.instanceOf('ConnectorClient', ConnectorClient);
+    static isType = assert.toTest(ConnectorClient.assert);
 
     // Operation groups
     attachments: operations.Attachments;

--- a/libraries/botframework-connector/src/connectorApi/operations/conversations.ts
+++ b/libraries/botframework-connector/src/connectorApi/operations/conversations.ts
@@ -124,21 +124,21 @@ export class Conversations {
    * @param [options] The optional parameters
    * @returns Promise<Models.ConversationsSendToConversationResponse>
    */
-  sendToConversation(conversationId: string, activity: Models.Activity, options?: msRest.RequestOptionsBase): Promise<Models.ConversationsSendToConversationResponse>;
+  sendToConversation(conversationId: string, activity: Partial<Models.Activity>, options?: msRest.RequestOptionsBase): Promise<Models.ConversationsSendToConversationResponse>;
   /**
    * @param conversationId Conversation ID
    * @param activity Activity to send
    * @param callback The callback
    */
-  sendToConversation(conversationId: string, activity: Models.Activity, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
+  sendToConversation(conversationId: string, activity: Partial<Models.Activity>, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
   /**
    * @param conversationId Conversation ID
    * @param activity Activity to send
    * @param options The optional parameters
    * @param callback The callback
    */
-  sendToConversation(conversationId: string, activity: Models.Activity, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
-  sendToConversation(conversationId: string, activity: Models.Activity, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceResponse>, callback?: msRest.ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsSendToConversationResponse> {
+  sendToConversation(conversationId: string, activity: Partial<Models.Activity>, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
+  sendToConversation(conversationId: string, activity: Partial<Models.Activity>, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceResponse>, callback?: msRest.ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsSendToConversationResponse> {
     return this.client.sendOperationRequest(
       {
         conversationId,
@@ -200,14 +200,14 @@ export class Conversations {
    * @param [options] The optional parameters
    * @returns Promise<Models.ConversationsUpdateActivityResponse>
    */
-  updateActivity(conversationId: string, activityId: string, activity: Models.Activity, options?: msRest.RequestOptionsBase): Promise<Models.ConversationsUpdateActivityResponse>;
+  updateActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options?: msRest.RequestOptionsBase): Promise<Models.ConversationsUpdateActivityResponse>;
   /**
    * @param conversationId Conversation ID
    * @param activityId activityId to update
    * @param activity replacement Activity
    * @param callback The callback
    */
-  updateActivity(conversationId: string, activityId: string, activity: Models.Activity, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
+  updateActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
   /**
    * @param conversationId Conversation ID
    * @param activityId activityId to update
@@ -215,8 +215,8 @@ export class Conversations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  updateActivity(conversationId: string, activityId: string, activity: Models.Activity, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
-  updateActivity(conversationId: string, activityId: string, activity: Models.Activity, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceResponse>, callback?: msRest.ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsUpdateActivityResponse> {
+  updateActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
+  updateActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceResponse>, callback?: msRest.ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsUpdateActivityResponse> {
     return this.client.sendOperationRequest(
       {
         conversationId,
@@ -248,14 +248,14 @@ export class Conversations {
    * @param [options] The optional parameters
    * @returns Promise<Models.ConversationsReplyToActivityResponse>
    */
-  replyToActivity(conversationId: string, activityId: string, activity: Models.Activity, options?: msRest.RequestOptionsBase): Promise<Models.ConversationsReplyToActivityResponse>;
+  replyToActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options?: msRest.RequestOptionsBase): Promise<Models.ConversationsReplyToActivityResponse>;
   /**
    * @param conversationId Conversation ID
    * @param activityId activityId the reply is to (OPTIONAL)
    * @param activity Activity to send
    * @param callback The callback
    */
-  replyToActivity(conversationId: string, activityId: string, activity: Models.Activity, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
+  replyToActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
   /**
    * @param conversationId Conversation ID
    * @param activityId activityId the reply is to (OPTIONAL)
@@ -263,8 +263,8 @@ export class Conversations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  replyToActivity(conversationId: string, activityId: string, activity: Models.Activity, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
-  replyToActivity(conversationId: string, activityId: string, activity: Models.Activity, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceResponse>, callback?: msRest.ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsReplyToActivityResponse> {
+  replyToActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceResponse>): void;
+  replyToActivity(conversationId: string, activityId: string, activity: Partial<Models.Activity>, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceResponse>, callback?: msRest.ServiceCallback<Models.ResourceResponse>): Promise<Models.ConversationsReplyToActivityResponse> {
     return this.client.sendOperationRequest(
       {
         conversationId,

--- a/libraries/botframework-connector/tests/auth/botFrameworkAuthenticationFactory.test.js
+++ b/libraries/botframework-connector/tests/auth/botFrameworkAuthenticationFactory.test.js
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const assert = require('assert');
+
+const {
+    BotFrameworkAuthenticationFactory,
+    GovernmentCloudBotFrameworkAuthentication,
+    GovernmentConstants,
+    ParameterizedBotFrameworkAuthentication,
+    PublicCloudBotFrameworkAuthentication,
+} = require('../..');
+
+describe('BotFrameworkAuthenticationFactory', () => {
+    it('creates a public cloud instance', () => {
+        assert(BotFrameworkAuthenticationFactory.create() instanceof PublicCloudBotFrameworkAuthentication);
+    });
+
+    it('creates a gov cloud instance', () => {
+        assert(
+            BotFrameworkAuthenticationFactory.create(GovernmentConstants.ChannelService) instanceof
+                GovernmentCloudBotFrameworkAuthentication
+        );
+    });
+
+    it('creates a parameterized instance', () => {
+        assert(
+            BotFrameworkAuthenticationFactory.create(undefined, false, 'something') instanceof
+                ParameterizedBotFrameworkAuthentication
+        );
+    });
+});

--- a/libraries/botframework-connector/tests/auth/jwtTokenValidation.test.js
+++ b/libraries/botframework-connector/tests/auth/jwtTokenValidation.test.js
@@ -138,7 +138,7 @@ describe('JwtTokenValidation', () => {
                         'https://service.url'
                     );
                 },
-                label: 'succeeds with a specific tenant',
+                label: 'succeeds with a service URL',
                 makeActivity: () => ({ serviceUrl: 'https://service.url' }),
                 makeClaims,
             },

--- a/libraries/botframework-connector/tests/auth/parameterizedBotFrameworkAuthentication.test.js
+++ b/libraries/botframework-connector/tests/auth/parameterizedBotFrameworkAuthentication.test.js
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const assert = require('assert');
+const url = require('url');
+const { JwtTokenExtractor } = require('../../lib/auth/jwtTokenExtractor');
+const { StatusCodes } = require('botframework-schema');
+const { jwt, oauth } = require('botbuilder-test-utils');
+
+const {
+    AuthenticationConfiguration,
+    AuthenticationConstants,
+    AuthenticationError,
+    GovernmentCloudBotFrameworkAuthentication,
+    GovernmentConstants,
+    PasswordServiceClientCredentialFactory,
+    PublicCloudBotFrameworkAuthentication,
+    UnauthorizedAccessError,
+} = require('../..');
+
+describe('ParameterizedBotFrameworkAuthentication', () => {
+    describe('derived classes', () => {
+        afterEach(() => {
+            JwtTokenExtractor.openIdMetadataCache.clear();
+        });
+
+        jwt.mocha();
+        oauth.mocha();
+
+        const authenticateRequest = async ({
+            activity = {},
+            appId = 'appId',
+            appPassword = 'password',
+            assertResult = (result) => assert(result.claimsIdentity.isAuthenticated),
+            authCtor,
+            channelService,
+            issuer,
+            makeAuthHeader = (tokenType, accessToken) => `${tokenType} ${accessToken}`,
+            makeClaims = (appId, defaultClaims) => ({
+                ...defaultClaims,
+                [AuthenticationConstants.AudienceClaim]: appId,
+            }),
+            makeFactory = (appId, appPassword) => new PasswordServiceClientCredentialFactory(appId, appPassword),
+            metadata,
+            rejectsWith,
+            skippedJwt = false,
+        } = {}) => {
+            const { sign, verify } = jwt.stub({
+                issuer,
+                metadata: url.parse(metadata),
+            });
+
+            const { accessToken, tokenType } = oauth.stub({
+                accessToken: sign(makeClaims(appId, {})),
+            });
+
+            const factory = makeFactory(appId, appPassword);
+            const config = new AuthenticationConfiguration();
+            const auth = new authCtor(factory, config, channelService);
+
+            const promise = auth.authenticateRequest(activity, makeAuthHeader(tokenType, accessToken));
+
+            if (rejectsWith) {
+                await assert.rejects(promise, rejectsWith);
+            } else {
+                assertResult(await promise);
+            }
+
+            verify(skippedJwt);
+        };
+
+        const generateTests = () => [
+            { label: 'succeeds' },
+            {
+                label: 'fails when claimed app ID differs from configured app ID',
+                makeClaims: (appId, defaultClaims) => ({
+                    ...defaultClaims,
+                    [AuthenticationConstants.AudienceClaim]: 'differentAppId',
+                }),
+                rejectsWith: new AuthenticationError(
+                    'Unauthorized. Invalid AppId passed on token: differentAppId',
+                    StatusCodes.UNAUTHORIZED
+                ),
+            },
+            {
+                label: 'fails early with empty auth header',
+                makeAuthHeader: () => '',
+                rejectsWith: new AuthenticationError(
+                    'Unauthorized Access. Request is not authorized',
+                    StatusCodes.UNAUTHORIZED
+                ),
+                skippedJwt: true,
+            },
+            {
+                label: 'succeeds with anonymous auth',
+                makeAuthHeader: () => '',
+                makeFactory: () => new PasswordServiceClientCredentialFactory(),
+                skippedJwt: true,
+            },
+        ];
+
+        const derivedClassTests = [
+            {
+                authCtor: PublicCloudBotFrameworkAuthentication,
+                issuer: AuthenticationConstants.ToBotFromChannelTokenIssuer,
+                label: 'PublicCloudBotFrameworkAuthentication',
+                metadata: AuthenticationConstants.ToBotFromChannelOpenIdMetadataUrl,
+                tests: generateTests(),
+            },
+            {
+                authCtor: GovernmentCloudBotFrameworkAuthentication,
+                channelService: GovernmentConstants.ChannelService,
+                issuer: GovernmentConstants.ToBotFromChannelTokenIssuer,
+                label: 'GovernmentCloudBotFrameworkAuthentication',
+                metadata: GovernmentConstants.ToBotFromChannelOpenIdMetadataUrl,
+                tests: generateTests(true),
+            },
+        ];
+
+        derivedClassTests.forEach(({ label, only, tests = [], ...derivedParams }) => {
+            const register = only ? describe.only : describe;
+            register(label, () => {
+                register('authenticateRequest', () => {
+                    tests.forEach(({ label = 'succeeds', only, ...testParams }) => {
+                        const register = only ? it.only : it;
+                        register(label, () => authenticateRequest({ ...derivedParams, ...testParams }));
+                    });
+                });
+            });
+        });
+    });
+});

--- a/libraries/botframework-connector/tests/auth/parameterizedBotFrameworkAuthentication.test.js
+++ b/libraries/botframework-connector/tests/auth/parameterizedBotFrameworkAuthentication.test.js
@@ -15,7 +15,6 @@ const {
     GovernmentConstants,
     PasswordServiceClientCredentialFactory,
     PublicCloudBotFrameworkAuthentication,
-    UnauthorizedAccessError,
 } = require('../..');
 
 describe('ParameterizedBotFrameworkAuthentication', () => {

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -1947,6 +1947,7 @@ export enum ActivityTypes {
     Suggestion = 'suggestion',
     Trace = 'trace',
     Handoff = 'handoff',
+    Delay = 'delay',
 }
 
 /**

--- a/testing/botbuilder-test-utils/src/index.ts
+++ b/testing/botbuilder-test-utils/src/index.ts
@@ -3,3 +3,4 @@
 
 export * as jwt from './jwt';
 export * as oauth from './oauth';
+export * as sinonExt from './sinonExt';

--- a/testing/botbuilder-test-utils/src/sinonExt.ts
+++ b/testing/botbuilder-test-utils/src/sinonExt.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import sinon from 'sinon';
+import { Func } from 'botbuilder-stdlib';
+
+/**
+ * Create a sinon sandbox that initializes and resets using mocha lifecycle hooks.
+ *
+ * @param {sinon.SinonSandboxConfig} config optional sandbox config
+ * @returns {Func<[], sinon.SinonSandbox>} a handle to the sandbox
+ */
+export function mocha(config?: sinon.SinonSandboxConfig): Func<[], sinon.SinonSandbox> {
+    let sandbox: sinon.SinonSandbox;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox(config);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    return () => sandbox;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3769,7 +3769,7 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-component-emitter@^1.2.0, component-emitter@^1.2.1:
+component-emitter@^1.2.0, component-emitter@^1.2.1, component-emitter@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -3868,7 +3868,7 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
-cookiejar@^2.0.1, cookiejar@^2.0.6:
+cookiejar@^2.0.1, cookiejar@^2.0.6, cookiejar@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
   integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
@@ -5725,7 +5725,7 @@ formatio@1.2.0:
   dependencies:
     samsam "1.x"
 
-formidable@^1.0.17, formidable@^1.2.1:
+formidable@^1.0.17, formidable@^1.2.1, formidable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
   integrity sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==
@@ -8308,7 +8308,7 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@^1.1.1, methods@~1.1.2:
+methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -8393,6 +8393,11 @@ mime@^2.4.3:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
   integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
+
+mime@^2.4.6:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.0.tgz#2b4af934401779806ee98026bb42e8c1ae1876b1"
+  integrity sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -10185,6 +10190,11 @@ qs@^6.1.0, qs@^6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
   integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
 
+qs@^6.9.4:
+  version "6.9.6"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
+  integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -11882,6 +11892,31 @@ superagent@^2.2:
     mime "^1.3.4"
     qs "^6.1.0"
     readable-stream "^2.0.5"
+
+superagent@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-6.1.0.tgz#09f08807bc41108ef164cfb4be293cebd480f4a6"
+  integrity sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.2"
+    debug "^4.1.1"
+    fast-safe-stringify "^2.0.7"
+    form-data "^3.0.0"
+    formidable "^1.2.2"
+    methods "^1.1.2"
+    mime "^2.4.6"
+    qs "^6.9.4"
+    readable-stream "^3.6.0"
+    semver "^7.3.2"
+
+supertest@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.1.2.tgz#1679c234b139eed93911c185b67f689348fc2453"
+  integrity sha512-hZ8bu3TebxCYQ40mF6/2ou58EEG5jxo1AbsE1vprqXo3emkmqbQMcQrF7acsQteOjYlkExSvYOAQ/feTE9n7uA==
+  dependencies:
+    methods "^1.1.2"
+    superagent "^6.1.0"
 
 supports-color@5.4.0:
   version "5.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1398,6 +1398,15 @@
     lodash.get "^4.4.2"
     type-detect "^4.0.8"
 
+"@sinonjs/samsam@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.3.0.tgz#1d2f0743dc54bf13fe9d508baefacdffa25d4329"
+  integrity sha512-hXpcfx3aq+ETVBwPlRFICld5EnrkexXuXDwqUNhDdr5L8VjvMeSRwyOa0qL7XFmR+jVWR4rUZtnxlG7RX72sBg==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
 "@sinonjs/samsam@^5.3.1":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.3.1.tgz#375a45fe6ed4e92fca2fb920e007c48232a6507f"
@@ -11272,6 +11281,19 @@ sinon@^9.2.0, sinon@^9.2.1:
     "@sinonjs/fake-timers" "^6.0.1"
     "@sinonjs/formatio" "^5.0.1"
     "@sinonjs/samsam" "^5.2.0"
+    diff "^4.0.2"
+    nise "^4.0.4"
+    supports-color "^7.1.0"
+
+sinon@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.2.2.tgz#b83cf5d43838f99cfa3644453f4c7db23e7bd535"
+  integrity sha512-9Owi+RisvCZpB0bdOVFfL314I6I4YoRlz6Isi4+fr8q8YQsDPoCe5UnmNtKHRThX3negz2bXHWIuiPa42vM8EQ==
+  dependencies:
+    "@sinonjs/commons" "^1.8.1"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@sinonjs/formatio" "^5.0.1"
+    "@sinonjs/samsam" "^5.3.0"
     diff "^4.0.2"
     nise "^4.0.4"
     supports-color "^7.1.0"


### PR DESCRIPTION
Fixes: #3000

This PR includes a port of the CloudAdapter from Dotnet. Several auth components needed to be ported, as well. In the process of porting those, I uncovered several (what I consider to be) beneficial refactorings (see [34e7297](https://github.com/microsoft/botbuilder-js/commit/34e7297a231a6261f8b704ae34f99fcee87d64f0) for details).

In particular, the `ParameterizedBotFrameworkAuthentication` class in Dotnet contains a good bit of duplicated JWT code. In this PR, the auth validation logic is reformulated as two function signature interfaces - `AuthValidator` and `IdentityValidator`. Common code now handles constructing a JWT Token Extractor, extracting claims from an auth header, and handling both the "auth disabled" flow and the "claims are not authenticated" flow.

To fully implement a new auth pattern, a user must construct an `AuthValidator` for general requests, one for Emulator requests, and one for Skill requests. The logic to decide between these exists in one place, in the `ParameterizedBotFrameworkAuthentication` class.

This refactoring is not fully API compatible with the current Dotnet code and would need to be ported to maintain parity.