### PR TITLE
fix: use package 'uuid' to generate RFC-compliant UUIDs

### DIFF
--- a/libraries/adaptive-expressions/package.json
+++ b/libraries/adaptive-expressions/package.json
@@ -27,16 +27,17 @@
     "antlr4ts": "0.5.0-alpha.3",
     "atob-lite": "^2.0.0",
     "big-integer": "^1.6.48",
+    "d3-format": "^1.4.4",
     "jspath": "^0.4.0",
     "lodash": "^4.17.19",
     "lru-cache": "^5.1.1",
-    "xml2js": "^0.4.23",
-    "x2js": "^3.4.0",
-    "xpath": "^0.0.32",
-    "xmldom": "^0.4.0",
-    "d3-format": "^1.4.4",
     "moment": "^2.29.1",
-    "moment-timezone": "^0.5.32"
+    "moment-timezone": "^0.5.32",
+    "uuid": "^8.3.2",
+    "x2js": "^3.4.0",
+    "xml2js": "^0.4.23",
+    "xmldom": "^0.4.0",
+    "xpath": "^0.0.32"
   },
   "devDependencies": {
     "@types/jspath": "^0.4.0",

--- a/libraries/adaptive-expressions/src/builtinFunctions/newGuid.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/newGuid.ts
@@ -6,6 +6,7 @@
  * Licensed under the MIT License.
  */
 
+import { v4 as uuidv4 } from 'uuid';
 import { Expression } from '../expression';
 import { EvaluateExpressionDelegate, ExpressionEvaluator } from '../expressionEvaluator';
 import { ExpressionType } from '../expressionType';
@@ -34,12 +35,7 @@ export class NewGuid extends ExpressionEvaluator {
      * @private
      */
     private static evalNewGuid(): string {
-        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c: any): string => {
-            const r: number = (Math.random() * 16) | 0;
-            const v: number = c === 'x' ? r : (r & 0x3) | 0x8;
-
-            return v.toString(16);
-        });
+        return uuidv4();
     }
 
     /**

--- a/libraries/botbuilder-ai-orchestrator/package.json
+++ b/libraries/botbuilder-ai-orchestrator/package.json
@@ -27,10 +27,11 @@
     }
   },
   "dependencies": {
-    "orchestrator-core": "beta",
     "adaptive-expressions": "4.1.6",
     "botbuilder-core": "4.1.6",
-    "botbuilder-dialogs": "4.1.6"
+    "botbuilder-dialogs": "4.1.6",
+    "orchestrator-core": "beta",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "sinon": "^9.2.1"

--- a/libraries/botbuilder-ai-orchestrator/src/orchestratorAdaptiveRecognizer.ts
+++ b/libraries/botbuilder-ai-orchestrator/src/orchestratorAdaptiveRecognizer.ts
@@ -8,6 +8,7 @@
 
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
+import { v4 as uuidv4 } from 'uuid';
 
 import {
     BoolExpression,
@@ -217,7 +218,7 @@ export class OrchestratorAdaptiveRecognizer extends Recognizer implements Orches
                                 })
                             )
                             .reduce((results: Record<string, RecognizerResult>, result: RecognizerResult) => {
-                                const guid = generate_guid();
+                                const guid = uuidv4();
                                 results[`${guid}`] = result;
                                 return results;
                             }, {});
@@ -282,18 +283,4 @@ export class OrchestratorAdaptiveRecognizer extends Recognizer implements Orches
             this._resolver = OrchestratorAdaptiveRecognizer.orchestrator.createLabelResolver(snapshot);
         }
     }
-}
-
-/*
- * This function generates a GUID-like random number that should be sufficient for our purposes of tracking
- * instances of a given waterfall dialog.
- * Source: https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
- */
-function generate_guid() {
-    function s4() {
-        return Math.floor((1 + Math.random()) * 0x10000)
-            .toString(16)
-            .substring(1);
-    }
-    return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
 }

--- a/libraries/botbuilder-core/package.json
+++ b/libraries/botbuilder-core/package.json
@@ -30,7 +30,8 @@
     "assert": "^1.4.1",
     "botbuilder-stdlib": "4.1.6",
     "botframework-connector": "4.1.6",
-    "botframework-schema": "4.1.6"
+    "botframework-schema": "4.1.6",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "sinon": "^7.5.0",

--- a/libraries/botbuilder-core/src/testAdapter.ts
+++ b/libraries/botbuilder-core/src/testAdapter.ts
@@ -7,6 +7,7 @@
  */
 // tslint:disable-next-line:no-require-imports
 import assert from 'assert';
+import { v4 as uuidv4 } from 'uuid';
 import {
     Activity,
     ActivityTypes,
@@ -248,7 +249,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
             const activity = activities[i];
 
             if (!activity.id) {
-                activity.id = generate_guid();
+                activity.id = uuidv4();
             }
 
             if (!activity.timestamp) {
@@ -1001,18 +1002,4 @@ function validateTranscriptActivity(
         expected.suggestedActions,
         `failed "suggestedActions" assert on ${description}`
     );
-}
-
-/*
- * This function generates a GUID-like random number that should be sufficient for our purposes of tracking
- * instances of a given waterfall dialog.
- * Source: https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
- */
-function generate_guid() {
-    function s4() {
-        return Math.floor((1 + Math.random()) * 0x10000)
-            .toString(16)
-            .substring(1);
-    }
-    return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
 }

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -32,7 +32,8 @@
     "@microsoft/recognizers-text-number": "1.1.4",
     "@microsoft/recognizers-text-suite": "1.1.4",
     "botbuilder-core": "4.1.6",
-    "globalize": "^1.4.2"
+    "globalize": "^1.4.2",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/globalize": "^1.5.0",

--- a/libraries/botbuilder-dialogs/src/waterfallDialog.ts
+++ b/libraries/botbuilder-dialogs/src/waterfallDialog.ts
@@ -5,7 +5,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ActivityTypes, Severity } from 'botbuilder-core';
+import { v4 as uuidv4 } from 'uuid';
+import { ActivityTypes } from 'botbuilder-core';
 import { TurnContext, telemetryTrackDialogView } from 'botbuilder-core';
 import { DialogInstance } from './dialog';
 import { Dialog, DialogReason, DialogTurnResult } from './dialog';
@@ -156,7 +157,7 @@ export class WaterfallDialog<O extends object = {}> extends Dialog<O> {
         const state: WaterfallDialogState = dc.activeDialog.state as WaterfallDialogState;
         state.options = options || {};
         state.values = {
-            instanceId: generate_guid(),
+            instanceId: uuidv4(),
         };
 
         this.telemetryClient.trackEvent({
@@ -346,19 +347,4 @@ interface WaterfallDialogState {
     options: object;
     stepIndex: number;
     values: object;
-}
-
-/*
- * This function generates a GUID-like random number that should be sufficient for our purposes of tracking
- * instances of a given waterfall dialog.
- * Source: https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
- */
-function generate_guid(): string {
-    function s4(): string {
-        return Math.floor((1 + Math.random()) * 0x10000)
-            .toString(16)
-            .substring(1);
-    }
-
-    return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
 }

--- a/libraries/botbuilder-lg/package.json
+++ b/libraries/botbuilder-lg/package.json
@@ -23,11 +23,11 @@
     "antlr4ts": "0.5.0-alpha.3",
     "lodash": "^4.17.19",
     "path": "^0.12.7",
-    "uuid": "^3.4.0"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "typescript": "3.5.3",
-    "antlr4ts-cli": "0.5.0-alpha.3"
+    "antlr4ts-cli": "0.5.0-alpha.3",
+    "typescript": "3.5.3"
   },
   "scripts": {
     "antlr-build": "antlr4ts src/LGFileLexer.g4 -o src/generated && antlr4ts src/LGFileParser.g4 -visitor -o src/generated && antlr4ts src/LGTemplateLexer.g4 -o src/generated && antlr4ts src/LGTemplateParser.g4 -visitor -o src/generated",

--- a/libraries/botbuilder-lg/src/templateExtensions.ts
+++ b/libraries/botbuilder-lg/src/templateExtensions.ts
@@ -8,6 +8,7 @@
  */
 
 import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
 import * as lp from './generated/LGTemplateParser';
 import { ParserRuleContext } from 'antlr4ts';
 import { Range } from './range';
@@ -137,12 +138,7 @@ export class TemplateExtensions {
      * Generate new guid string.
      */
     public static newGuid(): string {
-        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c: any): string => {
-            const r: number = (Math.random() * 16) | 0;
-            const v: number = c === 'x' ? r : (r & 0x3) | 0x8;
-
-            return v.toString(16);
-        });
+        return uuidv4();
     }
 
     /**

--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -7,6 +7,7 @@
  * Licensed under the MIT License.
  */
 
+import { v4 as uuidv4 } from 'uuid';
 import { Template } from './template';
 import { TemplateImport } from './templateImport';
 import { Diagnostic, DiagnosticSeverity } from './diagnostic';
@@ -301,7 +302,7 @@ export class Templates implements Iterable<Template> {
 
         this.checkErrors();
 
-        const inlineTemplateId = `${Templates.inlineTemplateIdPrefix}${this.getramdonTemplateId()}`;
+        const inlineTemplateId = `${Templates.inlineTemplateIdPrefix}${this.getRandomTemplateId()}`;
 
         // wrap inline string with "# name and -" to align the evaluation process
         const multiLineMark = '```';
@@ -455,13 +456,8 @@ export class Templates implements Iterable<Template> {
     /**
      * @private
      */
-    private getramdonTemplateId(): string {
-        return 'xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx'.replace(/[xy]/g, (c: any): string => {
-            const r: number = (Math.random() * 16) | 0;
-            const v: number = c === 'x' ? r : (r & 0x3) | 0x8;
-
-            return v.toString(16);
-        });
+    private getRandomTemplateId(): string {
+        return uuidv4().split('-').join('');
     }
 
     /**

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -34,13 +34,13 @@
     "botframework-streaming": "4.1.6",
     "filenamify": "^4.1.0",
     "fs-extra": "^7.0.1",
-    "moment-timezone": "^0.5.32"
+    "moment-timezone": "^0.5.32",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "assert": "^1.4.1",
     "chatdown": "^1.0.2",
-    "nock": "^11.9.1",
-    "uuid": "^3.4.0"
+    "nock": "^11.9.1"
   },
   "scripts": {
     "build": "tsc -b",

--- a/libraries/botbuilder/src/eventFactory.ts
+++ b/libraries/botbuilder/src/eventFactory.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { v4 as uuidv4 } from 'uuid';
 import { TurnContext } from 'botbuilder-core';
 import { Activity, Attachment, ConversationAccount, ConversationReference, Transcript } from 'botframework-schema';
 import * as moment from 'moment-timezone';
@@ -81,7 +82,7 @@ export class EventFactory {
 
         handoffEvent.name = name;
         handoffEvent.value = value;
-        handoffEvent.id = uuid();
+        handoffEvent.id = uuidv4();
         handoffEvent.timestamp = new Date(Date.now());
         // The timestamp does not contain the local offset which is a known limitation of Date objects in JavaScript.
         // Therefore, the localTimezone is included in the handoffEvent.
@@ -92,12 +93,4 @@ export class EventFactory {
 
         return handoffEvent as Activity;
     }
-}
-
-function uuid(): string {
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c): string => {
-        const r = (Math.random() * 16) | 0,
-            v = c == 'x' ? r : (r & 0x3) | 0x8;
-        return v.toString(16);
-    });
 }

--- a/libraries/botbuilder/src/inspectionMiddleware.ts
+++ b/libraries/botbuilder/src/inspectionMiddleware.ts
@@ -5,6 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+import { v4 as uuidv4 } from 'uuid';
 import { MicrosoftAppCredentials, ConnectorClient } from 'botframework-connector';
 import {
     Activity,
@@ -324,16 +325,7 @@ export class InspectionMiddleware extends InterceptionMiddleware {
         sessions: InspectionSessionsByStatus,
         conversationReference: Partial<ConversationReference>
     ): string {
-        function generate_guid() {
-            function s4() {
-                return Math.floor((1 + Math.random()) * 0x10000)
-                    .toString(16)
-                    .substring(1);
-            }
-            return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
-        }
-
-        const sessionId = generate_guid();
+        const sessionId = uuidv4();
         sessions.openedSessions[sessionId] = conversationReference;
         return sessionId;
     }

--- a/libraries/botbuilder/src/skills/skillHandler.ts
+++ b/libraries/botbuilder/src/skills/skillHandler.ts
@@ -6,6 +6,7 @@
  * Licensed under the MIT License.
  */
 
+import { v4 as uuidv4 } from 'uuid';
 import {
     Activity,
     ActivityHandlerBase,
@@ -288,7 +289,7 @@ export class SkillHandler extends ChannelServiceHandler {
         });
 
         if (!resourceResponse) {
-            resourceResponse = { id: uuid() };
+            resourceResponse = { id: uuidv4() };
         }
 
         return resourceResponse;
@@ -359,14 +360,4 @@ export class SkillHandler extends ChannelServiceHandler {
             }
         );
     }
-}
-
-// Helper function to generate an UUID.
-// Code is from @stevenic: https://github.com/stevenic
-function uuid(): string {
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c): string => {
-        const r = (Math.random() * 16) | 0,
-            v = c == 'x' ? r : (r & 0x3) | 0x8;
-        return v.toString(16);
-    });
 }

--- a/libraries/botbuilder/src/streaming/tokenResolver.ts
+++ b/libraries/botbuilder/src/streaming/tokenResolver.ts
@@ -6,6 +6,7 @@
  * Licensed under the MIT License.
  */
 
+import { v4 as uuidv4 } from 'uuid';
 import { BotFrameworkAdapter } from '../botFrameworkAdapter';
 import {
     Activity,
@@ -136,7 +137,7 @@ export class TokenResolver {
         connectionName: string
     ): Partial<Activity> {
         const tokenResponse: Partial<Activity> = {
-            id: this.generate_guid(),
+            id: uuidv4(),
             timestamp: new Date(),
             type: ActivityTypes.Event,
             serviceUrl: relatesTo.serviceUrl,
@@ -153,17 +154,5 @@ export class TokenResolver {
             },
         };
         return tokenResponse;
-    }
-
-    /**
-     * @private
-     */
-    private static generate_guid(): string {
-        function s4() {
-            return Math.floor((1 + Math.random()) * 0x10000)
-                .toString(16)
-                .substring(1);
-        }
-        return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
     }
 }

--- a/libraries/botbuilder/tests/fileTranscriptStore.test.js
+++ b/libraries/botbuilder/tests/fileTranscriptStore.test.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const path = require('path');
 const os = require('os');
 const fs = require('fs-extra');
-const uuid = require('uuid');
+const { v4: uuidv4 } = require('uuid');
 const { ActivityTypes } = require('botbuilder-core');
 
 const workingFolder = path.join(os.tmpdir(), 'botbuilder-transcript-tests');
@@ -219,7 +219,7 @@ describe('The FileTranscriptStore', () => {
 			activities = [];
 			let ct = 100;
 			while (ct--) {
-				activities.push(...createActivities(uuid(), startDate, 1));
+				activities.push(...createActivities(uuidv4(), startDate, 1));
 			}
 			storage = new FileTranscriptStore(workingFolder);
 			return Promise.all(activities.map(activity => storage.logActivity(activity)));
@@ -256,7 +256,7 @@ function createActivities (conversationId, ts, count = 5) {
 		activities.push({
 			type: ActivityTypes.Message,
 			timestamp: ts,
-			id: uuid(),
+			id: uuidv4(),
 			text: i.toString(),
 			channelId: 'test',
 			from: { id: `User${i}` },
@@ -269,7 +269,7 @@ function createActivities (conversationId, ts, count = 5) {
 		activities.push({
 			type: ActivityTypes.Message,
 			timestamp: ts,
-			id: uuid(),
+			id: uuidv4(),
 			text: i.toString(),
 			channelId: 'test',
 			from: { id: 'Bot1', name: '2' },

--- a/libraries/botframework-config/package.json
+++ b/libraries/botframework-config/package.json
@@ -36,10 +36,10 @@
   "dependencies": {
     "fs-extra": "^7.0.1",
     "read-text-file": "^1.1.0",
-    "uuid": "^3.4.0"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/uuid": "^3.4.3"
+    "@types/uuid": "^8.3.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/libraries/botframework-config/src/botConfiguration.ts
+++ b/libraries/botframework-config/src/botConfiguration.ts
@@ -8,7 +8,7 @@ import * as fsx from 'fs-extra';
 import * as path from 'path';
 import * as process from 'process';
 import * as txtfile from 'read-text-file';
-import * as uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 import { BotConfigurationBase } from './botConfigurationBase';
 import * as encrypt from './encrypt';
 import { ConnectedService } from './models';
@@ -307,7 +307,7 @@ export class BotConfiguration extends BotConfigurationBase {
         try {
             if (!this.padlock || this.padlock.length === 0) {
                 // if no key, create a guid and enrypt that to use as secret validator
-                this.padlock = encrypt.encryptString(uuid(), secret);
+                this.padlock = encrypt.encryptString(uuidv4(), secret);
             } else {
                 // validate we can decrypt the padlock, this tells us we have the correct secret for the rest of the file.
                 encrypt.decryptString(this.padlock, secret);

--- a/libraries/botframework-streaming/package.json
+++ b/libraries/botframework-streaming/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@types/node": "^10.17.27",
     "@types/ws": "^6.0.3",
-    "uuid": "^3.4.0",
+    "uuid": "^8.3.2",
     "ws": "^7.1.2"
   },
   "devDependencies": {

--- a/libraries/botframework-streaming/src/utilities/protocol-base.ts
+++ b/libraries/botframework-streaming/src/utilities/protocol-base.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import uuidv4 = require('uuid/v4');
+import { v4 as uuidv4 } from 'uuid';
 
 /**
  * Generates an uuid v4 string.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1658,10 +1658,10 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/uuid@^3.4.3":
-  version "3.4.9"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.9.tgz#fcf01997bbc9f7c09ae5f91383af076d466594e1"
-  integrity sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
 
 "@types/webpack-sources@*":
   version "2.0.0"
@@ -11429,6 +11429,11 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
+ts-essentials@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-7.0.1.tgz#d205508cae0cdadfb73c89503140cf2228389e2d"
+  integrity sha512-8lwh3QJtIc1UWhkQtr9XuksXu3O0YQdEE5g79guDfhCaU1FWTDIEDZ1ZSx4HTHUmlJZ8L812j3BZQ4a0aOUkSA==
+
 ts-loader@^7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-7.0.5.tgz#789338fb01cb5dc0a33c54e50558b34a73c9c4c5"
@@ -11857,6 +11862,11 @@ uuid@^8.1.0, uuid@^8.3.0:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
   integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
   version "2.2.0"


### PR DESCRIPTION
Fixes #3160 

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Using package [uuid](https://github.com/uuidjs/uuid) to generate RFC-compliant UUIDs

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Added `uuid` package to `adaptive-expressions`
  - Added `uuid` package to `botbuilder-ai-orchestrator`
  - Added `uuid` package to `botbuilder-core`
  - Added `uuid` package to `botbuilder`
  - Added `uuid` package to `botbuilder-lg`
  - Added `uuid` package to `botbuilder-dialogs`
  - Updated `uuid` package to 8.x in `botframework-config`
  - Updated `uuid` package to 8.x in `botframework-streaming`

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
Fixed tests.