### PR TITLE
fix: tests for BeginSkill with middlewares

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
@@ -1,9 +1,115 @@
+const { createHash } = require('crypto');
 const path = require('path');
 const nock = require('nock');
-const { ComponentRegistration, MessageFactory } = require('botbuilder-core');
+const {
+    ActivityTypes,
+    ComponentRegistration,
+    MessageFactory,
+    SkillConversationIdFactoryBase,
+    TurnContext,
+} = require('botbuilder-core');
 const { ResourceExplorer } = require('botbuilder-dialogs-declarative');
 const { AdaptiveTestComponentRegistration, TestUtils } = require('../lib');
-const { AdaptiveComponentRegistration } = require('botbuilder-dialogs-adaptive');
+const {
+    AdaptiveComponentRegistration,
+    skillConversationIdFactoryKey,
+    skillClientKey,
+} = require('botbuilder-dialogs-adaptive');
+class MockSkillConversationIdFactory extends SkillConversationIdFactoryBase {
+    constructor(opts = { useCreateSkillConversationId: false }) {
+        super();
+        this._conversationRefs = new Map();
+        this.useCreateSkillConversationId = opts.useCreateSkillConversationId;
+    }
+
+    async createSkillConversationIdWithOptions(opts) {
+        if (this.useCreateSkillConversationId) {
+            return super.createSkillConversationIdWithOptions();
+        }
+        const key = createHash('md5')
+            .update(opts.activity.conversation.id + opts.activity.serviceUrl)
+            .digest('hex');
+
+        const ref = this._conversationRefs.has(key);
+        if (!ref) {
+            this._conversationRefs.set(key, {
+                conversationReference: TurnContext.getConversationReference(opts.activity),
+                oAuthScope: opts.fromBotOAuthScope,
+            });
+        }
+        return key;
+    }
+
+    async createSkillConversationId(convRef) {
+        const key = createHash('md5')
+            .update(convRef.conversation.id + convRef.serviceUrl)
+            .digest('hex');
+
+        const ref = this._conversationRefs.has(key);
+        if (!ref) {
+            this._conversationRefs.set(key, {
+                conversationReference: convRef,
+            });
+        }
+        return key;
+    }
+
+    async getConversationReference(skillConversationId) {
+        return this._conversationRefs.get(skillConversationId);
+    }
+
+    async getSkillConversationReference(skillConversationId) {
+        return this.getConversationReference(skillConversationId);
+    }
+
+    async deleteConversationReference() {
+        /* not used in BeginSkill */
+    }
+}
+
+class MockSkillBotFrameworkClient {
+    async postActivity(fromBotId, toBotId, toUrl, serviceUrl, conversationId, activity) {
+        let responseActivity = activity;
+
+        if (activity.text.indexOf('skill') >= 0) {
+            responseActivity = {
+                type: 'message',
+                text: 'This is the skill talking: hello',
+            };
+        }
+
+        if (activity.text.indexOf('end') >= 0) {
+            responseActivity = {
+                type: ActivityTypes.EndOfConversation,
+            };
+        }
+
+        return {
+            status: 200,
+            body: {
+                activities: [responseActivity],
+            },
+        };
+    }
+}
+
+class SetSkillConversationIdFactoryBaseMiddleware {
+    async onTurn(context, next) {
+        if (context.activity.type === ActivityTypes.Message) {
+            context.turnState.set(skillConversationIdFactoryKey, new MockSkillConversationIdFactory());
+            await next();
+        }
+    }
+}
+
+class SetSkillBotFrameworkClientMiddleware {
+    async onTurn(context, next) {
+        if (context.activity.type === ActivityTypes.Message) {
+            context.turnState.set(skillClientKey, new MockSkillBotFrameworkClient());
+            await next();
+        }
+    }
+}
 
 describe('ActionTests', function () {
     this.timeout(10000);
@@ -27,6 +133,26 @@ describe('ActionTests', function () {
 
     it('BeginDialogWithActivity', async () => {
         await TestUtils.runTestScript(resourceExplorer, 'Action_BeginDialogWithActivity');
+    });
+
+    it('BeginSkill', async () => {
+        await TestUtils.runTestScript(
+            resourceExplorer,
+            'Action_BeginSkill',
+            undefined,
+            new SetSkillConversationIdFactoryBaseMiddleware(),
+            new SetSkillBotFrameworkClientMiddleware()
+        );
+    });
+
+    it('BeginSkillEndDialog', async () => {
+        await TestUtils.runTestScript(
+            resourceExplorer,
+            'Action_BeginSkillEndDialog',
+            undefined,
+            new SetSkillConversationIdFactoryBaseMiddleware(),
+            new SetSkillBotFrameworkClientMiddleware()
+        );
     });
 
     it('CancelAllDialogs', async () => {

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_BeginSkill.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_BeginSkill.test.dialog
@@ -1,0 +1,68 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "SkillIntent",
+                    "pattern": "skill"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "SkillIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.BeginSkill",
+                        "BotId": "test-bot-id",
+                        "SkillHostEndpoint": "http://localhost:3978/api/skills/",
+                        "SkillEndpoint": "http://localhost:39782/api/messages",
+                        "SkillAppId": "test-app-id",
+                        "ConnectionName": "test-skill-connection-name",
+                        "activity": {
+                            "$kind": "Microsoft.StaticActivityTemplate",
+                            "activity": {
+                                "type": "message",
+                                "text": "skill",
+                                "deliveryMode": "expectReplies"
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "I'm a skill bot. To get started say 'skill'"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "I'm a skill bot. To get started say 'skill'"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "skill"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "This is the skill talking: hello"
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_BeginSkillEndDialog.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_BeginSkillEndDialog.test.dialog
@@ -1,0 +1,66 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "autoEndDialog": false,
+        "id": "planningTest",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "SkillIntent",
+                    "pattern": "skill"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "autoEndDialog": false,
+                "intent": "SkillIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.BeginSkill",
+                        "BotId": "test-bot-id",
+                        "SkillHostEndpoint": "http://localhost:3978/api/skills/",
+                        "SkillEndpoint": "http://localhost:39782/api/messages",
+                        "SkillAppId": "test-app-id",
+                        "ConnectionName": "test-skill-connection-name",
+                        "AllowInterruptions": false,
+                        "activity": {
+                            "$kind": "Microsoft.StaticActivityTemplate",
+                            "activity": {
+                                "type": "message",
+                                "text": "skill",
+                                "deliveryMode": "expectReplies"
+                            }
+                        }
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Success"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "skill"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "This is the skill talking: hello"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "end"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Success"
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveComponentRegistration.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveComponentRegistration.ts
@@ -184,6 +184,14 @@ import {
     RandomSelector,
     TrueSelector,
 } from './selectors';
+import {
+    ActivityTemplate,
+    ActivityTemplateConguration,
+    StaticActivityTemplate,
+    StaticActivityTemplateConfiguration,
+    TextTemplate,
+    TextTemplateConfiguration,
+} from './templates';
 import { DynamicBeginDialogDeserializer } from './dynamicBeginDialogDeserializer';
 import { TriggerSelectorConfiguration } from './triggerSelector';
 
@@ -322,6 +330,11 @@ export class AdaptiveComponentRegistration extends ComponentRegistration impleme
         this._addDeclarativeType<ResourceMultiLanguageGenerator, ResourceMultiLanguageGeneratorConfiguration>(
             ResourceMultiLanguageGenerator
         );
+
+        // Templates
+        this._addDeclarativeType<ActivityTemplate, ActivityTemplateConguration>(ActivityTemplate);
+        this._addDeclarativeType<StaticActivityTemplate, StaticActivityTemplateConfiguration>(StaticActivityTemplate);
+        this._addDeclarativeType<TextTemplate, TextTemplateConfiguration>(TextTemplate);
 
         // Selectors
         this._addDeclarativeType<ConditionalSelector, ConditionalSelectorConfiguration>(ConditionalSelector);

--- a/libraries/botbuilder-dialogs-adaptive/src/input/inputDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/inputDialog.ts
@@ -37,9 +37,8 @@ import {
     TurnPath,
 } from 'botbuilder-dialogs';
 import { AdaptiveEvents } from '../adaptiveEvents';
-import { ActivityTemplate } from '../templates/activityTemplate';
 import { AttachmentInput } from './attachmentInput';
-import { StaticActivityTemplate } from '../templates/staticActivityTemplate';
+import { ActivityTemplate, StaticActivityTemplate } from '../templates';
 import { ActivityTemplateConverter } from '../converters';
 
 export enum InputState {

--- a/libraries/botbuilder-dialogs-adaptive/src/templates/activityTemplate.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/templates/activityTemplate.ts
@@ -7,20 +7,34 @@
  */
 
 import { Activity, ActivityFactory, MessageFactory } from 'botbuilder-core';
-import { DialogContext, DialogStateManager, TemplateInterface } from 'botbuilder-dialogs';
+import {
+    Configurable,
+    Converter,
+    ConverterFactory,
+    DialogContext,
+    DialogStateManager,
+    TemplateInterface,
+} from 'botbuilder-dialogs';
 import { LanguageGenerator } from '../languageGenerator';
 import { languageGeneratorKey } from '../languageGeneratorExtensions';
+
+export interface ActivityTemplateConguration {
+    template?: string;
+}
 
 /**
  * Defines an activity template where the template expression is local aka "inline"
  * and processed through registered language generator.
  */
-export class ActivityTemplate implements TemplateInterface<Partial<Activity>, DialogStateManager> {
+export class ActivityTemplate
+    implements TemplateInterface<Partial<Activity>, DialogStateManager>, ActivityTemplateConguration, Configurable {
+    public static $kind = 'Microsoft.ActivityTemplate';
+
     /**
      * Initialize a new instance of ActivityTemplate class.
      * @param template The template to evaluate to create the activity.
      */
-    public constructor(template: string) {
+    public constructor(template?: string) {
         this.template = template;
     }
 
@@ -28,6 +42,16 @@ export class ActivityTemplate implements TemplateInterface<Partial<Activity>, Di
      * Gets or sets the template to evaluate to create the activity.
      */
     public template: string;
+
+    public getConverter(_property: keyof ActivityTemplateConguration): Converter | ConverterFactory {
+        return undefined;
+    }
+
+    public configure(config: ActivityTemplateConguration): this {
+        const { template } = config;
+        this.template = template;
+        return this;
+    }
 
     /**
      * Bind data to template.

--- a/libraries/botbuilder-dialogs-adaptive/src/templates/staticActivityTemplate.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/templates/staticActivityTemplate.ts
@@ -7,12 +7,19 @@
  */
 
 import { Activity } from 'botbuilder-core';
-import { DialogContext, TemplateInterface } from 'botbuilder-dialogs';
+import { Converter, ConverterFactory, Configurable, DialogContext, TemplateInterface } from 'botbuilder-dialogs';
+
+export interface StaticActivityTemplateConfiguration {
+    activity?: Partial<Activity>;
+}
 
 /**
  * Defines a static activity as a template.
  */
-export class StaticActivityTemplate implements TemplateInterface<Partial<Activity>, unknown> {
+export class StaticActivityTemplate
+    implements TemplateInterface<Partial<Activity>, unknown>, StaticActivityTemplateConfiguration, Configurable {
+    public static $kind = 'Microsoft.StaticActivityTemplate';
+
     /**
      * Intialize a new instance of StaticActivityTemplate class.
      * @param activity Activity as a template.
@@ -25,6 +32,16 @@ export class StaticActivityTemplate implements TemplateInterface<Partial<Activit
      * Gets or sets the activity as template.
      */
     public activity: Partial<Activity>;
+
+    public getConverter(_property: keyof StaticActivityTemplateConfiguration): Converter | ConverterFactory {
+        return undefined;
+    }
+
+    public configure(config: StaticActivityTemplateConfiguration): this {
+        const { activity } = config;
+        this.activity = activity;
+        return this;
+    }
 
     /**
      * Get predefined activity.

--- a/libraries/botbuilder-dialogs-adaptive/src/templates/textTemplate.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/templates/textTemplate.ts
@@ -6,20 +6,27 @@
  * Licensed under the MIT License.
  */
 
-import { DialogContext, TemplateInterface } from 'botbuilder-dialogs';
+import { Converter, ConverterFactory, Configurable, DialogContext, TemplateInterface } from 'botbuilder-dialogs';
 import { LanguageGenerator } from '../languageGenerator';
 import { languageGeneratorKey } from '../languageGeneratorExtensions';
+
+export interface TextTemplateConfiguration {
+    template?: string;
+}
 
 /**
  * Defines a text template where the template expression is local aka "inline"
  * and processed through registered language generator.
  */
-export class TextTemplate<D = Record<string, unknown>> implements TemplateInterface<string, D> {
+export class TextTemplate<D = Record<string, unknown>>
+    implements TemplateInterface<string, D>, TextTemplateConfiguration, Configurable {
+    public static $kind = 'Microsoft.TextTemplate';
+
     /**
      * Initialize a new instance of TextTemplate class.
      * @param template The template to evaluate to create text.
      */
-    public constructor(template: string) {
+    public constructor(template?: string) {
         this.template = template;
     }
 
@@ -27,6 +34,16 @@ export class TextTemplate<D = Record<string, unknown>> implements TemplateInterf
      * Gets or sets the template to evaluate to create the text.
      */
     public template: string;
+
+    public getConverter(_property: keyof TextTemplateConfiguration): Converter | ConverterFactory {
+        return undefined;
+    }
+
+    public configure(config: TextTemplateConfiguration): this {
+        const { template } = config;
+        this.template = template;
+        return this;
+    }
 
     /**
      * Bind data to template.


### PR DESCRIPTION
Fixes #3037 
Fixes #3042 

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
adds two BeginSkill action tests using .dialog files and required middleware

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Registered `Microsoft.StaticActivityTemplate`
  - Registered `Microsoft.ActivityTemplate`
  - Registered `Microsoft.TextTemplate`
  - Added tests for BeginSkill with middlewares

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
Added tests.