### PR TITLE
fix: clean up bf-connector useragent handling

### DIFF
--- a/libraries/botframework-connector/src/connectorApi/connectorClientContext.ts
+++ b/libraries/botframework-connector/src/connectorApi/connectorClientContext.ts
@@ -3,38 +3,29 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as Models from "./models";
+import { ConnectorClientOptions } from './models';
+import { ServiceClient, ServiceClientCredentials } from '@azure/ms-rest-js';
+import { resolveUserAgent } from '../userAgent';
 
-const packageName = "botframework-connector";
-const packageVersion = "4.0.0";
+export class ConnectorClientContext extends ServiceClient {
+    credentials: ServiceClientCredentials;
 
-export class ConnectorClientContext extends msRest.ServiceClient {
-  credentials: msRest.ServiceClientCredentials;
+    /**
+     * Initializes a new instance of the ConnectorClientContext class.
+     * @param {ServiceClientCredentials} credentials Subscription credentials which uniquely identify client subscription.
+     * @param {ConnectorClientContext} options The parameter options
+     */
+    constructor(credentials: ServiceClientCredentials, options: ConnectorClientOptions = {}) {
+        if (credentials === null || credentials === undefined) {
+            throw new Error("'credentials' cannot be null.");
+        }
 
-  /**
-   * Initializes a new instance of the ConnectorClientContext class.
-   * @param credentials Subscription credentials which uniquely identify client subscription.
-   * @param [options] The parameter options
-   */
-  constructor(credentials: msRest.ServiceClientCredentials, options?: Models.ConnectorClientOptions) {
-    if (credentials === null || credentials === undefined) {
-      throw new Error('\'credentials\' cannot be null.');
+        options.userAgent = resolveUserAgent(options.userAgent);
+
+        super(credentials, options);
+
+        this.baseUri = options.baseUri ?? this.baseUri ?? 'https://api.botframework.com';
+        this.requestContentType = 'application/json; charset=utf-8';
+        this.credentials = credentials;
     }
-
-    if (!options) {
-      // NOTE: autogen creates a {} which is invalid, it needs to be cast
-      options = {} as Models.ConnectorClientOptions;
-    }
-    // TODO  This is to workaround fact that AddUserAgent() was removed.  
-    const defaultUserAgent = msRest.getDefaultUserAgentValue();
-    options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent} ${options.userAgent || ''}`;
-
-    super(credentials, options);
-
-    this.baseUri = options.baseUri || this.baseUri || "https://api.botframework.com";
-    this.requestContentType = "application/json; charset=utf-8";
-    this.credentials = credentials;
-
-  }
 }

--- a/libraries/botframework-connector/src/tokenApi/tokenApiClientContext.ts
+++ b/libraries/botframework-connector/src/tokenApi/tokenApiClientContext.ts
@@ -3,36 +3,29 @@
  * Licensed under the MIT License.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as Models from "./models";
+import { ServiceClient, ServiceClientCredentials } from '@azure/ms-rest-js';
+import { TokenApiClientOptions } from './models';
+import { resolveUserAgent } from '../userAgent';
 
-const packageName = "botframework-Token";
-const packageVersion = "4.0.0";
+export class TokenApiClientContext extends ServiceClient {
+    credentials: ServiceClientCredentials;
 
-export class TokenApiClientContext extends msRest.ServiceClient {
-  credentials: msRest.ServiceClientCredentials;
+    /**
+     * Initializes a new instance of the TokenApiClientContext class.
+     * @param credentials Subscription credentials which uniquely identify client subscription.
+     * @param [options] The parameter options
+     */
+    constructor(credentials: ServiceClientCredentials, options: TokenApiClientOptions = {}) {
+        if (credentials === null || credentials === undefined) {
+            throw new Error("'credentials' cannot be null.");
+        }
 
-  /**
-   * Initializes a new instance of the TokenApiClientContext class.
-   * @param credentials Subscription credentials which uniquely identify client subscription.
-   * @param [options] The parameter options
-   */
-  constructor(credentials: msRest.ServiceClientCredentials, options?: Models.TokenApiClientOptions) {
-    if (credentials === null || credentials === undefined) {
-      throw new Error('\'credentials\' cannot be null.');
+        options.userAgent = resolveUserAgent(options.userAgent, 'botframework-Token');
+
+        super(credentials, options);
+
+        this.baseUri = options.baseUri ?? this.baseUri ?? 'https://token.botframework.com';
+        this.requestContentType = 'application/json; charset=utf-8';
+        this.credentials = credentials;
     }
-
-    if (!options) {
-      options = {};
-    }
-    const defaultUserAgent = msRest.getDefaultUserAgentValue();
-    options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent} ${options.userAgent || ''}`;
-
-    super(credentials, options);
-
-    this.baseUri = options.baseUri || this.baseUri || "https://token.botframework.com";
-    this.requestContentType = "application/json; charset=utf-8";
-    this.credentials = credentials;
-
-  }
 }

--- a/libraries/botframework-connector/src/userAgent.ts
+++ b/libraries/botframework-connector/src/userAgent.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { getDefaultUserAgentValue } from '@azure/ms-rest-js';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pjson: Record<'name' | 'version', string> = require('../package.json');
+
+/**
+ * Augment default msRest user-agent HTTP header
+ *
+ * @param {string} userAgent existing user agent to augment
+ * @param {string} packageName package name to report, defaults to package.json name
+ * @param {string} packageVersion package version to report, defaults to package.json version
+ * @returns {string} augmented user agent
+ */
+export function resolveUserAgent(
+    userAgent: ((defaultUserAgent: string) => string) | string = '',
+    packageName = pjson.name,
+    packageVersion = pjson.version
+): string {
+    const defaultValue = getDefaultUserAgentValue();
+    return `${packageName}/${packageVersion} ${defaultValue} ${
+        typeof userAgent === 'function' ? userAgent(defaultValue) : userAgent
+    }`;
+}


### PR DESCRIPTION
Fixes #3170

Note: we didn't quite have identical code to the linked issue. However, there were some cleanup opportunities. @stevengum, the versioning looked inconsistent with `package.json`; perhaps that was intentional, though?