### PR TITLE
Fix MemoryAssertions and test

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/memoryAssertions.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/memoryAssertions.ts
@@ -47,7 +47,7 @@ export class MemoryAssertions extends TestAction implements MemoryAssertionsConf
             await inspector((dc) => {
                 this.assertions.forEach((assertion) => {
                     const { value, error } = Expression.parse(assertion).tryEvaluate(dc.state);
-                    if (error && !value) {
+                    if (error || !value) {
                         throw new Error(`${this.description} ${assertion} failed`);
                     }
                 });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/TestScriptTests_PropertyMock.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/TestScriptTests_PropertyMock.test.dialog
@@ -3,54 +3,65 @@
     "$kind": "Microsoft.Test.Script",
     "description": "Test setting memory",
     "dialog": {
-        "$kind": "Microsoft.AdaptiveDialog"
+      "$kind": "Microsoft.AdaptiveDialog",
+      "triggers": [
+        {
+          "$kind": "Microsoft.OnError",
+          "actions": [
+            {
+              "$kind": "Microsoft.SendActivity",
+              "activity": "${turn.dialogEvent.value.message}"
+            }
+          ]
+        }
+      ]
     },
     "script": [
-        {
-            "$kind": "Microsoft.Test.SetProperties",
-            "assignments": [
-                {
-                    "property": "settings.value",
-                    "value": "settings value"
-                },
-                {
-                    "property": "settings.value",
-                    "value": "settings overwrite"
-                },
-                {
-                    "property": "settings.object.value",
-                    "value": "within object value"
-                },
-                {
-                    "property": "user.number",
-                    "value": 123
-                },
-                {
-                    "property": "user.object",
-                    "value": {
-                        "value": "object value"
-                    }
-                },
-                {
-                    "property": "conversation.value",
-                    "value": "conversation value"
-                },
-                {
-                    "property": "dialog.value",
-                    "value": "dialog value"
-                }
-            ]
-        },
-        {
-            "$kind": "Microsoft.Test.MemoryAssertions",
-            "assertions": [
-                "settings.value == 'settings overwrite'",
-                "settings.object.value == 'within object value",
-                "user.number == 123",
-                "user.object.value == 'object value'",
-                "conversation.value == 'conversation.value'",
-                "dialog.value == 'dialog value'"
-            ]
-        }
-   ]
-}
+      {
+        "$kind": "Microsoft.Test.SetProperties",
+        "assignments": [
+          {
+            "property": "user.noOverwrite",
+            "value": "original"
+          },
+          {
+            "property": "user.overwrite",
+            "value": "original"
+          },
+          {
+            "property": "user.overwrite",
+            "value": "overwritten"
+          },
+          {
+            "property": "user.object",
+            "value": {
+              "innerValue": "value"
+            }
+          },
+          {
+            "property": "user.number",
+            "value": 123
+          },
+          {
+            "property": "conversation.value",
+            "value": "conversation value"
+          }
+        ]
+      },
+      {
+        "$kind": "Microsoft.Test.MemoryAssertions",
+        "assertions": [
+          "settings.file == 'set settings.file'",
+          "user.noOverwrite == 'original'",
+          "user.overwrite == 'overwritten'",
+          "user.object.innerValue == 'value'",
+          "user.number == 123",
+          "conversation.value == 'conversation value'"
+        ]
+      },
+      {
+        "$kind": "Microsoft.Test.AssertNoActivity",
+        "description":  "An error message was sent while performing PropertyMock test. Check that MemoryAssertions are accurate."
+      }
+    ]
+  }

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/testScript.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/testScript.test.js
@@ -78,7 +78,17 @@ describe('TestScriptTests', function () {
     });
 
     it('PropertyMock', async () => {
+        const origFile = process.env.file;
+        process.env.file = 'set settings.file';
+
         await TestUtils.runTestScript(resourceExplorer, 'TestScriptTests_PropertyMock');
+
+        // Cleanup, restoring original process.env.file, if any.
+        if (origFile) {
+            process.env.file = origFile;
+        } else {
+            delete process.env.file;
+        }
     });
 
     it('UserConversationUpdate', async () => {


### PR DESCRIPTION
Related: https://github.com/microsoft/botbuilder-dotnet/pull/5084

## Description

The MemoryAssertions tests were silently failing. They'll now pass and also elicit errors if they fail. In the Node version, it also was passing the assertions when it shouldn't, due to [this](https://github.com/microsoft/botbuilder-js/compare/main...mdrichardson:main?expand=1#diff-934af35e8c122351d11ac7a4f294230a5fa2a3bf641d17c5d408af46061e48cfL50), which was correct in Dotnet, which [correctly uses `||`](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/MemoryAssertions.cs#L62). You can see the issues in the original code if you throw a breakpoint [here](https://github.com/microsoft/botbuilder-js/blob/main/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/memoryAssertions.ts#L50)

## Specific Changes

- Added an `OnError` trigger for the PropertyMock test script. It would otherwise silently swallow errors.
- Adjusted what memory properties get written and overwritten.
