### PR TITLE
Ensure UserActivity activities inherit from set activity

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/userActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/userActivity.ts
@@ -63,7 +63,7 @@ export class UserActivity extends TestAction implements UserActivityConfiguratio
             activity.from.id = this.user;
             activity.from.name = this.user;
         } else if (tests.isObject(this.activity?.from)) {
-            activity.from = Object.assign({}, this.activity.from);
+            activity.from = { ...this.activity.from };
         }
 
         activity.locale = testAdapter.locale;

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/userActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/userActivity.ts
@@ -8,6 +8,7 @@
 
 import { Activity, TurnContext, TestAdapter } from 'botbuilder-core';
 import { Inspector, TestAction } from '../testAction';
+import { tests } from 'botbuilder-stdlib';
 
 export interface UserActivityConfiguration {
     activity?: Activity;
@@ -46,7 +47,7 @@ export class UserActivity extends TestAction implements UserActivityConfiguratio
             throw new Error('You must define one of Text of Activity properties');
         }
 
-        const activity = Object.assign({}, this.activity);
+        const activity = { ...this.activity };
         const reference = testAdapter.conversation;
         activity.channelId = reference.channelId;
         activity.serviceUrl = reference.serviceUrl;
@@ -58,10 +59,10 @@ export class UserActivity extends TestAction implements UserActivityConfiguratio
         }
 
         if (this.user) {
-            activity.from = Object.assign({}, activity.from);
+            activity.from = { ...activity.from };
             activity.from.id = this.user;
             activity.from.name = this.user;
-        } else if (this.activity?.from && Object.keys(this.activity.from)) {
+        } else if (tests.isObject(this.activity?.from)) {
             activity.from = Object.assign({}, this.activity.from);
         }
 

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/userActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/testActions/userActivity.ts
@@ -61,7 +61,10 @@ export class UserActivity extends TestAction implements UserActivityConfiguratio
             activity.from = Object.assign({}, activity.from);
             activity.from.id = this.user;
             activity.from.name = this.user;
+        } else if (this.activity?.from && Object.keys(this.activity.from)) {
+            activity.from = Object.assign({}, this.activity.from);
         }
+
         activity.locale = testAdapter.locale;
 
         await testAdapter.processActivity(activity, callback);

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/TestScriptTests_UserActivity.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/TestScriptTests_UserActivity.test.dialog
@@ -1,0 +1,75 @@
+{
+    "$schema": "../../../schemas/sdk.schema",
+    "$kind": "Microsoft.Test.Script",
+    "description": "Test AssertReply",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "test",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "conversation.activity",
+                        "value": "=turn.activity"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "text": "some text"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.MemoryAssertions",
+            "assertions": [
+                "conversation.activity.channelId == 'test'",
+                "conversation.activity.serviceUrl == 'https://test.com'",
+                "conversation.activity.conversation.id == 'TestScriptTests_UserActivity'",
+                "conversation.activity.conversation.isGroup == false",
+                "conversation.activity.conversation.name == 'TestScriptTests_UserActivity'",
+                "conversation.activity.from.id == 'user1'",
+                "conversation.activity.from.name == 'User1'",
+                "conversation.activity.recipient.id == 'bot'",
+                "conversation.activity.recipient.name == 'Bot'",
+                "conversation.activity.locale == 'en-us'"
+            ]
+        },
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "text": "some text",
+                "from": {
+                    "id": "from id",
+                    "name": "from name"
+                }
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.MemoryAssertions",
+            "assertions": [
+                "conversation.activity.from.id == 'from id'",
+                "conversation.activity.from.name == 'from name'"
+            ]
+        },
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "text": "some text"
+            },
+            "user": "user id"
+        },
+        {
+            "$kind": "Microsoft.Test.MemoryAssertions",
+            "assertions": [
+                "conversation.activity.from.id == 'user id'",
+                "conversation.activity.from.name == 'user id'"
+            ]
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/testScript.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/testScript.test.js
@@ -91,6 +91,10 @@ describe('TestScriptTests', function () {
         }
     });
 
+    it('UserActivity', async () => {
+        await TestUtils.runTestScript(resourceExplorer, 'TestScriptTests_UserActivity');
+    });
+
     it('UserConversationUpdate', async () => {
         await TestUtils.runTestScript(resourceExplorer, 'TestScriptTests_UserConversationUpdate');
     });


### PR DESCRIPTION
## Description

`userActivity` in the Node SDK didn't match the one in the .NET SDK, with respect to using `activity.from` in the `activity` property supplied in `test.dialog` files.

## Specific Changes

  - Added an `else if` condition to match [.NET SDK](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Testing/TestActions/UserActivity.cs#L72), that sets `activity.from` to match the `activity.from` if passed in from the `test.dialog` file.

## Testing

Added a test for `UserActivity` that would catch this as well as other things, since the test didn't exist.

The first `Microsoft.Test.UserActivity` is to check that it sets the adapter defaults. The next activity is to check that from gets set by the `activity.from` property. The next is to make sure it gets set by the `user` property