### PR TITLE
fix: null/undefined is not an object

### DIFF
--- a/libraries/botbuilder-stdlib/src/types.ts
+++ b/libraries/botbuilder-stdlib/src/types.ts
@@ -451,7 +451,7 @@ function maybeNumber(val: unknown, path: string[]): asserts val is Maybe<number>
  * @returns {boolean} true if `val` is of type `object`
  */
 function isObject(val: unknown): val is object {
-    return typeof val === 'object' && !isArray(val);
+    return !isNil(val) && typeof val === 'object' && !isArray(val);
 }
 
 /**


### PR DESCRIPTION
Small issue with `typeof null === 'object'` is true.