### PR TITLE
make bigInt more applicability in adaptive-expressions

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/dateTimeDiff.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dateTimeDiff.ts
@@ -6,6 +6,7 @@
  * Licensed under the MIT License.
  */
 
+import bigInt from 'big-integer';
 import { Expression } from '../expression';
 import { ExpressionEvaluator, ValueWithError } from '../expressionEvaluator';
 import { ExpressionType } from '../expressionType';
@@ -43,7 +44,7 @@ export class DateTimeDiff extends ExpressionEvaluator {
         }
 
         if (!error) {
-            value = dateTimeStart - dateTimeEnd;
+            value = bigInt(dateTimeStart).minus(bigInt(dateTimeEnd)).toJSNumber();
         }
 
         return { value, error };

--- a/libraries/adaptive-expressions/src/builtinFunctions/int.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/int.ts
@@ -6,6 +6,7 @@
  * Licensed under the MIT License.
  */
 
+import bigInt from 'big-integer';
 import { EvaluateExpressionDelegate, ExpressionEvaluator } from '../expressionEvaluator';
 import { ExpressionType } from '../expressionType';
 import { FunctionUtils } from '../functionUtils';
@@ -28,6 +29,9 @@ export class Int extends ExpressionEvaluator {
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError((args: any[]): any => {
             let error: string;
+            if (bigInt.isInstance(args[0])) {
+                return {value: args[0].toJSNumber(), error}
+            }
             const value: number = parseInt(args[0], 10);
             if (!FunctionUtils.isNumber(value)) {
                 error = `parameter ${args[0]} is not a valid number string.`;

--- a/libraries/adaptive-expressions/src/functionUtils.internal.ts
+++ b/libraries/adaptive-expressions/src/functionUtils.internal.ts
@@ -195,11 +195,11 @@ export class InternalFunctionUtils {
     }
 
     /**
-     * Convert a string input to ticks number.
+     * Convert a string input to ticks bigInt.
      * @param timeStamp String timestamp input.
      */
     public static ticks(timeStamp: string): ValueWithError {
-        let result: any;
+        let result: bigInt.BigInteger;
         const { value: parsed, error } = this.parseTimestamp(timeStamp);
         if (!error) {
             const unixMilliSec: number = parseInt(moment(parsed).utc().format('x'), 10);

--- a/libraries/adaptive-expressions/tests/expressionParser.test.js
+++ b/libraries/adaptive-expressions/tests/expressionParser.test.js
@@ -400,6 +400,7 @@ const testCases = [
             ['float(\'10.333\')', 10.333],
             ['float(\'10\')', 10.0],
             ['int(\'10\')', 10],
+            ['int(ticks)/100000000', 6372436242],
             ['string(\'str\')', 'str'],
             ['string(\'str"\')', 'str"'],
             ['string(one)', '1'], //ts-->1, C#-->1.0


### PR DESCRIPTION
Fixes #2211
Currently, JS sdk uses Number to handler all number input, and with BigInt to handler ticks().
Here SDK provides such a solution to reduce the gap between these two languages:

- Keep the range gap of the normal number.**-2^63 ~ 2^63 -1** for C# and **-2^53+1 ~ 2^53** for JS. (JS would provide inaccurate calculation of numbers beyond this range)
- Provide a solution to convert bigint object into a normal number in js. `int()` function can accept a bigint input, and output a fuzzy number output.
  For example: `int(ticks(utcNow())) - 1` would be valid and the output would be a `number`. But the accuracy of the output is not guaranteed
