### PR TITLE
ActionPolicy clean up

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/package.json
+++ b/libraries/botbuilder-dialogs-adaptive-testing/package.json
@@ -26,6 +26,7 @@
     "botbuilder-dialogs": "4.1.6",
     "botbuilder-dialogs-adaptive": "4.1.6",
     "botbuilder-dialogs-declarative": "4.1.6",
+    "botbuilder-stdlib": "4.1.6",
     "adaptive-expressions": "4.1.6"
   },
   "devDependencies": {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/policies/actionPolicy.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/policies/actionPolicy.ts
@@ -6,39 +6,8 @@
  * Licensed under the MIT License.
  */
 
-import { ActionPolicyType  } from './actionPolicyTypes'
+import { ActionPolicyType } from './actionPolicyTypes';
 
 export class ActionPolicy {
-    policyType: ActionPolicyType;
-    actions: string[];
-    kind: string;
-    public constructor (kind: string, actionPolicyType: ActionPolicyType, actions: string[] = undefined) {
-        this.policyType = actionPolicyType;
-        this.actions = actions;
-        this.kind = kind;
-    }
-    
-    public get Kind(): string {
-        return this.kind;
-    }
-
-    public set Kind(newKind: string) {
-        this.kind = newKind;
-    }
-
-    public get ActionPolicyType(): ActionPolicyType {
-        return this.policyType;
-    }
-    
-    public set ActionPolicyType(newPolicyType: ActionPolicyType) {
-        this.policyType = newPolicyType;
-    }
-    
-    public get Actions(): string[] {
-        return this.actions;
-    }
-
-    public set Actions(newActions: string[]) {
-        this.actions = newActions;
-    }
+    public constructor(public kind: string, public actionPolicyType: ActionPolicyType, public actions: string[] = []) {}
 }

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/policies/actionPolicyException.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/policies/actionPolicyException.ts
@@ -6,14 +6,13 @@
  * Licensed under the MIT License.
  */
 
-import { Dialog } from "botbuilder-dialogs";
-import { ActionPolicy } from "./actionPolicy";
+import { ActionPolicy } from './actionPolicy';
+import { Dialog } from 'botbuilder-dialogs';
 
 export class ActionPolicyException extends Error {
-    constructor(
-        public readonly policy: ActionPolicy,
-        public readonly dialog: Dialog
-    ) {
+    constructor(public readonly policy: ActionPolicy, public readonly dialog: Dialog) {
         super();
+
+        this.name = 'ActionPolicyException';
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/policies/actionPolicyValidator.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/policies/actionPolicyValidator.ts
@@ -65,7 +65,6 @@ export class ActionPolicyValidator {
 
     private validateKind(parentKinds: string[], kind: string, dialogs?: Dialog[]): void {
         const kindPolicy = this.actionPolicies.find((item) => item.kind === kind);
-
         if (kindPolicy) {
             this.validatePolicy(parentKinds, kindPolicy, dialogs);
         }
@@ -120,9 +119,9 @@ export class ActionPolicyValidator {
 
             case ActionPolicyType.TriggerNotInteractive: {
                 //  ensure no dialogs, or child dialogs, are Input dialogs
-                const childDialogs = dialogs.filter((d) => d.id !== dialog.id);
+                const childDialogs = dialogs.filter((d) => d.id !== dialog?.id);
 
-                while (childDialogs.length > 0) {
+                while (childDialogs.length) {
                     const childDialog = childDialogs.shift();
                     assertConstructorKind(childDialog, ['childDialog']);
 
@@ -143,7 +142,7 @@ export class ActionPolicyValidator {
             }
             case ActionPolicyType.TriggerRequiresAction: {
                 //  ensure the required action is present in the dialogs chain
-                const childActions = dialogs.filter((d) => d.id !== dialog.id);
+                const childActions = dialogs.filter((d) => d.id !== dialog?.id);
                 while (childActions.length) {
                     const childDialog = childActions.shift();
                     assertConstructorKind(childDialog, ['childDialog']);
@@ -177,7 +176,7 @@ export class ActionPolicyValidator {
             return dialog.actions;
         }
 
-        let dialogs: Dialog[];
+        const dialogs: Dialog[] = [];
 
         if (isDialogDependencies(dialog)) {
             for (const dependency of dialog.getDependencies()) {

--- a/libraries/botbuilder-dialogs-adaptive-testing/src/policies/actionPolicyValidator.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/policies/actionPolicyValidator.ts
@@ -6,33 +6,41 @@
  * Licensed under the MIT License.
  */
 
-import { ResourceExplorer } from 'botbuilder-dialogs-declarative'
-import { ActionPolicyType  } from './actionPolicyTypes'
-import { ActionPolicy } from './actionPolicy'
-import { 
-    BreakLoop, 
-    ContinueLoop, 
-    GotoAction, 
+import { ResourceExplorer } from 'botbuilder-dialogs-declarative';
+import { ActionPolicyType } from './actionPolicyTypes';
+import { ActionPolicy } from './actionPolicy';
+import {
+    BreakLoop,
+    ContinueLoop,
+    GotoAction,
     CancelDialog,
-    CancelAllDialogs, 
-    EndDialog, 
-    RepeatDialog, 
-    ThrowException, 
-    Ask, 
-    AttachmentInput, 
-    ChoiceInput, 
-    ConfirmInput, 
-    DateTimeInput, 
+    CancelAllDialogs,
+    EndDialog,
+    RepeatDialog,
+    ThrowException,
+    Ask,
+    AttachmentInput,
+    ChoiceInput,
+    ConfirmInput,
+    DateTimeInput,
     NumberInput,
     OAuthInput,
     TextInput,
     OnEndOfConversationActivity,
     AdaptiveDialog,
     OnCondition,
-    ActionScope
-} from '../../../botbuilder-dialogs-adaptive'
-import { Dialog, DialogDependencies } from 'botbuilder-dialogs';
+    ActionScope,
+} from 'botbuilder-dialogs-adaptive';
+import { Dialog, isDialogDependencies } from 'botbuilder-dialogs';
 import { ActionPolicyException } from './ActionPolicyException';
+import { Assertion, assert } from 'botbuilder-stdlib';
+
+// Asserts that a given value is an instance of a constructor that, itself, has a static $kind property
+type ConstructorKind = { constructor: { $kind: string } };
+const assertConstructorKind: Assertion<ConstructorKind> = (val, path) => {
+    assert.unsafe.castObjectAs<ConstructorKind>(val, path);
+    assert.string(val.constructor?.$kind, path.concat('constructor', '$kind'));
+};
 
 ///  <summary>
 ///  Validator used to verify a dialog with its triggers and actions are not violating
@@ -40,153 +48,149 @@ import { ActionPolicyException } from './ActionPolicyException';
 ///  if any policy violations are found.
 ///  </summary>
 export class ActionPolicyValidator {
-    public validatePolicies(dialog: Dialog) {
-        const asAdaptive = dialog as AdaptiveDialog;
-        //  validate policies for all triggers and their child actions
-        for (const trigger of asAdaptive.triggers) {
-            this.ValidateCondition(trigger);
-        }
-    }
-    
-    private ValidateCondition(condition: any) {
-        let triggerKind = condition.$kind;
-        let parentKinds: string[] = [];
-        parentKinds.push(triggerKind);
-        //  Validate the actions of the trigger
-        this.ValidateKind(parentKinds, triggerKind, condition.actions);
-    }
-    
-    private ValidateKind(parentKinds: string[], kind: string, dialogs: Dialog[]) {
-        const  kindPolicy = this.actionPolicies.find((item) => item.Kind === kind);
-
-        if ((kindPolicy != null)) {
-            this.ValidatePolicy(parentKinds, kindPolicy, dialogs);
-        }
-        
-        if ((dialogs != null)) {
-            for (const dialog of dialogs) {
-                let actionKind = (dialog as any).$kind;
-                let parentKindsInner: string[] = [];
-                parentKindsInner = parentKindsInner.concat(parentKinds);
-                parentKindsInner.push(actionKind);
-
-                let actionPolicy = this.actionPolicies.find((item) => item.Kind === actionKind);
-                if ((actionPolicy != null)) {
-                    this.ValidatePolicy(parentKindsInner, actionPolicy, dialogs, dialog);
-                }
-                
-                this.ValidateKind(parentKindsInner, actionKind, this.getDialogs(dialog));
+    public validatePolicies(dialog: Dialog): void {
+        if (dialog instanceof AdaptiveDialog) {
+            for (const trigger of dialog.triggers) {
+                this.validateCondition(trigger);
             }
         }
     }
-    
-    private ValidatePolicy(parentKinds: string[], policy: ActionPolicy, dialogs: Dialog[], dialog: Dialog = undefined) {
-        switch (policy.ActionPolicyType) {
+
+    private validateCondition(condition: OnCondition): void {
+        assertConstructorKind(condition, ['condition']);
+        const triggerKind = condition.constructor.$kind;
+
+        this.validateKind([triggerKind], triggerKind, condition.actions);
+    }
+
+    private validateKind(parentKinds: string[], kind: string, dialogs?: Dialog[]): void {
+        const kindPolicy = this.actionPolicies.find((item) => item.kind === kind);
+
+        if (kindPolicy) {
+            this.validatePolicy(parentKinds, kindPolicy, dialogs);
+        }
+
+        if (dialogs?.length) {
+            for (const dialog of dialogs) {
+                assertConstructorKind(dialog, ['dialog']);
+
+                const actionKind = dialog.constructor?.$kind;
+                const parentKindsInner = [...parentKinds, actionKind];
+
+                const actionPolicy = this.actionPolicies.find((item) => item.kind === actionKind);
+                if (actionPolicy) {
+                    this.validatePolicy(parentKindsInner, actionPolicy, dialogs, dialog);
+                }
+
+                this.validateKind(parentKindsInner, actionKind, this.getDialogs(dialog));
+            }
+        }
+    }
+
+    private validatePolicy(parentKinds: string[], policy: ActionPolicy, dialogs: Dialog[], dialog?: Dialog): void {
+        switch (policy.actionPolicyType) {
             case ActionPolicyType.LastAction:
                 //  This dialog must be the last in the list
-                if ((dialogs.indexOf(dialog) < (dialogs.length - 1))) {
+                if (dialogs.indexOf(dialog) < dialogs.length - 1) {
                     throw new ActionPolicyException(policy, dialog);
                 }
-                
+
                 break;
-            case ActionPolicyType.Interactive:
+
+            case ActionPolicyType.Interactive: {
                 //  This dialog is interactive, so cannot be under NonInteractive triggers
-                for (let parentKind in parentKinds) {
-                    let parentPolicy = this.actionPolicies.find((item) => item.Kind === parentKind);
-                    if (((parentPolicy != null) 
-                                && (parentPolicy.ActionPolicyType == ActionPolicyType.TriggerNotInteractive))) {
+                for (const parentKind in parentKinds) {
+                    const parentPolicy = this.actionPolicies.find((item) => item.kind === parentKind);
+                    if (parentPolicy?.actionPolicyType === ActionPolicyType.TriggerNotInteractive) {
                         throw new ActionPolicyException(policy, dialog);
                     }
-                    
                 }
-                
+
                 break;
+            }
+
             case ActionPolicyType.AllowedTrigger:
                 //  ensure somewhere up the chain the specific trigger type is found
-                if (parentKinds.some( (pk) => policy.Actions.some((a) => pk == a))) {
+                if (parentKinds.some((pk) => policy.actions.some((a) => pk === a))) {
                     return;
                 }
 
                 //  Trigger type not found up the chain.  This action is in the wrong trigger.
                 throw new ActionPolicyException(policy, dialog);
-                break;
-            case ActionPolicyType.TriggerNotInteractive:
+
+            case ActionPolicyType.TriggerNotInteractive: {
                 //  ensure no dialogs, or child dialogs, are Input dialogs
-                let childDialogs = dialog ? dialogs.filter(d => d.id != dialog.id) : dialogs;
+                const childDialogs = dialogs.filter((d) => d.id !== dialog.id);
 
                 while (childDialogs.length > 0) {
-                    let childDialog = childDialogs[0];
-                    let childKind = (childDialog as any).$kind;
-                    let childPolicy = this.actionPolicies.find((item) => item.kind === childKind);
-                    if (childPolicy && (childPolicy.ActionPolicyType == ActionPolicyType.Interactive)) {
+                    const childDialog = childDialogs.shift();
+                    assertConstructorKind(childDialog, ['childDialog']);
+
+                    const childKind = childDialog.constructor.$kind;
+                    const childPolicy = this.actionPolicies.find((item) => item.kind === childKind);
+                    if (childPolicy?.actionPolicyType === ActionPolicyType.Interactive) {
                         //  Interactive action found below TriggerNotInteractive trigger
                         throw new ActionPolicyException(policy, dialog);
                     }
-                    
-                
-                    childDialogs.shift();
-                    let innerChildDialogs = this.getDialogs(childDialog);
-                    if ((innerChildDialogs != null)) {
-                        childDialogs = childDialogs.concat(innerChildDialogs);
+
+                    const innerChildDialogs = this.getDialogs(childDialog);
+                    if (innerChildDialogs) {
+                        childDialogs.push(...innerChildDialogs);
                     }
                 }
-                
+
                 break;
-            case ActionPolicyType.TriggerRequiresAction:
+            }
+            case ActionPolicyType.TriggerRequiresAction: {
                 //  ensure the required action is present in the dialogs chain
-                let childActions = dialog ? dialogs.filter(d => d.id != dialog.id) : dialogs;
-                while (childActions.length > 0) {
-                    let childDialog = childActions[0];
-                    let childKind = (childDialog as any).$kind;
-                    
-                    if (policy.Actions.some((pa) => pa == childKind )) {
+                const childActions = dialogs.filter((d) => d.id !== dialog.id);
+                while (childActions.length) {
+                    const childDialog = childActions.shift();
+                    assertConstructorKind(childDialog, ['childDialog']);
+
+                    const childKind = childDialog.constructor.$kind;
+                    if (policy.actions.some((pa) => pa === childKind)) {
                         //  found the action required
                         return;
                     }
-                    
-                    childActions.shift();
-                    let innerChildDialogs = this.getDialogs(childDialog);
-                    if ((innerChildDialogs != null)) {
-                        childActions = childActions.concat(innerChildDialogs);
+
+                    const innerChildDialogs = this.getDialogs(childDialog);
+                    if (innerChildDialogs) {
+                        childActions.push(...innerChildDialogs);
                     }
-                    
                 }
-                
+
                 //  Required action not found
                 throw new ActionPolicyException(policy, dialog);
+            }
             default:
-                throw new Error(`Invalid ActionPolicy.ActionPolicyType: ${policy.ActionPolicyType}`);
+                throw new Error(`Invalid ActionPolicy.ActionPolicyType: ${policy.actionPolicyType}`);
         }
-        
     }
-    
+
     private getDialogs(dialog: Dialog): Dialog[] {
-        if ((dialog instanceof AdaptiveDialog)) {
+        if (dialog instanceof AdaptiveDialog) {
             return dialog.dialogs.getDialogs();
         }
-        
-        if ((dialog instanceof  ActionScope)) {
+
+        if (dialog instanceof ActionScope) {
             return dialog.actions;
         }
-        
-        let dialogs: Dialog[] = [];
-        if (typeof ((dialog as any) as DialogDependencies).getDependencies == 'function') {
-            for(const dependency of ((dialog as any) as DialogDependencies).getDependencies()) {
-                const asAny = dependency as any;
-                if ((asAny.actions)) {
-                    dialogs = dialogs.concat(asAny.actions);
-                }
-                else {
-                    dialogs.push(dependency);
+
+        let dialogs: Dialog[];
+
+        if (isDialogDependencies(dialog)) {
+            for (const dependency of dialog.getDependencies()) {
+                if (dependency instanceof ActionScope) {
+                    dialogs.push(...dependency.actions);
                 }
             }
         }
-        
+
         return dialogs;
     }
-    
+
     get actionPolicies(): ActionPolicy[] {
-        
         return [
             //  LastAction (dialog continues)
             new ActionPolicy(BreakLoop.$kind, ActionPolicyType.LastAction),
@@ -216,6 +220,6 @@ export class ActionPolicyValidator {
             // ? yield return new ActionPolicy(OnConversationUpdateActivity.Kind, ActionPolicyType.TriggerNotInteractive);
             // AllowedTrigger (Action only valid in n Triggers)
             // TriggerRequiresAction (Trigger requries one of n actions)
-        ]
+        ];
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/actionPolicy.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/actionPolicy.test.js
@@ -1,20 +1,16 @@
 const assert = require('assert');
 const path = require('path');
-const {
-    ComponentRegistration,
-} = require('botbuilder-core');
+const { AdaptiveTestComponentRegistration, ActionPolicyType, ActionPolicyValidator, ActionPolicy } = require('../lib');
+const { ComponentRegistration } = require('botbuilder-core');
 const { ResourceExplorer } = require('botbuilder-dialogs-declarative');
-const { AdaptiveTestComponentRegistration, TestUtils, TestScript, ActionPolicyType, ActionPolicyValidator } = require('../lib');
 const {
     AdaptiveComponentRegistration,
     BreakLoop,
     CancelAllDialogs,
-    OnEndOfConversationActivity
+    OnEndOfConversationActivity,
 } = require('botbuilder-dialogs-adaptive');
 
-describe('ActionPolicyTests', function () {
-    this.timeout(10000);
-
+describe('ActionPolicyTests', () => {
     ComponentRegistration.add(new AdaptiveComponentRegistration());
     ComponentRegistration.add(new AdaptiveTestComponentRegistration());
 
@@ -26,51 +22,33 @@ describe('ActionPolicyTests', function () {
 
     const validator = new ActionPolicyValidator();
 
-    it('LastAction_BreakLoop', async () => {
-        let threwError = false;
-        try {
-            validatePolicies('LastAction_BreakLoop_Invalid')
-        } catch (error) {
-            threwError = true;
-            assert(BreakLoop.$kind === error.policy.Kind, `kind of error does not match expected kind.`);
-            assert(ActionPolicyType.LastAction === error.policy.ActionPolicyType, `policy type of error does not match.`);
-        }
-
-        assert(threwError, 'LastAction_BreakLoop test failed');
+    it('LastAction_BreakLoop', () => {
+        assert.throws(() => validatePolicies('LastAction_BreakLoop_Invalid'), {
+            name: 'ActionPolicyException',
+            policy: new ActionPolicy(BreakLoop.$kind, ActionPolicyType.LastAction),
+        });
     });
 
     function validatePolicies(testName) {
-        var script = resourceExplorer.loadType(`${testName}.test.dialog`);
+        const script = resourceExplorer.loadType(`${testName}.test.dialog`);
         validator.validatePolicies(script.dialog);
     }
 
-    it('LastAction_CancelAllDialogs', async () => {
-        let threwError = false;
-        try {
-            validatePolicies('LastAction_CancelAllDialogs_Invalid')
-        } catch (error) {
-            threwError = true;
-            assert(CancelAllDialogs.$kind === error.policy.Kind, `kind of error does not match expected kind.`);
-            assert(ActionPolicyType.LastAction === error.policy.ActionPolicyType, `policy type of error does not match.`);
-        }
-
-        assert(threwError, 'LastAction_CancelAllDialogs test failed');
+    it('LastAction_CancelAllDialogs', () => {
+        assert.throws(() => validatePolicies('LastAction_CancelAllDialogs_Invalid'), {
+            name: 'ActionPolicyException',
+            policy: new ActionPolicy(CancelAllDialogs.$kind, ActionPolicyType.LastAction),
+        });
     });
 
-    it('OnEndOfConversationActivity', async () => {
-        validatePolicies('OnEndOfConversationActivity_Valid')
+    it('OnEndOfConversationActivity', () => {
+        validatePolicies('OnEndOfConversationActivity_Valid');
     });
 
-    it('TriggerNotInteractive_OnEndOfConversationActivity', async () => {
-        let threwError = false;
-        try {
-            validatePolicies('TriggerNotInteractive_OnEndOfConversationActivity_Invalid')
-        } catch (error) {
-            threwError = true;
-            assert(OnEndOfConversationActivity.$kind === error.policy.Kind, `kind of error does not match expected kind.`);
-            assert(ActionPolicyType.TriggerNotInteractive === error.policy.ActionPolicyType, `policy type of error does not match.`);
-        }
-
-        assert(threwError, 'TriggerNotInteractive_OnEndOfConversationActivity_Invalid test failed');
+    it('TriggerNotInteractive_OnEndOfConversationActivity', () => {
+        assert.throws(() => validatePolicies('TriggerNotInteractive_OnEndOfConversationActivity_Invalid'), {
+            name: 'ActionPolicyException',
+            policy: new ActionPolicy(OnEndOfConversationActivity.$kind, ActionPolicyType.TriggerNotInteractive),
+        });
     });
 });

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -32,6 +32,7 @@
     "@microsoft/recognizers-text-number": "1.1.4",
     "@microsoft/recognizers-text-suite": "1.1.4",
     "botbuilder-core": "4.1.6",
+    "botbuilder-stdlib": "4.1.6",
     "globalize": "^1.4.2",
     "uuid": "^8.3.2"
   },

--- a/libraries/botbuilder-dialogs/src/dialogSet.ts
+++ b/libraries/botbuilder-dialogs/src/dialogSet.ts
@@ -5,7 +5,14 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { BotTelemetryClient, StatePropertyAccessor, TurnContext, StringUtils, NullTelemetryClient } from 'botbuilder-core';
+import {
+    BotTelemetryClient,
+    StatePropertyAccessor,
+    TurnContext,
+    StringUtils,
+    NullTelemetryClient,
+} from 'botbuilder-core';
+import { Assertion, assert } from 'botbuilder-stdlib';
 import { Dialog } from './dialog';
 import { DialogContext, DialogState } from './dialogContext';
 
@@ -15,6 +22,13 @@ export interface DialogDependencies {
      */
     getDependencies(): Dialog[];
 }
+
+export const assertDialogDependencies: Assertion<DialogDependencies> = (val, path) => {
+    assert.unsafe.castObjectAs<DialogDependencies>(val, path);
+    assert.func(val.getDependencies, path.concat('getDependencies'));
+};
+
+export const isDialogDependencies = assert.toTest(assertDialogDependencies);
 
 /**
  * A related set of dialogs that can all call each other.


### PR DESCRIPTION
Introduces a few small tweaks:
- Use type assertions for better runtime safety and compiler hinting
- Simplify classes a bit (remove unnecessary setters/getters)
- Use assert.throws in tests for clarity
- Prettier code formatting