### PR TITLE
fix: tune unused eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,13 +56,23 @@
     "security"
   ],
   "rules": {
-    "@typescript-eslint/no-unused-vars": ["error"],
-    "jsdoc/require-jsdoc": ["error", {"publicOnly": true, "enableFixer": false}],
+    "@typescript-eslint/no-unused-vars": ["error", {
+      "args": "after-used",
+      "argsIgnorePattern": "^_",
+      "caughtErrors": "all",
+      "caughtErrorsIgnorePattern": "^_",
+      "varsIgnorePattern": "^_"
+    }],
+    "jsdoc/require-jsdoc": ["error", {
+      "publicOnly": true,
+      "enableFixer": false
+    }],
     "jsdoc/require-param": ["error"],
     "jsdoc/require-param-type": ["error"],
     "jsdoc/require-returns": ["error"],
     "jsdoc/require-returns-type": ["error"],
-    "no-var": ["error"],
+    "no-unused-vars": "off",
+    "no-var": "error",
     "prettier/prettier": "error"
   }
 }

--- a/libraries/botbuilder-azure-queues/tests/azureQueueStorage.test.js
+++ b/libraries/botbuilder-azure-queues/tests/azureQueueStorage.test.js
@@ -23,7 +23,7 @@ const checkEmulator = async () => {
     try {
         await fetch(emulatorEndpoint);
         canConnectToEmulator = true;
-    } catch (err) {
+    } catch (_err) {
         canConnectToEmulator = false;
     }
     if (!canConnectToEmulator) {

--- a/libraries/botbuilder-repo-utils/src/file.ts
+++ b/libraries/botbuilder-repo-utils/src/file.ts
@@ -20,7 +20,7 @@ export async function readJsonFile<T>(path: string): Promise<T | undefined> {
     try {
         const rawPackageJson = await readFile(path, 'utf8');
         return JSON.parse(rawPackageJson);
-    } catch (err) {
+    } catch (_err) {
         return undefined;
     }
 }

--- a/libraries/botbuilder-repo-utils/src/run.ts
+++ b/libraries/botbuilder-repo-utils/src/run.ts
@@ -62,7 +62,7 @@ export type Result = Success | Failure;
  * Executes `logic` and handles transforming the `Result` into proper process state. Logs errors and exits the process.
  *
  * @param {() => Promise<Result>} logic an operation to execute that yields a `Result`
- * @param {Logger} logger optional, a logger to use
+ * @param {log.Logger} logger optional, a logger to use
  * @returns {Promise<void>} a promise representing execution of `logic`
  */
 export async function run(logic: () => Promise<Result>, logger: log.Logger | null = log): Promise<void> {

--- a/libraries/botbuilder-stdlib/src/types.ts
+++ b/libraries/botbuilder-stdlib/src/types.ts
@@ -520,7 +520,7 @@ function makeTest<T>(assertion: Assertion<T>): Test<T> {
         try {
             assertion(val, []);
             return true;
-        } catch (err) {
+        } catch (_err) {
             return false;
         }
     };


### PR DESCRIPTION
Tune unused eslint rule to support prefixing things with `_` to disable unused error