### PR TITLE
Append Composer ui schema 'flow' part to component schema files

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.BeginDialog.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.BeginDialog.uischema
@@ -17,5 +17,18 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "DialogRef",
+            "dialog": "=action.dialog"
+        },
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=action.resultProperty",
+            "description": "= Return value"
+        },
+        "hideFooter": "=!action.resultProperty"
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.BeginSkill.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.BeginSkill.uischema
@@ -11,5 +11,26 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "colors": {
+            "theme": "#004578",
+            "color": "#FFFFFF",
+            "icon": "#FFFFFF"
+        },
+        "icon": "Library",
+        "body": {
+            "widget": "ResourceOperation",
+            "operation": "Host",
+            "resource": "=coalesce(action.skillEndpoint, \"?\")",
+            "singleline": true
+        },
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=action.resultProperty",
+            "description": "= Result"
+        },
+        "hideFooter": "=!action.resultProperty"
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.CancelAllDialogs.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.CancelAllDialogs.uischema
@@ -4,5 +4,13 @@
         "label": "Cancel all active dialogs",
         "subtitle": "Cancel All Dialogs",
         "helpLink": "https://aka.ms/bfc-understanding-dialogs"
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "PropertyDescription",
+            "property": "=coalesce(action.eventName, \"?\")",
+            "description": "(Event)"
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.DeleteProperties.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.DeleteProperties.uischema
@@ -11,5 +11,12 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "ListOverview",
+            "items": "=action.properties"
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.DeleteProperty.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.DeleteProperty.uischema
@@ -11,5 +11,9 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": "=action.property"
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.EditActions.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.EditActions.uischema
@@ -3,5 +3,9 @@
     "form": {
         "label": "Modify active dialog",
         "subtitle": "Edit Actions"
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": "=action.changeType"
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.EditArray.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.EditArray.uischema
@@ -16,5 +16,19 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "ResourceOperation",
+            "operation": "=coalesce(action.changeType, \"?\")",
+            "resource": "=coalesce(action.itemsProperty, \"?\")"
+        },
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=action.resultProperty",
+            "description": "= Result"
+        },
+        "hideFooter": "=!action.resultProperty"
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.EmitEvent.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.EmitEvent.uischema
@@ -4,5 +4,13 @@
         "label": "Emit a custom event",
         "subtitle": "Emit Event",
         "helpLink": "https://aka.ms/bfc-custom-events"
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "PropertyDescription",
+            "property": "=coalesce(action.eventName, \"?\")",
+            "description": "(Event)"
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.Foreach.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.Foreach.uischema
@@ -28,5 +28,13 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ForeachWidget",
+        "nowrap": true,
+        "loop": {
+            "widget": "ActionCard",
+            "body": "=concat(\"Each value in \", coalesce(action.itemsProperty, \"?\"))"
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.ForeachPage.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.ForeachPage.uischema
@@ -29,5 +29,13 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ForeachWidget",
+        "nowrap": true,
+        "loop": {
+            "widget": "ActionCard",
+            "body": "=concat(\"Each page of \", coalesce(action.pageSize, \"?\"), \" in \", coalesce(action.page, \"?\"))"
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.GetActivityMembers.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.GetActivityMembers.uischema
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "PropertyDescription",
+            "property": "=coalesce(action.activityId, \"?\")",
+            "description": "= ActivityId"
+        },
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=coalesce(action.property, \"?\")",
+            "description": "= Result property"
+        }
+    }
+}

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.GetConversationMembers.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.GetConversationMembers.uischema
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "flow": {
+        "widget": "ActionCard",
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=action.property",
+            "description": "= Result property"
+        }
+    }
+}

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.HttpRequest.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.HttpRequest.uischema
@@ -18,5 +18,20 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "ResourceOperation",
+            "operation": "=action.method",
+            "resource": "=action.url",
+            "singleline": true
+        },
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=action.resultProperty",
+            "description": "= Result property"
+        },
+        "hideFooter": "=!action.resultProperty"
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.IfCondition.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.IfCondition.uischema
@@ -8,5 +8,13 @@
             "elseActions"
         ],
         "helpLink": "https://aka.ms/bfc-controlling-conversation-flow"
+    },
+    "flow": {
+        "widget": "IfConditionWidget",
+        "nowrap": true,
+        "judgement": {
+            "widget": "ActionCard",
+            "body": "=coalesce(action.condition, \"<condition>\")"
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.ReplaceDialog.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.ReplaceDialog.uischema
@@ -9,5 +9,12 @@
             "options",
             "*"
         ]
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "DialogRef",
+            "dialog": "=action.dialog"
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.SendActivity.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.SendActivity.uischema
@@ -8,5 +8,20 @@
             "activity",
             "*"
         ]
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "LgWidget",
+            "field": "activity"
+        },
+        "header": {
+            "widget": "ActionHeader",
+            "icon": "MessageBot",
+            "colors": {
+                "theme": "#EEEAF4",
+                "icon": "#5C2E91"
+            }
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.SetProperties.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.SetProperties.uischema
@@ -15,5 +15,12 @@
                 }
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "ListOverview",
+            "items": "=foreach(action.assignments, x => concat(coalesce(x.property, \"?\"), \" : \", coalesce(x.value, \"?\")))"
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.SetProperty.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.SetProperty.uischema
@@ -11,5 +11,9 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": "${coalesce(action.property, \"?\")} : ${coalesce(action.value, \"?\")}"
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.SwitchCondition.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.SwitchCondition.uischema
@@ -19,5 +19,13 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "SwitchConditionWidget",
+        "nowrap": true,
+        "judgement": {
+            "widget": "ActionCard",
+            "body": "=coalesce(action.condition, \"<condition>\")"
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.ThrowException.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.ThrowException.uischema
@@ -3,5 +3,13 @@
     "form": {
         "label": "Throw an exception",
         "subtitle": "Throw an exception"
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "PropertyDescription",
+            "property": "=coalesce(action.errorValue, \"?\")",
+            "description": "= ErrorValue"
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.UpdateActivity.schema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.UpdateActivity.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": "implements(Microsoft.IDialog)",
-    "title": "Send an activity",
+    "title": "Update an activity",
     "description": "Respond with an activity.",
     "type": "object",
     "properties": {

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.UpdateActivity.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Actions/Microsoft.UpdateActivity.uischema
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+    "form": {
+        "label": "Update an activity",
+        "subtitle": "Update Activity"
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "header": {
+            "widget": "ActionHeader",
+            "title": "Update activity",
+            "icon": "MessageBot",
+            "colors": {
+                "theme": "#D7D7D7",
+                "icon": "#656565"
+            }
+        },
+        "body": {
+            "widget": "LgWidget",
+            "field": "activity"
+        }
+    }
+}

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.Ask.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.Ask.uischema
@@ -8,5 +8,26 @@
             "activity",
             "*"
         ]
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "header": {
+            "widget": "ActionHeader",
+            "icon": "MessageBot",
+            "colors": {
+                "theme": "#EEEAF4",
+                "icon": "#5C2E91"
+            }
+        },
+        "body": {
+            "widget": "LgWidget",
+            "field": "activity"
+        },
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=action.defaultOperation",
+            "description": "= Default operation"
+        },
+        "hideFooter": "=!action.defaultOperation"
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.AttachmentInput.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.AttachmentInput.uischema
@@ -11,5 +11,39 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "PromptWidget",
+        "body": "=action.prompt",
+        "nowrap": true,
+        "botAsks": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "icon": "MessageBot",
+                "colors": {
+                    "theme": "#EEEAF4",
+                    "icon": "#5C2E91"
+                }
+            },
+            "body": {
+                "widget": "LgWidget",
+                "field": "prompt",
+                "defaultContent": "<prompt>"
+            }
+        },
+        "userInput": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "disableSDKTitle": true,
+                "icon": "User",
+                "menu": "none",
+                "colors": {
+                    "theme": "#E5F0FF",
+                    "icon": "#0078D4"
+                }
+            }
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.ChoiceInput.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.ChoiceInput.uischema
@@ -11,5 +11,39 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "PromptWidget",
+        "body": "=action.prompt",
+        "nowrap": true,
+        "botAsks": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "icon": "MessageBot",
+                "colors": {
+                    "theme": "#EEEAF4",
+                    "icon": "#5C2E91"
+                }
+            },
+            "body": {
+                "widget": "LgWidget",
+                "field": "prompt",
+                "defaultContent": "<prompt>"
+            }
+        },
+        "userInput": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "disableSDKTitle": true,
+                "icon": "User",
+                "menu": "none",
+                "colors": {
+                    "theme": "#E5F0FF",
+                    "icon": "#0078D4"
+                }
+            }
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.ConfirmInput.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.ConfirmInput.uischema
@@ -11,5 +11,39 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "PromptWidget",
+        "body": "=action.prompt",
+        "nowrap": true,
+        "botAsks": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "icon": "MessageBot",
+                "colors": {
+                    "theme": "#EEEAF4",
+                    "icon": "#5C2E91"
+                }
+            },
+            "body": {
+                "widget": "LgWidget",
+                "field": "prompt",
+                "defaultContent": "<prompt>"
+            }
+        },
+        "userInput": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "disableSDKTitle": true,
+                "icon": "User",
+                "menu": "none",
+                "colors": {
+                    "theme": "#E5F0FF",
+                    "icon": "#0078D4"
+                }
+            }
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.DateTimeInput.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.DateTimeInput.uischema
@@ -11,5 +11,39 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "PromptWidget",
+        "body": "=action.prompt",
+        "nowrap": true,
+        "botAsks": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "icon": "MessageBot",
+                "colors": {
+                    "theme": "#EEEAF4",
+                    "icon": "#5C2E91"
+                }
+            },
+            "body": {
+                "widget": "LgWidget",
+                "field": "prompt",
+                "defaultContent": "<prompt>"
+            }
+        },
+        "userInput": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "disableSDKTitle": true,
+                "icon": "User",
+                "menu": "none",
+                "colors": {
+                    "theme": "#E5F0FF",
+                    "icon": "#0078D4"
+                }
+            }
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.NumberInput.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.NumberInput.uischema
@@ -11,5 +11,39 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "PromptWidget",
+        "body": "=action.prompt",
+        "nowrap": true,
+        "botAsks": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "icon": "MessageBot",
+                "colors": {
+                    "theme": "#EEEAF4",
+                    "icon": "#5C2E91"
+                }
+            },
+            "body": {
+                "widget": "LgWidget",
+                "field": "prompt",
+                "defaultContent": "<prompt>"
+            }
+        },
+        "userInput": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "disableSDKTitle": true,
+                "icon": "User",
+                "menu": "none",
+                "colors": {
+                    "theme": "#E5F0FF",
+                    "icon": "#0078D4"
+                }
+            }
+        }
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.OAuthInput.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.OAuthInput.uischema
@@ -8,5 +8,20 @@
             "connectionName",
             "*"
         ]
+    },
+    "flow": {
+        "widget": "ActionCard",
+        "body": {
+            "widget": "ResourceOperation",
+            "operation": "Connection",
+            "resource": "=coalesce(action.connectionName, \"?\")",
+            "singleline": true
+        },
+        "footer": {
+            "widget": "PropertyDescription",
+            "property": "=action.property",
+            "description": "= Token property"
+        },
+        "hideFooter": "=!action.property"
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.TextInput.uischema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.TextInput.uischema
@@ -11,5 +11,39 @@
                 ]
             }
         }
+    },
+    "flow": {
+        "widget": "PromptWidget",
+        "body": "=action.prompt",
+        "nowrap": true,
+        "botAsks": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "icon": "MessageBot",
+                "colors": {
+                    "theme": "#EEEAF4",
+                    "icon": "#5C2E91"
+                }
+            },
+            "body": {
+                "widget": "LgWidget",
+                "field": "prompt",
+                "defaultContent": "<prompt>"
+            }
+        },
+        "userInput": {
+            "widget": "ActionCard",
+            "header": {
+                "widget": "ActionHeader",
+                "disableSDKTitle": true,
+                "icon": "User",
+                "menu": "none",
+                "colors": {
+                    "theme": "#E5F0FF",
+                    "icon": "#0078D4"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
(Copied from C#. Refs https://github.com/microsoft/botbuilder-dotnet/pull/5099)
follows #2986 

## Description
In #2986, we port the ui schema `form` part to runtime in order to support the customization of Composer Form Editor;
in this PR, the `flow` part is added to runtime as well to support the customization of Composer Flow Editor.

Refs ui.schema definition change in SDK repo: https://github.com/microsoft/botframework-sdk/pull/6163

## Affected SDK $kinds
- QnAMakerDialog
- BeginDialog
- BeginSkill
- CancelAllDialog
- DeleteProperty, DeleteProperties
- EditActions
- EditArray
- EmitEvent
- Foreach, ForeachPage
- GetActivityMembers, GetConversationMembers
- HttpRequest
- IfCondition
- ReplaceDialog
- SendActivity
- SetProperties, SetProperty
- SwitchCondition
- ThrowException
- UpdateActivity
- Ask
- AttachmentInput, ChoiceInput, ConfirmInput, DateTimeInput, NumberInput, TextInput
- OAuthInput

## Example
Below is an example of the `flow` schema:
```
{
    "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
    "form": {...},
    "flow": {
        "widget": "ActionCard",
        "body": {
            "widget": "ResourceOperation",
            "operation": "=coalesce(action.changeType, \"?\")",
            "resource": "=coalesce(action.itemsProperty, \"?\")"
        },
        "footer": {
            "widget": "PropertyDescription",
            "property": "=action.resultProperty",
            "description": "= Result"
        },
        "hideFooter": "=!action.resultProperty"
    }
}

```
which describes the `Microsoft.EditArray` type in Composer as
![image](https://user-images.githubusercontent.com/8528761/104685778-ccc14200-5736-11eb-8526-ff7a17f7b6f8.png)
