### PR TITLE
[PORT]Add abs and sqrt built-in function

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/abs.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/abs.ts
@@ -1,0 +1,29 @@
+/**
+ * @module adaptive-expressions
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { ExpressionType } from '../expressionType';
+import { NumberTransformEvaluator } from './numberTransformEvaluator';
+
+/**
+ * Returns the absolute value of the specified number.
+ */
+export class Abs extends NumberTransformEvaluator {
+    /**
+     * Initializes a new instance of the [Floor](xref:adaptive-expressions.Abs) class.
+     */
+    public constructor() {
+        super(ExpressionType.Abs, Abs.func);
+    }
+
+    /**
+     * @private
+     */
+    private static func(args: any[]): number {
+        return Math.abs(args[0]);
+    }
+}

--- a/libraries/adaptive-expressions/src/builtinFunctions/index.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/index.ts
@@ -6,6 +6,7 @@
  * Licensed under the MIT License.
  */
 
+export * from './abs';
 export * from './accessor';
 export * from './add';
 export * from './addDays';
@@ -128,6 +129,7 @@ export * from './skip';
 export * from './sortBy';
 export * from './sortByDescending';
 export * from './split';
+export * from './sqrt';
 export * from './startOfDay';
 export * from './startOfHour';
 export * from './startOfMonth';

--- a/libraries/adaptive-expressions/src/builtinFunctions/sqrt.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/sqrt.ts
@@ -1,0 +1,46 @@
+/**
+ * @module adaptive-expressions
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { EvaluateExpressionDelegate, ExpressionEvaluator } from '../expressionEvaluator';
+import { ExpressionType } from '../expressionType';
+import { FunctionUtils } from '../functionUtils';
+import { ReturnType } from '../returnType';
+
+/**
+ * Returns the square root of a specified number.
+ */
+export class Sqrt extends ExpressionEvaluator {
+    /**
+     * Initializes a new instance of the [SortBy](xref:adaptive-expressions.Sqrt) class.
+     */
+    public constructor() {
+        super(ExpressionType.Sqrt, Sqrt.evaluator(), ReturnType.Number, FunctionUtils.validateUnaryNumber);
+    }
+
+    /**
+     * @private
+     */
+    private static evaluator(): EvaluateExpressionDelegate {
+        return FunctionUtils.applyWithError(
+            (args: any[]): any =>
+            {
+                let error: string;
+                let value: any;
+                const originalNumber = Number(args[0]);
+                if (originalNumber < 0) {
+                    error = 'Do not support square root extraction of negative numbers.';
+                } else {
+                    value = Math.sqrt(originalNumber);
+                }
+
+                return {value, error}
+            },
+            FunctionUtils.verifyNumber
+        );
+    }
+}

--- a/libraries/adaptive-expressions/src/expressionFunctions.ts
+++ b/libraries/adaptive-expressions/src/expressionFunctions.ts
@@ -38,6 +38,7 @@ export class ExpressionFunctions {
      */
     private static getStandardFunctions(): ReadonlyMap<string, ExpressionEvaluator> {
         const functions: ExpressionEvaluator[] = [
+            new BuiltinFunctions.Abs(),
             new BuiltinFunctions.Accessor(),
             new BuiltinFunctions.Add(),
             new BuiltinFunctions.AddDays(),
@@ -156,6 +157,7 @@ export class ExpressionFunctions {
             new BuiltinFunctions.SortBy(),
             new BuiltinFunctions.SortByDescending(),
             new BuiltinFunctions.Split(),
+            new BuiltinFunctions.Sqrt(),
             new BuiltinFunctions.StartOfDay(),
             new BuiltinFunctions.StartOfHour(),
             new BuiltinFunctions.StartOfMonth(),

--- a/libraries/adaptive-expressions/src/expressionType.ts
+++ b/libraries/adaptive-expressions/src/expressionType.ts
@@ -26,6 +26,8 @@ export class ExpressionType {
     public static readonly Floor: string = 'floor';
     public static readonly Ceiling: string = 'ceiling';
     public static readonly Round: string = 'round';
+    public static readonly Abs: string = 'abs';
+    public static readonly Sqrt: string = 'sqrt';
 
     // Comparisons
     public static readonly LessThan: string = '<';

--- a/libraries/adaptive-expressions/tests/badExpression.test.js
+++ b/libraries/adaptive-expressions/tests/badExpression.test.js
@@ -252,6 +252,11 @@ const badExpressions = [
             ['ceiling(1.2, -2)', 'the second parameter should be integer not less than 0'],
             ['ceiling(1.2, 16)', 'the second parameter should be integer not greater than 15'],
             ['ceiling(1.2, 12, 7)', 'should have one or two numeric parameters'],
+            ['abs()', 'should have one parameter'],
+            ['abs(hello)', 'should have one number parameter'],
+            ['sqrt()', 'should have one parameter'],
+            ['sqrt(hello)', 'should have one number parameter'],
+            ['sqrt(-1)', 'should have one non-nagitive number parameter'],
         ],
     },
     {

--- a/libraries/adaptive-expressions/tests/expressionParser.test.js
+++ b/libraries/adaptive-expressions/tests/expressionParser.test.js
@@ -492,6 +492,11 @@ const testCases = [
             ['round(3.51)', 4],
             ['round(3.55, 1)', 3.6],
             ['round(3.12134, 3)', 3.121],
+            ['abs(3.12134)', 3.12134],
+            ['abs(-3.12134)', 3.12134],
+            ['abs(0)', 0],
+            ['sqrt(9)', 3],
+            ['sqrt(0)', 0],
         ],
     },
     // All the timestamp strings passed in must be in ISO format of YYYY-MM-DDTHH:mm:ss.sssZ


### PR DESCRIPTION
Fixes #3240

## Description
Add `abs` and `sqrt` prebuilt function.
Example:
```
abs(3.12134)  -> 3.12134
abs(-3.12134) -> 3.12134
abs(0) -> 0
sqrt(9) -> 3
sqrt(-1)  -> throw error
sqrt(0) ->  0
```