### PR TITLE
fix createHandoffEvent activity.type & cleanup

### DIFF
--- a/libraries/botbuilder/src/eventFactory.ts
+++ b/libraries/botbuilder/src/eventFactory.ts
@@ -4,8 +4,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
-import { TurnContext } from 'botbuilder-core';
-import { Activity, Attachment, ConversationAccount, ConversationReference, Transcript } from 'botframework-schema';
+import { Activity, ActivityTypes, Attachment, ConversationAccount, ConversationReference, Transcript, TurnContext } from 'botbuilder-core';
 import * as dayjs from 'dayjs';
 import * as timezone from 'dayjs/plugin/timezone';
 dayjs.extend(timezone);
@@ -33,7 +32,7 @@ export class EventFactory {
         const handoffEvent = this.createHandoffEvent(
             HandoffEventNames.InitiateHandoff,
             handoffContext,
-            context.activity.conversation as ConversationAccount // TODO(joshgummersall) why is this necessary?
+            context.activity.conversation
         );
 
         handoffEvent.from = context.activity.from;
@@ -80,7 +79,7 @@ export class EventFactory {
         value: T,
         conversation: ConversationAccount
     ): Activity {
-        const handoffEvent: Partial<Activity> = {};
+        const handoffEvent: Partial<Activity> = { type: ActivityTypes.Event };
 
         handoffEvent.name = name;
         handoffEvent.value = value;

--- a/libraries/botbuilder/tests/eventFactoryTests.test.js
+++ b/libraries/botbuilder/tests/eventFactoryTests.test.js
@@ -38,6 +38,7 @@ describe('EventFactory', function() {
             const handoffEvent = EventFactory.createHandoffInitiation(context, { skill: skillValue }, transcript);
 
             strictEqual(handoffEvent.name, HandoffEventNames.InitiateHandoff);
+            strictEqual(handoffEvent.type, ActivityTypes.Event);
             const skill = handoffEvent.value && handoffEvent.value.skill;
             strictEqual(skill, skillValue);
             strictEqual(handoffEvent.from.id, fromId);


### PR DESCRIPTION
Fixes #3242

## Description
Sets the `type` on the returned Activity to `ActivityTypes.Event` in EventFactory.createHandoffEvent()

## Specific Changes
  - Set returned `Activity.type` to `ActivityTypes.Event`
  - Cleanup imports, remove unnecessary cast
  - Add test coverage

## Testing
Updated existing test with coverage for changes.