### PR TITLE
Change the implementation in string a number in the string pre-built function

### DIFF
--- a/libraries/adaptive-expressions/tests/expressionParser.test.js
+++ b/libraries/adaptive-expressions/tests/expressionParser.test.js
@@ -232,6 +232,7 @@ const testCases = [
             ['substring(nullObj, 3)', ''],
             ['substring(nullObj, 0, 3)', ''],
             ['substring(\'hello\', 0, bag.index)', 'hel'],
+            ['string(1.22, "de-DE")', '1,22'],
             ['toLower(\'UpCase\')', 'upcase'],
             ['toLower(\'UpCase\', \'en-GB\')', 'upcase'],
             ['toLower(nullObj)', ''],


### PR DESCRIPTION
Currently, the string pre-built function does not always work correctly for numeric inputs. 
for example: `string(1.22, 'de-DE')` returns `1.22`. It is not the same as the result of C#.

So I switched the toLocaleString() to d3-format in the string function while a numeric input passed.
With the change, now `string(1.22, 'de-DE')` will return: `1,22`