### PR TITLE
Orchestrator Recognizer: Rename misleading parameter names

### DIFF
--- a/libraries/botbuilder-ai-orchestrator/schemas/Microsoft.OrchestratorRecognizer.schema
+++ b/libraries/botbuilder-ai-orchestrator/schemas/Microsoft.OrchestratorRecognizer.schema
@@ -13,14 +13,14 @@
         "modelFolder": {
             "$ref": "schema:#/definitions/stringExpression",
             "title": "Model",
-            "description": "NLR model file path.",
-            "default": "=settings.orchestrator.modelfolder"
+            "description": "Base model file path.",
+            "default": "=settings.orchestrator.modelFolder"
         },
         "snapshotFile": {
             "$ref": "schema:#/definitions/stringExpression",
-            "title": "Endpoint key",
-            "description": "SnapShot file path.",
-            "default": "=settings.orchestrator.shapshotfile"
+            "title": "Snapshot file",
+            "description": "Snapshot file path.",
+            "default": "=settings.orchestrator.snapshotFile"
         },
         "entityRecognizers": {
             "type": "array",
@@ -54,7 +54,7 @@
         }
     },
     "required": [
-        "model",
-        "shapShot"
+        "modelFolder",
+        "snapshotFile"
     ]
 }

--- a/libraries/botbuilder-ai-orchestrator/schemas/Microsoft.OrchestratorRecognizer.schema
+++ b/libraries/botbuilder-ai-orchestrator/schemas/Microsoft.OrchestratorRecognizer.schema
@@ -10,17 +10,17 @@
             "title": "Id",
             "description": "Optional unique id using with RecognizerSet."
         },
-        "modelPath": {
+        "modelFolder": {
             "$ref": "schema:#/definitions/stringExpression",
             "title": "Model",
             "description": "NLR model file path.",
-            "default": "=settings.orchestrator.modelpath"
+            "default": "=settings.orchestrator.modelfolder"
         },
-        "snapshotPath": {
+        "snapshotFile": {
             "$ref": "schema:#/definitions/stringExpression",
             "title": "Endpoint key",
             "description": "SnapShot file path.",
-            "default": "=settings.orchestrator.shapshotpath"
+            "default": "=settings.orchestrator.shapshotfile"
         },
         "entityRecognizers": {
             "type": "array",

--- a/libraries/botbuilder-ai-orchestrator/src/orchestratorRecognizer.ts
+++ b/libraries/botbuilder-ai-orchestrator/src/orchestratorRecognizer.ts
@@ -27,12 +27,12 @@ export class OrchestratorRecognizer extends Configurable {
     /**
      * Path to Orchestrator base model folder.
      */
-    public modelPath: string;
+    public modelFolder: string;
 
     /**
      * Path to the snapshot (.blu file) to load.
      */
-    public snapshotPath: string;
+    public snapshotFile: string;
 
     /**
      * The external entity recognizer.
@@ -60,8 +60,8 @@ export class OrchestratorRecognizer extends Configurable {
         const rec = new OrchestratorAdaptiveRecognizer().configure({
             id: this.id,
             detectAmbiguousIntents: this.detectAmbiguousIntents,
-            modelPath: this.modelPath,
-            snapshotPath: this.snapshotPath,
+            modelFolder: this.modelFolder,
+            snapshotFile: this.snapshotFile,
             disambiguationScoreThreshold: this.disambiguationScoreThreshold,
             externalEntityRecognizer: this.externalEntityRecognizer,
         });

--- a/libraries/botbuilder-ai-orchestrator/tests/orchestratorAdaptiveRecognizer.test.js
+++ b/libraries/botbuilder-ai-orchestrator/tests/orchestratorAdaptiveRecognizer.test.js
@@ -63,8 +63,8 @@ describe('OrchestratorAdpativeRecognizer tests', function () {
         const testPaths = 'test';
         const rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, mockResolver);
         OrchestratorAdaptiveRecognizer.orchestrator = 'mock';
-        rec.modelPath = new StringExpression(testPaths);
-        rec.snapshotPath = new StringExpression(testPaths);
+        rec.modelFolder = new StringExpression(testPaths);
+        rec.snapshotFile = new StringExpression(testPaths);
         const { dc, activity } = createTestDcAndActivity('hello');
 
         const res = await rec.recognize(dc, activity);
@@ -85,8 +85,8 @@ describe('OrchestratorAdpativeRecognizer tests', function () {
         const testPaths = 'test';
         const rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, mockResolver);
         OrchestratorAdaptiveRecognizer.orchestrator = 'mock';
-        rec.modelPath = new StringExpression(testPaths);
-        rec.snapshotPath = new StringExpression(testPaths);
+        rec.modelFolder = new StringExpression(testPaths);
+        rec.snapshotFile = new StringExpression(testPaths);
         rec.externalEntityRecognizer = new NumberEntityRecognizer();
         const { dc, activity } = createTestDcAndActivity('hello 123');
 
@@ -120,8 +120,8 @@ describe('OrchestratorAdpativeRecognizer tests', function () {
         const mockResolver = new MockResolver(result);
         const testPaths = 'test';
         const rec = new OrchestratorAdaptiveRecognizer(testPaths, testPaths, mockResolver);
-        rec.modelPath = new StringExpression(testPaths);
-        rec.snapshotPath = new StringExpression(testPaths);
+        rec.modelFolder = new StringExpression(testPaths);
+        rec.snapshotFile = new StringExpression(testPaths);
         rec.detectAmbiguousIntents = new BoolExpression(true);
         rec.disambiguationScoreThreshold = new NumberExpression(0.1);
         const { dc, activity } = createTestDcAndActivity('hello');


### PR DESCRIPTION
Note: This checkin associated with :

- C# Orchestrator recognizer update ([dotnet pr](https://github.com/microsoft/botbuilder-dotnet/pull/5147))
- A samples update that uses Orchestrator recognizer ([samples pr](https://github.com/microsoft/BotBuilder-Samples/pull/3062))
- Composer updates (@taicchoumsft : Will submit once new SDK released)
- bf-cli updated (@tsuwandy checked in updates)

## Description
From the first preview, we've received feedback that our parameter names are confusing. 

## Specific Changes
This performs the following parameter renames:
   modelPath => modelFolder
   snapshotPath => snapshotFile

## Testing
Tests have been updated to reflect new parameter names.