### PR TITLE
[Expression, LG]use gitattributes to mark files as generated

### DIFF
--- a/libraries/adaptive-expressions/.gitattributes
+++ b/libraries/adaptive-expressions/.gitattributes
@@ -1,0 +1,2 @@
+src/generated/* linguist-generated=true
+src/parser/generated/* linguist-generated=true

--- a/libraries/botbuilder-lg/.gitattributes
+++ b/libraries/botbuilder-lg/.gitattributes
@@ -1,0 +1,1 @@
+src/generated/* linguist-generated=true


### PR DESCRIPTION
## Description
Reference issue: #3007
Make the generated files from Antlr as generated to ignore for the repository's language statistics and hidden by default in diffs.