### PR TITLE
[PORT] Return invalid state instead of throwing exceptions for non-string input of TextInput action

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
@@ -385,6 +385,10 @@ describe('ActionTests', function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_TextInputWithValueExpression');
     });
 
+    it('TextInputWithNonStringInput', async () => {
+        await TestUtils.runTestScript(resourceExplorer, 'Action_TextInputWithNonStringInput');
+    });
+
     it('TraceActivity', async () => {
         await TestUtils.runTestScript(resourceExplorer, 'Action_TraceActivity');
     });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_TextInputWithNonStringInput.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_TextInputWithNonStringInput.test.dialog
@@ -1,0 +1,55 @@
+{
+    "$schema": "../../../../schemas/sdk.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "dialog.firstName",
+                        "value": "lu"
+                    },
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "dialog.lastName",
+                        "value": "han"
+                    },
+                    {
+                        "$kind": "Microsoft.IfCondition",
+                        "condition": "(user.name == null)",
+                        "actions": [
+                            {
+                                "$kind": "Microsoft.TextInput",
+                                "property": "user.name",
+                                "prompt": "Hello, what is your name?",
+                                "unrecognizedPrompt": "How should I call you?",
+                                "invalidPrompt": "That does not soud like a name",
+                                "value": "=createArray(toUpper($firstName),toUpper($lastName))"
+                            }
+                        ]
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Hello ${user.name}, nice to meet you!"
+                    }
+                ]
+            }
+        ],
+        "autoEndDialog": true,
+        "defaultResultProperty": "dialog.result"
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "That does not soud like a name"
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive/src/input/textInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/textInput.ts
@@ -42,7 +42,10 @@ export class TextInput extends InputDialog implements TextInputConfiguration {
      */
     protected async onRecognizeInput(dc: DialogContext): Promise<InputState> {
         // Treat input as a string
-        let input: string = dc.state.getValue(InputDialog.VALUE_PROPERTY).toString();
+        let input: any = dc.state.getValue(InputDialog.VALUE_PROPERTY);
+        if (typeof input !== 'string') {
+            return InputState.invalid;
+        }
 
         if (this.outputFormat) {
             const value = this.outputFormat.getValue(dc.state);


### PR DESCRIPTION
Port https://github.com/microsoft/botbuilder-dotnet/pull/4966

## Description
In adaptive dialog, TextInput action only accept string values, but in some cases, non-string values such as objects will be passed into TextInput action, in such cases, it will throw exceptions instead of throw invalid prompt to users for a valid input. This is not friendly. In this fix, we added the validation of string format for all values and if it's value is not string, it will go into invalid state instead of throwing exceptions. 

## Specific Changes
  - textInput.ts

## Testing
Test cases added