### PR TITLE
feat: Mock QnAMaker via http request mocks

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/HttpRequestMock/httpqnaanswer.mock.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/HttpRequestMock/httpqnaanswer.mock.dialog
@@ -3,7 +3,7 @@
     "$kind": "Microsoft.Test.HttpRequestSequenceMock",
     "method": "POST",
     "url": "https://dummy-hostname.azurewebsites.net/qnamaker/knowledgebases/dummy-id/generateanswer",
-    "body": "\"question\":\"QnaMaker_ReturnsAnswer\"",
+    "body": "\"question\": \"QnaMaker_ReturnsAnswer\"",
     "responses": [
         {
             "content": {

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/HttpRequestMock/httpqnaintent.mock.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/HttpRequestMock/httpqnaintent.mock.dialog
@@ -3,7 +3,7 @@
     "$kind": "Microsoft.Test.HttpRequestSequenceMock",
     "method": "POST",
     "url": "https://dummy-hostname.azurewebsites.net/qnamaker/knowledgebases/dummy-id/generateanswer",
-    "body": "\"question\":\"QnaMaker_ReturnsAnswerWithIntent\"",
+    "body": "\"question\": \"QnaMaker_ReturnsAnswerWithIntent\"",
     "responses": [
         {
             "content": {

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/HttpRequestMock/httpqnalevel1.mock.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/HttpRequestMock/httpqnalevel1.mock.dialog
@@ -3,7 +3,7 @@
     "$kind": "Microsoft.Test.HttpRequestSequenceMock",
     "method": "POST",
     "url": "https://dummy-hostname.azurewebsites.net/qnamaker/knowledgebases/dummy-id/generateanswer",
-    "body": "\"question\":\"Accidently deleted KB\"",
+    "body": "\"question\": \"Accidently deleted KB\"",
     "responses": [
         {
             "content": {

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/HttpRequestMock/httpqnanoanswer.mock.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/HttpRequestMock/httpqnanoanswer.mock.dialog
@@ -3,7 +3,7 @@
     "$kind": "Microsoft.Test.HttpRequestSequenceMock",
     "method": "POST",
     "url": "https://dummy-hostname.azurewebsites.net/qnamaker/knowledgebases/dummy-id/generateanswer",
-    "body": "\"question\":\"QnaMaker_ReturnsNoAnswer\"",
+    "body": "\"question\": \"QnaMaker_ReturnsNoAnswer\"",
     "responses": [
         {
             "content": {

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/HttpRequestMock/httpqnaprompts.mock.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/HttpRequestMock/httpqnaprompts.mock.dialog
@@ -3,7 +3,7 @@
     "$kind": "Microsoft.Test.HttpRequestSequenceMock",
     "method": "POST",
     "url": "https://dummy-hostname.azurewebsites.net/qnamaker/knowledgebases/dummy-id/generateanswer",
-    "body": "\"question\":\"I have issues related to KB\"",
+    "body": "\"question\": \"I have issues related to KB\"",
     "responses": [
         {
             "content": {

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/HttpRequestMock/httpqnatopnanswer.mock.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/HttpRequestMock/httpqnatopnanswer.mock.dialog
@@ -3,7 +3,7 @@
     "$kind": "Microsoft.Test.HttpRequestSequenceMock",
     "method": "POST",
     "url": "https://dummy-hostname.azurewebsites.net/qnamaker/knowledgebases/dummy-id/generateanswer",
-    "body": "\"question\":\"QnaMaker_TopNAnswer\"",
+    "body": "\"question\": \"QnaMaker_TopNAnswer\"",
     "responses": [
         {
             "content": {

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/TestScriptTests_HttpRequestQnAMakerDialogMock.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/TestScriptTests_HttpRequestQnAMakerDialogMock.test.dialog
@@ -1,0 +1,71 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "description": "Test HttpRequestMock QnAMakerDialog. Copy from QnAMakerTests",
+    "httpRequestMocks": [
+        "httpqnaprompts.mock",
+        "httpqnalevel1.mock"
+    ],
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.QnAMakerDialog",
+                        "knowledgeBaseId": "dummy-id",
+                        "hostname": "https://dummy-hostname.azurewebsites.net/qnamaker",
+                        "endpointKey": "dummy-key",
+                        "noAnswer": "No match found, please ask another question.",
+                        "cardNoMatchText": "None of the above."
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "I have issues related to KB"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+            "assertions": [
+                "type == 'message'",
+                "text == 'Please select one of the following KB issues. '",
+                "count(attachments) == 1",
+                "count(attachments[0].content.buttons) == 3"
+            ]
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "Accidently deleted KB"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "All deletes are permanent, including question and answer pairs, files, URLs, custom questions and answers, knowledge bases, or Azure resources. Make sure you export your knowledge base from the Settings**page before deleting any part of your knowledge base."
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "I have issues related to KB"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+            "assertions": [
+                "type == 'message'",
+                "text == 'Please select one of the following KB issues. '",
+                "count(attachments) == 1",
+                "count(attachments[0].content.buttons) == 3"
+            ]
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "None of the above."
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Thanks for the feedback."
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/TestScriptTests_HttpRequestQnAMakerRecognizerMock.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/TestScriptTests_HttpRequestQnAMakerRecognizerMock.test.dialog
@@ -1,0 +1,112 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "description": "Test HttpRequestMock QnAMakerRecognizer. Copy from QnAMakerRecognizerTests",
+    "httpRequestMocks": [
+        "httpqnatopnanswer.mock",
+        "httpqnaanswer.mock",
+        "httpqnanoanswer.mock",
+        "httpqnaintent.mock"
+    ],
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "recognizer": {
+            "$kind": "Microsoft.QnAMakerRecognizer",
+            "knowledgeBaseId": "dummy-id",
+            "hostname": "https://dummy-hostname.azurewebsites.net/qnamaker",
+            "endpointKey": "dummy-key"
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnQnAMatch",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${@answer}"
+                    },
+                    {
+                        "$kind": "Microsoft.Test.AssertCondition",
+                        "condition": "count(turn.recognized.entities.answer) == 1"
+                    },
+                    {
+                        "$kind": "Microsoft.Test.AssertCondition",
+                        "condition": "turn.recognized.entities.$instance.answer[0].startIndex == 0"
+                    },
+                    {
+                        "$kind": "Microsoft.Test.AssertCondition",
+                        "condition": "turn.recognized.entities.$instance.answer[0].endIndex != null"
+                    },
+                    {
+                        "$kind": "Microsoft.Test.AssertCondition",
+                        "condition": "turn.recognized.answers[0].answer != null"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "done"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "DeferToRecognizer_xxx",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "DeferToRecognizer_xxx"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "Wha?"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "QnaMaker_TopNAnswer"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "A1"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "done"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "QnaMaker_ReturnsAnswer"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "BaseCamp: You can use a damp rag to clean around the Power Pack"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "done"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "QnaMaker_ReturnsNoAnswer"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Wha?"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "QnaMaker_ReturnsAnswerWithIntent"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "DeferToRecognizer_xxx"
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/testScript.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/testScript.test.js
@@ -77,6 +77,14 @@ describe('TestScriptTests', function () {
         await TestUtils.runTestScript(resourceExplorer, 'TestScriptTests_HttpRequestMock');
     });
 
+    it('HttpRequestQnAMakerRecognizerMock', async () => {
+        await TestUtils.runTestScript(resourceExplorer, 'TestScriptTests_HttpRequestQnAMakerRecognizerMock');
+    });
+
+    it('HttpRequestQnAMakerDialogMock', async () => {
+        await TestUtils.runTestScript(resourceExplorer, 'TestScriptTests_HttpRequestQnAMakerDialogMock');
+    });
+
     it('OAuthInputRetries_WithNullMessageText', async () => {
         await TestUtils.runTestScript(resourceExplorer, 'TestScriptTests_OAuthInputRetries_WithNullMessageText');
     });

--- a/libraries/botbuilder-dialogs-declarative/src/resources/resourceExplorer.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/resources/resourceExplorer.ts
@@ -233,7 +233,7 @@ export class ResourceExplorer {
         Object.assign(
             result,
             JSON.parse(json, (_key: string, value: unknown): unknown => {
-                if (typeof value !== 'object') {
+                if (typeof value !== 'object' || value === null) {
                     return value;
                 }
                 if (Array.isArray(value)) {


### PR DESCRIPTION
Fixes #3017 

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Ported tests for `QnAMakerDialog` and `QnAMakerRecognizer`.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Test `QnAMakerDialog` via http request mocks
  - Test `QnAMakerRecognizer` via http request mocks
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->