### PR TITLE
fix: correct QnAMaker response types and expose error from server

### DIFF
--- a/libraries/botbuilder-ai/src/qnamaker-utils/generateAnswerUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/generateAnswerUtils.ts
@@ -89,7 +89,7 @@ export class GenerateAnswerUtils {
             queryOptions.timeout
         );
 
-        if (qnaResults?.answers && Array.isArray(qnaResults.answers)) {
+        if (Array.isArray(qnaResults?.answers)) {
             return this.formatQnaResult(qnaResults);
         }
 

--- a/libraries/botbuilder-ai/src/qnamaker-utils/httpRequestUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/httpRequestUtils.ts
@@ -38,7 +38,7 @@ export class HttpRequestUtils {
         payloadBody: string,
         endpoint: QnAMakerEndpoint,
         timeout?: number
-    ): Promise<QnAMakerResults> {
+    ): Promise<QnAMakerResults | undefined> {
         if (!requestUrl) {
             throw new TypeError('Request url cannot be null.');
         }

--- a/libraries/botbuilder-ai/src/qnamaker-utils/httpRequestUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/httpRequestUtils.ts
@@ -9,7 +9,7 @@
 import * as os from 'os';
 
 import { QnAMakerEndpoint } from '../qnamaker-interfaces/qnamakerEndpoint';
-import { QnAMakerResult } from '../qnamaker-interfaces/qnamakerResult';
+import { QnAMakerResults } from '../qnamaker-interfaces/qnamakerResults';
 
 import { getFetch } from '../globals';
 const fetch = getFetch();
@@ -31,14 +31,14 @@ export class HttpRequestUtils {
      * @param {string} payloadBody Http request body.
      * @param {QnAMakerEndpoint} endpoint QnA Maker endpoint details.
      * @param {number} timeout (Optional)Timeout for http call
-     * @returns {QnAMakerResult} a promise that resolves to the QnAMakerResult
+     * @returns {QnAMakerResults} a promise that resolves to the QnAMakerResults
      */
     public async executeHttpRequest(
         requestUrl: string,
         payloadBody: string,
         endpoint: QnAMakerEndpoint,
         timeout?: number
-    ): Promise<QnAMakerResult> {
+    ): Promise<QnAMakerResults> {
         if (!requestUrl) {
             throw new TypeError('Request url cannot be null.');
         }
@@ -60,7 +60,7 @@ export class HttpRequestUtils {
             body: payloadBody,
         });
 
-        return qnaResult.status == 204 ? this.getSuccessful204Result() : await qnaResult.json();
+        return qnaResult.status !== 204 ? await qnaResult.json() : undefined;
     }
 
     /**
@@ -91,23 +91,5 @@ export class HttpRequestUtils {
         const platformUserAgent = `(${os.arch()}-${os.type()}-${os.release()}; Node.js,Version=${process.version})`;
 
         return `${packageUserAgent} ${platformUserAgent}`;
-    }
-
-    /**
-     * Creates a QnAMakerResult for successful responses from QnA Maker service that return status code 204 No-Content.
-     * The [Train API](https://docs.microsoft.com/en-us/rest/api/cognitiveservices/qnamakerruntime/runtime/train)
-     * is an example of one of QnA Maker's APIs that return a 204 status code.
-     *
-     * @private
-     */
-    private getSuccessful204Result(): QnAMakerResult {
-        return {
-            questions: [],
-            answer: '204 No-Content',
-            score: 100,
-            id: -1,
-            source: null,
-            metadata: [],
-        };
     }
 }

--- a/libraries/botbuilder-ai/tests/qnaMaker.test.js
+++ b/libraries/botbuilder-ai/tests/qnaMaker.test.js
@@ -947,15 +947,6 @@ describe('QnAMaker', function () {
         const trainApi = `/knowledgebases/${testKbId}/train`;
         const feedbackRecords = [{ userId: 'user1', userQuestion: 'wi-fi', qnaId: '17' }];
 
-        const successfullyTrainedResult = {
-            questions: [],
-            answer: '204 No-Content',
-            score: 100,
-            id: -1,
-            source: null,
-            metadata: [],
-        };
-
         it('executeHttpRequest() should return JSON result from Train API response of 204 No-Content', async function () {
             nock(endpoint.host).post(trainApi).reply(204);
 
@@ -967,7 +958,7 @@ describe('QnAMaker', function () {
 
             const qnaResult = await httpUtils.executeHttpRequest(endpoint.host + trainApi, payloadBody, endpoint);
 
-            assert.deepStrictEqual(qnaResult, successfullyTrainedResult);
+            assert.strictEqual(qnaResult, undefined);
         });
 
         it('executeHttpRequest() should throw when payload to QnA Service is malformed', async function () {


### PR DESCRIPTION
Fixes #2317 

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
This PR exposed error message from QnAMaker server to allow users locating and fixing errors.
Response type of `HttpRequestUtils` of QnAMaker is not correctly defined, it should be `QnAMakerResults` (while calling `generate` api) or undefined (while calling `train` api).  Check out https://docs.microsoft.com/en-us/rest/api/cognitiveservices/qnamaker4.0/runtime/generateanswer#response . This PR will fix this.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Exposed error from QnAMaker server side
  - Corrected return type to `QnAMakerResults`
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->