### PR TITLE
fix: add --no-flat flag to browserify script in AEL

### DIFF
--- a/libraries/adaptive-expressions/package.json
+++ b/libraries/adaptive-expressions/package.json
@@ -48,7 +48,7 @@
     "build:src": "tsc -b",
     "build:tests": "tsc -p tests/tsconfig.json",
     "build": "npm-run-all build:src build:tests",
-    "browserify": "browserify -s AEL --debug -p tinyify lib/browser.js | exorcist lib/browser.js.map | sponge lib/browser.js",
+    "browserify": "browserify lib/browser.js -s AEL --debug -p [ tinyify --no-flat ]  | exorcist lib/browser.js.map | sponge lib/browser.js",
     "postbuild": "rimraf lib/browser.* && shx cp lib/index.js lib/browser.js && yarn browserify",
     "clean": "rimraf lib tsconfig.tsbuildinfo",
     "build-docs": "typedoc --theme markdown --entryPoint adaptive-expressions --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\adaptive-expressions .\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK - Expression\" --readme none",


### PR DESCRIPTION
Fixes #3274

## Description
In #3222, the tinyified adaptive-expressions `browser.js` was malformed and caused Composer to break. This PR fixes the break by disabling a plugin in tinyify.

Using ce99c67, the browserified-and-tinyified `lib/browser.js` is 1,091 KB in size and a 40 KB increase after https://github.com/microsoft/botbuilder-js/pull/3222.


## Specific Changes
  - add --no-flat flag to browserify script in AEL

## Testing
1. Cloned and setup BotFramework-Composer repo per [README instructions](https://github.com/microsoft/botframework-composer#build-composer-locally)
1. Used `yarn link` to symlink a local clone of the JS repository
1. Built JS repo @`main` (729a577)
1. Ran `yarn startall` in `BotFramework-Composer/Composer` and observed bug
1. Applied fix to `adaptive-expressions` package.json's "browserify" script
1. Rebuilt `adaptive-expressions` and Composer
1. Ran `yarn startall` in `BotFramework-Composer/Composer`
1. Verified Composer started without bug