### PR TITLE
fix: filter out undefined regex match  groups

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/regexRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/regexRecognizer.ts
@@ -103,15 +103,17 @@ export class RegexRecognizer extends Recognizer implements RegexRecognizerConfig
 
             matches.forEach((match: RegExpExecArray) => {
                 if (match.groups) {
-                    Object.entries(match.groups).forEach(([name, text]) => {
-                        const entity: Entity = {
-                            type: name,
-                            text,
-                            start: match.index,
-                            end: match.index + text.length,
-                        };
-                        entityPool.push(entity);
-                    });
+                    Object.entries(match.groups)
+                        .filter(([_name, text]) => text !== undefined)
+                        .forEach(([name, text]) => {
+                            const entity: Entity = {
+                                type: name,
+                                text,
+                                start: match.index,
+                                end: match.index + text.length,
+                            };
+                            entityPool.push(entity);
+                        });
                 }
             });
 

--- a/libraries/botbuilder-dialogs-adaptive/tests/regexRecognizer.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/regexRecognizer.test.js
@@ -336,6 +336,21 @@ describe('RegexRecognizer Tests', () => {
         assert.strictEqual(entities.url[0], 'https://www.microsoft.com', 'should recognize url');
     });
 
+    it('optional match groups', async function () {
+        const recognizer = new RegexRecognizer().configure({
+            intents: [
+                new IntentPattern('AddIntent', '(?:add|create) .*(?:to-do|todo|task)(?: )?(?:named (?<title>.*))?'),
+            ],
+        });
+        const dc = createContext('');
+        let activity = createMessageActivity('add a todo named first');
+        let result = await recognizer.recognize(dc, activity);
+        assert.strictEqual(result.entities.title[0], 'first');
+        activity = createMessageActivity('add a todo');
+        result = await recognizer.recognize(dc, activity);
+        assert.strictEqual(result.entities.title, undefined);
+    });
+
     it('basic telemetry test', () => {
         let properties = {};
         properties['test'] = 'testvalue';


### PR DESCRIPTION
## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
The value of a regex matched group could be `undefined` in JavaScript. We have to filter these values out.


## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - RegexRecognizer
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
Added test.