### PR TITLE
fix: add messagingEndpointPath to Options in restify integration lib

### DIFF
--- a/libraries/botbuilder-runtime-integration-restify/package.json
+++ b/libraries/botbuilder-runtime-integration-restify/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "botbuilder-runtime": "4.1.6",
     "botbuilder-runtime-core": "4.1.6",
+    "botbuilder-stdlib": "4.1.6",
     "restify": "^8.5.1",
     "runtypes": "^5.0.1"
   },

--- a/libraries/botbuilder-runtime-integration-restify/package.json
+++ b/libraries/botbuilder-runtime-integration-restify/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "botbuilder-runtime": "4.1.6",
     "botbuilder-runtime-core": "4.1.6",
-    "botbuilder-stdlib": "4.1.6",
     "restify": "^8.5.1",
     "runtypes": "^5.0.1"
   },

--- a/libraries/botbuilder-runtime-integration-restify/src/index.ts
+++ b/libraries/botbuilder-runtime-integration-restify/src/index.ts
@@ -5,26 +5,27 @@ import * as t from 'runtypes';
 import restify from 'restify';
 import { Configuration, getRuntimeServices } from 'botbuilder-runtime';
 import { IServices, ServiceCollection } from 'botbuilder-runtime-core';
-import { tests } from 'botbuilder-stdlib';
 
-/**
- * Options for runtime restify adapter
- */
-export type Options = {
+const TypedOptions = t.Record({
     /**
      * Port that server should listen on
      */
-    port: number;
+    port: t.Number,
 
     /**
      * Path that the server will listen to for [Activities](xref:botframework-schema.Activity)
      */
-    messagingEndpointPath: string;
-};
+    messagingEndpointPath: t.String,
+});
+
+/**
+ * Options for runtime restify adapter
+ */
+export type Options = t.Static<typeof TypedOptions>;
 
 const defaultOptions: Options = {
     port: 3978,
-    messagingEndpointPath: '/api/messages'
+    messagingEndpointPath: '/api/messages',
 };
 
 /**
@@ -37,12 +38,10 @@ const defaultOptions: Options = {
 export async function start(
     applicationRoot: string,
     settingsDirectory: string,
-    options = {} as Options
+    options: Partial<Options> = {}
 ): Promise<void> {
+    const { port, messagingEndpointPath } = TypedOptions.check(Object.assign({}, defaultOptions, options));
     const [services, configuration] = await getRuntimeServices(applicationRoot, settingsDirectory);
-    const { port, messagingEndpointPath } = tests.isObject(options)
-        ? { ...defaultOptions, ...options }
-        : defaultOptions;
 
     const server = await makeServer(messagingEndpointPath, services, configuration);
 

--- a/libraries/botbuilder-runtime-integration-restify/src/index.ts
+++ b/libraries/botbuilder-runtime-integration-restify/src/index.ts
@@ -40,29 +40,30 @@ export async function start(
     settingsDirectory: string,
     options: Partial<Options> = {}
 ): Promise<void> {
-    const { port, messagingEndpointPath } = TypedOptions.check(Object.assign({}, defaultOptions, options));
+    const validatedOptions = TypedOptions.check(Object.assign({}, defaultOptions, options));
     const [services, configuration] = await getRuntimeServices(applicationRoot, settingsDirectory);
 
-    const server = await makeServer(messagingEndpointPath, services, configuration);
+    const server = await makeServer(services, configuration, validatedOptions);
 
-    server.listen(port, () => {
-        console.log(`server listening on port ${port}`);
+    server.listen(validatedOptions.port, () => {
+        console.log(`server listening on port ${validatedOptions.port}`);
     });
 }
 
 /**
  * Create a server using the runtime restify integration.
  *
- * @param messagingEndpointPath path for receiving and processing [Activities](xref:botframework-schema.Activity)
  * @param services runtime service collection
  * @param configuration runtime configuration
- * @returns a restify server ready to listen for connections
+ * @param options options bag for configuring restify Server
+ * @returns a restify Server ready to listen for connections
  */
 export async function makeServer(
-    messagingEndpointPath: string,
     services: ServiceCollection<IServices>,
-    configuration: Configuration
+    configuration: Configuration,
+    options: Partial<Options> = {}
 ): Promise<restify.Server> {
+    const { messagingEndpointPath } = TypedOptions.check(Object.assign({}, defaultOptions, options));
     const { adapter, bot, customAdapters } = await services.mustMakeInstances('adapter', 'bot', 'customAdapters');
 
     const server = restify.createServer();


### PR DESCRIPTION
## Description
Adds `messagingEndpointPath: string` to `botbuilder-runtime-integration-restify.Options` for configurability of messaging endpoint. `start()` uses ternary and spread operators to combine `defaultOptions` with the optional passed in `options`. 

https://github.com/microsoft/botbuilder-js/blob/d44179f6f344b2882cc585bd373509852ba91e10/libraries/botbuilder-runtime-integration-restify/src/index.ts#L37-L45

The value for `defaultOptions.messagingEndpointPath` is `'/api/messages'`.

`makeServer()` now takes the `messagingEndpointPath` as its first argument.

To avoid annoying JS runtime errors around the incorrect type being passed in for `options`, `botbuilder-stdlib` was added to make use of `tests.isObject` in the ternary operator. 

https://github.com/microsoft/botbuilder-js/blob/1774d5104b1e40073e577955212ec859819418f2/libraries/botbuilder-stdlib/src/types.ts#L453-L455

