### PR TITLE
feat: add botbuilder-runtime-integration-express

### DIFF
--- a/libraries/botbuilder-runtime-integration-express/.eslintrc.json
+++ b/libraries/botbuilder-runtime-integration-express/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../.eslintrc.json"
+}

--- a/libraries/botbuilder-runtime-integration-express/.gitignore
+++ b/libraries/botbuilder-runtime-integration-express/.gitignore
@@ -1,0 +1,4 @@
+_ts3.4
+lib
+node_modules
+runtime.json

--- a/libraries/botbuilder-runtime-integration-express/README.md
+++ b/libraries/botbuilder-runtime-integration-express/README.md
@@ -1,0 +1,1 @@
+# botbuilder-runtime-integration-express (PREVIEW)

--- a/libraries/botbuilder-runtime-integration-express/package.json
+++ b/libraries/botbuilder-runtime-integration-express/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "botbuilder-runtime-integration-express",
+  "preview": true,
+  "author": "Microsoft Corp.",
+  "version": "4.1.6",
+  "license": "MIT",
+  "description": "Bot Framework runtime Express integration library",
+  "keywords": [
+    "botbuilder",
+    "botframework",
+    "bots",
+    "chatbots"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/botbuilder-js.git"
+  },
+  "main": "lib/index.js",
+  "types": "./lib/index.d.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rimraf _ts3.4 lib tsconfig.tsbuildinfo",
+    "lint": "eslint . --ext .js,.ts"
+  },
+  "files": [
+    "lib",
+    "src"
+  ],
+  "dependencies": {
+    "botbuilder-runtime": "4.1.6",
+    "botbuilder-runtime-core": "4.1.6",
+    "botbuilder-stdlib": "4.1.6",
+    "express": "^4.17.1",
+    "runtypes": "^5.0.1"
+  }
+}

--- a/libraries/botbuilder-runtime-integration-express/package.json
+++ b/libraries/botbuilder-runtime-integration-express/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "botbuilder-runtime": "4.1.6",
     "botbuilder-runtime-core": "4.1.6",
-    "botbuilder-stdlib": "4.1.6",
     "express": "^4.17.1",
     "runtypes": "^5.0.1"
   }

--- a/libraries/botbuilder-runtime-integration-express/src/index.ts
+++ b/libraries/botbuilder-runtime-integration-express/src/index.ts
@@ -37,7 +37,7 @@ const defaultOptions: Options = {
 export async function start(
     applicationRoot: string,
     settingsDirectory: string,
-    options = {} as Options
+    options: Partial<Options> = {}
 ): Promise<void> {
     const [services, configuration] = await getRuntimeServices(applicationRoot, settingsDirectory);
     const { port, messagingEndpointPath } = tests.isObject(options)

--- a/libraries/botbuilder-runtime-integration-express/src/index.ts
+++ b/libraries/botbuilder-runtime-integration-express/src/index.ts
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as t from 'runtypes';
+import express from 'express';
+import { Configuration, getRuntimeServices } from 'botbuilder-runtime';
+import { IServices, ServiceCollection } from 'botbuilder-runtime-core';
+import { tests } from 'botbuilder-stdlib';
+
+/**
+ * Options for runtime Express adapter
+ */
+export type Options = {
+    /**
+     * Port that server should listen on
+     */
+    port: number;
+
+    /**
+     * Path that the server will listen to for [Activities](xref:botframework-schema.Activity)
+     */
+    messagingEndpointPath: string;
+};
+
+const defaultOptions: Options = {
+    messagingEndpointPath: '/api/messages',
+    port: 3978,
+};
+
+/**
+ * Start a bot using the runtime Express integration.
+ *
+ * @param applicationRoot application root directory
+ * @param settingsDirectory settings directory
+ * @param options options bag
+ */
+export async function start(
+    applicationRoot: string,
+    settingsDirectory: string,
+    options = {} as Options
+): Promise<void> {
+    const [services, configuration] = await getRuntimeServices(applicationRoot, settingsDirectory);
+    const { port, messagingEndpointPath } = tests.isObject(options)
+        ? { ...defaultOptions, ...options }
+        : defaultOptions;
+
+    const app = await makeApp(messagingEndpointPath, services, configuration);
+    const { bot } = await services.mustMakeInstances('bot');
+
+    // The 'upgrade' event handler for processing WebSocket requests needs to be registered on the Node.js http.Server, not the Express.Application.
+    // In Express the underlying http.Server is made available after the app starts listening for requests.
+    const server = app.listen(port, () => {
+        console.log(`server listening on port ${port}`);
+    });
+
+    server.on('upgrade', async (req, socket, head) => {
+        const adapter = await services.mustMakeInstance('adapter');
+        adapter.useWebSocket(req, socket, head, async (context) => {
+            await bot.run(context);
+        });
+    });
+}
+
+/**
+ * Create an Express App using the runtime Express integration.
+ *
+ * @param messagingEndpointPath path for receiving and processing [Activities](xref:botframework-schema.Activity)
+ * @param services runtime service collection
+ * @param configuration runtime configuration
+ * @returns an Express App ready to listen for connections
+ */
+export async function makeApp(
+    messagingEndpointPath: string,
+    services: ServiceCollection<IServices>,
+    configuration: Configuration
+): Promise<express.Application> {
+    const { adapter, bot, customAdapters } = await services.mustMakeInstances('adapter', 'bot', 'customAdapters');
+
+    const server = express();
+
+    server.post(messagingEndpointPath, (req, res) => {
+        adapter.processActivity(req, res, async (turnContext) => {
+            await bot.run(turnContext);
+        });
+    });
+
+    const adapters =
+        (await configuration.type(
+            ['runtimeSettings', 'adapters'],
+            t.Array(
+                t.Record({
+                    name: t.String,
+                    enabled: t.Union(t.Boolean, t.Undefined),
+                    route: t.String,
+                })
+            )
+        )) ?? [];
+
+    adapters
+        .filter((settings) => settings.enabled)
+        .forEach((settings) => {
+            const adapter = customAdapters.get(settings.name);
+            if (adapter) {
+                server.post(`/api/${settings.route}`, (req, res) => {
+                    adapter.processActivity(req, res, async (turnContext) => {
+                        await bot.run(turnContext);
+                    });
+                });
+            } else {
+                console.warn(`Custom Adapter for \`${settings.name}\` not registered.`);
+            }
+        });
+
+    return server;
+}

--- a/libraries/botbuilder-runtime-integration-express/src/index.ts
+++ b/libraries/botbuilder-runtime-integration-express/src/index.ts
@@ -5,22 +5,23 @@ import * as t from 'runtypes';
 import express from 'express';
 import { Configuration, getRuntimeServices } from 'botbuilder-runtime';
 import { IServices, ServiceCollection } from 'botbuilder-runtime-core';
-import { tests } from 'botbuilder-stdlib';
 
 /**
  * Options for runtime Express adapter
  */
-export type Options = {
+const TypedOptions = t.Record({
     /**
      * Port that server should listen on
      */
-    port: number;
+    port: t.Number,
 
     /**
      * Path that the server will listen to for [Activities](xref:botframework-schema.Activity)
      */
-    messagingEndpointPath: string;
-};
+    messagingEndpointPath: t.String,
+});
+
+export type Options = t.Static<typeof TypedOptions>;
 
 const defaultOptions: Options = {
     messagingEndpointPath: '/api/messages',
@@ -37,12 +38,11 @@ const defaultOptions: Options = {
 export async function start(
     applicationRoot: string,
     settingsDirectory: string,
-    options: Partial<Options> = {}
+    options: Partial<Options> = defaultOptions
 ): Promise<void> {
+    TypedOptions.check(options);
     const [services, configuration] = await getRuntimeServices(applicationRoot, settingsDirectory);
-    const { port, messagingEndpointPath } = tests.isObject(options)
-        ? { ...defaultOptions, ...options }
-        : defaultOptions;
+    const { port, messagingEndpointPath } = Object.assign({}, defaultOptions, options);
 
     const app = await makeApp(messagingEndpointPath, services, configuration);
     const { bot } = await services.mustMakeInstances('bot');

--- a/libraries/botbuilder-runtime-integration-express/src/index.ts
+++ b/libraries/botbuilder-runtime-integration-express/src/index.ts
@@ -38,11 +38,10 @@ const defaultOptions: Options = {
 export async function start(
     applicationRoot: string,
     settingsDirectory: string,
-    options: Partial<Options> = defaultOptions
+    options: Partial<Options> = {}
 ): Promise<void> {
-    TypedOptions.check(options);
+    const { port, messagingEndpointPath } = TypedOptions.check(Object.assign({}, defaultOptions, options));
     const [services, configuration] = await getRuntimeServices(applicationRoot, settingsDirectory);
-    const { port, messagingEndpointPath } = Object.assign({}, defaultOptions, options);
 
     const app = await makeApp(messagingEndpointPath, services, configuration);
     const { bot } = await services.mustMakeInstances('bot');

--- a/libraries/botbuilder-runtime-integration-express/src/index.ts
+++ b/libraries/botbuilder-runtime-integration-express/src/index.ts
@@ -59,7 +59,7 @@ export async function makeApp(
     services: ServiceCollection<IServices>,
     configuration: Configuration,
     options: Partial<Options> = {}
-): Promise<[express.Application, (callback?: () => void) => http.Server]> {
+): Promise<[app: express.Application, listen: (callback?: () => void) => http.Server]> {
     const { port, messagingEndpointPath } = TypedOptions.check(Object.assign({}, defaultOptions, options));
     const { adapter, bot, customAdapters } = await services.mustMakeInstances('adapter', 'bot', 'customAdapters');
     const app = express();

--- a/libraries/botbuilder-runtime-integration-express/tsconfig.json
+++ b/libraries/botbuilder-runtime-integration-express/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "strictNullChecks": true,
+    "target": "es6"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
Fixes #3352

## Description
Adds `botbuilder-runtime-integration-express` to enable JS Runtime bots to use `express` instead of `restify`.

## Specific Changes
  - `start()`, makeApp()`, `Options` are the exports
  - `index.d.ts` exposes a public dependency on `runtypes`
    - `runtypes` is a new public dependency in `botbuilder-runtime` used for type checking at compile time and runtime.

## Testing
Tested using [`stgum/runtime-contoso`](https://github.com/microsoft/botbuilder-js/tree/stgum/runtime-contoso) (forked from `jpg/runtime-contoso`)