### PR TITLE
fix: trigger condition cache expressions correctly

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsAppBasedLinkQuery.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsAppBasedLinkQuery.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 
@@ -16,10 +16,15 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsAppBasedLinkQuery extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnAppBasedLinkQuery';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(`${TurnPath.activity}.name == 'composeExtension/queryLink'`),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsCardAction.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsCardAction.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsCardAction extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnCardAction';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == null`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsChannelCreated.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsChannelCreated.ts
@@ -18,12 +18,17 @@ import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsChannelCreated extends OnConversationUpdateActivity {
     public static readonly $kind = 'Teams.OnChannelCreated';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.channelData.eventType == 'channelCreated'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsChannelCreated.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsChannelCreated.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsChannelDeleted.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsChannelDeleted.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
@@ -18,12 +18,17 @@ import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsChannelDeleted extends OnConversationUpdateActivity {
     public static readonly $kind = 'Teams.OnChannelDeleted';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.channelData.eventType == 'channelDeleted'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsChannelRenamed.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsChannelRenamed.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
@@ -18,12 +18,17 @@ import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsChannelRenamed extends OnConversationUpdateActivity {
     public static readonly $kind = 'Teams.OnChannelRenamed';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.channelData.eventType == 'channelRenamed'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsChannelRestored.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsChannelRestored.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
@@ -18,12 +18,17 @@ import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsChannelRestored extends OnConversationUpdateActivity {
     public static readonly $kind = 'Teams.OnChannelRestored';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.channelData.eventType == 'channelRestored'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsFileConsent.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsFileConsent.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsFileConsent extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnFileConsent';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'fileConsent/invoke'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMEBotMessagePreviewEdit.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMEBotMessagePreviewEdit.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -18,13 +18,18 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsMEBotMessagePreviewEdit extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnMEBotMessagePreviewEdit';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'composeExtension/submitAction' && ` +
                     `${TurnPath.activity}.value.botMessagePreviewAction == 'edit'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMEBotMessagePreviewSend.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMEBotMessagePreviewSend.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -18,13 +18,18 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsMEBotMessagePreviewSend extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnMEBotMessagePreviewEdit';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'composeExtension/submitAction' && ` +
                     `${TurnPath.activity}.value.botMessagePreviewAction == 'send'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMECardButtonClicked.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMECardButtonClicked.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsMECardButtonClicked extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnMECardButtonClicked';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'composeExtension/onCardButtonClicked'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMEConfigQuerySettingUrl.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMEConfigQuerySettingUrl.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsMEConfigQuerySettingUrl extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnMEConfigQuerySettingUrl';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'composeExtension/querySettingUrl'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMEConfigSetting.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMEConfigSetting.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsMEConfigSetting extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnMEConfigSetting';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'composeExtension/setting'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMEConfigurationSetting.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMEConfigurationSetting.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsMEConfigurationSetting extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnMEConfigurationSetting';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'composeExtension/setting'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMEFetchTask.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMEFetchTask.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsMEFetchTask extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnMEFetchTask';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'composeExtension/fetchTask'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMEQuery.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMEQuery.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsMEQuery extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnMEQuery';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'composeExtension/query'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMESelectItem.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMESelectItem.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsMESelectItem extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnMESelectItem';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'composeExtension/selectItem'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMESubmitAction.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsMESubmitAction.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsMESubmitAction extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnMESubmitAction';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'composeExtension/submitAction'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsO365ConnectorCardAction.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsO365ConnectorCardAction.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsO365ConnectorCardAction extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnO365ConnectorCardAction';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'actionableMessage/executeAction'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTabFetch.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTabFetch.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsTabFetch extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnTabFetch';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'tab/fetch'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTabSubmit.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTabSubmit.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsTabSubmit extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnTabSubmit';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'tab/submit'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTaskModuleFetch.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTaskModuleFetch.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsTaskModuleFetch extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnTaskModuleFetch';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'task/fetch'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTaskModuleSubmit.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTaskModuleSubmit.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
@@ -17,12 +17,17 @@ import { OnInvokeActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsTaskModuleSubmit extends OnInvokeActivity {
     public static readonly $kind = 'Teams.OnTaskModuleSubmit';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.name == 'task/submit'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTeamArchived.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTeamArchived.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
@@ -18,12 +18,17 @@ import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsTeamArchived extends OnConversationUpdateActivity {
     public static readonly $kind = 'Teams.OnTeamArchived';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.channelData.eventType == 'teamArchived'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTeamDeleted.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTeamDeleted.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
@@ -18,12 +18,17 @@ import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsTeamDeleted extends OnConversationUpdateActivity {
     public static readonly $kind = 'Teams.OnTeamDeleted';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    public createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.channelData.eventType == 'teamDeleted'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTeamHardDeleted.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTeamHardDeleted.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
@@ -18,12 +18,17 @@ import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsTeamHardDeleted extends OnConversationUpdateActivity {
     public static readonly $kind = 'Teams.OnTeamHardDeleted';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.channelData.eventType == 'teamHardDeleted'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTeamRenamed.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTeamRenamed.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
@@ -18,12 +18,17 @@ import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsTeamRenamed extends OnConversationUpdateActivity {
     public static readonly $kind = 'Teams.OnTeamRenamed';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.channelData.eventType == 'teamRenamed'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTeamRestored.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTeamRestored.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
@@ -18,12 +18,17 @@ import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsTeamRestored extends OnConversationUpdateActivity {
     public static readonly $kind = 'Teams.OnTeamRestored';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.channelData.eventType == 'teamRestored'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTeamUnarchived.ts
+++ b/libraries/botbuilder-dialogs-adaptive-teams/src/conditions/onTeamsTeamUnarchived.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Channels } from 'botbuilder';
 import { TurnPath } from 'botbuilder-dialogs';
 import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
@@ -18,12 +18,17 @@ import { OnConversationUpdateActivity } from 'botbuilder-dialogs-adaptive';
 export class OnTeamsTeamUnarchived extends OnConversationUpdateActivity {
     public static readonly $kind = 'Teams.OnTeamUnarchived';
 
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    /**
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
         return Expression.andExpression(
             Expression.parse(
                 `${TurnPath.activity}.channelId == '${Channels.Msteams}' && ${TurnPath.activity}.channelData.eventType == 'teamUnarchived'`
             ),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveComponentRegistration.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveComponentRegistration.ts
@@ -101,7 +101,6 @@ import {
     OnChooseIntent,
     OnChooseIntentConfiguration,
     OnChooseProperty,
-    OnChoosePropertyConfiguration,
     OnCondition,
     OnConditionConfiguration,
     OnContinueConversation,
@@ -198,7 +197,6 @@ import {
     TextTemplateConfiguration,
 } from './templates';
 import { DynamicBeginDialogDeserializer } from './dynamicBeginDialogDeserializer';
-import { TriggerSelectorConfiguration } from './triggerSelector';
 import { HasPendingActionsFunction, IsDialogActiveFunction } from './functions';
 
 type Type<T> = {
@@ -272,7 +270,7 @@ export class AdaptiveComponentRegistration extends ComponentRegistration impleme
         this._addDeclarativeType<OnCancelDialog, OnDialogEventConfiguration>(OnCancelDialog);
         this._addDeclarativeType<OnChooseEntity, OnChooseEntityConfiguration>(OnChooseEntity);
         this._addDeclarativeType<OnChooseIntent, OnChooseIntentConfiguration>(OnChooseIntent);
-        this._addDeclarativeType<OnChooseProperty, OnChoosePropertyConfiguration>(OnChooseProperty);
+        this._addDeclarativeType<OnChooseProperty, OnDialogEventConfiguration>(OnChooseProperty);
         this._addDeclarativeType<OnCondition, OnConditionConfiguration>(OnCondition);
         this._addDeclarativeType<OnContinueConversation, OnActivityConfiguration>(OnContinueConversation);
         this._addDeclarativeType<OnConversationUpdateActivity, OnActivityConfiguration>(OnConversationUpdateActivity);
@@ -348,9 +346,9 @@ export class AdaptiveComponentRegistration extends ComponentRegistration impleme
 
         // Selectors
         this._addDeclarativeType<ConditionalSelector, ConditionalSelectorConfiguration>(ConditionalSelector);
-        this._addDeclarativeType<FirstSelector, TriggerSelectorConfiguration>(FirstSelector);
-        this._addDeclarativeType<RandomSelector, TriggerSelectorConfiguration>(RandomSelector);
-        this._addDeclarativeType<TrueSelector, TriggerSelectorConfiguration>(TrueSelector);
+        this._addDeclarativeType<FirstSelector, unknown>(FirstSelector);
+        this._addDeclarativeType<RandomSelector, unknown>(RandomSelector);
+        this._addDeclarativeType<TrueSelector, unknown>(TrueSelector);
         this._addDeclarativeType<MostSpecificSelector, MostSpecificSelectorConfiguration>(MostSpecificSelector);
 
         Expression.functions.add(IsDialogActiveFunction.functionName, new IsDialogActiveFunction());

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
@@ -6,13 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-    BoolExpression,
-    BoolExpressionConverter,
-    Expression,
-    ExpressionParser,
-    IntExpression,
-} from 'adaptive-expressions';
+import { BoolExpression, BoolExpressionConverter, Expression, IntExpression } from 'adaptive-expressions';
 import {
     Activity,
     ActivityTypes,
@@ -225,9 +219,8 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
             }
 
             // change if triggers type/constraint change
-            const parser = new ExpressionParser();
             this.triggers.forEach((trigger): void => {
-                version += trigger.getExpression(parser).toString();
+                version += trigger.getExpression().toString();
             });
 
             this._internalVersion = StringUtils.hash(version);
@@ -649,10 +642,9 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
         const selection: OnCondition[] = await this.selector.select(actionContext);
         if (selection.length > 0) {
             const evt = selection[0];
-            const parser = new ExpressionParser();
             const properties: { [key: string]: string } = {
                 DialogId: this.id,
-                Expression: evt.getExpression(parser).toString(),
+                Expression: evt.getExpression().toString(),
                 Kind: `Microsoft.${evt.constructor.name}`,
                 ConditionId: evt.id,
             };

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onActivity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onActivity.ts
@@ -5,8 +5,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+import { Expression } from 'adaptive-expressions';
 import { Dialog, TurnPath } from 'botbuilder-dialogs';
-import { Expression, ExpressionType, ExpressionParserInterface } from 'adaptive-expressions';
 import { OnDialogEvent, OnDialogEventConfiguration } from './onDialogEvent';
 import { AdaptiveEvents } from '../adaptiveEvents';
 
@@ -27,9 +27,10 @@ export class OnActivity extends OnDialogEvent implements OnActivityConfiguration
 
     /**
      * Initializes a new instance of the [OnActivity](xref:botbuilder-dialogs-adaptive.OnActivity) class.
-     * @param type Optional. ActivityType which must be matched for this event to trigger.
-     * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
-     * @param condition Optional. Condition which needs to be met for the actions to be executed.
+     *
+     * @param type Optional, ActivityType which must be matched for this event to trigger.
+     * @param actions Optional, actions to add to the plan when the rule constraints are met.
+     * @param condition Optional, condition which needs to be met for the actions to be executed.
      */
     public constructor(type?: string, actions: Dialog[] = [], condition?: string) {
         super(AdaptiveEvents.activityReceived, actions, condition);
@@ -37,13 +38,15 @@ export class OnActivity extends OnDialogEvent implements OnActivityConfiguration
     }
 
     /**
-     * Gets this activity representing expression.
-     * @param parser [ExpressionParserInterface](xref:adaptive-expressions.ExpressionParserInterface) used to parse a string into an [Expression](xref:adaptive-expressions.Expression).
-     * @returns An [Expression](xref:adaptive-expressions.Expression) representing the [Activity](xref:botframework-schema.Activity).
+     * Create expression for this condition.
+     *
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
      */
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    protected createExpression(): Expression {
         // add constraints for activity type
-        const expression = parser.parse(`${TurnPath.activity}.type == '${this.type}'`);
-        return Expression.makeExpression(ExpressionType.And, undefined, expression, super.getExpression(parser));
+        return Expression.andExpression(
+            Expression.parse(`${TurnPath.activity}.type == '${this.type}'`),
+            super.createExpression()
+        );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onAssignEntity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onAssignEntity.ts
@@ -5,8 +5,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+import { Expression } from 'adaptive-expressions';
 import { Dialog, TurnPath } from 'botbuilder-dialogs';
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
 import { AdaptiveEvents } from '../adaptiveEvents';
 import { OnDialogEvent, OnDialogEventConfiguration } from './onDialogEvent';
 
@@ -21,14 +21,15 @@ export interface OnAssignEntityConfiguration extends OnDialogEventConfiguration 
  */
 export class OnAssignEntity extends OnDialogEvent implements OnAssignEntityConfiguration {
     public static $kind = 'Microsoft.OnAssignEntity';
-  
+
     /**
      * Initializes a new instance of the [OnAssignEntity](xref:botbuilder-dialogs-adaptive.OnAssignEntity) class.
-     * @param property Optional. Property to be assigned for filtering events.
-     * @param entity Optional. Entity name being assigned for filtering events.
-     * @param operation Optional. Operation being used to assign the entity for filtering events.
-     * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
-     * @param condition Optional. Condition which needs to be met for the actions to be executed.
+     *
+     * @param property Optional, property filter on event.
+     * @param entity Optional, entity filter on event.
+     * @param operation Optional, operation filter on event.
+     * @param actions Optional, actions to add to the plan when the rule constraints are met.
+     * @param condition Optional, condition which needs to be met for the actions to be executed.
      */
     public constructor(
         property?: string,
@@ -44,37 +45,38 @@ export class OnAssignEntity extends OnDialogEvent implements OnAssignEntityConfi
     }
 
     /**
-     * Gets or sets the property to be assigned for filtering events.
+     * Gets or sets the property filter on events.
      */
     public property: string;
 
     /**
-     * Gets or sets the entity name being assigned for filtering events.
+     * Gets or sets the entity filter on events.
      */
     public entity: string;
 
     /**
-     * Gets or sets the operation being used to assign the entity for filtering events.
+     * Gets or sets the operation filter on events.
      */
     public operation: string;
 
     /**
-     * Get the expression for this rule.
-     * @param parser [ExpressionParserInterface](xref:adaptive-expressions.ExpressionParserInterface) used to parse a string into an [Expression](xref:adaptive-expressions.Expression).
-     * @returns [Expression](xref:adaptive-expressions.Expression) which will be cached and used to evaluate this rule.
+     * Create the expression for this condition.
+     *
+     * @returns [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
      */
-    public getExpression(parser: ExpressionParserInterface): Expression {
-        const expressions = [super.getExpression(parser)];
+    protected createExpression(): Expression {
+        const expressions = [super.createExpression()];
+
         if (this.property) {
-            expressions.push(parser.parse(`${TurnPath.dialogEvent}.value.property == '${this.property}'`));
+            expressions.push(Expression.parse(`${TurnPath.dialogEvent}.value.property == '${this.property}'`));
         }
         if (this.entity) {
-            expressions.push(parser.parse(`${TurnPath.dialogEvent}.value.entity.name == '${this.entity}'`));
+            expressions.push(Expression.parse(`${TurnPath.dialogEvent}.value.entity.name == '${this.entity}'`));
         }
         if (this.operation) {
-            expressions.push(parser.parse(`${TurnPath.dialogEvent}.value.operation == '${this.operation}'`));
+            expressions.push(Expression.parse(`${TurnPath.dialogEvent}.value.operation == '${this.operation}'`));
         }
 
-        return Expression.andExpression.apply(Expression, expressions);
+        return Expression.andExpression(...expressions);
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onChooseEntity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onChooseEntity.ts
@@ -5,8 +5,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+import { Expression } from 'adaptive-expressions';
 import { Dialog, TurnPath } from 'botbuilder-dialogs';
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
 import { AdaptiveEvents } from '../adaptiveEvents';
 import { OnDialogEvent, OnDialogEventConfiguration } from './onDialogEvent';
 
@@ -23,10 +23,11 @@ export class OnChooseEntity extends OnDialogEvent implements OnChooseEntityConfi
 
     /**
      * Initializes a new instance of the [OnChooseEntity](xref:botbuilder-dialogs-adaptive.OnChooseEntity) class.
-     * @param property Optional. Property to be assigned for filtering events.
-     * @param entity Optional. Entity name being assigned for filtering events.
-     * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
-     * @param condition Optional. Condition which needs to be met for the actions to be executed.
+     *
+     * @param {string} property Optional, property filter on event.
+     * @param {string} entity Optional, entity filter on event.
+     * @param {Dialog[]} actions Optional, actions to add to the plan when the rule constraints are met.
+     * @param {string} condition Optional, condition which needs to be met for the actions to be executed.
      */
     public constructor(property?: string, entity?: string, actions: Dialog[] = [], condition?: string) {
         super(AdaptiveEvents.chooseEntity, actions, condition);
@@ -35,29 +36,30 @@ export class OnChooseEntity extends OnDialogEvent implements OnChooseEntityConfi
     }
 
     /**
-     * Gets or sets the property to be assigned for filtering events.
+     * Gets or sets the property filter on event.
      */
     public property: string;
 
     /**
-     * Gets or sets the entity name being assigned for filtering events.
+     * Gets or sets the entity filter on event.
      */
     public entity: string;
 
     /**
-     * Get the expression for this rule.
-     * @param parser [ExpressionParserInterface](xref:adaptive-expressions.ExpressionParserInterface) used to parse a string into an [Expression](xref:adaptive-expressions.Expression).
-     * @returns [Expression](xref:adaptive-expressions.Expression) which will be cached and used to evaluate this rule.
+     * Create the expression for this condition.
+     *
+     * @returns [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
      */
-    public getExpression(parser: ExpressionParserInterface): Expression {
-        const expressions = [super.getExpression(parser)];
+    protected createExpression(): Expression {
+        const expressions = [super.createExpression()];
+
         if (this.property) {
-            expressions.push(parser.parse(`${TurnPath.dialogEvent}.value.property == '${this.property}'`));
+            expressions.push(Expression.parse(`${TurnPath.dialogEvent}.value.property == '${this.property}'`));
         }
         if (this.entity) {
-            expressions.push(parser.parse(`${TurnPath.dialogEvent}.value.entity.name == '${this.entity}'`));
+            expressions.push(Expression.parse(`${TurnPath.dialogEvent}.value.entity.name == '${this.entity}'`));
         }
 
-        return Expression.andExpression.apply(Expression, expressions);
+        return Expression.andExpression(...expressions);
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onChooseIntent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onChooseIntent.ts
@@ -6,8 +6,8 @@
  * Licensed under the MIT License.
  */
 
+import { Expression } from 'adaptive-expressions';
 import { Dialog, TurnPath } from 'botbuilder-dialogs';
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
 import { OnIntent, OnIntentConfiguration } from './onIntent';
 
 export interface OnChooseIntentConfiguration extends OnIntentConfiguration {
@@ -24,27 +24,30 @@ export class OnChooseIntent extends OnIntent implements OnChooseIntentConfigurat
 
     /**
      * Initializes a new instance of the [OnChooseIntent](xref:botbuilder-dialogs-adaptive.OnChooseIntent) class.
-     * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
-     * @param condition Optional. Condition which needs to be met for the actions to be executed.
+     *
+     * @param {Dialog[]} actions Optional, actions to add to the plan when the rule constraints are met.
+     * @param {string} condition Optional, condition which needs to be met for the actions to be executed.
      */
-    public constructor(actons: Dialog[] = [], condition?: string) {
-        super('ChooseIntent', [], actons, condition);
+    public constructor(actions: Dialog[] = [], condition?: string) {
+        super('ChooseIntent', [], actions, condition);
     }
 
     /**
-     * Get the expression for this rule.
-     * @param parser [ExpressionParserInterface](xref:adaptive-expressions.ExpressionParserInterface) used to parse a string into an [Expression](xref:adaptive-expressions.Expression).
-     * @returns [Expression](xref:adaptive-expressions.Expression) which will be cached and used to evaluate this rule.
+     * Create the expression for this condition.
+     *
+     * @returns [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
      */
-    public getExpression(parser: ExpressionParserInterface): Expression {
-        if (this.intents.length > 0) {
+    protected createExpression(): Expression {
+        if (this.intents?.length) {
             const constraints = this.intents.map(
                 (intent: string): Expression => {
-                    return parser.parse(`contains(jPath(${TurnPath.recognized}, '.candidates.intent'), '${intent}')`);
+                    return Expression.parse(
+                        `contains(jPath(${TurnPath.recognized}, '.candidates.intent'), '${intent}')`
+                    );
                 }
             );
-            return Expression.andExpression(super.getExpression(parser), ...constraints);
+            return Expression.andExpression(super.createExpression(), ...constraints);
         }
-        return super.getExpression(parser);
+        return super.createExpression();
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onChooseProperty.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onChooseProperty.ts
@@ -5,67 +5,23 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Dialog, TurnPath } from 'botbuilder-dialogs';
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Dialog } from 'botbuilder-dialogs';
 import { AdaptiveEvents } from '../adaptiveEvents';
-import { OnDialogEvent, OnDialogEventConfiguration } from './onDialogEvent';
-
-export interface OnChoosePropertyConfiguration extends OnDialogEventConfiguration {
-    properties?: string[];
-    entities?: string[];
-}
+import { OnDialogEvent } from './onDialogEvent';
 
 /**
  * Triggered to choose which property an entity goes to.
  */
-export class OnChooseProperty extends OnDialogEvent implements OnChoosePropertyConfiguration {
+export class OnChooseProperty extends OnDialogEvent {
     public static $kind = 'Microsoft.OnChooseProperty';
 
     /**
      * Initializes a new instance of the [OnChooseProperty](xref:botbuilder-dialogs-adaptive.OnChooseProperty) class.
-     * @param properties Optional. List of properties being chosen between to filter events.
-     * @param entities Optional. List of entities being chosen between to filter events.
-     * @param actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
-     * @param condition Optional. Condition which needs to be met for the actions to be executed.
+     *
+     * @param {Dialog[]} actions Optional, actions to add to the plan when the rule constraints are met.
+     * @param {string} condition Optional, condition which needs to be met for the actions to be executed.
      */
-    public constructor(properties: string[] = [], entities: string[] = [], actions: Dialog[] = [], condition?: string) {
+    public constructor(actions: Dialog[] = [], condition?: string) {
         super(AdaptiveEvents.chooseProperty, actions, condition);
-        this.properties = properties;
-        this.entities = entities;
-    }
-
-    /**
-     * Gets or sets the properties being chosen between to filter events.
-     */
-    public properties: string[];
-
-    /**
-     * Gets or sets the entities being chosen between to filter events.
-     */
-    public entities: string[];
-
-    /**
-     * Get the expression for this rule.
-     * @param parser [ExpressionParserInterface](xref:adaptive-expressions.ExpressionParserInterface) used to parse a string into an [Expression](xref:adaptive-expressions.Expression).
-     * @returns [Expression](xref:adaptive-expressions.Expression) which will be cached and used to evaluate this rule.
-     */
-    public getExpression(parser: ExpressionParserInterface): Expression {
-        const expressions = [super.getExpression(parser)];
-        this.properties.forEach((property) => {
-            expressions.push(
-                parser.parse(
-                    `contains(foreach(${TurnPath.dialogEvent}.value, mapping, mapping.property), '${property}')`
-                )
-            );
-        });
-        this.entities.forEach((entity) => {
-            expressions.push(
-                parser.parse(
-                    `contains(foreach(${TurnPath.dialogEvent}.value, mapping, mapping.entity.name), '${entity}')`
-                )
-            );
-        });
-
-        return Expression.andExpression.apply(Expression, expressions);
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onCondition.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onCondition.ts
@@ -10,13 +10,13 @@ import {
     BoolExpressionConverter,
     Constant,
     Expression,
-    ExpressionParserInterface,
     ExpressionParser,
     ExpressionEvaluator,
     FunctionUtils,
     IntExpression,
     IntExpressionConverter,
     ReturnType,
+    ExpressionType,
 } from 'adaptive-expressions';
 import {
     Configurable,
@@ -121,52 +121,13 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
     }
 
     /**
-     * Get the expression for this condition
-     * @param parser Expression parser.
-     * @returns Expression which will be cached and used to evaluate this condition.
+     * Get the cached expression for this condition.
+     *
+     * @returns Cached expression used to evaluate this condition.
      */
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    public getExpression(): Expression {
         if (!this._fullConstraint) {
-            const allExpressions: Expression[] = [];
-            if (this.condition) {
-                try {
-                    allExpressions.push(this.condition.toExpression());
-                } catch (err) {
-                    throw Error(`Invalid constraint expression: ${this.condition.toString()}, ${err.toString()}`);
-                }
-            }
-
-            if (this._extraConstraints.length > 0) {
-                allExpressions.push(...this._extraConstraints);
-            }
-
-            if (allExpressions.length > 0) {
-                this._fullConstraint = Expression.andExpression(...allExpressions);
-            } else {
-                this._fullConstraint = new Constant(true);
-            }
-
-            if (this.runOnce) {
-                // TODO: Once we add support for the MostSpecificSelector the code below will need
-                //       some tweaking to wrap runOnce with a call to 'ignore'.
-                const runOnce = new ExpressionEvaluator(
-                    `runOnce${this.id}`,
-                    (exp, state: DialogStateManager) => {
-                        const basePath = `${AdaptiveDialog.conditionTracker}.${this.id}.`;
-                        const lastRun: number = state.getValue(basePath + 'lastRun');
-                        const paths: string[] = state.getValue(basePath + 'paths');
-                        const changed = state.anyPathChanged(lastRun, paths);
-                        return { value: changed, error: undefined };
-                    },
-                    ReturnType.Boolean,
-                    FunctionUtils.validateUnary
-                );
-
-                this._fullConstraint = Expression.andExpression(
-                    this._fullConstraint,
-                    new Expression(runOnce.type, runOnce)
-                );
-            }
+            this._fullConstraint = this.createExpression();
         }
 
         return this._fullConstraint;
@@ -219,6 +180,51 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
      */
     public getDependencies(): Dialog[] {
         return [this.actionScope];
+    }
+
+    /**
+     * Create the expression for this condition.
+     *
+     * @returns {Expression} Expression used to evaluate this rule.
+     */
+    protected createExpression(): Expression {
+        const allExpressions: Expression[] = [];
+
+        if (this.condition) {
+            allExpressions.push(this.condition.toExpression());
+        }
+
+        if (this._extraConstraints?.length) {
+            allExpressions.push(...this._extraConstraints);
+        }
+
+        if (this.runOnce) {
+            const evaluator = new ExpressionEvaluator(
+                `runOnce${this.id}`,
+                (_expression, state: DialogStateManager, _) => {
+                    const basePath = `${AdaptiveDialog.conditionTracker}.${this.id}.`;
+                    const lastRun: number = state.getValue(basePath + 'lastRun');
+                    const paths: string[] = state.getValue(basePath + 'paths');
+                    const changed = state.anyPathChanged(lastRun, paths);
+                    return { value: changed, error: undefined };
+                },
+                ReturnType.Boolean,
+                FunctionUtils.validateUnary
+            );
+            allExpressions.push(
+                new Expression(
+                    ExpressionType.Ignore,
+                    Expression.lookup(ExpressionType.Ignore),
+                    new Expression(evaluator.type, evaluator)
+                )
+            );
+        }
+
+        if (allExpressions.length) {
+            return Expression.andExpression(...allExpressions);
+        }
+
+        return new Constant(true);
     }
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onContinueConversation.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onContinueConversation.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Expression, ExpressionParserInterface } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { Dialog, TurnPath } from 'botbuilder-dialogs';
 import { OnEventActivity } from './onEventActivity';
 
@@ -18,24 +18,23 @@ export class OnContinueConversation extends OnEventActivity {
     /**
      * Initializes a new instance of the [OnContinueConversation](xref:botbuilder-dialogs-adaptive.OnContinueConversation) class.
      *
-     * @param {Dialog[]} actions Optional. A [Dialog](xref:botbuilder-dialogs.Dialog) list containing the actions to add to the plan when the rule constraints are met.
-     * @param {string} condition Optional. Condition which needs to be met for the actions to be executed.
+     * @param {Dialog[]} actions Optional, actions to add to the plan when the rule constraints are met.
+     * @param {string} condition Optional, ondition which needs to be met for the actions to be executed.
      */
     public constructor(actions: Dialog[] = [], condition?: string) {
         super(actions, condition);
     }
 
     /**
-     * Gets this activity representing expression.
+     * Create expression for this condition.
      *
-     * @param {ExpressionParserInterface} parser [ExpressionParserInterface](xref:adaptive-expressions.ExpressionParserInterface) used to parse a string into an [Expression](xref:adaptive-expressions.Expression).
-     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) representing the [Activity](xref:botframework-schema.Activity).
+     * @returns {Expression} An [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
      */
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    protected createExpression(): Expression {
         // add constraints for activity type
         return Expression.andExpression(
             Expression.parse(`${TurnPath.activity}.name == 'ContinueConversation'`),
-            super.getExpression(parser)
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onDialogEvent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onDialogEvent.ts
@@ -5,8 +5,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+import { Expression } from 'adaptive-expressions';
 import { Dialog, TurnPath } from 'botbuilder-dialogs';
-import { ExpressionParserInterface, Expression, ExpressionType } from 'adaptive-expressions';
 import { OnCondition, OnConditionConfiguration } from './onCondition';
 
 export interface OnDialogEventConfiguration extends OnConditionConfiguration {
@@ -36,16 +36,14 @@ export class OnDialogEvent extends OnCondition implements OnDialogEventConfigura
     }
 
     /**
-     * Get the expression for this rule.
-     * @param parser [ExpressionParserInterface](xref:adaptive-expressions.ExpressionParserInterface) used to parse a string into an [Expression](xref:adaptive-expressions.Expression).
-     * @returns [Expression](xref:adaptive-expressions.Expression) which will be cached and used to evaluate this rule.
+     * Create the expression for this condition.
+     *
+     * @returns [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
      */
-    public getExpression(parser: ExpressionParserInterface): Expression {
-        return Expression.makeExpression(
-            ExpressionType.And,
-            undefined,
-            parser.parse(`${TurnPath.dialogEvent}.name == '${this.event}'`),
-            super.getExpression(parser)
+    protected createExpression(): Expression {
+        return Expression.andExpression(
+            Expression.parse(`${TurnPath.dialogEvent}.name == '${this.event}'`),
+            super.createExpression()
         );
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onIntent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onIntent.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ExpressionParserInterface, Expression, ExpressionType } from 'adaptive-expressions';
+import { Expression } from 'adaptive-expressions';
 import { RecognizerResult } from 'botbuilder-core';
 import { Dialog, TurnPath } from 'botbuilder-dialogs';
 import { OnDialogEvent, OnDialogEventConfiguration } from './onDialogEvent';
@@ -50,33 +50,31 @@ export class OnIntent extends OnDialogEvent implements OnIntentConfiguration {
     }
 
     /**
-     * Get the expression for this rule.
-     * @param parser [ExpressionParserInterface](xref:adaptive-expressions.ExpressionParserInterface) used to parse a string into an [Expression](xref:adaptive-expressions.Expression).
-     * @returns [Expression](xref:adaptive-expressions.Expression) which will be cached and used to evaluate this rule.
+     * Create the expression for this condition.
+     *
+     * @returns [Expression](xref:adaptive-expressions.Expression) used to evaluate this rule.
      */
-    public getExpression(parser: ExpressionParserInterface): Expression {
+    protected createExpression(): Expression {
         if (!this.intent) {
             throw new Error('Intent cannot be null.');
         }
 
         const trimmedIntent = this.intent.startsWith('#') ? this.intent.substring(1) : this.intent;
-        let intentExpression = parser.parse(`${TurnPath.recognized}.intent == '${trimmedIntent}'`);
+        let intentExpression = Expression.parse(`${TurnPath.recognized}.intent == '${trimmedIntent}'`);
 
         if (this.entities.length > 0) {
-            intentExpression = Expression.makeExpression(
-                ExpressionType.And,
-                undefined,
+            intentExpression = Expression.andExpression(
                 intentExpression,
                 ...this.entities.map((entity) => {
                     if (entity.startsWith('@') || entity.startsWith(TurnPath.recognized)) {
-                        return parser.parse(`exists(${entity})`);
+                        return Expression.parse(`exists(${entity})`);
                     }
-                    return parser.parse(`exists(@${entity})`);
+                    return Expression.parse(`exists(@${entity})`);
                 })
             );
         }
 
-        return Expression.makeExpression(ExpressionType.And, undefined, intentExpression, super.getExpression(parser));
+        return Expression.andExpression(intentExpression, super.createExpression());
     }
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onIntent.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onIntent.ts
@@ -65,12 +65,14 @@ export class OnIntent extends OnDialogEvent implements OnIntentConfiguration {
         if (this.entities.length > 0) {
             intentExpression = Expression.andExpression(
                 intentExpression,
-                ...this.entities.map((entity) => {
-                    if (entity.startsWith('@') || entity.startsWith(TurnPath.recognized)) {
-                        return Expression.parse(`exists(${entity})`);
-                    }
-                    return Expression.parse(`exists(@${entity})`);
-                })
+                Expression.andExpression(
+                    ...this.entities.map((entity) => {
+                        if (entity.startsWith('@') || entity.startsWith(TurnPath.recognized)) {
+                            return Expression.parse(`exists(${entity})`);
+                        }
+                        return Expression.parse(`exists(@${entity})`);
+                    })
+                )
             );
         }
 

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/conditionalSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/conditionalSelector.ts
@@ -14,10 +14,10 @@ import {
 } from 'adaptive-expressions';
 import { Converter, ConverterFactory } from 'botbuilder-dialogs';
 import { OnCondition } from '../conditions/onCondition';
-import { TriggerSelector, TriggerSelectorConfiguration } from '../triggerSelector';
+import { TriggerSelector } from '../triggerSelector';
 import { ActionContext } from '../actionContext';
 
-export interface ConditionalSelectorConfiguration extends TriggerSelectorConfiguration {
+export interface ConditionalSelectorConfiguration {
     condition?: boolean | string | Expression | BoolExpression;
     ifTrue?: TriggerSelector;
     ifFalse?: TriggerSelector;

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/firstSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/firstSelector.ts
@@ -5,7 +5,6 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ExpressionParser, ExpressionParserInterface } from 'adaptive-expressions';
 import { OnCondition } from '../conditions/onCondition';
 import { TriggerSelector } from '../triggerSelector';
 import { ActionContext } from '../actionContext';
@@ -18,11 +17,6 @@ export class FirstSelector extends TriggerSelector {
 
     private _conditionals: OnCondition[];
     private _evaluate: boolean;
-
-    /**
-     * Gets or sets the expression parser to use.
-     */
-    public parser: ExpressionParserInterface = new ExpressionParser();
 
     /**
      * Initialize the selector with the set of rules.
@@ -46,7 +40,7 @@ export class FirstSelector extends TriggerSelector {
         if (this._evaluate) {
             for (let i = 0; i < this._conditionals.length; i++) {
                 const conditional = this._conditionals[i];
-                const expression = conditional.getExpression(this.parser);
+                const expression = conditional.getExpression();
                 const { value, error } = expression.tryEvaluate(actionContext.state);
                 if (value && !error) {
                     const priority = conditional.currentPriority(actionContext);

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/mostSpecificSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/mostSpecificSelector.ts
@@ -5,12 +5,12 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ExpressionParser, ExpressionParserInterface, TriggerTree, Trigger } from 'adaptive-expressions';
+import { TriggerTree, Trigger } from 'adaptive-expressions';
 import { OnCondition } from '../conditions/onCondition';
-import { TriggerSelector, TriggerSelectorConfiguration } from '../triggerSelector';
+import { TriggerSelector } from '../triggerSelector';
 import { ActionContext } from '../actionContext';
 
-export interface MostSpecificSelectorConfiguration extends TriggerSelectorConfiguration {
+export interface MostSpecificSelectorConfiguration {
     selector?: TriggerSelector;
 }
 
@@ -19,16 +19,11 @@ export class MostSpecificSelector extends TriggerSelector implements MostSpecifi
 
     private readonly _tree = new TriggerTree();
 
-    /**
-     * Gets or sets the expression parser to use.
-     */
-    public parser: ExpressionParserInterface = new ExpressionParser();
-
     public selector: TriggerSelector;
 
     public initialize(conditionals: OnCondition[], _evaluate: boolean): void {
         for (const conditional of conditionals) {
-            this._tree.addTrigger(conditional.getExpression(this.parser), conditional);
+            this._tree.addTrigger(conditional.getExpression(), conditional);
         }
     }
 

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/randomSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/randomSelector.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ExpressionParserInterface, ExpressionParser, Extensions } from 'adaptive-expressions';
+import { Extensions } from 'adaptive-expressions';
 import { TriggerSelector } from '../triggerSelector';
 import { OnCondition } from '../conditions';
 import { ActionContext } from '../actionContext';
@@ -18,11 +18,6 @@ export class RandomSelector extends TriggerSelector {
 
     private _conditionals: OnCondition[];
     private _evaluate: boolean;
-
-    /**
-     * Gets or sets the expression parser to use.
-     */
-    public parser: ExpressionParserInterface = new ExpressionParser();
 
     /**
      * Initialize the selector with the set of rules.
@@ -45,7 +40,7 @@ export class RandomSelector extends TriggerSelector {
         for (let i = 0; i < this._conditionals.length; i++) {
             const conditional = this._conditionals[i];
             if (this._evaluate) {
-                const expression = conditional.getExpression(this.parser);
+                const expression = conditional.getExpression();
                 const { value, error } = expression.tryEvaluate(actionContext.state);
                 if (value && !error) {
                     candidates.push(conditional);

--- a/libraries/botbuilder-dialogs-adaptive/src/selectors/trueSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/selectors/trueSelector.ts
@@ -5,7 +5,6 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ExpressionParserInterface, ExpressionParser } from 'adaptive-expressions';
 import { TriggerSelector } from '../triggerSelector';
 import { OnCondition } from '../conditions';
 import { ActionContext } from '../actionContext';
@@ -18,11 +17,6 @@ export class TrueSelector extends TriggerSelector {
 
     private _conditionals: OnCondition[];
     private _evaluate: boolean;
-
-    /**
-     * Gets or sets the expression parser to use.
-     */
-    public parser: ExpressionParserInterface = new ExpressionParser();
 
     /**
      * Initialize the selector with the set of rules.
@@ -45,7 +39,7 @@ export class TrueSelector extends TriggerSelector {
         for (let i = 0; i < this._conditionals.length; i++) {
             const conditional = this._conditionals[i];
             if (this._evaluate) {
-                const expression = conditional.getExpression(this.parser);
+                const expression = conditional.getExpression();
                 const { value, error } = expression.tryEvaluate(actionContext.state);
                 if (value && !error) {
                     candidates.push(conditional);

--- a/libraries/botbuilder-dialogs-adaptive/src/triggerSelector.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/triggerSelector.ts
@@ -5,24 +5,14 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ExpressionParserInterface } from 'adaptive-expressions';
 import { Configurable } from 'botbuilder-dialogs';
 import { ActionContext } from './actionContext';
 import { OnCondition } from './conditions';
 
-export interface TriggerSelectorConfiguration {
-    parser?: ExpressionParserInterface;
-}
-
 /**
  * Select the trigger to execute in a given state.
  */
-export abstract class TriggerSelector extends Configurable implements TriggerSelectorConfiguration {
-    /**
-     * Gets or sets the expression parser for expressions.
-     */
-    public parser: ExpressionParserInterface;
-
+export abstract class TriggerSelector extends Configurable {
     /**
      * Initialize the selector with the set of rules.
      * @param conditionHandlers Possible rules to match.

--- a/libraries/botbuilder-dialogs-adaptive/tests/conditionals.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/conditionals.test.js
@@ -1,0 +1,169 @@
+const assert = require('assert');
+const {
+    OnActivity,
+    OnAssignEntity,
+    OnBeginDialog,
+    OnCancelDialog,
+    OnChooseEntity,
+    OnChooseIntent,
+    OnChooseProperty,
+    OnContinueConversation,
+    OnConversationUpdateActivity,
+    OnDialogEvent,
+    OnEndOfActions,
+    OnEndOfConversationActivity,
+    OnError,
+    OnEventActivity,
+    OnHandoffActivity,
+    OnInstallationUpdateActivity,
+    OnIntent,
+    OnInvokeActivity,
+    OnMessageActivity,
+    OnMessageDeleteActivity,
+    OnMessageReactionActivity,
+    OnMessageUpdateActivity,
+    OnQnAMatch,
+    OnRepromptDialog,
+    OnTypingActivity,
+    OnUnknownIntent,
+    OnCondition,
+} = require('../lib');
+
+const assertExpression = (condition, expectedExpression) => {
+    const exp = condition.getExpression();
+    assert.strictEqual(exp.toString(), expectedExpression);
+};
+
+describe('ConditionalsTests', () => {
+    it('verify getExpression', () => {
+        const conditions = [
+            new OnActivity(),
+            new OnAssignEntity(),
+            new OnBeginDialog(),
+            new OnCancelDialog(),
+            new OnCancelDialog(),
+            new OnChooseEntity(),
+            new OnChooseIntent(),
+            new OnChooseProperty(),
+            new OnContinueConversation(),
+            new OnConversationUpdateActivity(),
+            new OnDialogEvent(),
+            new OnEndOfActions(),
+            new OnEndOfConversationActivity(),
+            new OnError(),
+            new OnEventActivity(),
+            new OnHandoffActivity(),
+            new OnInstallationUpdateActivity(),
+            new OnIntent('test'),
+            new OnInvokeActivity(),
+            new OnMessageActivity(),
+            new OnMessageDeleteActivity(),
+            new OnMessageReactionActivity(),
+            new OnMessageUpdateActivity(),
+            new OnQnAMatch(),
+            new OnRepromptDialog(),
+            new OnTypingActivity(),
+            new OnUnknownIntent(),
+        ];
+        conditions.forEach((condition) => {
+            assert.strictEqual(condition.getExpression(), condition.getExpression());
+        });
+    });
+
+    it('OnCondition with conditioan', () => {
+        assertExpression(
+            new OnActivity('event', [], 'turn.test == 1'),
+            "((turn.activity.type == 'event') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+        );
+        assertExpression(
+            new OnAssignEntity('property', 'entity', 'operation', [], 'turn.test == 1'),
+            "(((turn.dialogEvent.name == 'assignEntity') && (turn.test == 1)) && (turn.dialogEvent.value.property == 'property') && (turn.dialogEvent.value.entity.name == 'entity') && (turn.dialogEvent.value.operation == 'operation'))"
+        );
+        assertExpression(
+            new OnBeginDialog([], 'turn.test == 1'),
+            "((turn.dialogEvent.name == 'beginDialog') && (turn.test == 1))"
+        );
+        assertExpression(
+            new OnCancelDialog([], 'turn.test == 1'),
+            "((turn.dialogEvent.name == 'cancelDialog') && (turn.test == 1))"
+        );
+        assertExpression(
+            new OnChooseEntity('property', 'entity', [], 'turn.test == 1'),
+            "(((turn.dialogEvent.name == 'chooseEntity') && (turn.test == 1)) && (turn.dialogEvent.value.property == 'property') && (turn.dialogEvent.value.entity.name == 'entity'))"
+        );
+        assertExpression(new OnCondition('turn.test == 1'), '(turn.test == 1)');
+        assertExpression(
+            new OnContinueConversation([], 'turn.test == 1'),
+            "((turn.activity.name == 'ContinueConversation') && ((turn.activity.type == 'event') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1))))"
+        );
+        assertExpression(
+            new OnConversationUpdateActivity([], 'turn.test == 1'),
+            "((turn.activity.type == 'conversationUpdate') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+        );
+        assertExpression(
+            new OnDialogEvent('DialogEvent', [], 'turn.test == 1'),
+            "((turn.dialogEvent.name == 'DialogEvent') && (turn.test == 1))"
+        );
+        assertExpression(
+            new OnEndOfActions([], 'turn.test == 1'),
+            "((turn.dialogEvent.name == 'endOfActions') && (turn.test == 1))"
+        );
+        assertExpression(
+            new OnEndOfConversationActivity([], 'turn.test == 1'),
+            "((turn.activity.type == 'endOfConversation') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+        );
+        assertExpression(new OnError([], 'turn.test == 1'), "((turn.dialogEvent.name == 'error') && (turn.test == 1))");
+        assertExpression(
+            new OnEventActivity([], 'turn.test == 1'),
+            "((turn.activity.type == 'event') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+        );
+        assertExpression(
+            new OnHandoffActivity([], 'turn.test == 1'),
+            "((turn.activity.type == 'handoff') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+        );
+        assertExpression(
+            new OnInstallationUpdateActivity([], 'turn.test == 1'),
+            "((turn.activity.type == 'installationUpdate') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+        );
+        assertExpression(
+            new OnIntent('Intent', ['@foo', '@@bar', 'turn.recognized.entities.blat', 'gronk'], [], 'turn.test == 1'),
+            "(((turn.recognized.intent == 'Intent') && (exists(@foo) && exists(@@bar) && exists(turn.recognized.entities.blat) && exists(@gronk))) && ((turn.dialogEvent.name == 'recognizedIntent') && (turn.test == 1)))"
+        );
+        assertExpression(
+            new OnInvokeActivity([], 'turn.test == 1'),
+            "((turn.activity.type == 'invoke') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+        );
+        assertExpression(
+            new OnMessageActivity([], 'turn.test == 1'),
+            "((turn.activity.type == 'message') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+        );
+        assertExpression(
+            new OnMessageDeleteActivity([], 'turn.test == 1'),
+            "((turn.activity.type == 'messageDelete') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+        );
+        assertExpression(
+            new OnMessageReactionActivity([], 'turn.test == 1'),
+            "((turn.activity.type == 'messageReaction') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+        );
+        assertExpression(
+            new OnMessageUpdateActivity([], 'turn.test == 1'),
+            "((turn.activity.type == 'messageUpdate') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+        );
+        assertExpression(
+            new OnQnAMatch([], 'turn.test == 1'),
+            "((turn.recognized.intent == 'QnAMatch') && ((turn.dialogEvent.name == 'recognizedIntent') && (turn.test == 1)))"
+        );
+        assertExpression(
+            new OnRepromptDialog([], 'turn.test == 1'),
+            "((turn.dialogEvent.name == 'repromptDialog') && (turn.test == 1))"
+        );
+        assertExpression(
+            new OnTypingActivity([], 'turn.test == 1'),
+            "((turn.activity.type == 'typing') && ((turn.dialogEvent.name == 'activityReceived') && (turn.test == 1)))"
+        );
+        assertExpression(
+            new OnUnknownIntent([], 'turn.test == 1'),
+            "((turn.dialogEvent.name == 'unknownIntent') && (turn.test == 1))"
+        );
+    });
+});


### PR DESCRIPTION
Fixes #3356 

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
OnCondition.getExpression() was caches the root expression, but all of the children which override getExpression() were not. This means all child conditions which overrode getExpression() were calling Expression.parse() on **EVERY call**.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

- Changed getExpression() documentation to state that it must return **CACHED** expression
- Moved all of the creation logic to protected method createExpression(). This should be backward compatible with classes which do override this method but creates a pattern that causes correct behavior for all OnCondition classes written in the future.
- Changed all of our OnCondition classes from public getExpression() => protected createExpression()

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->