### PR TITLE
Port: Switch priority in triggers to float type

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/SelectorTests/SelectorTests_Float_Priority.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/SelectorTests/SelectorTests_Float_Priority.test.dialog
@@ -1,0 +1,79 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "a",
+                    "pattern": "a"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "a",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "rule1"
+                    },
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "user.a",
+                        "value": "=1.2"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "a",
+                "priority": "=user.a + 1.1",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "rule2"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "a",
+                "priority": "=user.a",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "rule3"
+                    }
+                ]
+            }
+        ],
+        "autoEndDialog": false,
+        "selector": {
+            "$kind": "Microsoft.FirstSelector"
+        },
+        "defaultResultProperty": "dialog.result"
+    },
+    "locale": "en-us",
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "a"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "rule1"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "a"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "rule3"
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/selector.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/selector.test.js
@@ -36,6 +36,10 @@ describe('SelectorTests', function () {
         await TestUtils.runTestScript(resourceExplorer, 'SelectorTests_Priority');
     });
 
+    it('Priority', async () => {
+        await TestUtils.runTestScript(resourceExplorer, 'SelectorTests_Float_Priority');
+    });
+
     it('RandomSelector', async () => {
         await TestUtils.runTestScript(resourceExplorer, 'SelectorTests_RandomSelector');
     });

--- a/libraries/botbuilder-dialogs-adaptive/schemas/TriggerConditions/Microsoft.OnCondition.schema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/TriggerConditions/Microsoft.OnCondition.schema
@@ -22,7 +22,7 @@
             }
         },
         "priority": {
-            "$ref": "schema:#/definitions/integerExpression",
+            "$ref": "schema:#/definitions/numberExpression",
             "title": "Priority",
             "description": "Priority for trigger with 0 being the highest and < 0 ignored."
         },

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onCondition.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onCondition.ts
@@ -13,10 +13,10 @@ import {
     ExpressionParser,
     ExpressionEvaluator,
     FunctionUtils,
-    IntExpression,
-    IntExpressionConverter,
     ReturnType,
     ExpressionType,
+    NumberExpression,
+    NumberExpressionConverter,
 } from 'adaptive-expressions';
 import {
     Configurable,
@@ -38,7 +38,7 @@ import { DialogListConverter } from '../converters';
 export interface OnConditionConfiguration {
     condition?: boolean | string | Expression | BoolExpression;
     actions?: string[] | Dialog[];
-    priority?: number | string | Expression | IntExpression;
+    priority?: number | string | Expression | NumberExpression;
     runOnce?: boolean;
     id?: string;
 }
@@ -74,7 +74,7 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
     /**
      * Get or sets the rule priority expression where 0 is the highest and less than 0 is ignored.
      */
-    public priority: IntExpression = new IntExpression(0);
+    public priority: NumberExpression = new NumberExpression(0.0);
 
     /**
      * A value indicating whether rule should only run once per unique set of memory paths.
@@ -114,7 +114,7 @@ export class OnCondition extends Configurable implements DialogDependencies, OnC
             case 'actions':
                 return DialogListConverter;
             case 'priority':
-                return new IntExpressionConverter();
+                return new NumberExpressionConverter();
             default:
                 return super.getConverter(property);
         }


### PR DESCRIPTION
closes: #3349 
Now the priority in triggers is float number, where 0 is the highest and less than 0 is ignored.

The `priority` property in OnCondition now is NumberExpression, the default value is 0.