### PR TITLE
Add startTest() to all test flows

### DIFF
--- a/libraries/botbuilder-ai/tests/qnaMakerDialog.test.js
+++ b/libraries/botbuilder-ai/tests/qnaMakerDialog.test.js
@@ -163,8 +163,11 @@ describe('QnAMakerDialog', function () {
                 }
             });
 
-            await adapter.send(beginMessage);
-            await adapter.send('hi').assertReply('Welcome to the **Smart lightbulb** bot.');
+            await adapter
+                .send(beginMessage)
+                .send('hi')
+                .assertReply('Welcome to the **Smart lightbulb** bot.')
+                .startTest();
             strictEqual(qnaMessageCount, 1);
         });
 
@@ -231,8 +234,11 @@ describe('QnAMakerDialog', function () {
                 }
             });
 
-            await adapter.send(beginMessage);
-            await adapter.send('hi').assertReply('Welcome to the **Smart lightbulb** bot.');
+            await adapter
+                .send(beginMessage)
+                .send('hi')
+                .assertReply('Welcome to the **Smart lightbulb** bot.')
+                .startTest();
             strictEqual(qnaMessageCount, 1);
         });
     });

--- a/libraries/botbuilder-applicationinsights/tests/telemetryInitializer.test.js
+++ b/libraries/botbuilder-applicationinsights/tests/telemetryInitializer.test.js
@@ -53,8 +53,8 @@ describe(`TelemetryInitializerMiddleware`, function () {
             })
             .assertReply((activity) => assert.equal(activity.type, ActivityTypes.Typing))
             .assertReply('echo:bar')
-            .then(done)
-            .startTest();
+            .startTest()
+            .then(done);
     });
 
     it('calls logging middleware (when logActivityTelemetry is true)', function (done) {
@@ -87,8 +87,8 @@ describe(`TelemetryInitializerMiddleware`, function () {
             .send('bar')
             .assertReply((activity) => assert.equal(activity.type, ActivityTypes.Typing))
             .assertReply('echo:bar')
-            .then(done)
-            .startTest();
+            .startTest()
+            .then(done);
     });
 
     it('does not call logging middleware (when logActivityTelemetry is false)', function (done) {
@@ -117,8 +117,8 @@ describe(`TelemetryInitializerMiddleware`, function () {
             .send('bar')
             .assertReply((activity) => assert.equal(activity.type, ActivityTypes.Typing))
             .assertReply('echo:bar')
-            .then(done)
-            .startTest();
+            .startTest()
+            .then(done);
     });
 
     it('logActivityTelemetry() getter calls logActivityTelemetry function passed into constructor', function () {

--- a/libraries/botbuilder-applicationinsights/tests/telemetryInitializer.test.js
+++ b/libraries/botbuilder-applicationinsights/tests/telemetryInitializer.test.js
@@ -53,7 +53,8 @@ describe(`TelemetryInitializerMiddleware`, function () {
             })
             .assertReply((activity) => assert.equal(activity.type, ActivityTypes.Typing))
             .assertReply('echo:bar')
-            .then(done);
+            .then(done)
+            .startTest();
     });
 
     it('calls logging middleware (when logActivityTelemetry is true)', function (done) {
@@ -86,7 +87,8 @@ describe(`TelemetryInitializerMiddleware`, function () {
             .send('bar')
             .assertReply((activity) => assert.equal(activity.type, ActivityTypes.Typing))
             .assertReply('echo:bar')
-            .then(done);
+            .then(done)
+            .startTest();
     });
 
     it('does not call logging middleware (when logActivityTelemetry is false)', function (done) {
@@ -115,7 +117,8 @@ describe(`TelemetryInitializerMiddleware`, function () {
             .send('bar')
             .assertReply((activity) => assert.equal(activity.type, ActivityTypes.Typing))
             .assertReply('echo:bar')
-            .then(done);
+            .then(done)
+            .startTest();
     });
 
     it('logActivityTelemetry() getter calls logActivityTelemetry function passed into constructor', function () {

--- a/libraries/botbuilder-core/tests/showTypingMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/showTypingMiddleware.test.js
@@ -35,8 +35,8 @@ describe(`ShowTypingMiddleware`, function () {
             .send('bar')
             .assertReply(activity => assert.strictEqual(activity.type, ActivityTypes.Typing))
             .assertReply('echo:bar')
-            .then(done)
-            .startTest();
+            .startTest()
+            .then(done);
     });
 
     const noMiddlewareAdapter = new TestAdapter(async (context) => {
@@ -47,24 +47,24 @@ describe(`ShowTypingMiddleware`, function () {
         noMiddlewareAdapter
             .send('foo')
             .assertReply('echo:foo')
-            .then(done)
-            .startTest();
+            .startTest()
+            .then(done);
     });
 
     it('should not immediately respond with a message (rather get a typing indicator)', function (done) {
         adapter
             .send('foo')
             .assertReply(activity => assert.notStrictEqual(activity.type, ActivityTypes.Message))
-            .then(done)
-            .startTest();
+            .startTest()
+            .then(done);
     });
 
     it('should immediately respond with a message (rather get a typing indicator) if middleware not applied', function (done) {
         noMiddlewareAdapter
             .send('foo')
             .assertReply(activity => assert.strictEqual(activity.type, ActivityTypes.Message))
-            .then(done)
-            .startTest();
+            .startTest()
+            .then(done);
     });
 
     it('should not emit an uncaught exception when a promise is rejected', function (done) {
@@ -97,7 +97,7 @@ describe(`ShowTypingMiddleware`, function () {
         skillAdapter
             .send('foo')
             .assertReply('echo:foo')
-            .then(done)
-            .startTest();
+            .startTest()
+            .then(done);
     });
 });

--- a/libraries/botbuilder-core/tests/showTypingMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/showTypingMiddleware.test.js
@@ -35,7 +35,8 @@ describe(`ShowTypingMiddleware`, function () {
             .send('bar')
             .assertReply(activity => assert.strictEqual(activity.type, ActivityTypes.Typing))
             .assertReply('echo:bar')
-            .then(done);
+            .then(done)
+            .startTest();
     });
 
     const noMiddlewareAdapter = new TestAdapter(async (context) => {
@@ -46,21 +47,24 @@ describe(`ShowTypingMiddleware`, function () {
         noMiddlewareAdapter
             .send('foo')
             .assertReply('echo:foo')
-            .then(done);
+            .then(done)
+            .startTest();
     });
 
     it('should not immediately respond with a message (rather get a typing indicator)', function (done) {
         adapter
             .send('foo')
             .assertReply(activity => assert.notStrictEqual(activity.type, ActivityTypes.Message))
-            .then(done);
+            .then(done)
+            .startTest();
     });
 
     it('should immediately respond with a message (rather get a typing indicator) if middleware not applied', function (done) {
         noMiddlewareAdapter
             .send('foo')
             .assertReply(activity => assert.strictEqual(activity.type, ActivityTypes.Message))
-            .then(done);
+            .then(done)
+            .startTest();
     });
 
     it('should not emit an uncaught exception when a promise is rejected', function (done) {
@@ -93,6 +97,7 @@ describe(`ShowTypingMiddleware`, function () {
         skillAdapter
             .send('foo')
             .assertReply('echo:foo')
-            .then(done);
+            .then(done)
+            .startTest();
     });
 });

--- a/libraries/botbuilder-core/tests/storageBaseTests.js
+++ b/libraries/botbuilder-core/tests/storageBaseTests.js
@@ -300,7 +300,8 @@ class StorageBaseTests {
 
         dialogs.add(new WaterfallDialog('waterfallDialog', steps));
 
-        await adapter.send('hello')
+        await adapter
+            .send('hello')
             .assertReply('step1')
             .send('hello')
             .assertReply('Please type your name.')

--- a/libraries/botbuilder-core/tests/transcriptMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/transcriptMiddleware.test.js
@@ -33,7 +33,8 @@ describe(`TranscriptLoggerMiddleware`, function () {
             .assertReply('echo:foo')
             .send('bar')
             .assertReply((activity) => assert.equal(activity.type, ActivityTypes.Typing))
-            .assertReply('echo:bar');
+            .assertReply('echo:bar')
+            .startTest();
 
         const pagedResult = await transcriptStore.getTranscriptActivities('test', conversationId);
         assert.equal(pagedResult.items.length, 6);
@@ -67,7 +68,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
             }
         }).use(new TranscriptLoggerMiddleware(transcriptStore));
 
-        await adapter.send('foo').delay(100).send('update').delay(100);
+        await adapter.send('foo').delay(100).send('update').delay(100).startTest();
 
         const pagedResult = await transcriptStore.getTranscriptActivities('test', conversationId);
         assert(pagedResult.items.length, 4);
@@ -92,7 +93,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
             }
         }).use(new TranscriptLoggerMiddleware(transcriptStore));
 
-        await adapter.send('foo').assertReply('response').send('deleteIt').delay(500);
+        await adapter.send('foo').assertReply('response').send('deleteIt').delay(500).startTest();
 
         const pagedResult = await transcriptStore.getTranscriptActivities('test', conversationId);
 
@@ -113,7 +114,8 @@ describe(`TranscriptLoggerMiddleware`, function () {
         await adapter
             .send('foo')
             .send('bar')
-            .send({ type: ActivityTypes.Event, name: ActivityEventNames.ContinueConversation });
+            .send({ type: ActivityTypes.Event, name: ActivityEventNames.ContinueConversation })
+            .startTest();
 
         const pagedResult = await transcriptStore.getTranscriptActivities('test', conversationId);
         assert.strictEqual(pagedResult.items.length, 2, 'only the two message activities should be logged');
@@ -150,7 +152,8 @@ describe(`TranscriptLoggerMiddleware`, function () {
             .assertReply('echo:foo')
             .send('bar')
             .assertReply((activity) => assert.equal(activity.type, ActivityTypes.Typing))
-            .assertReply('echo:bar');
+            .assertReply('echo:bar')
+            .startTest();
 
         const pagedResult = await transcriptStore.getTranscriptActivities('test', conversationId);
         assert.equal(pagedResult.items.length, 6);
@@ -203,7 +206,8 @@ describe(`TranscriptLoggerMiddleware`, function () {
             .assertReply('echo:foo')
             .send('bar')
             .assertReply((activity) => assert.equal(activity.type, ActivityTypes.Typing))
-            .assertReply('echo:bar');
+            .assertReply('echo:bar')
+            .startTest();
 
         const pagedResult = await transcriptStore.getTranscriptActivities('test', conversationId);
         assert.equal(pagedResult.items.length, 6);
@@ -246,7 +250,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         adapter.use(new TranscriptLoggerMiddleware(transcriptStore));
         adapter.use(new NoResourceResponseMiddleware());
 
-        await adapter.send('foo').assertReply('echo:foo');
+        await adapter.send('foo').assertReply('echo:foo').startTest();
 
         const pagedResult = await transcriptStore.getTranscriptActivities('test', conversationId);
         assert.equal(pagedResult.items.length, 2);
@@ -298,7 +302,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         adapter.use(new TranscriptLoggerMiddleware(transcriptStore));
         adapter.use(new Returns1Middleware());
 
-        await adapter.send('foo').assertReply('echo:foo');
+        await adapter.send('foo').assertReply('echo:foo').startTest();
 
         const pagedResult = await transcriptStore.getTranscriptActivities('test', conversationId);
         assert.equal(pagedResult.items.length, 2);
@@ -359,12 +363,12 @@ describe(`TranscriptLoggerMiddleware`, function () {
 
         testCases.forEach((testCase) => {
             it(`should print to console ${testCase.label} from synchronous logActivity()`, async function () {
-                await mockedAdapter(testCase.expectedError).send('test');
+                await mockedAdapter(testCase.expectedError).send('test').startTest();
                 sandbox.verify();
             });
 
             it(`should print to console ${testCase.label} from asynchronous logActivity().`, async function () {
-                await mockedAdapter(testCase.expectedError, true).send('test');
+                await mockedAdapter(testCase.expectedError, true).send('test').startTest();
                 await new Promise((resolve) => process.nextTick(resolve));
                 sandbox.verify();
             });
@@ -391,7 +395,8 @@ describe(`TranscriptLoggerMiddleware`, function () {
             // sent activities do not contain the id returned from the service, so it should be undefined here
             .assertReply((activity) => assert.equal(activity.id, undefined) && assert.equal(activity.text, 'echo:foo'))
             .send('bar')
-            .assertReply((activity) => assert.equal(activity.id, undefined) && assert.equal(activity.text, 'echo:bar'));
+            .assertReply((activity) => assert.equal(activity.id, undefined) && assert.equal(activity.text, 'echo:bar'))
+            .startTest();
 
         const pagedResult = await transcriptStore.getTranscriptActivities('test', conversationId);
         assert.equal(pagedResult.items.length, 4);
@@ -437,7 +442,8 @@ describe(`TranscriptLoggerMiddleware`, function () {
                 assert.equal(activity.id, undefined);
                 assert.equal(activity.text, 'echo:foo');
                 assert.equal(activity.timestamp, timestamp);
-            });
+            })
+            .startTest();
 
         const pagedResult = await transcriptStore.getTranscriptActivities('test', conversationId);
         assert.equal(pagedResult.items.length, 2);
@@ -483,7 +489,8 @@ describe(`TranscriptLoggerMiddleware`, function () {
             .assertReply((activity) => {
                 assert.equal(activity.id, undefined);
                 assert.equal(activity.text, 'echo:foo');
-            });
+            })
+            .startTest();
 
         const pagedResult = await transcriptStore.getTranscriptActivities('test', conversationId);
         assert.equal(pagedResult.items.length, 2);

--- a/libraries/botbuilder-dialogs-adaptive/tests/adaptiveDialog.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/adaptiveDialog.test.js
@@ -182,6 +182,7 @@ describe('AdaptiveDialog', function () {
             .assertReply('child dialog has ended and returned back')
             .send('where')
             .assertReply('outer dialog..')
+            .startTest();
     });
 
     it('Custom AttachmentInput dialog with no file', async () => {

--- a/libraries/botbuilder-dialogs-adaptive/tests/beginSkill.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/beginSkill.test.js
@@ -126,7 +126,7 @@ describe('BeginSkill', function () {
             ok(postActivityStub.calledOnce);
         });
 
-        await adapter.send('test');
+        await adapter.send('test').startTest();
     });
     
     it('should respect allow interruptions settings', async () => {
@@ -138,7 +138,7 @@ describe('BeginSkill', function () {
             strictEqual(bubbling, true);
         });
         
-        await adapter.send('test');
+        await adapter.send('test').startTest();
     });
 });
 

--- a/libraries/botbuilder-dialogs-adaptive/tests/inputDialog.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/inputDialog.test.js
@@ -50,6 +50,6 @@ describe('InputDialog', function () {
             ok(trackEventStub.calledOnce);
         });
 
-        await adapter.send('test');
+        await adapter.send('test').startTest();
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive/tests/logAction.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/logAction.test.js
@@ -48,6 +48,6 @@ describe('LogAction', function () {
             ok(trackEventStub.calledOnce);
         });
 
-        await adapter.send('test');
+        await adapter.send('test').startTest();
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive/tests/memory_memoryScopes.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/memory_memoryScopes.test.js
@@ -47,7 +47,8 @@ describe('Memory - Memory Scopes', function () {
             .assertReply('adaptiveDialog2')
             .assertReply('false')
             .assertReply('true')
-            .assertReply('true');
+            .assertReply('true')
+            .startTest();
     });
 
     it('DialogContextMemoryScope interruption test', async function () {

--- a/libraries/botbuilder-dialogs-adaptive/tests/sendActivity.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/sendActivity.test.js
@@ -47,6 +47,6 @@ describe('SendActivity', function () {
             ok(trackEventStub.calledOnce);
         });
 
-        await adapter.send('test');
+        await adapter.send('test').startTest();
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive/tests/telemetryTrackEventAction.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/telemetryTrackEventAction.test.js
@@ -45,6 +45,6 @@ describe('TelemetryTrackEventAction', function () {
             ok(trackEventStub.calledOnce);
         });
 
-        await adapter.send('test');
+        await adapter.send('test').startTest();
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive/tests/updateActivity.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/updateActivity.test.js
@@ -50,6 +50,6 @@ describe('UpdateActivity', function () {
             ok(trackEventStub.calledOnce);
         });
 
-        await adapter.send('test');
+        await adapter.send('test').startTest();
     });
 });

--- a/libraries/botbuilder-dialogs/tests/activityPrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/activityPrompt.test.js
@@ -44,7 +44,8 @@ describe('ActivityPrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please send an activity.')
             .send('test')
-            .assertReply('You said test');
+            .assertReply('You said test')
+            .startTest();
     });
 
     it('should re-prompt with original prompt if validator returned false.', async function () {
@@ -73,7 +74,8 @@ describe('ActivityPrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please send an activity.')
             .send('test')
-            .assertReply('Please send an activity.');
+            .assertReply('Please send an activity.')
+            .startTest();
     });
 
     it('should re-prompt with custom retryPrompt if validator returned false.', async function () {
@@ -102,7 +104,8 @@ describe('ActivityPrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please send activity.')
             .send('test')
-            .assertReply('Activity not received.');
+            .assertReply('Activity not received.')
+            .startTest();
     });
 
     it('should see attemptCount increment.', async function() {
@@ -153,7 +156,8 @@ describe('ActivityPrompt', function () {
             .send('300')
             .assertReply('attemptCount 3')
             .send({ type: ActivityTypes.Event })
-            .assertReply(`You sent a(n) ${ ActivityTypes.Event }`);
+            .assertReply(`You sent a(n) ${ ActivityTypes.Event }`)
+            .startTest();
     });
 
     it('should not have resumeDialog() use the retry prompt.', async function() {

--- a/libraries/botbuilder-dialogs/tests/attachmentPrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/attachmentPrompt.test.js
@@ -36,7 +36,8 @@ describe('AttachmentPrompt', function() {
         await adapter.send('Hello')
         .assertReply('Please send an attachment.')
         .send(answerMessage)
-        .assertReply('test1');
+        .assertReply('test1')
+        .startTest();
     });
 
     it('should call AttachmentPrompt with custom validator.', function (done) {
@@ -66,7 +67,8 @@ describe('AttachmentPrompt', function() {
         adapter.send('Hello')
         .assertReply('Please send an attachment.')
         .send(answerMessage)
-        .assertReply('test1');
+        .assertReply('test1')
+        .startTest();
         done();
     });
 
@@ -100,6 +102,7 @@ describe('AttachmentPrompt', function() {
         .assertReply('Please try again.')
         .send(answerMessage)
         .assertReply('test1')
+        .startTest();
         done();
     });
 
@@ -137,6 +140,7 @@ describe('AttachmentPrompt', function() {
         .assertReply('Bad input.')
         .send(answerMessage)
         .assertReply('test1')
+        .startTest();
         done();
     });
 
@@ -165,6 +169,7 @@ describe('AttachmentPrompt', function() {
         .send('what?')
         .send(answerMessage)
         .assertReply('test1')
+        .startTest();
         done();
     });
 

--- a/libraries/botbuilder-dialogs/tests/choicePrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/choicePrompt.test.js
@@ -40,7 +40,8 @@ describe('ChoicePrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please choose a color.')
             .send(answerMessage)
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should send a prompt and choices if they are passed in via PromptOptions.', async function () {
@@ -68,7 +69,8 @@ describe('ChoicePrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please choose a color.')
             .send(answerMessage)
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should call ChoicePrompt with custom validator.', async function () {
@@ -100,7 +102,8 @@ describe('ChoicePrompt', function () {
             .send(invalidMessage)
             .assertReply('Please choose a color.')
             .send(answerMessage)
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should convert incomplete Choices with `action` when using ListStyle.suggestedAction styling.', async function () {
@@ -134,7 +137,8 @@ describe('ChoicePrompt', function () {
             .send(invalidMessage)
             .assertReply('Please choose a color.')
             .send(answerMessage)
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should appropriately apply ListStyle.none when set via PromptOptions', async function () {
@@ -167,7 +171,8 @@ describe('ChoicePrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please choose a color.')
             .send(answerMessage)
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should send custom retryPrompt.', async function () {
@@ -196,7 +201,8 @@ describe('ChoicePrompt', function () {
             .send(invalidMessage)
             .assertReply('Please choose red, blue, or green.')
             .send(answerMessage)
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should send ignore retryPrompt if validator replies.', async function () {
@@ -231,7 +237,8 @@ describe('ChoicePrompt', function () {
             .send(invalidMessage)
             .assertReply('bad input.')
             .send(answerMessage)
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should use defaultLocale when rendering choices', async function () {
@@ -267,7 +274,8 @@ describe('ChoicePrompt', function () {
             .send(invalidMessage)
             .assertReply('bad input.')
             .send({ text: 'red', type: ActivityTypes.Message, locale: undefined })
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should use context.activity.locale when rendering choices', async function () {
@@ -299,7 +307,8 @@ describe('ChoicePrompt', function () {
         await adapter.send({ text: 'Hello', type: ActivityTypes.Message, locale: 'es-es' })
             .assertReply('Please choose a color. (1) red, (2) green, o (3) blue')
             .send(answerMessage)
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should use context.activity.locale over defaultLocale when rendering choices', async function () {
@@ -331,7 +340,8 @@ describe('ChoicePrompt', function () {
         await adapter.send({ text: 'Hello', type: ActivityTypes.Message, locale: 'en-us' })
             .assertReply('Please choose a color. (1) red, (2) green, or (3) blue')
             .send(answerMessage)
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should recognize locale variations of correct locales', async function () {
@@ -415,7 +425,8 @@ describe('ChoicePrompt', function () {
                             expectedAnswer = activity.text;
                         }
                         assert.strictEqual(activity.text, expectedAnswer);
-                    });
+                    })
+                    .startTest();
             }));
         }));      
     });
@@ -460,7 +471,8 @@ describe('ChoicePrompt', function () {
                         inlineSeparator: PromptCultureModels.English.separator,
                     }).text;
                     assert.strictEqual(activity.text, `Please choose a color.${ expectedChoices }`);
-                });
+                })
+                .startTest();
         }));   
     });
 
@@ -516,7 +528,8 @@ describe('ChoicePrompt', function () {
                     inlineSeparator: culture.separator
                 }).text;
                 assert.strictEqual(activity.text, `Please choose a color.${ expectedChoices }`);
-            });
+            })
+            .startTest();
     });
 
     it('should not render choices and not blow up if choices aren\'t passed in', async function () {
@@ -542,7 +555,8 @@ describe('ChoicePrompt', function () {
         dialogs.add(choicePrompt);
 
         await adapter.send('Hello')
-            .assertReply('Please choose a color.');
+            .assertReply('Please choose a color.')
+            .startTest();
     });
 
     it('should render choices if PromptOptions & choices are passed into DialogContext.prompt()', async function() {
@@ -570,7 +584,8 @@ describe('ChoicePrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please choose a color. (1) red, (2) green, or (3) blue')
             .send(answerMessage)
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should send a prompt and choices if they are passed in via third argument in dc.prompt().', async function () {
@@ -598,7 +613,8 @@ describe('ChoicePrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please choose a color.')
             .send(answerMessage)
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should not recognize if choices are not passed in.', async function () {
@@ -626,7 +642,8 @@ describe('ChoicePrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please choose a color.')
             .send('hello')
-            .assertReply('Please choose a color.');
+            .assertReply('Please choose a color.')
+            .startTest();
     });
 
     it('should use a Partial Activity when calculating message text during appendChoices.', async function () {
@@ -658,7 +675,8 @@ describe('ChoicePrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please choose a color.')
             .send(answerMessage)
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should create prompt with inline choices when specified.', async function () {
@@ -690,7 +708,8 @@ describe('ChoicePrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please choose a color. (1) red, (2) green, or (3) blue')
             .send(answerMessage)
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should create prompt with list choices when specified.', async function () {
@@ -722,7 +741,8 @@ describe('ChoicePrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please choose a color.\n\n   1. red\n   2. green\n   3. blue')
             .send(answerMessage)
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should recognize valid number choice.', async function () {
@@ -753,7 +773,8 @@ describe('ChoicePrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please choose a color.')
             .send('1')
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should not recognize, then re-prompt without error for falsy input.', async function () {
@@ -788,7 +809,8 @@ describe('ChoicePrompt', function () {
             .send({ type: ActivityTypes.Message, text: null })
             .assertReply('Please choose a color.')
             .send('1')
-            .assertReply('red');
+            .assertReply('red')
+            .startTest();
     });
 
     it('should display choices on a hero card', async function () {
@@ -824,7 +846,8 @@ describe('ChoicePrompt', function () {
                 assert(activity.attachments[0].content.text === 'Please choose a size.');
             })
             .send('1')
-            .assertReply('large');
+            .assertReply('large')
+            .startTest();
     });
     
     it('should display choices on a hero card with an additional attachment', async function (done) {
@@ -866,7 +889,8 @@ describe('ChoicePrompt', function () {
                 assert(response.attachments.length === 2);
                 assert(response.attachments[0].contentType === CardFactory.contentTypes.adaptiveCard);
                 assert(response.attachments[1].contentType === CardFactory.contentTypes.heroCard);
-            });
+            })
+            .startTest();
         done();
     });
 

--- a/libraries/botbuilder-dialogs/tests/componentDialog.test.js
+++ b/libraries/botbuilder-dialogs/tests/componentDialog.test.js
@@ -49,7 +49,7 @@ describe('ComponentDialog', function () {
             const results = await dc.beginDialog('composite', { foo: 'bar' });
         });
 
-        adapter.send('Hi');
+        adapter.send('Hi').startTest();
         done();
     });
 
@@ -77,7 +77,7 @@ describe('ComponentDialog', function () {
                     done();
                 });
         });
-        adapter.send('Hi');
+        adapter.send('Hi').startTest();
     });
 
     it('should have DialogTurnResult.status equal DialogTurnStatus.complete when endComponent() is called.', (done) => {
@@ -104,7 +104,7 @@ describe('ComponentDialog', function () {
             done();
         });
 
-        adapter.send('Hi');
+        adapter.send('Hi').startTest();
     });
 
     it(`should return Dialog.EndOfTurn if the dialog's turnResult.status === 'waiting'.`, (done) => {
@@ -135,7 +135,7 @@ describe('ComponentDialog', function () {
             done();
         });
 
-        adapter.send('Hi');
+        adapter.send('Hi').startTest();
     });
 
     it('should return any found dialogs.', (done) => {
@@ -198,6 +198,7 @@ describe('ComponentDialog', function () {
             .send('Hi again')
             .assertReply('Called onContinueDialog.')
             .assertReply('Done.')
+            .startTest();
     });
 
     it('should cancel all Dialogs inside of ComponentDialog namespace.', () => {
@@ -213,7 +214,7 @@ describe('ComponentDialog', function () {
             },
             async step => {
                 simpleStepContextCheck(step);
-                await step.context.send('Should not have sent this message.');
+                await step.context.sendActivity('Should not have sent this message.');
                 return await step.endDialog();
             }
         ]);
@@ -242,7 +243,8 @@ describe('ComponentDialog', function () {
 
         adapter.send('Hi')
             .assertReply('Reached first component dialog child.')
-            .assertReply('Cancelling all component dialog dialogs.');
+            .assertReply('Cancelling all component dialog dialogs.')
+            .startTest();
     });
 
     it('should not cancel any Dialogs outside of ComponentDialog namespace.', () => {
@@ -292,7 +294,8 @@ describe('ComponentDialog', function () {
         adapter.send('Hi')
             .assertReply('Reached first component dialog child.')
             .assertReply('Cancelling all component dialog dialogs.')
-            .assertReply('Cancelled successfully.');
+            .assertReply('Cancelled successfully.')
+            .startTest();
     });
 
     it('should call a dialog defined in a parent component.', (done) => {
@@ -345,7 +348,8 @@ describe('ComponentDialog', function () {
             .assertReply('Child started.')
             .assertReply('Parent called with: test')
             .assertReply('Child finished.')
-            .then(() => done());
+            .then(() => done())
+            .startTest();
     });
 
     it('should handle that a components children have changed.', (done) => {
@@ -396,7 +400,8 @@ describe('ComponentDialog', function () {
             .assertReply('First step.')
             .send('Hi again')
             .assertReply('Second step.')
-            .assertReply('Done.');
+            .assertReply('Done.')
+            .startTest();
     });
 });
 

--- a/libraries/botbuilder-dialogs/tests/confirmPrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/confirmPrompt.test.js
@@ -34,7 +34,8 @@ describe('ConfirmPrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please confirm. (1) Yes or (2) No')
             .send('yes')
-            .assertReply(`The result found is 'true'.`);
+            .assertReply(`The result found is 'true'.`)
+            .startTest();
     });
 
     it('should call ConfirmPrompt with custom validator.', async function () {
@@ -65,6 +66,7 @@ describe('ConfirmPrompt', function () {
             .assertReply('Please confirm. Yes or No')
             .send('no')
             .assertReply(`The result found is 'false'.`)
+            .startTest();
     });
 
     it('should send custom retryPrompt.', async function () {
@@ -98,6 +100,7 @@ describe('ConfirmPrompt', function () {
             .assertReply(`Please reply with 'Yes' or 'No'.`)
             .send('no')
             .assertReply(`The result found is 'false'.`)
+            .startTest();
     });
 
     it('should send custom retryPrompt if validator does not reply.', async function () {
@@ -133,6 +136,7 @@ describe('ConfirmPrompt', function () {
             .assertReply(`Please reply with 'Yes' or 'No'.`)
             .send('no')
             .assertReply(`The result found is 'false'.`)
+            .startTest();
     });
 
     it('should ignore retryPrompt if validator replies.', async function () {
@@ -172,6 +176,7 @@ describe('ConfirmPrompt', function () {
             .assertReply('The correct response is either yes or no. Please choose one.')
             .send('no')
             .assertReply(`The result found is 'false'.`)
+            .startTest();
     });
 
     it('should not send any retryPrompt if no prompt is specified.', async function () {
@@ -202,6 +207,7 @@ describe('ConfirmPrompt', function () {
             .assertReply('')
             .send('no')
             .assertReply(`The result found is 'false'.`)
+            .startTest();
     });
 
     it('should send retryPrompt if user sends attachment and no text.', async function () {
@@ -234,7 +240,8 @@ describe('ConfirmPrompt', function () {
             .send({ type: ActivityTypes.Message, attachments: ['ignoreThis']})
             .assertReply(`Please reply with 'Yes' or 'No'.`)
             .send('no')
-            .assertReply(`The result found is 'false'.`);
+            .assertReply(`The result found is 'false'.`)
+            .startTest();
     });
 
     it('should not recognize, then re-prompt without error for falsy input.', async function () {
@@ -269,7 +276,8 @@ describe('ConfirmPrompt', function () {
             .send({ type: ActivityTypes.Message, text: null })
             .assertReply('Please reply with \'Yes\' or \'No\'.')
             .send('no')
-            .assertReply(`The result found is 'false'.`);
+            .assertReply(`The result found is 'false'.`)
+            .startTest();
     });
 
     it('should use defaultLocale when rendering choices', async function () {
@@ -307,7 +315,8 @@ describe('ConfirmPrompt', function () {
             .send(invalidMessage)
             .assertReply('bad input.')
             .send({ text: 'はい', type: ActivityTypes.Message })
-            .assertReply('true');
+            .assertReply('true')
+            .startTest();
     });
 
     it('should use context.activity.locale when rendering choices', async function () {
@@ -343,7 +352,8 @@ describe('ConfirmPrompt', function () {
         await adapter.send({ text: 'Hello', type: ActivityTypes.Message, locale: 'ja-jp' })
             .assertReply('Please confirm. (1) はい または (2) いいえ')
             .send({ text: 'いいえ', type: ActivityTypes.Message, locale: 'ja-jp' })
-            .assertReply('false');
+            .assertReply('false')
+            .startTest();
     });
 
     it('should use context.activity.locale over defaultLocale when rendering choices', async function () {
@@ -379,7 +389,8 @@ describe('ConfirmPrompt', function () {
         await adapter.send({ text: 'Hello', type: ActivityTypes.Message, locale: 'ja-jp' })
             .assertReply('Please confirm. (1) はい または (2) いいえ')
             .send({ text: 'いいえ', type: ActivityTypes.Message, locale: 'ja-jp' })
-            .assertReply('false');
+            .assertReply('false')
+            .startTest();
     });
 
     it('should recognize locale variations of correct locales', async function () {
@@ -467,7 +478,8 @@ describe('ConfirmPrompt', function () {
                             expectedAnswer = activity.text;
                         }
                         assert.strictEqual(activity.text, expectedAnswer);
-                    });
+                    })
+                    .startTest();
             }));
         }));       
     });
@@ -526,7 +538,8 @@ describe('ConfirmPrompt', function () {
         await adapter.send({ text: 'Hello', type: ActivityTypes.Message, locale: culture.locale })
             .assertReply('Please confirm. (1) customYes customOr (2) customNo')
             .send('customYes')
-            .assertReply('true');
+            .assertReply('true')
+            .startTest();
     });
 
     it('should recognize yes with no PromptOptions.', async function () {
@@ -555,7 +568,8 @@ describe('ConfirmPrompt', function () {
             .send('lala')
             .assertReply(' (1) Yes or (2) No')
             .send('yes')
-            .assertReply(`The result found is 'true'.`);
+            .assertReply(`The result found is 'true'.`)
+            .startTest();
     });
 
     it('should recognize valid number when choiceOptions.includeNumbers is true.', async function () {
@@ -587,7 +601,8 @@ describe('ConfirmPrompt', function () {
             .send('lala')
             .assertReply('Please confirm, say "yes" or "no" or something like that. (1) Yes or (2) No')
             .send('1')
-            .assertReply(`The result found is 'true'.`);
+            .assertReply(`The result found is 'true'.`)
+            .startTest();
     });
 
     it('should recognize valid number and default to en if locale is null.', async function () {
@@ -622,7 +637,8 @@ describe('ConfirmPrompt', function () {
             .send('lala')
             .assertReply('Please confirm, say "yes" or "no" or something like that. (1) Yes or (2) No')
             .send('1')
-            .assertReply(`The result found is 'true'.`);
+            .assertReply(`The result found is 'true'.`)
+            .startTest();
     });
 
     it('should recognize valid number and default to en if locale invalid string.', async function () {
@@ -657,7 +673,8 @@ describe('ConfirmPrompt', function () {
             .send('lala')
             .assertReply('Please confirm, say "yes" or "no" or something like that. (1) Yes or (2) No')
             .send('1')
-            .assertReply(`The result found is 'true'.`);
+            .assertReply(`The result found is 'true'.`)
+            .startTest();
     });
 
     it('should recognize valid number and default to en if defaultLocale invalid string.', async function () {
@@ -690,7 +707,8 @@ describe('ConfirmPrompt', function () {
             .send('lala')
             .assertReply('Please confirm, say "yes" or "no" or something like that. (1) Yes or (2) No')
             .send('1')
-            .assertReply(`The result found is 'true'.`);
+            .assertReply(`The result found is 'true'.`)
+            .startTest();
     });
     
     it('should not recognize invalid number when choiceOptions.includeNumbers is true.', async function () {
@@ -722,7 +740,8 @@ describe('ConfirmPrompt', function () {
             .send('400')
             .assertReply('Please confirm, say "yes" or "no" or something like that. (1) Yes or (2) No')
             .send('1')
-            .assertReply(`The result found is 'true'.`);
+            .assertReply(`The result found is 'true'.`)
+            .startTest();
     });
 
     it('should not recognize valid number choice when choiceOptions.includeNumbers is false.', async function () {
@@ -754,7 +773,8 @@ describe('ConfirmPrompt', function () {
             .send('1')
             .assertReply('Please confirm, say "yes" or "no" or something like that. Yes or No')
             .send('no')
-            .assertReply(`The result found is 'false'.`);
+            .assertReply(`The result found is 'false'.`)
+            .startTest();
     });
 
     it('should recognize valid number when choiceOptions.includeNumbers is undefined.', async function () {
@@ -786,6 +806,7 @@ describe('ConfirmPrompt', function () {
             .send('lala')
             .assertReply('Please confirm, say "yes" or "no" or something like that. Yes or No')
             .send('1')
-            .assertReply(`The result found is 'true'.`);
+            .assertReply(`The result found is 'true'.`)
+            .startTest();
     });
 });

--- a/libraries/botbuilder-dialogs/tests/datetimePrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/datetimePrompt.test.js
@@ -34,7 +34,8 @@ describe('DatetimePrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please say something.')
             .send(answerMessage)
-            .assertReply('2018-01-01T09');
+            .assertReply('2018-01-01T09')
+            .startTest();
     });
 
     it('should send a prompt if the prompt is passed in via PromptOptions.', async function () {
@@ -59,7 +60,8 @@ describe('DatetimePrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please say something.')
             .send(answerMessage)
-            .assertReply('2018-01-01T09');
+            .assertReply('2018-01-01T09')
+            .startTest();
     });
 
     it('should call DateTimePrompt with custom validator.', async function () {
@@ -88,7 +90,8 @@ describe('DatetimePrompt', function () {
         await adapter.send('Hello')
             .assertReply('Please say something.')
             .send(answerMessage)
-            .assertReply('2018-01-01T09');
+            .assertReply('2018-01-01T09')
+            .startTest();
     });
 
     it('should send custom retryPrompt.', async function () {
@@ -119,7 +122,8 @@ describe('DatetimePrompt', function () {
             .send(invalidMessage)
             .assertReply('Please provide a valid datetime.')
             .send(answerMessage2)
-            .assertReply('2012-09-02');
+            .assertReply('2012-09-02')
+            .startTest();
     });
 
     it('should send ignore retryPrompt if validator replies.', async function () {
@@ -153,7 +157,8 @@ describe('DatetimePrompt', function () {
             .send(invalidMessage)
             .assertReply('That was a bad date.')
             .send(answerMessage2)
-            .assertReply('2012-09-02');
+            .assertReply('2012-09-02')
+            .startTest();
     });
 
     it('should not send any retryPrompt no prompt specified.', async function () {
@@ -182,7 +187,8 @@ describe('DatetimePrompt', function () {
         await adapter.send('Hello')
             .send(invalidMessage)
             .send(answerMessage2)
-            .assertReply('2012-09-02');
+            .assertReply('2012-09-02')
+            .startTest();
     });
 
     it('should not recognize, then re-prompt without error for falsy input.', async function () {
@@ -214,6 +220,7 @@ describe('DatetimePrompt', function () {
             .send({ type: ActivityTypes.Message, text: null })
             .assertReply('Enter a date.')
             .send(answerMessage)
-            .assertReply('2018-01-01T09');
+            .assertReply('2018-01-01T09')
+            .startTest();
     });
 });

--- a/libraries/botbuilder-dialogs/tests/dialog.test.js
+++ b/libraries/botbuilder-dialogs/tests/dialog.test.js
@@ -46,7 +46,8 @@ describe('Dialog', function () {
         dialogs.add(dialog);
 
         await adapter.send(beginMessage)
-            .assertReply('begin called');
+            .assertReply('begin called')
+            .startTest();
     });
 
     it('should receive dialog options when beginning a dialog from a dialog set.', async function () {
@@ -64,7 +65,8 @@ describe('Dialog', function () {
         dialogs.add(dialog);
 
         await adapter.send(beginMessage)
-            .assertReply('begin called');
+            .assertReply('begin called')
+            .startTest();
     });
 
     it('should continue() a multi-turn dialog.', async function () {
@@ -95,6 +97,7 @@ describe('Dialog', function () {
         await adapter.send(beginMessage)
             .assertReply('begin called')
             .send('continue')
-            .assertReply('120');
+            .assertReply('120')
+            .startTest();
     });
 });

--- a/libraries/botbuilder-dialogs/tests/dialogContext.test.js
+++ b/libraries/botbuilder-dialogs/tests/dialogContext.test.js
@@ -34,7 +34,7 @@ describe('DialogContext', function() {
             }
         ]));
 
-        adapter.send(beginMessage);
+        adapter.send(beginMessage).startTest();
     });
 
     it('beginDialog() should pass in dialogOptions to a begun dialog.', function (done) {
@@ -61,7 +61,7 @@ describe('DialogContext', function() {
             }
         ]));
 
-        adapter.send(beginMessage);
+        adapter.send(beginMessage).startTest();
     });
 
     it('should return error if beginDialog() called with invalid dialogId.', function (done) {
@@ -94,7 +94,7 @@ describe('DialogContext', function() {
             }
         ]));
 
-        adapter.send(beginMessage);
+        adapter.send(beginMessage).startTest();
     });
 
     it('should pass prompt() args to dialog.', function (done) {
@@ -118,7 +118,7 @@ describe('DialogContext', function() {
             }
         ]));
 
-        adapter.send(beginMessage);
+        adapter.send(beginMessage).startTest();
     });
 
     it('should pass undefined prompt() to dialog.', function (done) {
@@ -141,7 +141,7 @@ describe('DialogContext', function() {
             }
         ]));
 
-        adapter.send(beginMessage);
+        adapter.send(beginMessage).startTest();
     });
 
     it('should pass choice array to prompt() to dialog.', function (done) {
@@ -166,7 +166,7 @@ describe('DialogContext', function() {
             }
         ]));
 
-        adapter.send(beginMessage);
+        adapter.send(beginMessage).startTest();
     });
 
     it('should return a value to parent when endDialog() called with a value.', function (done) {
@@ -202,7 +202,7 @@ describe('DialogContext', function() {
             }
         ]));
 
-        adapter.send(beginMessage);
+        adapter.send(beginMessage).startTest();
     });
 
     it('should continue() execution of a dialog.', function (done) {
@@ -240,7 +240,8 @@ describe('DialogContext', function() {
         ]));
 
         adapter.send(beginMessage)
-            .send(continueMessage);
+            .send(continueMessage)
+            .startTest();
     });
 
     it('should return an error if dialog not found when continue() called.', function (done) {
@@ -283,7 +284,8 @@ describe('DialogContext', function() {
         ]));
 
         adapter.send(beginMessage)
-            .send(continueMessage);
+            .send(continueMessage)
+            .startTest();
     });
 
     it(`should return a DialogTurnResult if continue() is called without an activeDialog.`, function (done) {
@@ -301,7 +303,7 @@ describe('DialogContext', function() {
 
         const dialogs = new DialogSet(dialogState);        
 
-        adapter.send(beginMessage);
+        adapter.send(beginMessage).startTest();
     });
 
     it('should return to parent dialog when endDialog() called.', function (done) {
@@ -339,7 +341,7 @@ describe('DialogContext', function() {
             }
         ]));
 
-        adapter.send(beginMessage);
+        adapter.send(beginMessage).startTest();
     });
 
     it(`should accept calls to end when no activeDialogs or parent dialogs exist.`, function (done) {
@@ -365,7 +367,7 @@ describe('DialogContext', function() {
             }
         ]));
 
-        adapter.send(beginMessage);
+        adapter.send(beginMessage).startTest();
     });
 
     it(`should replace() dialog.`, function (done) {
@@ -399,7 +401,7 @@ describe('DialogContext', function() {
             }
         ]));
 
-        adapter.send(beginMessage);
+        adapter.send(beginMessage).startTest();
     });
 
     it(`should begin dialog if stack empty when replaceDialog() called with valid dialogId.`, function (done) {
@@ -422,6 +424,6 @@ describe('DialogContext', function() {
             }
         ]));
 
-        adapter.send(beginMessage);
+        adapter.send(beginMessage).startTest();
     });
 });

--- a/libraries/botbuilder-dialogs/tests/dialogSet.test.js
+++ b/libraries/botbuilder-dialogs/tests/dialogSet.test.js
@@ -123,7 +123,8 @@ describe('DialogSet', function () {
             .assertReply('Greetings')
             .send(continueMessage)
             .assertReply('Good bye!')
-            .then(() => done());
+            .then(() => done())
+            .startTest();
     });
 
     it('should generate a version hash of added dialogs.', function (done) {

--- a/libraries/botbuilder-dialogs/tests/numberPrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/numberPrompt.test.js
@@ -37,7 +37,7 @@ describe('NumberPrompt', function () {
             (turnContext, result) => turnContext.sendActivity(result.toString())
         );
 
-        await adapter.send('Hello').assertReply('Please send a number.').send('35').assertReply('35');
+        await adapter.send('Hello').assertReply('Please send a number.').send('35').assertReply('35').startTest();
     });
 
     it('should call NumberPrompt with custom validator.', async function () {
@@ -57,7 +57,8 @@ describe('NumberPrompt', function () {
             .send('0')
             .assertReply('Please send a number.')
             .send('25')
-            .assertReply('25');
+            .assertReply('25')
+            .startTest();
     });
 
     it('should send custom retryPrompt.', async function () {
@@ -81,7 +82,8 @@ describe('NumberPrompt', function () {
             .send('0')
             .assertReply('Please send a number between 1 and 100.')
             .send('42')
-            .assertReply('42');
+            .assertReply('42')
+            .startTest();
     });
 
     it('should send ignore retryPrompt if validator replies.', async function () {
@@ -109,7 +111,8 @@ describe('NumberPrompt', function () {
             .send('-1')
             .assertReply('out of range')
             .send('67')
-            .assertReply('67');
+            .assertReply('67')
+            .startTest();
     });
 
     it('should not send any retryPrompt no prompt specified.', async function () {
@@ -123,7 +126,7 @@ describe('NumberPrompt', function () {
             }
         );
 
-        await adapter.send('Hello').send('0').send('25').assertReply('25');
+        await adapter.send('Hello').send('0').send('25').assertReply('25').startTest();
     });
 
     it('should recognize 0 and zero as valid values', async function () {
@@ -147,7 +150,8 @@ describe('NumberPrompt', function () {
             .send('Another!')
             .assertReply('Send me a zero')
             .send('zero')
-            .assertReply('0');
+            .assertReply('0')
+            .startTest();
     });
 
     it('should see attemptCount increment', async function () {
@@ -185,7 +189,8 @@ describe('NumberPrompt', function () {
             .send('300')
             .assertReply('attemptCount 3')
             .send('0')
-            .assertReply('ok');
+            .assertReply('ok')
+            .startTest();
     });
 
     it('should consider culture specified in constructor', async function () {
@@ -199,7 +204,7 @@ describe('NumberPrompt', function () {
             'es-es'
         );
 
-        await adapter.send('Hello').assertReply('Please send a number.').send('3,14');
+        await adapter.send('Hello').assertReply('Please send a number.').send('3,14').startTest();
     });
 
     it('should consider culture specified in activity', async function () {
@@ -216,7 +221,8 @@ describe('NumberPrompt', function () {
         await adapter
             .send('Hello')
             .assertReply('Please send a number.')
-            .send({ type: ActivityTypes.Message, text: '3,14', locale: 'es-es' });
+            .send({ type: ActivityTypes.Message, text: '3,14', locale: 'es-es' })
+            .startTest();
     });
 
     it('should consider default to en-us culture when no culture is specified', async function () {
@@ -228,7 +234,7 @@ describe('NumberPrompt', function () {
             }
         );
 
-        await adapter.send('Hello').assertReply('Please send a number.').send('1,500.25');
+        await adapter.send('Hello').assertReply('Please send a number.').send('1,500.25').startTest();
     });
 
     it('should fall back to default locale if culture is not registered', async function () {
@@ -243,6 +249,7 @@ describe('NumberPrompt', function () {
         await adapter
             .send('Hello')
             .assertReply('Please send a number.')
-            .send({ type: ActivityTypes.Message, text: '3,14', locale: 'it-it' });
+            .send({ type: ActivityTypes.Message, text: '3,14', locale: 'it-it' })
+            .startTest();
     });
 });

--- a/libraries/botbuilder-dialogs/tests/oauthPrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/oauthPrompt.test.js
@@ -65,7 +65,8 @@ describe('OAuthPrompt', function() {
 
                 adapter.send(eventActivity);
             })
-            .assertReply('Logged in.');
+            .assertReply('Logged in.')
+            .startTest();
     });
 
     it('should call OAuthPrompt with code', async function() {
@@ -111,7 +112,8 @@ describe('OAuthPrompt', function() {
                 adapter.addUserToken(connectionName, activity.channelId, activity.recipient.id, token, magicCode);
             })
             .send(magicCode)
-            .assertReply('Logged in.');
+            .assertReply('Logged in.')
+            .startTest();
     });
 
     it('should timeout OAuthPrompt with message activity', async function() {
@@ -212,7 +214,8 @@ describe('OAuthPrompt', function() {
                 adapter.addExchangeableToken(connectionName, activity.channelId, activity.recipient.id, exchangeToken, token);
             })  
             .send('invalid text message here')
-            .assertReply('Ended');
+            .assertReply('Ended')
+            .startTest();
     });
 
     it('should see attemptCount increment', async function() {
@@ -290,7 +293,8 @@ describe('OAuthPrompt', function() {
             .send('123456')
             .assertReply('attemptCount 3')
             .send(magicCode)
-            .assertReply('Logged in');
+            .assertReply('Logged in')
+            .startTest();
     });
 
     it('should call OAuthPrompt for streaming connection', async function() {
@@ -367,7 +371,8 @@ describe('OAuthPrompt', function() {
 
                 adapter.send(eventActivity);
             })
-            .assertReply('Logged in.');
+            .assertReply('Logged in.')
+            .startTest();
     });
 
     describe('private methods', () => {
@@ -656,7 +661,8 @@ describe('OAuthPrompt', function() {
 
         it('Test adapter should be able to perform token exchanges for token', async function() {
             await adapter
-                .send('hello');
+                .send('hello')
+                .startTest();
         });
     });
 
@@ -727,7 +733,8 @@ describe('OAuthPrompt', function() {
                     assert.strictEqual(a.value.body.connectionName, connectionName);
                     assert(a.value.body.failureDetail === null);
                 })
-                .assertReply('Logged in.');
+                .assertReply('Logged in.')
+                .startTest();
         });
 
         it('Should reject token exchange requests if token cannot be exchanged', async function() {
@@ -754,7 +761,8 @@ describe('OAuthPrompt', function() {
                     assert(a.value);
                     assert.strictEqual(a.value.status, 412);
                     assert(a.value.body.failureDetail);
-                });
+                })
+                .startTest();
         });
 
         it('Should reject token exhchange requests with no body', async function() {
@@ -777,7 +785,8 @@ describe('OAuthPrompt', function() {
                     assert(a.value);
                     assert.strictEqual(a.value.status, 400);
                     assert(a.value.body.failureDetail);
-                });
+                })
+                .startTest();
         });
 
         it('Should reject token exhchange requests with wrong connection name', async function() {
@@ -805,7 +814,8 @@ describe('OAuthPrompt', function() {
                     assert.strictEqual(a.value.status, 400);
                     assert.strictEqual(a.value.body.connectionName, connectionName);
                     assert(a.value.body.failureDetail);
-                });
+                })
+                .startTest();
         });
     });
 });
@@ -908,5 +918,6 @@ async function testTimeout(oauthPromptActivity, shouldSucceed = true, tokenRespo
             adapter.addExchangeableToken(connectionName, activity.channelId, activity.recipient.id, exchangeToken, token);
         })  
         .send(oauthPromptActivity)
-        .assertReply(noTokenResponse);
+        .assertReply(noTokenResponse)
+        .startTest();
 }

--- a/libraries/botbuilder-dialogs/tests/textPrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/textPrompt.test.js
@@ -34,7 +34,8 @@ describe('TextPrompt', function() {
         await adapter.send('Hello')
             .assertReply('Please say something.')
             .send('test')
-            .assertReply('test');
+            .assertReply('test')
+            .startTest();
     });
 
     it('should call TextPrompt with custom validator.', async function() {
@@ -65,7 +66,8 @@ describe('TextPrompt', function() {
             .send('i')
             .assertReply('Please say something.')
             .send('test')
-            .assertReply('test');
+            .assertReply('test')
+            .startTest();
     });
 
     it('should call TextPrompt with naughty strings.', async function() {
@@ -93,7 +95,8 @@ describe('TextPrompt', function() {
                 await adapter.send('Hello')
                     .assertReply('Enter some text')
                     .send(naughtyString)
-                    .assertReply(naughtyString);
+                    .assertReply(naughtyString)
+                    .startTest();
             }
         });
     });
@@ -123,7 +126,8 @@ describe('TextPrompt', function() {
             .send(invalidMessage)
             .assertReply('Text is required.')
             .send('test')
-            .assertReply('test');
+            .assertReply('test')
+            .startTest();
     });
 
     it('should send ignore retryPrompt if validator replies.', async function() {
@@ -158,7 +162,8 @@ describe('TextPrompt', function() {
             .send('i')
             .assertReply('too short')
             .send('test')
-            .assertReply('test');
+            .assertReply('test')
+            .startTest();
     });
 
     it('should not send any retryPrompt no prompt specified.', async function() {
@@ -184,6 +189,7 @@ describe('TextPrompt', function() {
         await adapter.send('Hello')
             .send(invalidMessage)
             .send('test')
-            .assertReply('test');
+            .assertReply('test')
+            .startTest();
     });
 });

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -36,7 +36,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, `I'm a teapot.`);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
 
         });
@@ -58,7 +57,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.text, 'Hello');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
     });
@@ -100,7 +98,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 501, 'should be a status code 501.');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -118,7 +115,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -136,7 +132,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -154,7 +149,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -172,7 +166,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -190,7 +183,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -208,7 +200,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -226,7 +217,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -244,7 +234,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -272,7 +261,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.message, 'Cannot read property \'activity\' of null', 'should have thrown an error.');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
     });
@@ -294,7 +282,6 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -314,7 +301,6 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
     });
@@ -336,7 +322,6 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -356,7 +341,6 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -376,7 +360,6 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -396,7 +379,6 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -415,7 +397,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -434,7 +415,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -453,7 +433,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -472,7 +451,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -491,7 +469,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -510,7 +487,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -529,7 +505,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -586,7 +561,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -605,7 +579,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -624,7 +597,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -643,7 +615,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -662,7 +633,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -681,7 +651,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -700,7 +669,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
     });
@@ -734,7 +702,6 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -754,7 +721,6 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -780,7 +746,6 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -934,7 +899,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -952,7 +916,6 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
     });
@@ -1015,7 +978,6 @@ describe('TeamsActivityHandler', () => {
                     assert(fileConsentAcceptCalled, 'handleTeamsFileConsentAccept handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1037,7 +999,6 @@ describe('TeamsActivityHandler', () => {
                     assert(fileConsentDeclineCalled, 'handleTeamsFileConsentDecline handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
     });
@@ -1104,7 +1065,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1127,7 +1087,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1150,7 +1109,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1208,7 +1166,6 @@ describe('TeamsActivityHandler', () => {
                     TeamsInfo.getMember = wasGetMember;
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1234,7 +1191,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1292,7 +1248,6 @@ describe('TeamsActivityHandler', () => {
                     TeamsInfo.getMember = wasGetMember;
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1416,7 +1371,6 @@ describe('TeamsActivityHandler', () => {
                     TeamsInfo.getMember = wasGetMember;
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1466,7 +1420,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1492,7 +1445,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1541,7 +1493,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1590,7 +1541,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1639,7 +1589,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1688,7 +1637,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
         
@@ -1734,7 +1682,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1780,7 +1727,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1826,7 +1772,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1872,7 +1817,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1918,7 +1862,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -1964,7 +1907,6 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -2004,7 +1946,6 @@ describe('TeamsActivityHandler', () => {
                     assert(handleTeamsSigninVerifyStateCalled, 'handleTeamsSigninVerifyState handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
 
@@ -2044,7 +1985,6 @@ describe('TeamsActivityHandler', () => {
                     assert(handleTeamsSigninTokenExchangeCalled, 'handleTeamsSigninTokenExchange handler not called');
                     done();
                 })
-                .catch(err => done(err))
                 .startTest();
         });
     });

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -36,7 +36,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, `I'm a teapot.`);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
 
         });
 
@@ -57,7 +58,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.text, 'Hello');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
     });
 
@@ -98,7 +100,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 501, 'should be a status code 501.');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('activity.name is "actionableMessage/executeAction". should return status code [200] when handleTeamsO365ConnectorCardAction method is overridden.', done => {
@@ -115,7 +118,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('activity.name is "composeExtension/queryLink". should return status code [200] when handleTeamsAppBasedLinkQuery method is overridden.', done => {
@@ -132,7 +136,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('activity.name is "composeExtension/query". should return status code [200] when handleTeamsMessagingExtensionQuery method is overridden.', done => {
@@ -149,7 +154,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('activity.name is "composeExtension/selectItem". should return status code [200] when handleTeamsMessagingExtensionSelectItem method is overridden.', done => {
@@ -166,7 +172,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('activity.name is "composeExtension/fetchTask". should return status code [200] when handleTeamsMessagingExtensionFetchTask method is overridden.', done => {
@@ -183,7 +190,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('activity.name is "composeExtension/querySettingUrl". should return status code [200] when handleTeamsMessagingExtensionConfigurationQuerySettingUrl method is overridden.', done => {
@@ -200,7 +208,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('activity.name is "composeExtension/setting". should return status code [200] when handleTeamsMessagingExtensionConfigurationSetting method is overridden.', done => {
@@ -217,7 +226,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('activity.name is "composeExtension/onCardButtonClicked". should return status code [200] when handleTeamsMessagingExtensionCardButtonClicked method is overridden.', done => {
@@ -234,7 +244,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('should throw an error when onInvokeActivity param context is null.', done => {
@@ -261,7 +272,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.message, 'Cannot read property \'activity\' of null', 'should have thrown an error.');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
     });
 
@@ -282,7 +294,8 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('a bad FileConsentCardResponse.action is received by the bot', done => {
@@ -301,7 +314,8 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
     });
 
@@ -322,7 +336,8 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsBotMessagePreviewEdit is not overridden', done => {
@@ -341,7 +356,8 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsBotMessagePreviewSend is not overridden', done => {
@@ -360,7 +376,8 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsFileConsentAccept is not overridden', done => {
@@ -379,7 +396,8 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsFileConsentDecline is not overridden', done => {
@@ -397,7 +415,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsO365ConnectorCardAction is not overridden', done => {
@@ -415,7 +434,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsSigninVerifyState is not overridden', done => {
@@ -433,7 +453,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsSigninTokenExchange is not overridden', done => {
@@ -451,7 +472,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsMessagingExtensionCardButtonClicked is not overridden', done => {
@@ -469,7 +491,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsTaskModuleFetch is not overridden', done => {
@@ -487,7 +510,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsTaskModuleSubmit is not overridden', done => {
@@ -505,7 +529,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsTabFetch is not overridden', async () => {
@@ -561,7 +586,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsMessagingExtensionConfigurationQuerySettingUrl is not overridden', done => {
@@ -579,7 +605,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsMessagingExtensionQuery is not overridden', done => {
@@ -597,7 +624,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsMessagingExtensionSelectItem is not overridden', done => {
@@ -615,7 +643,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsMessagingExtensionFetchTask is not overridden', done => {
@@ -633,7 +662,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsMessagingExtensionConfigurationQuerySettingUrl is not overridden', done => {
@@ -651,7 +681,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsMessagingExtensionConfigurationSetting is not overridden', done => {
@@ -669,7 +700,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
     });
 
@@ -702,7 +734,8 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('when a "fileConsent/invoke" activity is handled by handleTeamsFileConsentDecline', done => {
@@ -721,7 +754,8 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('when a "fileConsent/invoke" activity handled by handleTeamsFileConsent', done => {
@@ -746,7 +780,8 @@ describe('TeamsActivityHandler', () => {
                         `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
 
@@ -802,7 +837,8 @@ describe('TeamsActivityHandler', () => {
                         assert.strictEqual(activity.value.body, bot.taskFetchReturn);
                         done();
                     })
-                    .catch(err => done(err));
+                    .catch(err => done(err))
+                    .startTest();
             });
 
             it('an overridden handleTeamsTaskModuleSubmit()', done => {
@@ -821,7 +857,8 @@ describe('TeamsActivityHandler', () => {
                         assert.strictEqual(activity.value.body, bot.taskSubmitReturn);
                         done();
                     })
-                    .catch(err => done(err));
+                    .catch(err => done(err))
+                    .startTest();
             });
 
             it('an overridden handleTeamsTabFetch()', async () => {
@@ -897,7 +934,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsMessagingExtensionSubmitActionDispatch() receives an unexpected botMessagePreviewAction value', done => {
@@ -914,7 +952,8 @@ describe('TeamsActivityHandler', () => {
                     assert.strictEqual(activity.value.body, undefined);
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
     });
 
@@ -976,7 +1015,8 @@ describe('TeamsActivityHandler', () => {
                     assert(fileConsentAcceptCalled, 'handleTeamsFileConsentAccept handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('handleTeamsFileConsent handler before an handleTeamsFileConsentDecline handler', done => {
@@ -997,7 +1037,8 @@ describe('TeamsActivityHandler', () => {
                     assert(fileConsentDeclineCalled, 'handleTeamsFileConsentDecline handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
     });
 
@@ -1063,7 +1104,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('MS-Teams with non-existent channelData.eventType routed activity', done => {
@@ -1085,7 +1127,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('MS-Teams with no channelData routed activity', done => {
@@ -1107,7 +1150,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsMembersAdded routed activity', done => {
@@ -1164,7 +1208,8 @@ describe('TeamsActivityHandler', () => {
                     TeamsInfo.getMember = wasGetMember;
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsMembersAdded routed activity with no TeamsMembersAddedEvent handler', done => {
@@ -1189,7 +1234,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsMembersAdded for bot routed activity should throw a ConversationNotFound Error on TeamsInfo.getMember', done => {
@@ -1246,7 +1292,8 @@ describe('TeamsActivityHandler', () => {
                     TeamsInfo.getMember = wasGetMember;
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsMembersAdded for bot routed activity should throw an Error on TeamsInfo.getMember', done => {
@@ -1310,7 +1357,8 @@ describe('TeamsActivityHandler', () => {
                     } else {
                         done(err);
                     }
-                });
+                })
+                .startTest();
         });
 
         it('onTeamsMembersAdded for bot routed activity does NOT call TeamsInfo.getMember', done => {
@@ -1368,7 +1416,8 @@ describe('TeamsActivityHandler', () => {
                     TeamsInfo.getMember = wasGetMember;
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsMembersRemoved routed activity', done => {
@@ -1417,7 +1466,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsMembersRemoved routed activity with no TeamsMembersRemovedEvent handler', done => {
@@ -1442,7 +1492,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsChannelCreated routed activity', done => {
@@ -1490,7 +1541,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsChannelDeleted routed activity', done => {
@@ -1538,7 +1590,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsChannelRenamed routed activity', done => {
@@ -1586,7 +1639,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsChannelRestored routed activity', done => {
@@ -1634,7 +1688,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
         
         it('onTeamsTeamRenamed routed activity', done => {
@@ -1679,7 +1734,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsTeamArchived routed activity', done => {
@@ -1724,7 +1780,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsTeamDeleted routed activity', done => {
@@ -1769,7 +1826,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsTeamHardDeleted routed activity', done => {
@@ -1814,7 +1872,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsTeamRestored routed activity', done => {
@@ -1859,7 +1918,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('onTeamsTeamUnarchived routed activity', done => {
@@ -1904,7 +1964,8 @@ describe('TeamsActivityHandler', () => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('signin/verifyState routed activity', done => {
@@ -1943,7 +2004,8 @@ describe('TeamsActivityHandler', () => {
                     assert(handleTeamsSigninVerifyStateCalled, 'handleTeamsSigninVerifyState handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
 
         it('signin/tokenExchange routed activity', done => {
@@ -1982,7 +2044,8 @@ describe('TeamsActivityHandler', () => {
                     assert(handleTeamsSigninTokenExchangeCalled, 'handleTeamsSigninTokenExchange handler not called');
                     done();
                 })
-                .catch(err => done(err));
+                .catch(err => done(err))
+                .startTest();
         });
     });
 });


### PR DESCRIPTION
Fixes #3231

## Description

Mostly no-op, but makes debugging a little easier. See linked issue for more info.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Append `startTest()` to the end of all TestFlows

## Testing

I edited a few flows to make them fail to confirm they all still work appropriately.