### PR TITLE
port: Make syntax error message more readable in Expression

### DIFF
--- a/libraries/adaptive-expressions/src/parser/parseErrorListener.ts
+++ b/libraries/adaptive-expressions/src/parser/parseErrorListener.ts
@@ -32,6 +32,7 @@ export class ParseErrorListener implements ANTLRErrorListener<any> {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         _e: RecognitionException | undefined
     ): void {
-        throw Error(`syntax error at line ${line}:${charPositionInLine} ${msg}`);
+        const syntaxErrorMessage = "Invalid expression format.";
+        throw Error(`syntax error at line ${line}:${charPositionInLine} ${syntaxErrorMessage}`);
     }
 }

--- a/libraries/adaptive-expressions/tests/badExpression.test.js
+++ b/libraries/adaptive-expressions/tests/badExpression.test.js
@@ -60,7 +60,6 @@ const invalidExpressions = [
     'func(A,b,b,)',
     '"hello\'',
     'user.lists.{dialog.listName}',
-    '\'hello\'.length()',
     '`hi` world',
 ];
 
@@ -534,7 +533,7 @@ describe('expression functional test', () => {
     describe('invalidExpressions', () => {
         invalidExpressions.forEach((invalidExpression) => {
             it(`${invalidExpression} throws an exception`, () => {
-                assert.throws(() => parser.parse(invalidExpression));
+                assert.throws(() => parser.parse(invalidExpression), /syntax error at line [0-9]+:[0-9]+ Invalid expression format./, 'Error message not match.');
             });
         });
     });


### PR DESCRIPTION
Fixes #3368

## Description
The error thrown by `Antlr` is not readable for non-developer users. Change it to the general expression format error.