### PR TITLE
port: enable LG syntax in OAuthInput

### DIFF
--- a/libraries/adaptive-expressions/src/expression.ts
+++ b/libraries/adaptive-expressions/src/expression.ts
@@ -227,7 +227,7 @@ export class Expression {
      * @returns The expression object.
      */
     public static parse(expression: string, lookup?: EvaluatorLookup): Expression {
-        return new ExpressionParser(lookup || Expression.lookup).parse(expression);
+        return new ExpressionParser(lookup || Expression.lookup).parse(expression.replace(/^=/, ''));
     }
 
     /**

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/TestScriptTests_OAuthInputLG.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/TestScriptTests_OAuthInputLG.test.dialog
@@ -1,0 +1,36 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "description": "Test UserTokenMock set Property",
+    "generator": "main.lg",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.OAuthInput",
+                        "connectionName": "magiccode x",
+                        "text": "${OAuthInputText()}",
+                        "title": "${OAuthInputTitle()}",
+                        "property": "dialog.token"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hello"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+            "assertions": [
+              "attachments[0].content.text == 'OAuth text set!'",
+              "attachments[0].content.buttons[0].title == 'OAuth title set!'"
+            ]
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/TestScriptTests_OAuthInputMockProperties.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/TestScriptTests_OAuthInputMockProperties.test.dialog
@@ -1,0 +1,45 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "description": "Test UserTokenMock set Property",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "property": "dialog.textProperty",
+                      "value": "Set the text!"
+                    },
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "property": "dialog.titleProperty",
+                      "value": "Set the title!"
+                    },
+                    {
+                        "$kind": "Microsoft.OAuthInput",
+                        "connectionName": "magiccode x",
+                        "text": "=dialog.textProperty",
+                        "title": "=dialog.titleProperty",
+                        "property": "dialog.token"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hello"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+            "assertions": [
+              "attachments[0].content.text == 'Set the text!'",
+              "attachments[0].content.buttons[0].title == 'Set the title!'"
+            ]
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/main.lg
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/TestScriptTests/main.lg
@@ -1,0 +1,5 @@
+# OAuthInputText()
+- OAuth text set!
+
+# OAuthInputTitle()
+- OAuth title set!

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/testScript.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/testScript.test.js
@@ -104,6 +104,14 @@ describe('TestScriptTests', function () {
         await TestUtils.runTestScript(resourceExplorer, 'TestScriptTests_HttpRequestQnAMakerDialogMock');
     });
 
+    it('OAuthInputLG', async () => {
+        await TestUtils.runTestScript(resourceExplorer, 'TestScriptTests_OAuthInputLG');
+    });
+
+    it('OAuthInputMockProperties', async () => {
+        await TestUtils.runTestScript(resourceExplorer, 'TestScriptTests_OAuthInputMockProperties');
+    });
+
     it('OAuthInputRetries_WithNullMessageText', async () => {
         await TestUtils.runTestScript(resourceExplorer, 'TestScriptTests_OAuthInputRetries_WithNullMessageText');
     });

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -206,8 +206,7 @@ export class OAuthPrompt extends Dialog {
             return await dc.endDialog(output);
         } else {
             // Prompt user to login
-            await this.sendOAuthCardAsync(dc.context, state.options.prompt);
-
+            await OAuthPrompt.sendOAuthCard(this.settings, dc.context, state.options.prompt);
             return Dialog.EndOfTurn;
         }
     }
@@ -229,9 +228,9 @@ export class OAuthPrompt extends Dialog {
         const isMessage: boolean = dc.context.activity.type === ActivityTypes.Message;
         const isTimeoutActivityType: boolean =
             isMessage ||
-            this.isTokenResponseEvent(dc.context) ||
-            this.isTeamsVerificationInvoke(dc.context) ||
-            this.isTokenExchangeRequestInvoke(dc.context);
+            OAuthPrompt.isTokenResponseEvent(dc.context) ||
+            OAuthPrompt.isTeamsVerificationInvoke(dc.context) ||
+            OAuthPrompt.isTokenExchangeRequestInvoke(dc.context);
 
         // If the incoming Activity is a message, or an Activity Type normally handled by OAuthPrompt,
         // check to see if this OAuthPrompt Expiration has elapsed, and end the dialog if so.
@@ -327,14 +326,17 @@ export class OAuthPrompt extends Dialog {
         return adapter.signOutUser(context, this.settings.connectionName, null, this.settings.oAuthAppCredentials);
     }
 
-    /**
-     * @private
-     */
-    private async sendOAuthCardAsync(context: TurnContext, prompt?: string | Partial<Activity>): Promise<void> {
+    public static async sendOAuthCard(
+        settings: OAuthPromptSettings,
+        turnContext: TurnContext,
+        prompt?: string | Partial<Activity>
+    ): Promise<void> {
         // Validate adapter type
-        if (!('getUserToken' in context.adapter)) {
-            throw new Error(`OAuthPrompt.sendOAuthCardAsync(): not supported for the current adapter.`);
+        if (!('getUserToken' in turnContext.adapter)) {
+            throw new Error(`OAuthPrompt.sendOAuthCard(): not supported for the current adapter.`);
         }
+
+        const adapter: ExtendedUserTokenProvider = turnContext.adapter;
 
         // Initialize outgoing message
         const msg: Partial<Activity> =
@@ -345,78 +347,73 @@ export class OAuthPrompt extends Dialog {
             msg.attachments = [];
         }
 
-        // Add login card as needed
-        if (this.isOAuthCardSupported(context)) {
-            const cards: Attachment[] = msg.attachments.filter(
-                (a: Attachment) => a.contentType === CardFactory.contentTypes.oauthCard
-            );
-            if (cards.length === 0) {
-                let cardActionType = ActionTypes.Signin;
-                const signInResource = await (context.adapter as ExtendedUserTokenProvider).getSignInResource(
-                    context,
-                    this.settings.connectionName,
-                    context.activity.from.id,
-                    null,
-                    this.settings.oAuthAppCredentials
-                );
-                let link = signInResource.signInLink;
-                const identity = context.turnState.get((context.adapter as BotAdapter).BotIdentityKey);
-
-                // use the SignInLink when
-                //   in speech channel or
-                //   bot is a skill or
-                //   an extra OAuthAppCredentials is being passed in
-                if (
-                    (identity && isSkillClaim(identity.claims)) ||
-                    OAuthPrompt.isFromStreamingConnection(context.activity) ||
-                    this.settings.oAuthAppCredentials
-                ) {
-                    if (context.activity.channelId === Channels.Emulator) {
-                        cardActionType = ActionTypes.OpenUrl;
-                    }
-                } else if (!this.channelRequiresSignInLink(context.activity.channelId)) {
-                    link = undefined;
-                }
-
-                // Append oauth card
-                const card = CardFactory.oauthCard(
-                    this.settings.connectionName,
-                    this.settings.title,
-                    this.settings.text,
-                    link,
-                    signInResource.tokenExchangeResource
-                );
-
-                // Set the appropriate ActionType for the button.
-                (card.content as OAuthCard).buttons[0].type = cardActionType;
-                msg.attachments.push(card);
-            }
-        } else {
-            const cards: Attachment[] = msg.attachments.filter(
-                (a: Attachment) => a.contentType === CardFactory.contentTypes.signinCard
-            );
-            if (cards.length === 0) {
+        // Append appropriate card if missing
+        if (!this.isOAuthCardSupported(turnContext)) {
+            if (!msg.attachments.some((a: Attachment) => a.contentType === CardFactory.contentTypes.signinCard)) {
                 // Append signin card
-                const signInResource = await (context.adapter as ExtendedUserTokenProvider).getSignInResource(
-                    context,
-                    this.settings.connectionName,
-                    context.activity.from.id,
-                    null,
-                    this.settings.oAuthAppCredentials
+                const signInResource = await adapter.getSignInResource(
+                    turnContext,
+                    settings.connectionName,
+                    turnContext.activity.from.id,
+                    undefined,
+                    settings.oAuthAppCredentials
                 );
-                msg.attachments.push(
-                    CardFactory.signinCard(this.settings.title, signInResource.signInLink, this.settings.text)
-                );
+                msg.attachments.push(CardFactory.signinCard(settings.title, signInResource.signInLink, settings.text));
             }
+        } else if (!msg.attachments.some((a: Attachment) => a.contentType === CardFactory.contentTypes.oauthCard)) {
+            let cardActionType = ActionTypes.Signin;
+            const signInResource = await adapter.getSignInResource(
+                turnContext,
+                settings.connectionName,
+                turnContext.activity.from.id,
+                undefined,
+                settings.oAuthAppCredentials
+            );
+            let link = signInResource.signInLink;
+            const identity = turnContext.turnState.get((turnContext.adapter as BotAdapter).BotIdentityKey);
+
+            // use the SignInLink when
+            //   in speech channel or
+            //   bot is a skill or
+            //   an extra OAuthAppCredentials is being passed in
+            if (
+                OAuthPrompt.isFromStreamingConnection(turnContext.activity) ||
+                (identity && isSkillClaim(identity.claims)) ||
+                settings.oAuthAppCredentials
+            ) {
+                if (turnContext.activity.channelId === Channels.Emulator) {
+                    cardActionType = ActionTypes.OpenUrl;
+                }
+            } else if (!this.channelRequiresSignInLink(turnContext.activity.channelId)) {
+                link = undefined;
+            }
+
+            // Append oauth card
+            const card = CardFactory.oauthCard(
+                settings.connectionName,
+                settings.title,
+                settings.text,
+                link,
+                signInResource.tokenExchangeResource
+            );
+
+            // Set the appropriate ActionType for the button.
+            (card.content as OAuthCard).buttons[0].type = cardActionType;
+            msg.attachments.push(card);
         }
 
         // Add the login timeout specified in OAuthPromptSettings to TurnState so it can be referenced if polling is needed
-        if (!context.turnState.get(OAuthLoginTimeoutKey) && this.settings.timeout) {
-            context.turnState.set(OAuthLoginTimeoutKey, this.settings.timeout);
+        if (!turnContext.turnState.get(OAuthLoginTimeoutKey) && settings.timeout) {
+            turnContext.turnState.set(OAuthLoginTimeoutKey, settings.timeout);
+        }
+
+        // Set input hint
+        if (!msg.inputHint) {
+            msg.inputHint = InputHints.AcceptingInput;
         }
 
         // Send prompt
-        await context.sendActivity(msg);
+        await turnContext.sendActivity(msg);
     }
 
     /**
@@ -425,7 +422,7 @@ export class OAuthPrompt extends Dialog {
     private async recognizeToken(dc: DialogContext): Promise<PromptRecognizerResult<TokenResponse>> {
         const context = dc.context;
         let token: TokenResponse | undefined;
-        if (this.isTokenResponseEvent(context)) {
+        if (OAuthPrompt.isTokenResponseEvent(context)) {
             token = context.activity.value as TokenResponse;
 
             // Fix-up the DialogContext's state context if this was received from a skill host caller.
@@ -454,7 +451,7 @@ export class OAuthPrompt extends Dialog {
                 // For JavaScript Maps, set() functions as Add() and Set() in the C# TurnContextStateCollection
                 context.turnState.set(connectorClientBuilder.ConnectorClientKey, connectorClient);
             }
-        } else if (this.isTeamsVerificationInvoke(context)) {
+        } else if (OAuthPrompt.isTeamsVerificationInvoke(context)) {
             const code: any = context.activity.value.state;
             try {
                 token = await this.getUserToken(context, code);
@@ -466,9 +463,9 @@ export class OAuthPrompt extends Dialog {
             } catch (e) {
                 await context.sendActivity({ type: 'invokeResponse', value: { status: 500 } });
             }
-        } else if (this.isTokenExchangeRequestInvoke(context)) {
+        } else if (OAuthPrompt.isTokenExchangeRequestInvoke(context)) {
             // Received activity is not a token exchange request
-            if (!(context.activity.value && this.isTokenExchangeRequest(context.activity.value))) {
+            if (!(context.activity.value && OAuthPrompt.isTokenExchangeRequest(context.activity.value))) {
                 await context.sendActivity(
                     this.getTokenExchangeInvokeResponse(
                         StatusCodes.BAD_REQUEST,
@@ -481,7 +478,7 @@ export class OAuthPrompt extends Dialog {
                     this.getTokenExchangeInvokeResponse(
                         StatusCodes.BAD_REQUEST,
                         'The bot received an InvokeActivity with a TokenExchangeInvokeRequest containing a ConnectionName that does not match the ConnectionName' +
-                            'expected by the bots active OAuthPrompt. Ensure these names match when sending the InvokeActivityInvalid ConnectionName in the TokenExchangeInvokeRequest'
+                        'expected by the bots active OAuthPrompt. Ensure these names match when sending the InvokeActivityInvalid ConnectionName in the TokenExchangeInvokeRequest'
                     )
                 );
             } else if (!('exchangeToken' in context.adapter)) {
@@ -574,7 +571,7 @@ export class OAuthPrompt extends Dialog {
     /**
      * @private
      */
-    private isTokenResponseEvent(context: TurnContext): boolean {
+    private static isTokenResponseEvent(context: TurnContext): boolean {
         const activity: Activity = context.activity;
 
         return activity.type === ActivityTypes.Event && activity.name === tokenResponseEventName;
@@ -583,7 +580,7 @@ export class OAuthPrompt extends Dialog {
     /**
      * @private
      */
-    private isTeamsVerificationInvoke(context: TurnContext): boolean {
+    private static isTeamsVerificationInvoke(context: TurnContext): boolean {
         const activity: Activity = context.activity;
 
         return activity.type === ActivityTypes.Invoke && activity.name === verifyStateOperationName;
@@ -592,7 +589,7 @@ export class OAuthPrompt extends Dialog {
     /**
      * @private
      */
-    private isOAuthCardSupported(context: TurnContext): boolean {
+    private static isOAuthCardSupported(context: TurnContext): boolean {
         // Azure Bot Service OAuth cards are not supported in the community adapters. Since community adapters
         // have a 'name' in them, we cast the adapter to 'any' to check for the name.
         const adapter: any = context.adapter;
@@ -615,7 +612,7 @@ export class OAuthPrompt extends Dialog {
     /**
      * @private
      */
-    private isTokenExchangeRequestInvoke(context: TurnContext): boolean {
+    private static isTokenExchangeRequestInvoke(context: TurnContext): boolean {
         const activity: Activity = context.activity;
 
         return activity.type === ActivityTypes.Invoke && activity.name === tokenExchangeOperationName;
@@ -624,17 +621,14 @@ export class OAuthPrompt extends Dialog {
     /**
      * @private
      */
-    private isTokenExchangeRequest(obj: unknown): obj is TokenExchangeInvokeRequest {
+    private static isTokenExchangeRequest(obj: unknown): obj is TokenExchangeInvokeRequest {
         if (obj.hasOwnProperty('token')) {
             return true;
         }
         return false;
     }
 
-    /**
-     * @private
-     */
-    private channelSupportsOAuthCard(channelId: string): boolean {
+    public static channelSupportsOAuthCard(channelId: string): boolean {
         switch (channelId) {
             case Channels.Cortana:
             case Channels.Skype:
@@ -649,7 +643,7 @@ export class OAuthPrompt extends Dialog {
     /**
      * @private
      */
-    private channelRequiresSignInLink(channelId: string): boolean {
+    private static channelRequiresSignInLink(channelId: string): boolean {
         switch (channelId) {
             case Channels.Msteams:
                 return true;

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -628,7 +628,10 @@ export class OAuthPrompt extends Dialog {
         return false;
     }
 
-    public static channelSupportsOAuthCard(channelId: string): boolean {
+    /**
+     * @private
+     */
+    private static channelSupportsOAuthCard(channelId: string): boolean {
         switch (channelId) {
             case Channels.Cortana:
             case Channels.Skype:

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -326,6 +326,13 @@ export class OAuthPrompt extends Dialog {
         return adapter.signOutUser(context, this.settings.connectionName, null, this.settings.oAuthAppCredentials);
     }
 
+    /**
+     * Sends an OAuth card.
+     *
+     * @param {OAuthPromptSettings} settings OAuth settings.
+     * @param {TurnContext} turnContext Turn context.
+     * @param {string | Partial<Activity>} prompt Message activity.
+     */
     public static async sendOAuthCard(
         settings: OAuthPromptSettings,
         turnContext: TurnContext,

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -227,9 +227,9 @@ export class OAuthPrompt extends Dialog {
         const state: OAuthPromptState = dc.activeDialog.state as OAuthPromptState;
         const isMessage: boolean = dc.context.activity.type === ActivityTypes.Message;
         const isTimeoutActivityType: boolean =
-            isMessage ||
-            OAuthPrompt.isTokenResponseEvent(dc.context) ||
-            OAuthPrompt.isTeamsVerificationInvoke(dc.context) ||
+            isMessage ??
+            OAuthPrompt.isTokenResponseEvent(dc.context) ??
+            OAuthPrompt.isTeamsVerificationInvoke(dc.context) ??
             OAuthPrompt.isTokenExchangeRequestInvoke(dc.context);
 
         // If the incoming Activity is a message, or an Activity Type normally handled by OAuthPrompt,

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -227,9 +227,9 @@ export class OAuthPrompt extends Dialog {
         const state: OAuthPromptState = dc.activeDialog.state as OAuthPromptState;
         const isMessage: boolean = dc.context.activity.type === ActivityTypes.Message;
         const isTimeoutActivityType: boolean =
-            isMessage ??
-            OAuthPrompt.isTokenResponseEvent(dc.context) ??
-            OAuthPrompt.isTeamsVerificationInvoke(dc.context) ??
+            isMessage ||
+            OAuthPrompt.isTokenResponseEvent(dc.context) ||
+            OAuthPrompt.isTeamsVerificationInvoke(dc.context) ||
             OAuthPrompt.isTokenExchangeRequestInvoke(dc.context);
 
         // If the incoming Activity is a message, or an Activity Type normally handled by OAuthPrompt,

--- a/libraries/botbuilder-dialogs/tests/oauthPrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/oauthPrompt.test.js
@@ -1,14 +1,26 @@
 const assert = require('assert');
-const { ActionTypes, ActivityTypes, CardFactory, Channels, ConversationState, InputHints, MemoryStorage, TestAdapter, tokenResponseEventName, TurnContext, verifyStateOperationName } = require('botbuilder-core');
+const {
+    ActionTypes,
+    ActivityTypes,
+    CardFactory,
+    Channels,
+    ConversationState,
+    InputHints,
+    MemoryStorage,
+    TestAdapter,
+    tokenResponseEventName,
+    TurnContext,
+    verifyStateOperationName,
+} = require('botbuilder-core');
 const { spy } = require('sinon');
 const { ok, strictEqual } = require('assert');
 const { OAuthPrompt, DialogSet, DialogTurnStatus, ListStyle } = require('../');
 const { AuthConstants } = require('../lib/prompts/skillsHelpers');
 
-describe('OAuthPrompt', function() {
+describe('OAuthPrompt', function () {
     this.timeout(60000);
 
-    it('should call OAuthPrompt', async function() {
+    it('should call OAuthPrompt', async function () {
         var connectionName = 'myConnection';
         var token = 'abc123';
 
@@ -18,12 +30,11 @@ describe('OAuthPrompt', function() {
 
             const results = await dc.continueDialog();
             if (results.status === DialogTurnStatus.empty) {
-                await dc.prompt('prompt', { });
+                await dc.prompt('prompt', {});
             } else if (results.status === DialogTurnStatus.complete) {
                 if (results.result.token) {
                     await turnContext.sendActivity(`Logged in.`);
-                }
-                else {
+                } else {
                     await turnContext.sendActivity(`Failed`);
                 }
             }
@@ -36,14 +47,17 @@ describe('OAuthPrompt', function() {
         // Create a DialogState property, DialogSet and OAuthPrompt
         const dialogState = convoState.createProperty('dialogState');
         const dialogs = new DialogSet(dialogState);
-        dialogs.add(new OAuthPrompt('prompt', {
-            connectionName,
-            title: 'Login',
-            timeout: 300000
-        }));
+        dialogs.add(
+            new OAuthPrompt('prompt', {
+                connectionName,
+                title: 'Login',
+                timeout: 300000,
+            })
+        );
 
-        await adapter.send('Hello')
-            .assertReply(activity  => {
+        await adapter
+            .send('Hello')
+            .assertReply((activity) => {
                 assert(activity.attachments.length === 1);
                 assert(activity.attachments[0].contentType === CardFactory.contentTypes.oauthCard);
                 assert(activity.inputHint === InputHints.AcceptingInput);
@@ -60,7 +74,7 @@ describe('OAuthPrompt', function() {
                 eventActivity.name = 'tokens/response';
                 eventActivity.value = {
                     connectionName,
-                    token
+                    token,
                 };
 
                 adapter.send(eventActivity);
@@ -69,7 +83,7 @@ describe('OAuthPrompt', function() {
             .startTest();
     });
 
-    it('should call OAuthPrompt with code', async function() {
+    it('should call OAuthPrompt with code', async function () {
         var connectionName = 'myConnection';
         var token = 'abc123';
         var magicCode = '888999';
@@ -80,12 +94,11 @@ describe('OAuthPrompt', function() {
 
             const results = await dc.continueDialog();
             if (results.status === DialogTurnStatus.empty) {
-                await dc.prompt('prompt', { });
+                await dc.prompt('prompt', {});
             } else if (results.status === DialogTurnStatus.complete) {
                 if (results.result.token) {
                     await turnContext.sendActivity(`Logged in.`);
-                }
-                else {
+                } else {
                     await turnContext.sendActivity(`Failed`);
                 }
             }
@@ -98,14 +111,17 @@ describe('OAuthPrompt', function() {
         // Create a DialogState property, DialogSet and OAuthPrompt
         const dialogState = convoState.createProperty('dialogState');
         const dialogs = new DialogSet(dialogState);
-        dialogs.add(new OAuthPrompt('prompt', {
-            connectionName,
-            title: 'Login',
-            timeout: 300000
-        }));
+        dialogs.add(
+            new OAuthPrompt('prompt', {
+                connectionName,
+                title: 'Login',
+                timeout: 300000,
+            })
+        );
 
-        await adapter.send('Hello')
-            .assertReply(activity  => {
+        await adapter
+            .send('Hello')
+            .assertReply((activity) => {
                 assert(activity.attachments.length === 1);
                 assert(activity.attachments[0].contentType === CardFactory.contentTypes.oauthCard);
 
@@ -116,7 +132,7 @@ describe('OAuthPrompt', function() {
             .startTest();
     });
 
-    it('should timeout OAuthPrompt with message activity', async function() {
+    it('should timeout OAuthPrompt with message activity', async function () {
         const message = {
             activityId: '1234',
             type: ActivityTypes.message,
@@ -125,7 +141,7 @@ describe('OAuthPrompt', function() {
         await testTimeout(message);
     });
 
-    it('should timeout OAuthPrompt with tokenResponseEvent activity', async function() {
+    it('should timeout OAuthPrompt with tokenResponseEvent activity', async function () {
         const message = {
             activityId: '1234',
             type: ActivityTypes.Event,
@@ -135,7 +151,7 @@ describe('OAuthPrompt', function() {
         await testTimeout(message);
     });
 
-    it('should timeout OAuthPrompt with verifyStateOperation activity', async function() {
+    it('should timeout OAuthPrompt with verifyStateOperation activity', async function () {
         const message = {
             activityId: '1234',
             type: ActivityTypes.Invoke,
@@ -146,17 +162,17 @@ describe('OAuthPrompt', function() {
         await testTimeout(message);
     });
 
-    it('should not timeout OAuthPrompt with custom event activity', async function() {
+    it('should not timeout OAuthPrompt with custom event activity', async function () {
         const message = {
             activityId: '1234',
             type: ActivityTypes.Event,
             name: 'custom_event_name',
         };
 
-        await testTimeout(message, false, 'Failed', 'Ended' );
+        await testTimeout(message, false, 'Failed', 'Ended');
     });
 
-    it('should end OAuthPrompt on invalid message when endOnInvalidMessage', async function() {
+    it('should end OAuthPrompt on invalid message when endOnInvalidMessage', async function () {
         const message = {
             activityId: '1234',
             type: ActivityTypes.Event,
@@ -167,58 +183,70 @@ describe('OAuthPrompt', function() {
         var token = 'abc123';
         var magicCode = '888999';
         const exchangeToken = 'exch123';
-    
+
         // Create new ConversationState with MemoryStorage
         const convoState = new ConversationState(new MemoryStorage());
-    
+
         // Create a DialogState property, DialogSet and OAuthPrompt
         const dialogState = convoState.createProperty('dialogState');
         const dialogs = new DialogSet(dialogState);
-        dialogs.add(new OAuthPrompt('prompt', {
-            connectionName,
-            title: 'Login',
-            endOnInvalidMessage: true,
-        }, async (prompt) => {
-            if (prompt.recognized.succeeded) {
-                assert(false, 'recognition succeeded but should have failed during test');
-                return true;
-            }
-            
-            return false;
-        }));
-    
+        dialogs.add(
+            new OAuthPrompt(
+                'prompt',
+                {
+                    connectionName,
+                    title: 'Login',
+                    endOnInvalidMessage: true,
+                },
+                async (prompt) => {
+                    if (prompt.recognized.succeeded) {
+                        assert(false, 'recognition succeeded but should have failed during test');
+                        return true;
+                    }
+
+                    return false;
+                }
+            )
+        );
+
         // Initialize TestAdapter.
         const adapter = new TestAdapter(async (turnContext) => {
             const dc = await dialogs.createContext(turnContext);
-    
+
             const results = await dc.continueDialog();
             if (results.status === DialogTurnStatus.empty) {
-                await dc.prompt('prompt', { });
+                await dc.prompt('prompt', {});
             } else if (results.status === DialogTurnStatus.complete) {
                 if (results.result && results.result.token) {
                     await turnContext.sendActivity('Failed');
-                }
-                else {
+                } else {
                     await turnContext.sendActivity('Ended');
                 }
             }
             await convoState.saveChanges(turnContext);
         });
-    
-        await adapter.send('Hello')
-            .assertReply(activity  => {
+
+        await adapter
+            .send('Hello')
+            .assertReply((activity) => {
                 assert(activity.attachments.length === 1);
                 assert(activity.attachments[0].contentType === CardFactory.contentTypes.oauthCard);
-    
+
                 adapter.addUserToken(connectionName, activity.channelId, activity.recipient.id, token, magicCode);
-                adapter.addExchangeableToken(connectionName, activity.channelId, activity.recipient.id, exchangeToken, token);
-            })  
+                adapter.addExchangeableToken(
+                    connectionName,
+                    activity.channelId,
+                    activity.recipient.id,
+                    exchangeToken,
+                    token
+                );
+            })
             .send('invalid text message here')
             .assertReply('Ended')
             .startTest();
     });
 
-    it('should see attemptCount increment', async function() {
+    it('should see attemptCount increment', async function () {
         var connectionName = 'myConnection';
         var token = 'abc123';
         var magicCode = '888999';
@@ -229,18 +257,24 @@ describe('OAuthPrompt', function() {
         // Create a DialogState property, DialogSet and OAuthPrompt
         const dialogState = convoState.createProperty('dialogState');
         const dialogs = new DialogSet(dialogState);
-        
-        dialogs.add(new OAuthPrompt('prompt', {
-            connectionName,
-            title: 'Login',
-            timeout: 300000
-        }, async (prompt) => {
-            if (prompt.recognized.succeeded) {
-                return true;
-            }
-            prompt.context.sendActivity(`attemptCount ${ prompt.attemptCount }`);
-            return false;
-        }));
+
+        dialogs.add(
+            new OAuthPrompt(
+                'prompt',
+                {
+                    connectionName,
+                    title: 'Login',
+                    timeout: 300000,
+                },
+                async (prompt) => {
+                    if (prompt.recognized.succeeded) {
+                        return true;
+                    }
+                    prompt.context.sendActivity(`attemptCount ${prompt.attemptCount}`);
+                    return false;
+                }
+            )
+        );
 
         // Initialize TestAdapter.
         const adapter = new TestAdapter(async (turnContext) => {
@@ -252,16 +286,16 @@ describe('OAuthPrompt', function() {
             } else if (results.status === DialogTurnStatus.complete) {
                 if (results.result.token) {
                     await turnContext.sendActivity('Logged in');
-                }
-                else {
+                } else {
                     await turnContext.sendActivity('Failed');
                 }
             }
             await convoState.saveChanges(turnContext);
         });
-        
-        await adapter.send('Hello')
-            .assertReply(activity => {
+
+        await adapter
+            .send('Hello')
+            .assertReply((activity) => {
                 assert(activity.attachments.length === 1);
                 assert(activity.attachments[0].contentType === CardFactory.contentTypes.oauthCard);
 
@@ -274,13 +308,16 @@ describe('OAuthPrompt', function() {
             .send('123')
             .assertReply('attemptCount 3')
             .send(magicCode)
-            .assertReply(activity => {
+            .assertReply((activity) => {
                 assert(activity.text === 'Logged in');
 
-                adapter.signOutUser(new TurnContext(adapter, { channelId: activity.channelId, from: activity.recipient }), connectionName);
+                adapter.signOutUser(
+                    new TurnContext(adapter, { channelId: activity.channelId, from: activity.recipient }),
+                    connectionName
+                );
             })
             .send('Another!')
-            .assertReply(activity => {
+            .assertReply((activity) => {
                 assert(activity.attachments.length === 1);
                 assert(activity.attachments[0].contentType === CardFactory.contentTypes.oauthCard);
 
@@ -297,7 +334,7 @@ describe('OAuthPrompt', function() {
             .startTest();
     });
 
-    it('should call OAuthPrompt for streaming connection', async function() {
+    it('should call OAuthPrompt for streaming connection', async function () {
         var connectionName = 'myConnection';
         var token = 'abc123';
 
@@ -307,12 +344,11 @@ describe('OAuthPrompt', function() {
 
             const results = await dc.continueDialog();
             if (results.status === DialogTurnStatus.empty) {
-                await dc.prompt('prompt', { });
+                await dc.prompt('prompt', {});
             } else if (results.status === DialogTurnStatus.complete) {
                 if (results.result.token) {
                     await turnContext.sendActivity(`Logged in.`);
-                }
-                else {
+                } else {
                     await turnContext.sendActivity(`Failed`);
                 }
             }
@@ -325,11 +361,13 @@ describe('OAuthPrompt', function() {
         // Create a DialogState property, DialogSet and AttachmentPrompt.
         const dialogState = convoState.createProperty('dialogState');
         const dialogs = new DialogSet(dialogState);
-        dialogs.add(new OAuthPrompt('prompt', {
-            connectionName,
-            title: 'Login',
-            timeout: 300000
-        }));
+        dialogs.add(
+            new OAuthPrompt('prompt', {
+                connectionName,
+                title: 'Login',
+                timeout: 300000,
+            })
+        );
 
         const streamingActivity = {
             activityId: '1234',
@@ -337,19 +375,20 @@ describe('OAuthPrompt', function() {
             serviceUrl: 'urn:botframework.com:websocket:wss://channel.com/blah',
             user: { id: 'user', name: 'User Name' },
             bot: { id: 'bot', name: 'Bot Name' },
-            conversation: { 
+            conversation: {
                 id: 'convo1',
                 properties: {
-                    'foo': 'bar'
-                }
+                    foo: 'bar',
+                },
             },
             attachments: [],
             type: 'message',
-            text: 'Hello'
+            text: 'Hello',
         };
 
-        await adapter.send(streamingActivity)
-            .assertReply(activity  => {
+        await adapter
+            .send(streamingActivity)
+            .assertReply((activity) => {
                 assert(activity.attachments.length === 1);
                 assert(activity.attachments[0].contentType === CardFactory.contentTypes.oauthCard);
                 assert(activity.inputHint === InputHints.AcceptingInput);
@@ -366,7 +405,7 @@ describe('OAuthPrompt', function() {
                 eventActivity.name = 'tokens/response';
                 eventActivity.value = {
                     connectionName,
-                    token
+                    token,
                 };
 
                 adapter.send(eventActivity);
@@ -375,8 +414,8 @@ describe('OAuthPrompt', function() {
             .startTest();
     });
 
-    describe('private methods', () => {
-        describe('sendOAuthCardAsync()', () => {
+    describe('static methods', () => {
+        describe('sendOAuthCard()', () => {
             class SendActivityAdapter {
                 constructor(settings = {}) {
                     // Lazily and forcefully assign all properties and values to SendActivityAdapter instance.
@@ -405,7 +444,7 @@ describe('OAuthPrompt', function() {
                     assert(userId, 'userId not passed in to getSignInResource call');
                     return {
                         signInLink: this.signInLink,
-                        tokenExchangeResource: this.tokenExchangeResource
+                        tokenExchangeResource: this.tokenExchangeResource,
                     };
                 }
             }
@@ -416,14 +455,16 @@ describe('OAuthPrompt', function() {
                     activity: {
                         channelId: Channels.Webchat,
                         serviceUrl: 'https://bing.com',
-                    }
+                    },
                 });
 
-                const prompt = new OAuthPrompt('OAuthPrompt', {});
                 try {
-                    await prompt.sendOAuthCardAsync(context);
+                    await OAuthPrompt.sendOAuthCard({}, context);
                 } catch (e) {
-                    assert.strictEqual(e.message, `OAuthPrompt.sendOAuthCardAsync(): not supported for the current adapter.`);
+                    assert.strictEqual(
+                        e.message,
+                        `OAuthPrompt.sendOAuthCard(): not supported for the current adapter.`
+                    );
                 }
             });
 
@@ -434,21 +475,24 @@ describe('OAuthPrompt', function() {
                 const signInLink = 'https://dev.botframework.com';
                 const tokenExchangeResource = {
                     id: 'id',
-                    uri: 'some uri'
+                    uri: 'some uri',
                 };
                 const adapter = new SendActivityAdapter({
-                    connectionName, signInLink,
-                    text, title, tokenExchangeResource
+                    connectionName,
+                    signInLink,
+                    text,
+                    title,
+                    tokenExchangeResource,
                 });
                 const context = new TurnContext(adapter, {
                     channelId: Channels.Webchat,
                     serviceUrl: 'https://bing.com',
                     from: {
-                        id: 'someId'
-                    }
+                        id: 'someId',
+                    },
                 });
                 // Override sendActivity
-                context.sendActivity = async function(activity) {
+                context.sendActivity = async function (activity) {
                     assert.strictEqual(activity.attachments.length, 1);
                     const attachment = activity.attachments[0];
                     assert.strictEqual(attachment.contentType, CardFactory.contentTypes.oauthCard);
@@ -464,10 +508,9 @@ describe('OAuthPrompt', function() {
                     assert.strictEqual(button.value, undefined);
                 }.bind(context);
 
-                const prompt = new OAuthPrompt('OAuthPrompt', { connectionName, title, text });
-                await prompt.sendOAuthCardAsync(context);
+                await OAuthPrompt.sendOAuthCard({ connectionName, title, text }, context);
             });
-            
+
             it('should send a well-constructed OAuthCard for channels with OAuthCard support from a skill', async () => {
                 const connectionName = 'connection';
                 const title = 'myTitle';
@@ -475,26 +518,32 @@ describe('OAuthPrompt', function() {
                 const signInLink = 'https://dev.botframework.com';
                 const tokenExchangeResource = {
                     id: 'id',
-                    uri: 'some uri'
+                    uri: 'some uri',
                 };
                 const adapter = new SendActivityAdapter({
-                    connectionName, signInLink,
-                    text, title, tokenExchangeResource
+                    connectionName,
+                    signInLink,
+                    text,
+                    title,
+                    tokenExchangeResource,
                 });
                 const context = new TurnContext(adapter, {
                     channelId: Channels.Emulator,
                     serviceUrl: 'https://bing.com',
                     from: {
-                        id: 'someId'
-                    }
+                        id: 'someId',
+                    },
                 });
-                context.turnState.set(adapter.BotIdentityKey, new ClaimsIdentity([
-                    { type: 'azp', value: uuid() },
-                    { type: 'ver', value: '2.0' },
-                    { type: 'aud', value: uuid() }
-                ]));
+                context.turnState.set(
+                    adapter.BotIdentityKey,
+                    new ClaimsIdentity([
+                        { type: 'azp', value: uuid() },
+                        { type: 'ver', value: '2.0' },
+                        { type: 'aud', value: uuid() },
+                    ])
+                );
                 // Override sendActivity
-                context.sendActivity = async function(activity) {
+                context.sendActivity = async function (activity) {
                     assert.strictEqual(activity.attachments.length, 1);
                     const attachment = activity.attachments[0];
                     assert.strictEqual(attachment.contentType, CardFactory.contentTypes.oauthCard);
@@ -508,8 +557,7 @@ describe('OAuthPrompt', function() {
                     assert.strictEqual(button.value, signInLink);
                 }.bind(context);
 
-                const prompt = new OAuthPrompt('OAuthPrompt', { connectionName, title, text });
-                await prompt.sendOAuthCardAsync(context);
+                await OAuthPrompt.sendOAuthCard({ connectionName, title, text }, context);
             });
 
             it('should send a well-constructed OAuthCard for a streaming connection for channels with OAuthCard support', async () => {
@@ -518,18 +566,20 @@ describe('OAuthPrompt', function() {
                 const text = 'Sign in here';
                 const signInLink = 'https://dev.botframework.com';
                 const adapter = new SendActivityAdapter({
-                    connectionName, signInLink,
-                    text, title,
+                    connectionName,
+                    signInLink,
+                    text,
+                    title,
                 });
                 const context = new TurnContext(adapter, {
                     channelId: Channels.Webchat,
                     serviceUrl: 'wss://bing.com',
                     from: {
-                        id: 'someId'
-                    }
+                        id: 'someId',
+                    },
                 });
                 // Override sendActivity
-                context.sendActivity = async function(activity) {
+                context.sendActivity = async function (activity) {
                     assert.strictEqual(activity.attachments.length, 1);
                     const attachment = activity.attachments[0];
                     assert.strictEqual(attachment.contentType, CardFactory.contentTypes.oauthCard);
@@ -545,8 +595,7 @@ describe('OAuthPrompt', function() {
                     assert.strictEqual(button.value, signInLink);
                 }.bind(context);
 
-                const prompt = new OAuthPrompt('OAuthPrompt', { connectionName, title, text });
-                await prompt.sendOAuthCardAsync(context);
+                await OAuthPrompt.sendOAuthCard({ connectionName, title, text }, context);
             });
 
             it('should use the passed in activity as a base for the prompt', async () => {
@@ -555,23 +604,28 @@ describe('OAuthPrompt', function() {
                 const text = 'Sign in here';
                 const signInLink = 'https://dev.botframework.com';
                 const adapter = new SendActivityAdapter({
-                    connectionName, signInLink,
-                    text, title,
+                    connectionName,
+                    signInLink,
+                    text,
+                    title,
                 });
                 const context = new TurnContext(adapter, {
                     channelId: Channels.Webchat,
                     serviceUrl: 'https://bing.com',
                     from: {
-                        id: 'someId'
-                    }
+                        id: 'someId',
+                    },
                 });
-                context.turnState.set(adapter.BotIdentityKey, new ClaimsIdentity([
-                    { type: 'azp', value: uuid() },
-                    { type: 'ver', value: '2.0' },
-                    { type: 'aud', value: AuthConstants.ToBotFromChannelTokenIssuer }
-                ]));
+                context.turnState.set(
+                    adapter.BotIdentityKey,
+                    new ClaimsIdentity([
+                        { type: 'azp', value: uuid() },
+                        { type: 'ver', value: '2.0' },
+                        { type: 'aud', value: AuthConstants.ToBotFromChannelTokenIssuer },
+                    ])
+                );
                 // Override sendActivity
-                context.sendActivity = async function(activity) {
+                context.sendActivity = async function (activity) {
                     assert.strictEqual(activity.value, 1);
                     assert.strictEqual(activity.attachments.length, 1);
                     const attachment = activity.attachments[0];
@@ -588,8 +642,7 @@ describe('OAuthPrompt', function() {
                     assert.strictEqual(button.value, undefined);
                 }.bind(context);
 
-                const prompt = new OAuthPrompt('OAuthPrompt', { connectionName, title, text });
-                await prompt.sendOAuthCardAsync(context, { value: 1 });
+                await OAuthPrompt.sendOAuthCard({ connectionName, title, text }, context, { value: 1 });
             });
         });
 
@@ -597,22 +650,35 @@ describe('OAuthPrompt', function() {
             it('should throw an error during a Token Response Event and adapter is missing "createConnectorClientWithIdentity"', async () => {
                 const oAuthPrompt = new OAuthPrompt('OAuthPrompt');
                 // Create spy for private instance method called during recognizeToken
-                const isTokenResponseEventSpy = spy(oAuthPrompt, 'isTokenResponseEvent');
-                isTokenResponseEventSpy.returnValues = [ true ];
-                
-                const adapter = new TestAdapter(async (context) => { /* no-op */ });
+                const isTokenResponseEventSpy = spy(OAuthPrompt, 'isTokenResponseEvent');
+                isTokenResponseEventSpy.returnValues = [true];
+
+                const adapter = new TestAdapter(async (context) => {
+                    /* no-op */
+                });
                 const conversationState = new ConversationState(new MemoryStorage());
                 const dialogState = conversationState.createProperty('DialogState');
                 const dialogSet = new DialogSet(dialogState);
-                const dc = await dialogSet.createContext(new TurnContext(adapter, { type: ActivityTypes.Event, name: tokenResponseEventName, conversation: { id: 'conversationId' }, channelId: Channels.Test }));
+                const dc = await dialogSet.createContext(
+                    new TurnContext(adapter, {
+                        type: ActivityTypes.Event,
+                        name: tokenResponseEventName,
+                        conversation: { id: 'conversationId' },
+                        channelId: Channels.Test,
+                    })
+                );
                 function setActiveDialog(dc, dialog) {
                     // Create stack if not already there.
                     dc.stack = dc.stack || [];
-                    dc.stack.unshift({ id: dialog.id, state: {
-                        state: {},
-                        [dialog.PersistedCaller]: { callerServiceUrl: 'https://test1', scope: 'parent-appId' },
-                        options: { prompt: 'Login time' },
-                        expires: new Date().getTime() + 900000 }});
+                    dc.stack.unshift({
+                        id: dialog.id,
+                        state: {
+                            state: {},
+                            [dialog.PersistedCaller]: { callerServiceUrl: 'https://test1', scope: 'parent-appId' },
+                            options: { prompt: 'Login time' },
+                            expires: new Date().getTime() + 900000,
+                        },
+                    });
                 }
 
                 setActiveDialog(dc, oAuthPrompt);
@@ -622,74 +688,77 @@ describe('OAuthPrompt', function() {
                     throw new Error('recognizeToken call should have failed');
                 } catch (err) {
                     ok(isTokenResponseEventSpy.calledOnce, 'isTokenResponseEventSpy called more than once');
-                    ok(err instanceof TypeError, `unexpected error: ${ err.toString() }`);
-                    strictEqual(err.message, 'OAuthPrompt: ConnectorClientBuilder interface not implemented by the current adapter');
+                    ok(err instanceof TypeError, `unexpected error: ${err.toString()}`);
+                    strictEqual(
+                        err.message,
+                        'OAuthPrompt: ConnectorClientBuilder interface not implemented by the current adapter'
+                    );
                 }
-
             });
         });
     });
 
-    describe('Test Adapter should be able to exchange tokens for uri and token', async function() {
+    describe('Test Adapter should be able to exchange tokens for uri and token', async function () {
         let adapter;
         const connectionName = 'myConnection';
         const exchangeToken = 'exch123';
         const token = 'abc123';
-        this.beforeEach(function() {
+        this.beforeEach(function () {
             adapter = new TestAdapter(async (turnContext) => {
                 const userId = 'blah';
-                adapter.addExchangeableToken(connectionName, turnContext.activity.channelId, userId, exchangeToken, token);
+                adapter.addExchangeableToken(
+                    connectionName,
+                    turnContext.activity.channelId,
+                    userId,
+                    exchangeToken,
+                    token
+                );
 
                 // Positive case: Token
-                let result = await adapter.exchangeToken(turnContext, connectionName, userId, {token: exchangeToken});
+                let result = await adapter.exchangeToken(turnContext, connectionName, userId, { token: exchangeToken });
                 assert(result);
                 assert.strictEqual(result.token, token);
                 assert.strictEqual(result.connectionName, connectionName);
                 // Positive case: URI
-                result = await adapter.exchangeToken(turnContext, connectionName, userId, {uri: exchangeToken});
+                result = await adapter.exchangeToken(turnContext, connectionName, userId, { uri: exchangeToken });
                 assert(result);
                 assert.strictEqual(result.token, token);
                 assert.strictEqual(result.connectionName, connectionName);
                 // Negative case: Token
-                result = await adapter.exchangeToken(turnContext, connectionName, userId, {token: 'beepboop'});
+                result = await adapter.exchangeToken(turnContext, connectionName, userId, { token: 'beepboop' });
                 assert(result === null);
-                // Negative case: URI 
-                result = await adapter.exchangeToken(turnContext, connectionName, userId, {uri: 'beepboop'});
+                // Negative case: URI
+                result = await adapter.exchangeToken(turnContext, connectionName, userId, { uri: 'beepboop' });
                 assert(result === null);
             });
         });
 
-        it('Test adapter should be able to perform token exchanges for token', async function() {
-            await adapter
-                .send('hello')
-                .startTest();
+        it('Test adapter should be able to perform token exchanges for token', async function () {
+            await adapter.send('hello').startTest();
         });
     });
 
-    describe('OAuthPrompt should be able to exchange tokens', async function() {
+    describe('OAuthPrompt should be able to exchange tokens', async function () {
         let adapter;
         const connectionName = 'myConnection';
         const exchangeToken = 'exch123';
         const token = 'abc123';
-        this.beforeEach(function() {
+        this.beforeEach(function () {
             // Initialize TestAdapter
             adapter = new TestAdapter(async (turnContext) => {
                 const dc = await dialogs.createContext(turnContext);
                 const results = await dc.continueDialog();
-                if(results.status === DialogTurnStatus.empty) {
+                if (results.status === DialogTurnStatus.empty) {
                     await dc.prompt('OAuthPrompt', {});
-                }
-                else if(results.status === DialogTurnStatus.complete) {
+                } else if (results.status === DialogTurnStatus.complete) {
                     if (results.result.token) {
                         await turnContext.sendActivity(`Logged in.`);
-                    }
-                    else {
+                    } else {
                         await turnContext.sendActivity('Failed');
                     }
                 }
                 await convoState.saveChanges(turnContext);
             });
-
 
             //Create new ConversationState with MemoryStorage
             const convoState = new ConversationState(new MemoryStorage());
@@ -698,24 +767,32 @@ describe('OAuthPrompt', function() {
             const dialogState = convoState.createProperty('dialogState');
             const dialogs = new DialogSet(dialogState);
 
-            dialogs.add(new OAuthPrompt('OAuthPrompt', {
-                connectionName,
-                title: 'Sign in',
-                timeout: 30000,
-                text: 'Please sign in'
-            }));
+            dialogs.add(
+                new OAuthPrompt('OAuthPrompt', {
+                    connectionName,
+                    title: 'Sign in',
+                    timeout: 30000,
+                    text: 'Please sign in',
+                })
+            );
         });
 
-        it('Should handle token exchange invoke requests via OAuthPrompt', async function() {
+        it('Should handle token exchange invoke requests via OAuthPrompt', async function () {
             await adapter
                 .send('hello')
-                .assertReply(activity => {
+                .assertReply((activity) => {
                     assert.strictEqual(activity.attachments.length, 1);
                     assert.strictEqual(activity.attachments[0].contentType, CardFactory.contentTypes.oauthCard);
                     assert(activity.inputHint === InputHints.AcceptingInput);
 
                     // Add an exchangeable token to the adapter
-                    adapter.addExchangeableToken(connectionName, activity.channelId, activity.recipient.id, exchangeToken, token);
+                    adapter.addExchangeableToken(
+                        connectionName,
+                        activity.channelId,
+                        activity.recipient.id,
+                        exchangeToken,
+                        token
+                    );
                 })
                 .send({
                     type: ActivityTypes.Invoke,
@@ -723,10 +800,10 @@ describe('OAuthPrompt', function() {
                     value: {
                         id: null,
                         connectionName: connectionName,
-                        token: exchangeToken
-                    }
+                        token: exchangeToken,
+                    },
                 })
-                .assertReply(a => {
+                .assertReply((a) => {
                     assert.strictEqual('invokeResponse', a.type);
                     assert(a.value);
                     assert.strictEqual(a.value.status, 200);
@@ -737,15 +814,15 @@ describe('OAuthPrompt', function() {
                 .startTest();
         });
 
-        it('Should reject token exchange requests if token cannot be exchanged', async function() {
+        it('Should reject token exchange requests if token cannot be exchanged', async function () {
             await adapter
                 .send('hello')
-                .assertReply(activity => {
+                .assertReply((activity) => {
                     assert.strictEqual(activity.attachments.length, 1);
                     assert.strictEqual(activity.attachments[0].contentType, CardFactory.contentTypes.oauthCard);
                     assert(activity.inputHint === InputHints.AcceptingInput);
 
-                // No exchangeable token is added to the adapter
+                    // No exchangeable token is added to the adapter
                 })
                 .send({
                     type: ActivityTypes.Invoke,
@@ -753,10 +830,10 @@ describe('OAuthPrompt', function() {
                     value: {
                         id: null,
                         connectionName: connectionName,
-                        token: exchangeToken
-                    }
+                        token: exchangeToken,
+                    },
                 })
-                .assertReply(a => {
+                .assertReply((a) => {
                     assert.strictEqual('invokeResponse', a.type);
                     assert(a.value);
                     assert.strictEqual(a.value.status, 412);
@@ -765,22 +842,22 @@ describe('OAuthPrompt', function() {
                 .startTest();
         });
 
-        it('Should reject token exhchange requests with no body', async function() {
+        it('Should reject token exhchange requests with no body', async function () {
             await adapter
                 .send('hello')
-                .assertReply(activity => {
+                .assertReply((activity) => {
                     assert.strictEqual(activity.attachments.length, 1);
                     assert.strictEqual(activity.attachments[0].contentType, CardFactory.contentTypes.oauthCard);
                     assert(activity.inputHint === InputHints.AcceptingInput);
 
-                // No exchangeable token is added to the adapter
+                    // No exchangeable token is added to the adapter
                 })
                 .send({
                     type: ActivityTypes.Invoke,
-                    name: 'signin/tokenExchange'
-                //no body is sent
+                    name: 'signin/tokenExchange',
+                    //no body is sent
                 })
-                .assertReply(a => {
+                .assertReply((a) => {
                     assert.strictEqual('invokeResponse', a.type);
                     assert(a.value);
                     assert.strictEqual(a.value.status, 400);
@@ -789,15 +866,15 @@ describe('OAuthPrompt', function() {
                 .startTest();
         });
 
-        it('Should reject token exhchange requests with wrong connection name', async function() {
+        it('Should reject token exhchange requests with wrong connection name', async function () {
             await adapter
                 .send('hello')
-                .assertReply(activity => {
+                .assertReply((activity) => {
                     assert.strictEqual(activity.attachments.length, 1);
                     assert.strictEqual(activity.attachments[0].contentType, CardFactory.contentTypes.oauthCard);
                     assert(activity.inputHint === InputHints.AcceptingInput);
 
-                // No exchangeable token is added to the adapter
+                    // No exchangeable token is added to the adapter
                 })
                 .send({
                     type: ActivityTypes.Invoke,
@@ -805,10 +882,10 @@ describe('OAuthPrompt', function() {
                     value: {
                         id: null,
                         connectionName: 'foobar',
-                        token: exchangeToken
-                    }
+                        token: exchangeToken,
+                    },
                 })
-                .assertReply(a => {
+                .assertReply((a) => {
                     assert.strictEqual('invokeResponse', a.type);
                     assert(a.value);
                     assert.strictEqual(a.value.status, 400);
@@ -828,17 +905,21 @@ function createReply(activity) {
         replyToId: activity.id,
         serviceUrl: activity.serviceUrl,
         channelId: activity.channelId,
-        conversation: { isGroup: activity.conversation.isGroup, id: activity.conversation.id, name: activity.conversation.name },
+        conversation: {
+            isGroup: activity.conversation.isGroup,
+            id: activity.conversation.id,
+            name: activity.conversation.name,
+        },
     };
 }
 
 class ClaimsIdentity {
     /**
      * Each claim should be { type: 'type', value: 'value' }
-     * @param {*} claims 
-     * @param {*} isAuthenticated 
+     * @param {*} claims
+     * @param {*} isAuthenticated
      */
-    constructor(claims = [], isAuthenticated= false) {
+    constructor(claims = [], isAuthenticated = false) {
         this.claims = claims;
         this.isAuthenticated = isAuthenticated;
     }
@@ -852,12 +933,18 @@ class ClaimsIdentity {
 
 function uuid() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-        const r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+        const r = (Math.random() * 16) | 0,
+            v = c == 'x' ? r : (r & 0x3) | 0x8;
         return v.toString(16);
     });
 }
 
-async function testTimeout(oauthPromptActivity, shouldSucceed = true, tokenResponse = 'Failed', noTokenResponse = 'Ended') {
+async function testTimeout(
+    oauthPromptActivity,
+    shouldSucceed = true,
+    tokenResponse = 'Failed',
+    noTokenResponse = 'Ended'
+) {
     var connectionName = 'myConnection';
     var token = 'abc123';
     var magicCode = '888999';
@@ -869,25 +956,31 @@ async function testTimeout(oauthPromptActivity, shouldSucceed = true, tokenRespo
     // Create a DialogState property, DialogSet and OAuthPrompt
     const dialogState = convoState.createProperty('dialogState');
     const dialogs = new DialogSet(dialogState);
-    dialogs.add(new OAuthPrompt('prompt', {
-        connectionName,
-        title: 'Login',
-        timeout: -1
-    }, (prompt) => {
-        if (prompt.recognized.succeeded) {
-            assert(shouldSucceed, 'recognition succeeded but should have failed during testTimeout');
-            return true;
-        }
-        
-        assert(!shouldSucceed, 'recognition failed during testTimeout');
-        return false;
-    }));
+    dialogs.add(
+        new OAuthPrompt(
+            'prompt',
+            {
+                connectionName,
+                title: 'Login',
+                timeout: -1,
+            },
+            (prompt) => {
+                if (prompt.recognized.succeeded) {
+                    assert(shouldSucceed, 'recognition succeeded but should have failed during testTimeout');
+                    return true;
+                }
+
+                assert(!shouldSucceed, 'recognition failed during testTimeout');
+                return false;
+            }
+        )
+    );
 
     // Initialize TestAdapter.
     const adapter = new TestAdapter(async (turnContext) => {
         const dc = await dialogs.createContext(turnContext);
 
-        if(!oauthPromptActivity.conversation) {
+        if (!oauthPromptActivity.conversation) {
             oauthPromptActivity.conversation = turnContext.activity.conversation;
             oauthPromptActivity.recipient = turnContext.activity.recipient;
             oauthPromptActivity.from = turnContext.activity.from;
@@ -897,26 +990,35 @@ async function testTimeout(oauthPromptActivity, shouldSucceed = true, tokenRespo
 
         const results = await dc.continueDialog();
         if (results.status === DialogTurnStatus.empty) {
-            await dc.prompt('prompt', { });
-        } else if (results.status === DialogTurnStatus.complete || (results.status === DialogTurnStatus.waiting && !shouldSucceed)) {
+            await dc.prompt('prompt', {});
+        } else if (
+            results.status === DialogTurnStatus.complete ||
+            (results.status === DialogTurnStatus.waiting && !shouldSucceed)
+        ) {
             if (results.result && results.result.token) {
                 await turnContext.sendActivity(tokenResponse);
-            }
-            else {
+            } else {
                 await turnContext.sendActivity(noTokenResponse);
             }
         }
         await convoState.saveChanges(turnContext);
     });
 
-    await adapter.send('Hello')
-        .assertReply(activity  => {
+    await adapter
+        .send('Hello')
+        .assertReply((activity) => {
             assert(activity.attachments.length === 1);
             assert(activity.attachments[0].contentType === CardFactory.contentTypes.oauthCard);
 
             adapter.addUserToken(connectionName, activity.channelId, activity.recipient.id, token, magicCode);
-            adapter.addExchangeableToken(connectionName, activity.channelId, activity.recipient.id, exchangeToken, token);
-        })  
+            adapter.addExchangeableToken(
+                connectionName,
+                activity.channelId,
+                activity.recipient.id,
+                exchangeToken,
+                token
+            );
+        })
         .send(oauthPromptActivity)
         .assertReply(noTokenResponse)
         .startTest();

--- a/libraries/botbuilder-lg/src/templates.ts
+++ b/libraries/botbuilder-lg/src/templates.ts
@@ -307,9 +307,10 @@ export class Templates implements Iterable<Template> {
         // wrap inline string with "# name and -" to align the evaluation process
         const multiLineMark = '```';
 
-        inlineStr = !(inlineStr.trim().startsWith(multiLineMark) && inlineStr.includes('\n'))
-            ? `${multiLineMark}${inlineStr}${multiLineMark}`
-            : inlineStr;
+        inlineStr =
+            !inlineStr.trim().startsWith(multiLineMark) && inlineStr.includes('\n')
+                ? `${multiLineMark}${inlineStr}${multiLineMark}`
+                : inlineStr;
 
         const newContent = `#${inlineTemplateId} ${this.newLine} - ${inlineStr}`;
 
@@ -413,7 +414,8 @@ export class Templates implements Iterable<Template> {
 
             // adjust the last template's range when adding the template
             if (this.items.length > 0) {
-                this.items[this.items.length - 1].sourceRange.range.end.line = newTemplate.sourceRange.range.start.line - 1;
+                this.items[this.items.length - 1].sourceRange.range.end.line =
+                    newTemplate.sourceRange.range.start.line - 1;
             }
 
             this.items.push(newTemplate);


### PR DESCRIPTION
Fixes #3306 

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Enabled LG syntax in `OAuthInput`'s title and text.
Fixed blocking bugs as well.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Refactored `OAuthPrompt` to expose `sendOAuthCard()`
  - Updated `OAuthInput` to enable LG syntax
  - Fixed a blocking bug in Expression.parse() to trim starting `=` of expressions
  - Fixed a blocking bug in `Templates` to recognize multi line text correctly

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
Ported tests as well.