### PR TITLE
Replace done w/ async in tests part 1

### DIFF
--- a/libraries/botbuilder/tests/inspectionMiddleware.test.js
+++ b/libraries/botbuilder/tests/inspectionMiddleware.test.js
@@ -18,14 +18,14 @@ describe('InspectionMiddleware', function () {
         nock.cleanAll();
     });
 
-    const storage = new MemoryStorage();
-    const inspectionState = new InspectionState(storage);
-    const userState = new UserState(storage);
-    const conversationState = new ConversationState(storage);
+    // const storage = new MemoryStorage();
+    // const inspectionState = new InspectionState(storage);
+    // const userState = new UserState(storage);
+    // const conversationState = new ConversationState(storage);
 
     it('should not change behavior when inspection middleware is added', async function () {
-        let inspectionState = new InspectionState(new MemoryStorage());
-        let inspectionMiddleware = new InspectionMiddleware(inspectionState);
+        const inspectionState = new InspectionState(new MemoryStorage());
+        const inspectionMiddleware = new InspectionMiddleware(inspectionState);
 
         const adapter = new TestAdapter(async (turnContext) => {
             await turnContext.sendActivity(MessageFactory.text('hi'));
@@ -70,15 +70,15 @@ describe('InspectionMiddleware', function () {
 
         // create the various storage and middleware objects we will be using
 
-        let storage = new MemoryStorage();
-        let inspectionState = new InspectionState(storage);
-        let userState = new UserState(storage);
-        let conversationState = new ConversationState(storage);
-        let inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
+        const storage = new MemoryStorage();
+        const inspectionState = new InspectionState(storage);
+        const userState = new UserState(storage);
+        const conversationState = new ConversationState(storage);
+        const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // the emulator sends an /INSPECT open command - we can use another adapter here
 
-        let openActivity = MessageFactory.text('/INSPECT open');
+        const openActivity = MessageFactory.text('/INSPECT open');
 
         const inspectionAdapter = new TestAdapter(
             async (turnContext) => {
@@ -90,15 +90,15 @@ describe('InspectionMiddleware', function () {
 
         await inspectionAdapter.receiveActivity(openActivity);
 
-        let inspectionOpenResultActivity = inspectionAdapter.activityBuffer[0];
-        let attachCommand = inspectionOpenResultActivity.value;
+        const inspectionOpenResultActivity = inspectionAdapter.activityBuffer[0];
+        const attachCommand = inspectionOpenResultActivity.value;
 
         // the logic of teh bot including replying with a message and updating user and conversation state
 
-        let x = userState.createProperty('x');
-        let y = conversationState.createProperty('y');
+        const x = userState.createProperty('x');
+        const y = conversationState.createProperty('y');
 
-        let applicationAdapter = new TestAdapter(
+        const applicationAdapter = new TestAdapter(
             async (turnContext) => {
                 await turnContext.sendActivity(MessageFactory.text(`echo: ${turnContext.activity.text}`));
 
@@ -164,15 +164,15 @@ describe('InspectionMiddleware', function () {
 
         // create the various storage and middleware objects we will be using
 
-        let storage = new MemoryStorage();
-        let inspectionState = new InspectionState(storage);
-        let userState = new UserState(storage);
-        let conversationState = new ConversationState(storage);
-        let inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
+        const storage = new MemoryStorage();
+        const inspectionState = new InspectionState(storage);
+        const userState = new UserState(storage);
+        const conversationState = new ConversationState(storage);
+        const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // the emulator sends an /INSPECT open command - we can use another adapter here
 
-        let openActivity = MessageFactory.text('/INSPECT open');
+        const openActivity = MessageFactory.text('/INSPECT open');
 
         const inspectionAdapter = new TestAdapter(
             async (turnContext) => {
@@ -184,17 +184,17 @@ describe('InspectionMiddleware', function () {
 
         await inspectionAdapter.receiveActivity(openActivity);
 
-        let inspectionOpenResultActivity = inspectionAdapter.activityBuffer[0];
+        const inspectionOpenResultActivity = inspectionAdapter.activityBuffer[0];
 
-        let recipientId = 'bot';
-        let attachCommand = `<at>${recipientId}</at> ${inspectionOpenResultActivity.value}`;
+        const recipientId = 'bot';
+        const attachCommand = `<at>${recipientId}</at> ${inspectionOpenResultActivity.value}`;
 
         // the logic of the bot including replying with a message and updating user and conversation state
 
-        let x = userState.createProperty('x');
-        let y = conversationState.createProperty('y');
+        const x = userState.createProperty('x');
+        const y = conversationState.createProperty('y');
 
-        let applicationAdapter = new TestAdapter(
+        const applicationAdapter = new TestAdapter(
             async (turnContext) => {
                 await turnContext.sendActivity(MessageFactory.text(`echo: ${turnContext.activity.text}`));
 
@@ -212,7 +212,7 @@ describe('InspectionMiddleware', function () {
 
         applicationAdapter.use(inspectionMiddleware);
 
-        let attachActivity = {
+        const attachActivity = {
             type: 'message',
             text: attachCommand,
             recipient: { id: recipientId },
@@ -276,15 +276,15 @@ describe('InspectionMiddleware', function () {
 
         // create the various storage and middleware objects we will be using
 
-        let storage = new MemoryStorage();
-        let inspectionState = new InspectionState(storage);
-        let userState = new UserState(storage);
-        let conversationState = new ConversationState(storage);
-        let inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
+        const storage = new MemoryStorage();
+        const inspectionState = new InspectionState(storage);
+        const userState = new UserState(storage);
+        const conversationState = new ConversationState(storage);
+        const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // the emulator sends an /INSPECT open command - we can use another adapter here
 
-        let openActivity = MessageFactory.text('/INSPECT open');
+        const openActivity = MessageFactory.text('/INSPECT open');
 
         const inspectionAdapter = new TestAdapter(
             async (turnContext) => {
@@ -296,15 +296,15 @@ describe('InspectionMiddleware', function () {
 
         await inspectionAdapter.receiveActivity(openActivity);
 
-        let inspectionOpenResultActivity = inspectionAdapter.activityBuffer[0];
-        let attachCommand = inspectionOpenResultActivity.value;
+        const inspectionOpenResultActivity = inspectionAdapter.activityBuffer[0];
+        const attachCommand = inspectionOpenResultActivity.value;
 
         // the logic of teh bot including replying with a message and updating user and conversation state
 
-        let x = userState.createProperty('x');
-        let y = conversationState.createProperty('y');
+        const x = userState.createProperty('x');
+        const y = conversationState.createProperty('y');
 
-        let applicationAdapter = new TestAdapter(
+        const applicationAdapter = new TestAdapter(
             async (turnContext) => {
                 await turnContext.sendActivity(MessageFactory.text(`echo: ${turnContext.activity.text}`));
 
@@ -322,14 +322,14 @@ describe('InspectionMiddleware', function () {
 
         applicationAdapter.use(inspectionMiddleware);
 
-        let attachActivity = MessageFactory.text(attachCommand);
+        const attachActivity = MessageFactory.text(attachCommand);
         attachActivity.channelData = { team: { id: 'team-id' } };
 
         await applicationAdapter.receiveActivity(attachActivity);
 
         // the attach command response is a informational message
 
-        let hiActivity = MessageFactory.text('hi');
+        const hiActivity = MessageFactory.text('hi');
         hiActivity.channelData = { team: { id: 'team-id' } };
 
         await applicationAdapter.receiveActivity(hiActivity);
@@ -376,6 +376,10 @@ describe('InspectionMiddleware', function () {
             .reply(200, { id: 'test' });
 
         // create the various storage and middleware objects we will be using
+        const storage = new MemoryStorage();
+        const inspectionState = new InspectionState(storage);
+        const userState = new UserState(storage);
+        const conversationState = new ConversationState(storage);
         const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // the emulator sends an /INSPECT open command - we can use another adapter here
@@ -453,6 +457,10 @@ describe('InspectionMiddleware', function () {
             .reply(200, { id: 'test' });
 
         // create the various storage and middleware objects we will be using
+        const storage = new MemoryStorage();
+        const inspectionState = new InspectionState(storage);
+        const userState = new UserState(storage);
+        const conversationState = new ConversationState(storage);
         const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // the emulator sends an /INSPECT open command - we can use another adapter here
@@ -529,6 +537,10 @@ describe('InspectionMiddleware', function () {
             .reply(200, { id: 'test' });
 
         // create the various storage and middleware objects we will be using
+        const storage = new MemoryStorage();
+        const inspectionState = new InspectionState(storage);
+        const userState = new UserState(storage);
+        const conversationState = new ConversationState(storage);
         const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // the emulator sends an /INSPECT open command - we can use another adapter here
@@ -568,6 +580,10 @@ describe('InspectionMiddleware', function () {
     });
 
     it('should invokeInbound throw an error', async () => {
+        const storage = new MemoryStorage();
+        const inspectionState = new InspectionState(storage);
+        const userState = new UserState(storage);
+        const conversationState = new ConversationState(storage);
         const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // Override warn current behavior to intercept when it's called.
@@ -582,6 +598,10 @@ describe('InspectionMiddleware', function () {
     });
 
     it('should invokeOutbound throw an error', async () => {
+        const storage = new MemoryStorage();
+        const inspectionState = new InspectionState(storage);
+        const userState = new UserState(storage);
+        const conversationState = new ConversationState(storage);
         const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // Override warn current behavior to intercept when it's called.
@@ -596,6 +616,10 @@ describe('InspectionMiddleware', function () {
     });
 
     it('should invokeTraceState throw an error', async () => {
+        const storage = new MemoryStorage();
+        const inspectionState = new InspectionState(storage);
+        const userState = new UserState(storage);
+        const conversationState = new ConversationState(storage);
         const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         // Override warn current behavior to intercept when it's called.
@@ -610,6 +634,10 @@ describe('InspectionMiddleware', function () {
     });
 
     it('should attachCommand return false', async () => {
+        const storage = new MemoryStorage();
+        const inspectionState = new InspectionState(storage);
+        const userState = new UserState(storage);
+        const conversationState = new ConversationState(storage);
         const inspectionMiddleware = new InspectionMiddleware(inspectionState, userState, conversationState);
 
         const result = await inspectionMiddleware.attachCommand(

--- a/libraries/botbuilder/tests/skills/skillHandler.test.js
+++ b/libraries/botbuilder/tests/skills/skillHandler.test.js
@@ -176,27 +176,24 @@ describe('SkillHandler', function () {
             const identity = new ClaimsIdentity([{ type: 'aud', value: 'audience' }]);
             const conversationId = 'conversationId';
 
-            it('should cache the ClaimsIdentity, ConnectorClient and SkillConversationReference on the turnState', (done) => {
+            it('should cache the ClaimsIdentity, ConnectorClient and SkillConversationReference on the turnState', async function () {
                 expectsGetSkillConversationReference(conversationId);
 
-                handler
-                    .continueConversation(identity, conversationId, async (adapter, ref, context) => {
-                        assert.deepStrictEqual(
-                            context.turnState.get(adapter.BotIdentityKey),
-                            identity,
-                            'cached identity exists'
-                        );
+                await handler.continueConversation(identity, conversationId, async (adapter, ref, context) => {
+                    assert.deepStrictEqual(
+                        context.turnState.get(adapter.BotIdentityKey),
+                        identity,
+                        'cached identity exists'
+                    );
 
-                        assert.deepStrictEqual(
-                            context.turnState.get(handler.SkillConversationReferenceKey),
-                            ref,
-                            'cached conversation ref exists'
-                        );
+                    assert.deepStrictEqual(
+                        context.turnState.get(handler.SkillConversationReferenceKey),
+                        ref,
+                        'cached conversation ref exists'
+                    );
 
-                        sandbox.verify();
-                        done();
-                    })
-                    .catch(done);
+                    sandbox.verify();
+                });
             });
         });
 

--- a/libraries/botbuilder/tests/statusCodeError.test.js
+++ b/libraries/botbuilder/tests/statusCodeError.test.js
@@ -7,42 +7,35 @@ const assert = require('assert');
 const { StatusCodeError } = require('../');
 const { StatusCodes } = require('botbuilder-core');
 
-describe(`StatusCodeError`, function() {
+describe(`StatusCodeError`, function () {
     describe('constructor()', () => {
-        it(`should work with a message.`, done => {
-            try {
-                const message = 'This is an error message';
-                const error = new StatusCodeError(StatusCodes.NOT_FOUND, message);
+        it(`should work with a message.`, function () {
+            const message = 'This is an error message';
+            const error = new StatusCodeError(StatusCodes.NOT_FOUND, message);
 
-                assert.strictEqual(error.message, message, `message should be equal to "${message}".`)
-                assert.strictEqual(error.statusCode, StatusCodes.NOT_FOUND, `statusCode should be the code ${StatusCodes.NOT_FOUND}`)
-                done();
-            } catch (error) {
-                done(error);
-            }
+            assert.strictEqual(error.message, message, `message should be equal to "${message}".`);
+            assert.strictEqual(
+                error.statusCode,
+                StatusCodes.NOT_FOUND,
+                `statusCode should be the code ${StatusCodes.NOT_FOUND}`
+            );
         });
 
-        it(`should work without a message.`, done => {
-            try {
-                const error = new StatusCodeError(StatusCodes.NOT_FOUND);
+        it(`should work without a message.`, function () {
+            const error = new StatusCodeError(StatusCodes.NOT_FOUND);
 
-                assert.strictEqual(error.message, '', 'message should be empty.')
-                assert.strictEqual(error.statusCode, StatusCodes.NOT_FOUND, `statusCode should be the code ${StatusCodes.NOT_FOUND}`)
-                done();
-            } catch (error) {
-                done(error);
-            }
+            assert.strictEqual(error.message, '', 'message should be empty.');
+            assert.strictEqual(
+                error.statusCode,
+                StatusCodes.NOT_FOUND,
+                `statusCode should be the code ${StatusCodes.NOT_FOUND}`
+            );
         });
 
-        it(`should statusCode be undefined if not passed as a parameter.`, done => {
-            try {
-                const error = new StatusCodeError();
+        it(`should statusCode be undefined if not passed as a parameter.`, function () {
+            const error = new StatusCodeError();
 
-                assert.strictEqual(error.statusCode, undefined, 'statusCode should be undefined.')
-                done();
-            } catch (error) {
-                done(error);
-            }
+            assert.strictEqual(error.statusCode, undefined, 'statusCode should be undefined.');
         });
     });
 });

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -14,48 +14,50 @@ function createInvokeActivity(name, value = {}, channelData = {}) {
 
 describe('TeamsActivityHandler', () => {
     describe('onTurnActivity()', () => {
-        it('should not override the InvokeResponse on the context.turnState if it is set', done => {
+        it('should not override the InvokeResponse on the context.turnState if it is set', async function () {
             class InvokeHandler extends TeamsActivityHandler {
                 async onInvokeActivity(context) {
                     assert(context, 'context not found');
-                    await context.sendActivity({ type: 'invokeResponse', value: { status: 200, body: `I'm a teapot.` } });
+                    await context.sendActivity({
+                        type: 'invokeResponse',
+                        value: { status: 200, body: `I'm a teapot.` },
+                    });
                     return { status: 418 };
                 }
             }
 
             const bot = new InvokeHandler();
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send({ type: ActivityTypes.Invoke })
-                .assertReply(activity => {
+            await adapter
+                .send({ type: ActivityTypes.Invoke })
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert(activity.value, 'activity.value not found');
                     assert.strictEqual(activity.value.status, 200);
                     assert.strictEqual(activity.value.body, `I'm a teapot.`);
-                    done();
                 })
                 .startTest();
-
         });
 
-        it('should call onTurnActivity if non-Invoke is received', done => {
+        it('should call onTurnActivity if non-Invoke is received', async function () {
             const bot = new TeamsActivityHandler();
             bot.onMessage(async (context, next) => {
                 await context.sendActivity('Hello');
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send({ type: ActivityTypes.Message, text: 'Hello' })
-                .assertReply(activity => {
+            await adapter
+                .send({ type: ActivityTypes.Message, text: 'Hello' })
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, ActivityTypes.Message);
                     assert.strictEqual(activity.text, 'Hello');
-                    done();
                 })
                 .startTest();
         });
@@ -67,177 +69,177 @@ describe('TeamsActivityHandler', () => {
                 super();
             }
 
-            handleTeamsO365ConnectorCardAction() { }
+            handleTeamsO365ConnectorCardAction() {}
 
-            handleTeamsAppBasedLinkQuery() { }
+            handleTeamsAppBasedLinkQuery() {}
 
-            handleTeamsMessagingExtensionQuery() { }
+            handleTeamsMessagingExtensionQuery() {}
 
-            handleTeamsMessagingExtensionSelectItem() { }
+            handleTeamsMessagingExtensionSelectItem() {}
 
-            handleTeamsMessagingExtensionFetchTask() { }
+            handleTeamsMessagingExtensionFetchTask() {}
 
-            handleTeamsMessagingExtensionConfigurationQuerySettingUrl() { }
+            handleTeamsMessagingExtensionConfigurationQuerySettingUrl() {}
 
-            handleTeamsMessagingExtensionConfigurationSetting() { }
+            handleTeamsMessagingExtensionConfigurationSetting() {}
 
-            handleTeamsMessagingExtensionCardButtonClicked() { }
+            handleTeamsMessagingExtensionCardButtonClicked() {}
         }
 
-        it('activity.name is not defined. should return status code [501].', done => {
+        it('activity.name is not defined. should return status code [501].', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const activity = { type: ActivityTypes.Invoke, channelId: 'msteams' };
 
-            adapter.send(activity)
-                .assertReply(activity => {
+            await adapter
+                .send(activity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.value.status, 501, 'should be a status code 501.');
-                    done();
                 })
                 .startTest();
         });
 
-        it('activity.name is "actionableMessage/executeAction". should return status code [200] when handleTeamsO365ConnectorCardAction method is overridden.', done => {
+        it('activity.name is "actionableMessage/executeAction". should return status code [200] when handleTeamsO365ConnectorCardAction method is overridden.', async function () {
             const bot = new InvokeActivityEmptyHandlers();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const activity = createInvokeActivity('actionableMessage/executeAction');
 
-            adapter.send(activity)
-                .assertReply(activity => {
+            await adapter
+                .send(activity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
-                    done();
                 })
                 .startTest();
         });
 
-        it('activity.name is "composeExtension/queryLink". should return status code [200] when handleTeamsAppBasedLinkQuery method is overridden.', done => {
+        it('activity.name is "composeExtension/queryLink". should return status code [200] when handleTeamsAppBasedLinkQuery method is overridden.', async function () {
             const bot = new InvokeActivityEmptyHandlers();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const activity = createInvokeActivity('composeExtension/queryLink');
 
-            adapter.send(activity)
-                .assertReply(activity => {
+            await adapter
+                .send(activity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
-                    done();
                 })
                 .startTest();
         });
 
-        it('activity.name is "composeExtension/query". should return status code [200] when handleTeamsMessagingExtensionQuery method is overridden.', done => {
+        it('activity.name is "composeExtension/query". should return status code [200] when handleTeamsMessagingExtensionQuery method is overridden.', async function () {
             const bot = new InvokeActivityEmptyHandlers();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const activity = createInvokeActivity('composeExtension/query');
 
-            adapter.send(activity)
-                .assertReply(activity => {
+            await adapter
+                .send(activity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
-                    done();
                 })
                 .startTest();
         });
 
-        it('activity.name is "composeExtension/selectItem". should return status code [200] when handleTeamsMessagingExtensionSelectItem method is overridden.', done => {
+        it('activity.name is "composeExtension/selectItem". should return status code [200] when handleTeamsMessagingExtensionSelectItem method is overridden.', async function () {
             const bot = new InvokeActivityEmptyHandlers();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const activity = createInvokeActivity('composeExtension/selectItem');
 
-            adapter.send(activity)
-                .assertReply(activity => {
+            await adapter
+                .send(activity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
-                    done();
                 })
                 .startTest();
         });
 
-        it('activity.name is "composeExtension/fetchTask". should return status code [200] when handleTeamsMessagingExtensionFetchTask method is overridden.', done => {
+        it('activity.name is "composeExtension/fetchTask". should return status code [200] when handleTeamsMessagingExtensionFetchTask method is overridden.', async function () {
             const bot = new InvokeActivityEmptyHandlers();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const activity = createInvokeActivity('composeExtension/fetchTask');
 
-            adapter.send(activity)
-                .assertReply(activity => {
+            await adapter
+                .send(activity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
-                    done();
                 })
                 .startTest();
         });
 
-        it('activity.name is "composeExtension/querySettingUrl". should return status code [200] when handleTeamsMessagingExtensionConfigurationQuerySettingUrl method is overridden.', done => {
+        it('activity.name is "composeExtension/querySettingUrl". should return status code [200] when handleTeamsMessagingExtensionConfigurationQuerySettingUrl method is overridden.', async function () {
             const bot = new InvokeActivityEmptyHandlers();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const activity = createInvokeActivity('composeExtension/querySettingUrl');
 
-            adapter.send(activity)
-                .assertReply(activity => {
+            await adapter
+                .send(activity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
-                    done();
                 })
                 .startTest();
         });
 
-        it('activity.name is "composeExtension/setting". should return status code [200] when handleTeamsMessagingExtensionConfigurationSetting method is overridden.', done => {
+        it('activity.name is "composeExtension/setting". should return status code [200] when handleTeamsMessagingExtensionConfigurationSetting method is overridden.', async function () {
             const bot = new InvokeActivityEmptyHandlers();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const activity = createInvokeActivity('composeExtension/setting');
 
-            adapter.send(activity)
-                .assertReply(activity => {
+            await adapter
+                .send(activity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
-                    done();
                 })
                 .startTest();
         });
 
-        it('activity.name is "composeExtension/onCardButtonClicked". should return status code [200] when handleTeamsMessagingExtensionCardButtonClicked method is overridden.', done => {
+        it('activity.name is "composeExtension/onCardButtonClicked". should return status code [200] when handleTeamsMessagingExtensionCardButtonClicked method is overridden.', async function () {
             const bot = new InvokeActivityEmptyHandlers();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const activity = createInvokeActivity('composeExtension/onCardButtonClicked');
 
-            adapter.send(activity)
-                .assertReply(activity => {
+            await adapter
+                .send(activity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.value.status, 200, 'should be status code 200.');
-                    done();
                 })
                 .startTest();
         });
 
-        it('should throw an error when onInvokeActivity param context is null.', done => {
+        it('should throw an error when onInvokeActivity param context is null.', async function () {
             class InvokeActivityHandler extends TeamsActivityHandler {
                 async onInvokeActivity() {
                     try {
@@ -250,265 +252,348 @@ describe('TeamsActivityHandler', () => {
 
             const bot = new InvokeActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const activity = createInvokeActivity();
 
-            adapter.send(activity)
-                .assertReply(activity => {
-                    assert.strictEqual(activity.value.message, 'Cannot read property \'activity\' of null', 'should have thrown an error.');
-                    done();
+            await adapter
+                .send(activity)
+                .assertReply((activity) => {
+                    assert.strictEqual(
+                        activity.value.message,
+                        "Cannot read property 'activity' of null",
+                        'should have thrown an error.'
+                    );
                 })
                 .startTest();
         });
     });
 
     describe('should send a BadRequest status code if', () => {
-        it('a bad BotMessagePreview.action is received by the bot', done => {
+        it('a bad BotMessagePreview.action is received by the bot', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            const fileConsentActivity = createInvokeActivity('composeExtension/submitAction', { botMessagePreviewAction: 'this.is.a.bad.action' });
-            adapter.send(fileConsentActivity)
-                .assertReply(activity => {
-                    assert(activity.type === 'invokeResponse', `incorrect activity type "${ activity.type }", expected "invokeResponse"`);
-                    assert(activity.value.status === 400, `incorrect status code "${ activity.value.status }", expected "400"`);
-                    assert(!activity.value.body,
-                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                    done();
+            const fileConsentActivity = createInvokeActivity('composeExtension/submitAction', {
+                botMessagePreviewAction: 'this.is.a.bad.action',
+            });
+
+            await adapter
+                .send(fileConsentActivity)
+                .assertReply((activity) => {
+                    assert(
+                        activity.type === 'invokeResponse',
+                        `incorrect activity type "${activity.type}", expected "invokeResponse"`
+                    );
+                    assert(
+                        activity.value.status === 400,
+                        `incorrect status code "${activity.value.status}", expected "400"`
+                    );
+                    assert(
+                        !activity.value.body,
+                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(
+                            activity.value.body
+                        )}`
+                    );
                 })
                 .startTest();
         });
 
-        it('a bad FileConsentCardResponse.action is received by the bot', done => {
+        it('a bad FileConsentCardResponse.action is received by the bot', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'this.is.a.bad.action' });
-            adapter.send(fileConsentActivity)
-                .assertReply(activity => {
-                    assert(activity.type === 'invokeResponse', `incorrect activity type "${ activity.type }", expected "invokeResponse"`);
-                    assert(activity.value.status === 400, `incorrect status code "${ activity.value.status }", expected "400"`);
-                    assert(!activity.value.body,
-                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                    done();
+
+            await adapter
+                .send(fileConsentActivity)
+                .assertReply((activity) => {
+                    assert(
+                        activity.type === 'invokeResponse',
+                        `incorrect activity type "${activity.type}", expected "invokeResponse"`
+                    );
+                    assert(
+                        activity.value.status === 400,
+                        `incorrect status code "${activity.value.status}", expected "400"`
+                    );
+                    assert(
+                        !activity.value.body,
+                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(
+                            activity.value.body
+                        )}`
+                    );
                 })
                 .startTest();
         });
     });
 
     describe('should send a NotImplemented status code if', () => {
-        it('handleTeamsMessagingExtensionSubmitAction is not overridden', done => {
+        it('handleTeamsMessagingExtensionSubmitAction is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const fileConsentActivity = createInvokeActivity('composeExtension/submitAction');
-            adapter.send(fileConsentActivity)
-                .assertReply(activity => {
-                    assert(activity.type === 'invokeResponse', `incorrect activity type "${ activity.type }", expected "invokeResponse"`);
-                    assert(activity.value.status === 501, `incorrect status code "${ activity.value.status }", expected "501"`);
-                    assert(!activity.value.body,
-                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                    done();
+
+            await adapter
+                .send(fileConsentActivity)
+                .assertReply((activity) => {
+                    assert(
+                        activity.type === 'invokeResponse',
+                        `incorrect activity type "${activity.type}", expected "invokeResponse"`
+                    );
+                    assert(
+                        activity.value.status === 501,
+                        `incorrect status code "${activity.value.status}", expected "501"`
+                    );
+                    assert(
+                        !activity.value.body,
+                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(
+                            activity.value.body
+                        )}`
+                    );
                 })
                 .startTest();
         });
 
-        it('onTeamsBotMessagePreviewEdit is not overridden', done => {
+        it('onTeamsBotMessagePreviewEdit is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            const fileConsentActivity = createInvokeActivity('composeExtension/submitAction', { botMessagePreviewAction: 'edit' });
-            adapter.send(fileConsentActivity)
-                .assertReply(activity => {
-                    assert(activity.type === 'invokeResponse', `incorrect activity type "${ activity.type }", expected "invokeResponse"`);
-                    assert(activity.value.status === 501, `incorrect status code "${ activity.value.status }", expected "501"`);
-                    assert(!activity.value.body,
-                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                    done();
+            const fileConsentActivity = createInvokeActivity('composeExtension/submitAction', {
+                botMessagePreviewAction: 'edit',
+            });
+
+            await adapter
+                .send(fileConsentActivity)
+                .assertReply((activity) => {
+                    assert(
+                        activity.type === 'invokeResponse',
+                        `incorrect activity type "${activity.type}", expected "invokeResponse"`
+                    );
+                    assert(
+                        activity.value.status === 501,
+                        `incorrect status code "${activity.value.status}", expected "501"`
+                    );
+                    assert(
+                        !activity.value.body,
+                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(
+                            activity.value.body
+                        )}`
+                    );
                 })
                 .startTest();
         });
 
-        it('onTeamsBotMessagePreviewSend is not overridden', done => {
+        it('onTeamsBotMessagePreviewSend is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            const fileConsentActivity = createInvokeActivity('composeExtension/submitAction', { botMessagePreviewAction: 'send' });
-            adapter.send(fileConsentActivity)
-                .assertReply(activity => {
-                    assert(activity.type === 'invokeResponse', `incorrect activity type "${ activity.type }", expected "invokeResponse"`);
-                    assert(activity.value.status === 501, `incorrect status code "${ activity.value.status }", expected "501"`);
-                    assert(!activity.value.body,
-                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                    done();
+            const fileConsentActivity = createInvokeActivity('composeExtension/submitAction', {
+                botMessagePreviewAction: 'send',
+            });
+
+            await adapter
+                .send(fileConsentActivity)
+                .assertReply((activity) => {
+                    assert(
+                        activity.type === 'invokeResponse',
+                        `incorrect activity type "${activity.type}", expected "invokeResponse"`
+                    );
+                    assert(
+                        activity.value.status === 501,
+                        `incorrect status code "${activity.value.status}", expected "501"`
+                    );
+                    assert(
+                        !activity.value.body,
+                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(
+                            activity.value.body
+                        )}`
+                    );
                 })
                 .startTest();
         });
 
-        it('handleTeamsFileConsentAccept is not overridden', done => {
+        it('handleTeamsFileConsentAccept is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'accept' });
-            adapter.send(fileConsentActivity)
-                .assertReply(activity => {
-                    assert(activity.type === 'invokeResponse', `incorrect activity type "${ activity.type }", expected "invokeResponse"`);
-                    assert(activity.value.status === 501, `incorrect status code "${ activity.value.status }", expected "501"`);
-                    assert(!activity.value.body,
-                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                    done();
+
+            await adapter
+                .send(fileConsentActivity)
+                .assertReply((activity) => {
+                    assert(
+                        activity.type === 'invokeResponse',
+                        `incorrect activity type "${activity.type}", expected "invokeResponse"`
+                    );
+                    assert(
+                        activity.value.status === 501,
+                        `incorrect status code "${activity.value.status}", expected "501"`
+                    );
+                    assert(
+                        !activity.value.body,
+                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(
+                            activity.value.body
+                        )}`
+                    );
                 })
                 .startTest();
         });
 
-        it('handleTeamsFileConsentDecline is not overridden', done => {
+        it('handleTeamsFileConsentDecline is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'decline' });
-            adapter.send(fileConsentActivity)
-                .assertReply(activity => {
+
+            await adapter
+                .send(fileConsentActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsO365ConnectorCardAction is not overridden', done => {
+        it('handleTeamsO365ConnectorCardAction is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const teamsO365ConnectorCardActionActivity = createInvokeActivity('actionableMessage/executeAction');
-            adapter.send(teamsO365ConnectorCardActionActivity)
-                .assertReply(activity => {
+
+            await adapter
+                .send(teamsO365ConnectorCardActionActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsSigninVerifyState is not overridden', done => {
+        it('handleTeamsSigninVerifyState is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const signinVerifyStateActivity = createInvokeActivity('signin/verifyState');
-            adapter.send(signinVerifyStateActivity)
-                .assertReply(activity => {
+
+            await adapter
+                .send(signinVerifyStateActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsSigninTokenExchange is not overridden', done => {
+        it('handleTeamsSigninTokenExchange is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const signinVerifyStateActivity = createInvokeActivity('signin/tokenExchange');
-            adapter.send(signinVerifyStateActivity)
-                .assertReply(activity => {
+
+            await adapter
+                .send(signinVerifyStateActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsMessagingExtensionCardButtonClicked is not overridden', done => {
+        it('handleTeamsMessagingExtensionCardButtonClicked is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const cardButtonClickedActivity = createInvokeActivity('composeExtension/onCardButtonClicked');
-            adapter.send(cardButtonClickedActivity)
-                .assertReply(activity => {
+
+            await adapter
+                .send(cardButtonClickedActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsTaskModuleFetch is not overridden', done => {
+        it('handleTeamsTaskModuleFetch is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const taskFetchActivity = createInvokeActivity('task/fetch');
-            adapter.send(taskFetchActivity)
-                .assertReply(activity => {
+
+            await adapter
+                .send(taskFetchActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsTaskModuleSubmit is not overridden', done => {
+        it('handleTeamsTaskModuleSubmit is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const taskSubmitActivity = createInvokeActivity('task/submit');
-            adapter.send(taskSubmitActivity)
-                .assertReply(activity => {
+
+            await adapter
+                .send(taskSubmitActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsTabFetch is not overridden', async () => {
+        it('handleTeamsTabFetch is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
             const adapter = new TestAdapter(async (context) => {
@@ -516,6 +601,7 @@ describe('TeamsActivityHandler', () => {
             });
 
             const taskFetchActivity = createInvokeActivity('tab/fetch');
+
             await adapter
                 .send(taskFetchActivity)
                 .assertReply((activity) => {
@@ -527,7 +613,7 @@ describe('TeamsActivityHandler', () => {
                 .startTest();
         });
 
-        it('handleTeamsTabSubmit is not overridden', async () => {
+        it('handleTeamsTabSubmit is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
             const adapter = new TestAdapter(async (context) => {
@@ -535,6 +621,7 @@ describe('TeamsActivityHandler', () => {
             });
 
             const taskSubmitActivity = createInvokeActivity('tab/submit');
+
             await adapter
                 .send(taskSubmitActivity)
                 .assertReply((activity) => {
@@ -546,128 +633,129 @@ describe('TeamsActivityHandler', () => {
                 .startTest();
         });
 
-        it('handleTeamsAppBasedLinkQuery is not overridden', done => {
+        it('handleTeamsAppBasedLinkQuery is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const taskSubmitActivity = createInvokeActivity('composeExtension/queryLink');
-            adapter.send(taskSubmitActivity)
-                .assertReply(activity => {
+
+            await adapter
+                .send(taskSubmitActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsMessagingExtensionConfigurationQuerySettingUrl is not overridden', done => {
+        it('handleTeamsMessagingExtensionConfigurationQuerySettingUrl is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const taskSubmitActivity = createInvokeActivity('composeExtension/querySettingUrl');
-            adapter.send(taskSubmitActivity)
-                .assertReply(activity => {
+            await adapter
+                .send(taskSubmitActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsMessagingExtensionQuery is not overridden', done => {
+        it('handleTeamsMessagingExtensionQuery is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const taskSubmitActivity = createInvokeActivity('composeExtension/query');
-            adapter.send(taskSubmitActivity)
-                .assertReply(activity => {
+            await adapter
+                .send(taskSubmitActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsMessagingExtensionSelectItem is not overridden', done => {
+        it('handleTeamsMessagingExtensionSelectItem is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const taskSubmitActivity = createInvokeActivity('composeExtension/selectItem');
-            adapter.send(taskSubmitActivity)
-                .assertReply(activity => {
+            await adapter
+                .send(taskSubmitActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsMessagingExtensionFetchTask is not overridden', done => {
+        it('handleTeamsMessagingExtensionFetchTask is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const taskSubmitActivity = createInvokeActivity('composeExtension/fetchTask');
-            adapter.send(taskSubmitActivity)
-                .assertReply(activity => {
+            await adapter
+                .send(taskSubmitActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsMessagingExtensionConfigurationQuerySettingUrl is not overridden', done => {
+        it('handleTeamsMessagingExtensionConfigurationQuerySettingUrl is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const taskSubmitActivity = createInvokeActivity('composeExtension/querySettingUrl');
-            adapter.send(taskSubmitActivity)
-                .assertReply(activity => {
+            await adapter
+                .send(taskSubmitActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsMessagingExtensionConfigurationSetting is not overridden', done => {
+        it('handleTeamsMessagingExtensionConfigurationSetting is not overridden', async function () {
             const bot = new TeamsActivityHandler();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const taskSubmitActivity = createInvokeActivity('composeExtension/setting');
-            adapter.send(taskSubmitActivity)
-                .assertReply(activity => {
+            await adapter
+                .send(taskSubmitActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 501);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
@@ -686,45 +774,65 @@ describe('TeamsActivityHandler', () => {
             }
         }
 
-        it('when a "fileConsent/invoke" activity is handled by handleTeamsFileConsentAccept', done => {
+        it('when a "fileConsent/invoke" activity is handled by handleTeamsFileConsentAccept', async function () {
             const bot = new OKFileConsent();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'accept' });
-            adapter.send(fileConsentActivity)
-                .assertReply(activity => {
-                    assert(activity.type === 'invokeResponse', `incorrect activity type "${ activity.type }", expected "invokeResponse"`);
-                    assert(activity.value.status === 200, `incorrect status code "${ activity.value.status }", expected "200"`);
-                    assert(!activity.value.body,
-                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                    done();
+            await adapter
+                .send(fileConsentActivity)
+                .assertReply((activity) => {
+                    assert(
+                        activity.type === 'invokeResponse',
+                        `incorrect activity type "${activity.type}", expected "invokeResponse"`
+                    );
+                    assert(
+                        activity.value.status === 200,
+                        `incorrect status code "${activity.value.status}", expected "200"`
+                    );
+                    assert(
+                        !activity.value.body,
+                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(
+                            activity.value.body
+                        )}`
+                    );
                 })
                 .startTest();
         });
 
-        it('when a "fileConsent/invoke" activity is handled by handleTeamsFileConsentDecline', done => {
+        it('when a "fileConsent/invoke" activity is handled by handleTeamsFileConsentDecline', async function () {
             const bot = new OKFileConsent();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'decline' });
-            adapter.send(fileConsentActivity)
-                .assertReply(activity => {
-                    assert(activity.type === 'invokeResponse', `incorrect activity type "${ activity.type }", expected "invokeResponse"`);
-                    assert(activity.value.status === 200, `incorrect status code "${ activity.value.status }", expected "200"`);
-                    assert(!activity.value.body,
-                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                    done();
+            await adapter
+                .send(fileConsentActivity)
+                .assertReply((activity) => {
+                    assert(
+                        activity.type === 'invokeResponse',
+                        `incorrect activity type "${activity.type}", expected "invokeResponse"`
+                    );
+                    assert(
+                        activity.value.status === 200,
+                        `incorrect status code "${activity.value.status}", expected "200"`
+                    );
+                    assert(
+                        !activity.value.body,
+                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(
+                            activity.value.body
+                        )}`
+                    );
                 })
                 .startTest();
         });
 
-        it('when a "fileConsent/invoke" activity handled by handleTeamsFileConsent', done => {
+        it('when a "fileConsent/invoke" activity handled by handleTeamsFileConsent', async function () {
             class FileConsent extends TeamsActivityHandler {
                 async handleTeamsFileConsent(context, fileConsentCardResponse) {
                     assert(context, 'context not found');
@@ -733,22 +841,31 @@ describe('TeamsActivityHandler', () => {
             }
             const bot = new FileConsent();
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'accept' });
-            adapter.send(fileConsentActivity)
-                .assertReply(activity => {
-                    assert(activity.type === 'invokeResponse', `incorrect activity type "${ activity.type }", expected "invokeResponse"`);
-                    assert(activity.value.status === 200, `incorrect status code "${ activity.value.status }", expected "200"`);
-                    assert(!activity.value.body,
-                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                    done();
+            await adapter
+                .send(fileConsentActivity)
+                .assertReply((activity) => {
+                    assert(
+                        activity.type === 'invokeResponse',
+                        `incorrect activity type "${activity.type}", expected "invokeResponse"`
+                    );
+                    assert(
+                        activity.value.status === 200,
+                        `incorrect status code "${activity.value.status}", expected "200"`
+                    );
+                    assert(
+                        !activity.value.body,
+                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(
+                            activity.value.body
+                        )}`
+                    );
                 })
                 .startTest();
         });
-
 
         describe('and the return value from', () => {
             class TaskHandler extends TeamsActivityHandler {
@@ -786,47 +903,47 @@ describe('TeamsActivityHandler', () => {
                 }
             }
 
-            it('an overridden handleTeamsTaskModuleFetch()', done => {
+            it('an overridden handleTeamsTaskModuleFetch()', async function () {
                 const bot = new TaskHandler();
 
-                const adapter = new TestAdapter(async context => {
+                const adapter = new TestAdapter(async (context) => {
                     await bot.run(context);
                 });
 
                 const taskFetchActivity = createInvokeActivity('task/fetch', { data: 'fetch' });
-                adapter.send(taskFetchActivity)
-                    .assertReply(activity => {
+                await adapter
+                    .send(taskFetchActivity)
+                    .assertReply((activity) => {
                         assert.strictEqual(activity.type, 'invokeResponse');
                         assert(activity.value, 'activity.value not found');
                         assert.strictEqual(activity.value.status, 200);
                         assert.strictEqual(activity.value.body, bot.taskFetchReturn);
-                        done();
                     })
-                    .catch(err => done(err))
+
                     .startTest();
             });
 
-            it('an overridden handleTeamsTaskModuleSubmit()', done => {
+            it('an overridden handleTeamsTaskModuleSubmit()', async function () {
                 const bot = new TaskHandler();
 
-                const adapter = new TestAdapter(async context => {
+                const adapter = new TestAdapter(async (context) => {
                     await bot.run(context);
                 });
 
                 const taskSubmitActivity = createInvokeActivity('task/submit', { data: 'submit' });
-                adapter.send(taskSubmitActivity)
-                    .assertReply(activity => {
+                await adapter
+                    .send(taskSubmitActivity)
+                    .assertReply((activity) => {
                         assert.strictEqual(activity.type, 'invokeResponse');
                         assert(activity.value, 'activity.value not found');
                         assert.strictEqual(activity.value.status, 200);
                         assert.strictEqual(activity.value.body, bot.taskSubmitReturn);
-                        done();
                     })
-                    .catch(err => done(err))
+
                     .startTest();
             });
 
-            it('an overridden handleTeamsTabFetch()', async () => {
+            it('an overridden handleTeamsTabFetch()', async function () {
                 const bot = new TaskHandler();
 
                 const adapter = new TestAdapter(async (context) => {
@@ -854,7 +971,7 @@ describe('TeamsActivityHandler', () => {
                     .startTest();
             });
 
-            it('an overridden handleTeamsTabSubmit()', async () => {
+            it('an overridden handleTeamsTabSubmit()', async function () {
                 const bot = new TaskHandler();
 
                 const adapter = new TestAdapter(async (context) => {
@@ -885,36 +1002,38 @@ describe('TeamsActivityHandler', () => {
     });
 
     describe('should send a BadRequest status code when', () => {
-        it('handleTeamsFileConsent() receives an unexpected action value', done => {
+        it('handleTeamsFileConsent() receives an unexpected action value', async function () {
             const bot = new TeamsActivityHandler();
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'test' });
 
-            adapter.send(fileConsentActivity)
-                .assertReply(activity => {
+            await adapter
+                .send(fileConsentActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 400);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsMessagingExtensionSubmitActionDispatch() receives an unexpected botMessagePreviewAction value', done => {
+        it('handleTeamsMessagingExtensionSubmitActionDispatch() receives an unexpected botMessagePreviewAction value', async function () {
             const bot = new TeamsActivityHandler();
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
-            const fileConsentActivity = createInvokeActivity('composeExtension/submitAction', { botMessagePreviewAction: 'test' });
+            const fileConsentActivity = createInvokeActivity('composeExtension/submitAction', {
+                botMessagePreviewAction: 'test',
+            });
 
-            adapter.send(fileConsentActivity)
-                .assertReply(activity => {
+            await adapter
+                .send(fileConsentActivity)
+                .assertReply((activity) => {
                     assert.strictEqual(activity.type, 'invokeResponse');
                     assert.strictEqual(activity.value.status, 400);
                     assert.strictEqual(activity.value.body, undefined);
-                    done();
                 })
                 .startTest();
         });
@@ -936,14 +1055,20 @@ describe('TeamsActivityHandler', () => {
             async handleTeamsFileConsentAccept(context, fileConsentCardResponse) {
                 assert(context, 'context not found');
                 assert(fileConsentCardResponse, 'fileConsentCardResponse not found');
-                assert(fileConsentCalled, 'handleTeamsFileConsent handler was not called before handleTeamsFileConsentAccept handler');
+                assert(
+                    fileConsentCalled,
+                    'handleTeamsFileConsent handler was not called before handleTeamsFileConsentAccept handler'
+                );
                 fileConsentAcceptCalled = true;
             }
 
             async handleTeamsFileConsentDecline(context, fileConsentCardResponse) {
                 assert(context, 'context not found');
                 assert(fileConsentCardResponse, 'fileConsentCardResponse not found');
-                assert(fileConsentCalled, 'handleTeamsFileConsent handler was not called before handleTeamsFileConsentDecline handler');
+                assert(
+                    fileConsentCalled,
+                    'handleTeamsFileConsent handler was not called before handleTeamsFileConsentDecline handler'
+                );
                 fileConsentDeclineCalled = true;
             }
         }
@@ -960,57 +1085,77 @@ describe('TeamsActivityHandler', () => {
             fileConsentCalled = false;
         });
 
-        it('handleTeamsFileConsent handler before an handleTeamsFileConsentAccept handler', done => {
+        it('handleTeamsFileConsent handler before an handleTeamsFileConsentAccept handler', async function () {
             const bot = new FileConsentBot();
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'accept' });
-            adapter.send(fileConsentActivity)
-                .assertReply(activity => {
-                    assert(activity.type === 'invokeResponse', `incorrect activity type "${ activity.type }", expected "invokeResponse"`);
-                    assert(activity.value.status === 200, `incorrect status code "${ activity.value.status }", expected "200"`);
-                    assert(!activity.value.body,
-                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                }).then(() => {
+            await adapter
+                .send(fileConsentActivity)
+                .assertReply((activity) => {
+                    assert(
+                        activity.type === 'invokeResponse',
+                        `incorrect activity type "${activity.type}", expected "invokeResponse"`
+                    );
+                    assert(
+                        activity.value.status === 200,
+                        `incorrect status code "${activity.value.status}", expected "200"`
+                    );
+                    assert(
+                        !activity.value.body,
+                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(
+                            activity.value.body
+                        )}`
+                    );
+                })
+                .then(() => {
                     assert(fileConsentCalled, 'handleTeamsFileConsent handler not called');
                     assert(fileConsentAcceptCalled, 'handleTeamsFileConsentAccept handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('handleTeamsFileConsent handler before an handleTeamsFileConsentDecline handler', done => {
+        it('handleTeamsFileConsent handler before an handleTeamsFileConsentDecline handler', async function () {
             const bot = new FileConsentBot();
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const fileConsentActivity = createInvokeActivity('fileConsent/invoke', { action: 'decline' });
-            adapter.send(fileConsentActivity)
-                .assertReply(activity => {
-                    assert(activity.type === 'invokeResponse', `incorrect activity type "${ activity.type }", expected "invokeResponse"`);
-                    assert(activity.value.status === 200, `incorrect status code "${ activity.value.status }", expected "200"`);
-                    assert(!activity.value.body,
-                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${ JSON.stringify(activity.value.body) }`);
-                }).then(() => {
+            await adapter
+                .send(fileConsentActivity)
+                .assertReply((activity) => {
+                    assert(
+                        activity.type === 'invokeResponse',
+                        `incorrect activity type "${activity.type}", expected "invokeResponse"`
+                    );
+                    assert(
+                        activity.value.status === 200,
+                        `incorrect status code "${activity.value.status}", expected "200"`
+                    );
+                    assert(
+                        !activity.value.body,
+                        `expected empty body for invokeResponse from fileConsent flow.\nReceived: ${JSON.stringify(
+                            activity.value.body
+                        )}`
+                    );
+                })
+                .then(() => {
                     assert(fileConsentCalled, 'handleTeamsFileConsent handler not called');
                     assert(fileConsentDeclineCalled, 'handleTeamsFileConsentDecline handler not called');
-                    done();
                 })
                 .startTest();
         });
     });
 
-
-    describe('should call onDialog handlers after successfully handling an', () => {
-
+    describe('should call onDialog handlers after successfully handling an activity', () => {
         function createConvUpdateActivity(channelData) {
             const activity = {
                 type: ActivityTypes.ConversationUpdate,
                 channelData,
-                channelId: 'msteams'
+                channelId: 'msteams',
             };
             return activity;
         }
@@ -1019,7 +1164,7 @@ describe('TeamsActivityHandler', () => {
             const activity = {
                 type: ActivityTypes.Invoke,
                 name: 'signin/verifyState',
-                channelData
+                channelData,
             };
             return activity;
         }
@@ -1028,7 +1173,7 @@ describe('TeamsActivityHandler', () => {
             const activity = {
                 type: ActivityTypes.Invoke,
                 name: 'signin/tokenExchange',
-                channelData
+                channelData,
             };
             return activity;
         }
@@ -1046,12 +1191,12 @@ describe('TeamsActivityHandler', () => {
             onDialogCalled = true;
         });
 
-        it('No MS-Teams routed activity', done => {
+        it('No MS-Teams routed activity', async function () {
             const bot = new TeamsActivityHandler();
 
             const activity = { type: ActivityTypes.ConversationUpdate, channelId: 'no-msteams' };
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
@@ -1060,20 +1205,24 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('MS-Teams with non-existent channelData.eventType routed activity', done => {
+        it('MS-Teams with non-existent channelData.eventType routed activity', async function () {
             const bot = new TeamsActivityHandler();
 
-            const activity = { type: ActivityTypes.ConversationUpdate, channelId: 'msteams', channelData: { eventType: 'non-existent' } };
+            const activity = {
+                type: ActivityTypes.ConversationUpdate,
+                channelId: 'msteams',
+                channelData: { eventType: 'non-existent' },
+            };
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
@@ -1082,20 +1231,20 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('MS-Teams with no channelData routed activity', done => {
+        it('MS-Teams with no channelData routed activity', async function () {
             const bot = new TeamsActivityHandler();
 
             const activity = { type: ActivityTypes.ConversationUpdate, channelId: 'msteams' };
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
@@ -1104,15 +1253,15 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsMembersAdded routed activity', done => {
+        it('onTeamsMembersAdded routed activity', async function () {
             const bot = new TeamsActivityHandler();
             let onTeamsMemberAddedEvent = false;
             let getMemberCalledCount = 0;
@@ -1147,29 +1296,29 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const wasGetMember = TeamsInfo.getMember;
-            TeamsInfo.getMember = function(context, userId) {
+            TeamsInfo.getMember = function (context, userId) {
                 getMemberCalledCount++;
-                return membersAddedMock.filter(obj => obj.id === userId)[0];
+                return membersAddedMock.filter((obj) => obj.id === userId)[0];
             };
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsMemberAddedEvent, 'onTeamsMemberAddedEvent handler not called');
                     assert(onConversationUpdateCalled, 'handleTeamsFileConsentAccept handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
                     assert(getMemberCalledCount === 2, 'TeamsInfo.getMember not called twice');
                     TeamsInfo.getMember = wasGetMember;
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsMembersAdded routed activity with no TeamsMembersAddedEvent handler', done => {
+        it('onTeamsMembersAdded routed activity with no TeamsMembersAddedEvent handler', async function () {
             const bot = new TeamsActivityHandler();
 
             const membersAddedMock = [{ id: 'test' }, { id: 'id' }];
@@ -1182,19 +1331,19 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsMembersAdded for bot routed activity should throw a ConversationNotFound Error on TeamsInfo.getMember', done => {
+        it('onTeamsMembersAdded for bot routed activity should throw a ConversationNotFound Error on TeamsInfo.getMember', async function () {
             const bot = new TeamsActivityHandler();
             let onTeamsMemberAddedEvent = false;
             let getMemberCalled = false;
@@ -1229,29 +1378,29 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const wasGetMember = TeamsInfo.getMember;
-            TeamsInfo.getMember = function() {
+            TeamsInfo.getMember = function () {
                 getMemberCalled = true;
                 throw { body: { error: { code: 'ConversationNotFound' } } };
             };
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsMemberAddedEvent, 'onTeamsMemberAddedEvent handler not called');
                     assert(onConversationUpdateCalled, 'handleTeamsFileConsentAccept handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
                     assert(getMemberCalled, 'TeamsInfo.getMember handler not called');
                     TeamsInfo.getMember = wasGetMember;
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsMembersAdded for bot routed activity should throw an Error on TeamsInfo.getMember', done => {
+        it('onTeamsMembersAdded for bot routed activity should throw an Error on TeamsInfo.getMember', async function () {
             const bot = new TeamsActivityHandler();
             let onTeamsMemberAddedEvent = false;
             let getMemberCalled = false;
@@ -1286,37 +1435,36 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const wasGetMember = TeamsInfo.getMember;
-            TeamsInfo.getMember = function() {
+            TeamsInfo.getMember = function () {
                 getMemberCalled = true;
                 throw 'TeamsInfo.getMember Error';
             };
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsMemberAddedEvent, 'onTeamsMemberAddedEvent handler not called');
                     assert(onConversationUpdateCalled, 'handleTeamsFileConsentAccept handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
                     assert(getMemberCalled, 'TeamsInfo.getMember handler not called');
                     TeamsInfo.getMember = wasGetMember;
-                    done();
                 })
-                .catch(err => {
+                .catch((err) => {
                     if (err === 'TeamsInfo.getMember Error') {
                         TeamsInfo.getMember = wasGetMember;
-                        done();
                     } else {
-                        done(err);
+                        assert.fail(err);
                     }
                 })
                 .startTest();
         });
 
-        it('onTeamsMembersAdded for bot routed activity does NOT call TeamsInfo.getMember', done => {
+        it('onTeamsMembersAdded for bot routed activity does NOT call TeamsInfo.getMember', async function () {
             const bot = new TeamsActivityHandler();
             let onTeamsMemberAddedEvent = false;
             let getMemberCalled = false;
@@ -1352,29 +1500,29 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
             const wasGetMember = TeamsInfo.getMember;
-            TeamsInfo.getMember = function(context, userId) {
+            TeamsInfo.getMember = function (context, userId) {
                 getMemberCalled = true;
-                return membersAddedMock.filter(obj => obj.id === userId)[0];
+                return membersAddedMock.filter((obj) => obj.id === userId)[0];
             };
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsMemberAddedEvent, 'onTeamsMemberAddedEvent handler not called');
                     assert(onConversationUpdateCalled, 'handleTeamsFileConsentAccept handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
                     assert(getMemberCalled === false, 'TeamsInfo.getMember was called, but should not have been');
                     TeamsInfo.getMember = wasGetMember;
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsMembersRemoved routed activity', done => {
+        it('onTeamsMembersRemoved routed activity', async function () {
             const bot = new TeamsActivityHandler();
 
             let onTeamsMemberRemovedEvent = false;
@@ -1409,21 +1557,21 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsMemberRemovedEvent, 'onTeamsMemberRemovedEvent handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdateCalled handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsMembersRemoved routed activity with no TeamsMembersRemovedEvent handler', done => {
+        it('onTeamsMembersRemoved routed activity with no TeamsMembersRemovedEvent handler', async function () {
             const bot = new TeamsActivityHandler();
 
             const membersRemovedMock = [{ id: 'test' }, { id: 'id' }];
@@ -1436,19 +1584,19 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsChannelCreated routed activity', done => {
+        it('onTeamsChannelCreated routed activity', async function () {
             const bot = new TeamsActivityHandler();
 
             let onTeamsChannelCreatedEventCalled = false;
@@ -1482,21 +1630,21 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsChannelCreatedEventCalled, 'onTeamsChannelCreated handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsChannelDeleted routed activity', done => {
+        it('onTeamsChannelDeleted routed activity', async function () {
             const bot = new TeamsActivityHandler();
 
             let onTeamsChannelDeletedEventCalled = false;
@@ -1530,21 +1678,21 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsChannelDeletedEventCalled, 'onTeamsChannelDeletedEvent handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsChannelRenamed routed activity', done => {
+        it('onTeamsChannelRenamed routed activity', async function () {
             const bot = new TeamsActivityHandler();
 
             let onTeamsChannelRenamedEventCalled = false;
@@ -1578,25 +1726,25 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsChannelRenamedEventCalled, 'onTeamsChannelRenamedEvent handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsChannelRestored routed activity', done => {
+        it('onTeamsChannelRestored routed activity', async function () {
             const bot = new TeamsActivityHandler();
-    
+
             let onTeamsChannelRestoredEventCalled = false;
-    
+
             const team = { id: 'team' };
             const channel = { id: 'channel', name: 'channelName' };
             const activity = createConvUpdateActivity({ channel, team, eventType: 'channelRestored' });
@@ -1625,22 +1773,22 @@ describe('TeamsActivityHandler', () => {
                 onDialogCalled = true;
                 await next();
             });
-    
-            const adapter = new TestAdapter(async context => {
+
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
-    
-            adapter.send(activity)
+
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsChannelRestoredEventCalled, 'onTeamsChannelRestoredEvent handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
-        
-        it('onTeamsTeamRenamed routed activity', done => {
+
+        it('onTeamsTeamRenamed routed activity', async function () {
             const bot = new TeamsActivityHandler();
 
             let onTeamsTeamRenamedEventCalled = false;
@@ -1671,21 +1819,21 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsTeamRenamedEventCalled, 'onTeamsTeamRenamedEvent handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsTeamArchived routed activity', done => {
+        it('onTeamsTeamArchived routed activity', async function () {
             const bot = new TeamsActivityHandler();
 
             let onTeamsTeamArchivedEventCalled = false;
@@ -1716,21 +1864,21 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsTeamArchivedEventCalled, 'onTeamsTeamArchivedEvent handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsTeamDeleted routed activity', done => {
+        it('onTeamsTeamDeleted routed activity', async function () {
             const bot = new TeamsActivityHandler();
 
             let onTeamsTeamDeletedEventCalled = false;
@@ -1761,21 +1909,21 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsTeamDeletedEventCalled, 'onTeamsTeamDeletedEvent handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsTeamHardDeleted routed activity', done => {
+        it('onTeamsTeamHardDeleted routed activity', async function () {
             const bot = new TeamsActivityHandler();
 
             let onTeamsTeamHardDeletedEventCalled = false;
@@ -1806,21 +1954,21 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsTeamHardDeletedEventCalled, 'onTeamsTeamHardDeletedEvent handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsTeamRestored routed activity', done => {
+        it('onTeamsTeamRestored routed activity', async function () {
             const bot = new TeamsActivityHandler();
 
             let onTeamsTeamRestoredEventCalled = false;
@@ -1851,21 +1999,21 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsTeamRestoredEventCalled, 'onTeamsTeamRestoredEvent handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('onTeamsTeamUnarchived routed activity', done => {
+        it('onTeamsTeamUnarchived routed activity', async function () {
             const bot = new TeamsActivityHandler();
 
             let onTeamsTeamUnarchivedEventCalled = false;
@@ -1896,21 +2044,21 @@ describe('TeamsActivityHandler', () => {
                 await next();
             });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onTeamsTeamUnarchivedEventCalled, 'onTeamsTeamUnarchivedEvent handler not called');
                     assert(onConversationUpdateCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('signin/verifyState routed activity', done => {
+        it('signin/verifyState routed activity', async function () {
             onDialogCalled = false;
             let handleTeamsSigninVerifyStateCalled = false;
 
@@ -1936,20 +2084,20 @@ describe('TeamsActivityHandler', () => {
             const team = { id: 'team' };
             const activity = createSignInVerifyState({ team, channelId: 'msteams' });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     assert(handleTeamsSigninVerifyStateCalled, 'handleTeamsSigninVerifyState handler not called');
-                    done();
                 })
                 .startTest();
         });
 
-        it('signin/tokenExchange routed activity', done => {
+        it('signin/tokenExchange routed activity', async function () {
             onDialogCalled = false;
             let handleTeamsSigninTokenExchangeCalled = false;
 
@@ -1975,15 +2123,15 @@ describe('TeamsActivityHandler', () => {
             const team = { id: 'team' };
             const activity = createSigninTokenExchange({ team, channelId: 'msteams' });
 
-            const adapter = new TestAdapter(async context => {
+            const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
             });
 
-            adapter.send(activity)
+            await adapter
+                .send(activity)
                 .then(() => {
                     assert(onDialogCalled, 'onDialog handler not called');
                     assert(handleTeamsSigninTokenExchangeCalled, 'handleTeamsSigninTokenExchange handler not called');
-                    done();
                 })
                 .startTest();
         });

--- a/libraries/botbuilder/tests/teamsInfo.test.js
+++ b/libraries/botbuilder/tests/teamsInfo.test.js
@@ -147,14 +147,12 @@ const teamActivity = {
 };
 
 describe('TeamsInfo', () => {
-    beforeEach((done) => {
+    beforeEach(() => {
         nock.cleanAll();
-        done();
     });
 
-    afterEach((done) => {
+    afterEach(() => {
         nock.cleanAll();
-        done();
     });
 
     // Sets up nock expectation for an oauth token call, returning the expected auth header
@@ -807,23 +805,21 @@ describe('TeamsInfo', () => {
 
     describe('private methods', () => {
         describe('getConnectorClient()', () => {
-            it(`should error if the context doesn't have an adapter`, (done) => {
+            it(`should error if the context doesn't have an adapter`, function () {
                 try {
                     TeamsInfo.getConnectorClient({});
-                    done(new Error('should have thrown an error'));
+                    assert.fail('should have thrown an error');
                 } catch (err) {
                     assert.strictEqual(err.message, 'This method requires a connector client.');
-                    done();
                 }
             });
 
-            it(`should error if the adapter doesn't have a createConnectorClient method`, (done) => {
+            it(`should error if the adapter doesn't have a createConnectorClient method`, function () {
                 try {
                     TeamsInfo.getConnectorClient({ adapter: {} });
-                    done(new Error('should have thrown an error'));
+                    assert.fail('should have thrown an error');
                 } catch (err) {
                     assert.strictEqual(err.message, 'This method requires a connector client.');
-                    done();
                 }
             });
         });


### PR DESCRIPTION
Partial fix for #3226. This will be done in multiple PRs.

## Covers

(Alphabetically such that `botbuilder` comes before `botbuilder-`)

* `adaptive-expressions-ie11` through `botbuilder`, inclusive

## Excludes

* Many tests in [`channelServiceRoutes.test.js`](https://github.com/microsoft/botbuilder-js/blob/main/libraries/botbuilder/tests/channelServiceRoutes.test.js?rgh-link-date=2021-03-19T18%3A34%3A40Z#L118)

## Description

Replaces the use of `done()` in tests with proper `async/await`.

## Specific Changes

  - `done` => `async/await`
  - Remove `done` completely when used in synchronous tests. For example, it was in some `beforeEach()` hooks, but it's not needed; [nock doesn't even use it there](https://github.com/nock/nock/blob/af7105c3c1731be5c0f2051b20bd44ead006e177/tests/setup.js#L12)
  - Remove some of the try/catches that are no longer needed since we don't need `done(err)`
  - [Avoid arrow function in mocha tests](https://mochajs.org/#arrow-functions)
  - A lot of no-op stuff auto-fixes with our prettier/eslint settings

## Notes (mostly for me)

* Regex for finding done usage: `(done =>)|\(done\)`
* Search in: `./libraries/**/**/tests/**/*.js`
* For adding `await` to `adapter.send()` calls: `(?<!(await)|(const))\sadapter`