### PR TITLE
Replace done w/ async part 2

### DIFF
--- a/libraries/botbuilder-ai/tests/luisSdk.test.js
+++ b/libraries/botbuilder-ai/tests/luisSdk.test.js
@@ -72,7 +72,7 @@ function WithinDelta(token1, token2, delta, compare) {
 // 1) Create a <name>.json file with an object { text:<query> } in it.
 // 2) Run this test sith mockLuis = false which will fail and generate a <name>.json.new file.
 // 3) Check the .new file and if correct, replace the original .json file with it.
-function TestJson(file, done, includeAllIntents, includeInstance) {
+async function TestJson(file, includeAllIntents, includeInstance) {
     if (includeAllIntents === undefined) includeAllIntents = true;
     if (includeInstance === undefined) includeInstance = true;
 
@@ -82,30 +82,24 @@ function TestJson(file, done, includeAllIntents, includeInstance) {
     let newPath = expectedPath + '.new';
 
     let client = new LUISRuntimeClient(creds, baseUrl);
-    client.prediction
-        .resolve(applicationId, expected.query, {
-            includeAllIntents: includeAllIntents,
-            includeInstance: includeInstance,
-            verbose: true,
-            customHeaders: {
-                'Ocp-Apim-Subscription-Key': endpointKey,
-                'User-Agent': 'botbuilder',
-            },
-        })
-        .then((result) => {
-            result.v2 = result.luisResult;
-            delete result.luisResult;
-            if (!WithinDelta(expected, result, 0.1, false)) {
-                fs.outputJSONSync(newPath, result, { spaces: 2 });
-                assert(false, '\nReturned JSON\n ' + newPath + '\n!= expected JSON\n ' + expectedPath);
-            } else if (fs.existsSync(newPath)) {
-                fs.unlinkSync(newPath);
-            }
-            done(result);
-        })
-        .catch(function (err) {
-            console.error(err);
-        });
+    const result = await client.prediction.resolve(applicationId, expected.query, {
+        includeAllIntents: includeAllIntents,
+        includeInstance: includeInstance,
+        verbose: true,
+        customHeaders: {
+            'Ocp-Apim-Subscription-Key': endpointKey,
+            'User-Agent': 'botbuilder',
+        },
+    });
+    result.v2 = result.luisResult;
+    delete result.luisResult;
+    if (!WithinDelta(expected, result, 0.1, false)) {
+        fs.outputJSONSync(newPath, result, { spaces: 2 });
+        assert(false, '\nReturned JSON\n ' + newPath + '\n!= expected JSON\n ' + expectedPath);
+    } else if (fs.existsSync(newPath)) {
+        fs.unlinkSync(newPath);
+    }
+    return result;
 }
 
 function findIntent(key, data) {
@@ -158,146 +152,146 @@ describe('LuisPredict', function () {
         );
         return;
     }
-    it('test built-ins composite1', (done) => TestJson('Composite1.json', () => done()));
-    it('test built-ins composite2', (done) => TestJson('Composite2.json', () => done()));
-    it('test built-ins composite3', (done) => TestJson('Composite3.json', () => done()));
-    it('test built-ins prebuilt', (done) => TestJson('Prebuilt.json', () => done()));
-    it('test patterns', (done) => TestJson('Patterns.json', () => done()));
-    it('should return single intent and a simple entity', (done) => {
-        TestJson(
-            'SingleIntent_SimplyEntity.json',
-            (result) => {
-                assert(result);
-                assert(result.query == 'My name is Emad');
-                let specifyName = findIntent('SpecifyName', result.intents);
-                assert(specifyName != null);
-                assert(specifyName.score > 0 && specifyName.score <= 1);
-                assert(result.entities);
-                let name = findEntityByType('Name', result.entities);
-                assert(name);
-                assert(name.entity === 'emad');
-                assert(name.startIndex === 11);
-                assert(name.endIndex === 14);
-                assert(name.score > 0 && name.score <= 1);
-                done();
-            },
-            false
-        );
+    it('test built-ins composite1', async function () {
+        await TestJson('Composite1.json');
+    });
+    it('test built-ins composite2', async function () {
+        await TestJson('Composite2.json');
+    });
+    it('test built-ins composite3', async function () {
+        await TestJson('Composite3.json');
+    });
+    it('test built-ins prebuilt', async function () {
+        await TestJson('Prebuilt.json');
+    });
+    it('test patterns', async function () {
+        await TestJson('Patterns.json');
+    });
+    it('should return single intent and a simple entity', async function () {
+        const result = await TestJson('SingleIntent_SimplyEntity.json', false);
+
+        assert(result);
+        assert(result.query == 'My name is Emad');
+        let specifyName = findIntent('SpecifyName', result.intents);
+        assert(specifyName != null);
+        assert(specifyName.score > 0 && specifyName.score <= 1);
+        assert(result.entities);
+        let name = findEntityByType('Name', result.entities);
+        assert(name);
+        assert(name.entity === 'emad');
+        assert(name.startIndex === 11);
+        assert(name.endIndex === 14);
+        assert(name.score > 0 && name.score <= 1);
     });
 
-    it('should return multiple intents and prebuilt entities with a single value', (done) => {
-        TestJson('MultipleIntents_PrebuiltEntity.json', (result) => {
-            assert(result);
-            assert(result.query == 'Please deliver February 2nd 2001');
-            assert(result.intents);
-            let delivery = findIntent('Delivery', result.intents);
-            assert(delivery != null);
-            assert(delivery.score > 0 && delivery.score <= 1);
-            assert(result.topScoringIntent.intent == 'Delivery');
-            assert(result.entities);
-            let year = findEntity('2001', result.entities);
-            assert(year);
-            assert(year.type == 'builtin.number');
-            assert(year.startIndex == 28);
-            assert(year.endIndex == 31);
-            let dateTime = findEntityByType('builtin.datetimeV2.date', result.entities);
-            assert(dateTime.startIndex == 15);
-            assert(dateTime.endIndex == 31);
-            done();
-        });
+    it('should return multiple intents and prebuilt entities with a single value', async function () {
+        const result = await TestJson('MultipleIntents_PrebuiltEntity.json');
+
+        assert(result);
+        assert(result.query == 'Please deliver February 2nd 2001');
+        assert(result.intents);
+        let delivery = findIntent('Delivery', result.intents);
+        assert(delivery != null);
+        assert(delivery.score > 0 && delivery.score <= 1);
+        assert(result.topScoringIntent.intent == 'Delivery');
+        assert(result.entities);
+        let year = findEntity('2001', result.entities);
+        assert(year);
+        assert(year.type == 'builtin.number');
+        assert(year.startIndex == 28);
+        assert(year.endIndex == 31);
+        let dateTime = findEntityByType('builtin.datetimeV2.date', result.entities);
+        assert(dateTime.startIndex == 15);
+        assert(dateTime.endIndex == 31);
     });
 
-    it('should return multiple intents and prebuilt entities with multiple values', (done) => {
-        TestJson('MultipleIntents_PrebuiltEntitiesWithMultiValues.json', (result) => {
-            assert(result);
-            assert(result.query == 'Please deliver February 2nd 2001 in room 201');
-            assert(result.intents);
-            let deliveryIntent = findIntent('Delivery', result.intents);
-            assert(deliveryIntent != null);
-            assert(deliveryIntent.score > 0 && deliveryIntent.score <= 1);
-            assert(result.entities);
-            let dateTime = findEntityByType('builtin.datetimeV2.date', result.entities);
-            assert(dateTime.startIndex == 15);
-            assert(dateTime.endIndex == 31);
-            let builtin = findEntityByType('builtin.dimension', result.entities);
-            assert(builtin.startIndex == 28);
-            assert(builtin.endIndex == 34);
-            done();
-        });
+    it('should return multiple intents and prebuilt entities with multiple values', async function () {
+        const result = await TestJson('MultipleIntents_PrebuiltEntitiesWithMultiValues.json');
+
+        assert(result);
+        assert(result.query == 'Please deliver February 2nd 2001 in room 201');
+        assert(result.intents);
+        let deliveryIntent = findIntent('Delivery', result.intents);
+        assert(deliveryIntent != null);
+        assert(deliveryIntent.score > 0 && deliveryIntent.score <= 1);
+        assert(result.entities);
+        let dateTime = findEntityByType('builtin.datetimeV2.date', result.entities);
+        assert(dateTime.startIndex == 15);
+        assert(dateTime.endIndex == 31);
+        let builtin = findEntityByType('builtin.dimension', result.entities);
+        assert(builtin.startIndex == 28);
+        assert(builtin.endIndex == 34);
     });
 
-    it('should return multiple intents and a list entity with a single value', (done) => {
-        TestJson('MultipleIntents_ListEntityWithSingleValue.json', (result) => {
-            assert(result);
-            assert(result.query == 'I want to travel on united');
-            assert(result.intents);
-            let travelIntent = findIntent('Travel', result.intents);
-            assert(travelIntent != null);
-            assert(travelIntent.score > 0 && travelIntent.score <= 1);
-            assert(result.entities);
-            let airline = findEntityByType('Airline', result.entities);
-            assert(airline);
-            assert(airline.entity == 'united');
-            assert(airline.startIndex);
-            assert(airline.startIndex == 20);
-            assert(airline.endIndex);
-            assert(airline.endIndex == 25);
-            done();
-        });
+    it('should return multiple intents and a list entity with a single value', async function () {
+        const result = await TestJson('MultipleIntents_ListEntityWithSingleValue.json');
+
+        assert(result);
+        assert(result.query == 'I want to travel on united');
+        assert(result.intents);
+        let travelIntent = findIntent('Travel', result.intents);
+        assert(travelIntent != null);
+        assert(travelIntent.score > 0 && travelIntent.score <= 1);
+        assert(result.entities);
+        let airline = findEntityByType('Airline', result.entities);
+        assert(airline);
+        assert(airline.entity == 'united');
+        assert(airline.startIndex);
+        assert(airline.startIndex == 20);
+        assert(airline.endIndex);
+        assert(airline.endIndex == 25);
     });
 
-    it('should return multiple intents and a list entity with multiple values', (done) => {
-        TestJson('MultipleIntents_ListEntityWithMultiValues.json', (result) => {
-            assert(result);
-            assert(result.query == 'I want to travel on DL');
-            assert(result.intents);
-            let travelIntent = findIntent('Travel', result.intents);
-            assert(travelIntent != null);
-            assert(travelIntent.score > 0 && travelIntent.score <= 1);
-            assert(result.entities);
-            let builtIn = findEntityByType('builtin.dimension', result.entities);
-            assert(builtIn);
-            assert(builtIn.startIndex);
-            assert(builtIn.startIndex == 20);
-            assert(builtIn.endIndex);
-            assert(builtIn.endIndex == 21);
-            let airline = findEntityByType('Airline', result.entities);
-            assert(airline);
-            assert(airline.startIndex);
-            assert(airline.startIndex == 20);
-            assert(airline.endIndex);
-            assert(airline.endIndex == 21);
-            done();
-        });
+    it('should return multiple intents and a list entity with multiple values', async function () {
+        const result = await TestJson('MultipleIntents_ListEntityWithMultiValues.json');
+
+        assert(result);
+        assert(result.query == 'I want to travel on DL');
+        assert(result.intents);
+        let travelIntent = findIntent('Travel', result.intents);
+        assert(travelIntent != null);
+        assert(travelIntent.score > 0 && travelIntent.score <= 1);
+        assert(result.entities);
+        let builtIn = findEntityByType('builtin.dimension', result.entities);
+        assert(builtIn);
+        assert(builtIn.startIndex);
+        assert(builtIn.startIndex == 20);
+        assert(builtIn.endIndex);
+        assert(builtIn.endIndex == 21);
+        let airline = findEntityByType('Airline', result.entities);
+        assert(airline);
+        assert(airline.startIndex);
+        assert(airline.startIndex == 20);
+        assert(airline.endIndex);
+        assert(airline.endIndex == 21);
     });
 
-    it('should return multiple intents and a single composite entity', (done) => {
-        TestJson('MultipleIntents_CompositeEntityModel.json', (result) => {
-            assert(result);
-            assert(result.query == 'Please deliver it to 98033 WA');
-            assert(result.intents);
-            let deliveryIntent = findIntent('Delivery', result.intents);
-            assert(deliveryIntent != null);
-            assert(deliveryIntent.score > 0 && deliveryIntent.score <= 1);
-            assert(result.entities);
-            let stateEntity = findEntityByType('State', result.entities);
-            assert(stateEntity.entity === 'wa');
-            assert(stateEntity.startIndex == 27);
-            assert(stateEntity.endIndex == 28);
-            assert(stateEntity);
-            let addressEntity = findEntityByType('Address', result.entities);
-            assert(addressEntity);
-            assert(addressEntity.entity === '98033 wa');
-            assert(addressEntity.startIndex == 21);
-            assert(addressEntity.endIndex == 28);
-            let addressNumber = findEntityByType('builtin.number', result.entities);
-            assert(addressNumber);
-            assert(addressNumber.entity === '98033');
-            assert(addressNumber.startIndex == 21);
-            assert(addressNumber.endIndex == 25);
-            let composite = findCompositeByParentType('Address', result.compositeEntities);
-            assert(composite.value === '98033 wa');
-            done();
-        });
+    it('should return multiple intents and a single composite entity', async function () {
+        const result = await TestJson('MultipleIntents_CompositeEntityModel.json');
+
+        assert(result);
+        assert(result.query == 'Please deliver it to 98033 WA');
+        assert(result.intents);
+        let deliveryIntent = findIntent('Delivery', result.intents);
+        assert(deliveryIntent != null);
+        assert(deliveryIntent.score > 0 && deliveryIntent.score <= 1);
+        assert(result.entities);
+        let stateEntity = findEntityByType('State', result.entities);
+        assert(stateEntity.entity === 'wa');
+        assert(stateEntity.startIndex == 27);
+        assert(stateEntity.endIndex == 28);
+        assert(stateEntity);
+        let addressEntity = findEntityByType('Address', result.entities);
+        assert(addressEntity);
+        assert(addressEntity.entity === '98033 wa');
+        assert(addressEntity.startIndex == 21);
+        assert(addressEntity.endIndex == 28);
+        let addressNumber = findEntityByType('builtin.number', result.entities);
+        assert(addressNumber);
+        assert(addressNumber.entity === '98033');
+        assert(addressNumber.startIndex == 21);
+        assert(addressNumber.endIndex == 25);
+        let composite = findCompositeByParentType('Address', result.compositeEntities);
+        assert(composite.value === '98033 wa');
     });
 });

--- a/libraries/botbuilder-ai/tests/luisSdk.test.js
+++ b/libraries/botbuilder-ai/tests/luisSdk.test.js
@@ -72,10 +72,7 @@ function WithinDelta(token1, token2, delta, compare) {
 // 1) Create a <name>.json file with an object { text:<query> } in it.
 // 2) Run this test sith mockLuis = false which will fail and generate a <name>.json.new file.
 // 3) Check the .new file and if correct, replace the original .json file with it.
-async function TestJson(file, includeAllIntents, includeInstance) {
-    if (includeAllIntents === undefined) includeAllIntents = true;
-    if (includeInstance === undefined) includeInstance = true;
-
+async function TestJson(file, includeAllIntents = true, includeInstance = true) {
     let expectedPath = ExpectedPath(file);
     let expected = GetExpected(expectedPath);
 

--- a/libraries/botbuilder-ai/tests/luisV3OracleTests.test.js
+++ b/libraries/botbuilder-ai/tests/luisV3OracleTests.test.js
@@ -22,9 +22,8 @@ class TestContext extends TurnContext {
     }
 }
 
-function TestJson(
+async function TestJson(
     file,
-    done,
     includeAllIntents,
     includeInstance,
     telemetryClient,
@@ -49,20 +48,19 @@ function TestJson(
     const options = oracleOptions ? oracleOptions : { apiVersion: 'v3' };
     const luisRecognizer = GetLuisRecognizer({ applicationId: luisAppId, endpointKey: endpointKey }, options, true);
 
-    luisRecognizer.recognize(context, telemetryProperties, telemetryMetrics).then((res) => {
-        res.v3 = {
-            response: res.luisResult,
-        };
-        res.v3.options = options;
-        delete res.luisResult;
-        if (!WithinDelta(oracle, res, 0.1, false) && res.v3 !== oldResponse) {
-            fs.outputJSONSync(newPath, res, { spaces: 2 });
-            assert(false, '\nReturned JSON\n  ' + newPath + '\n!= expected JSON\n  ' + expectedPath);
-        } else if (fs.existsSync(newPath)) {
-            fs.unlinkSync(newPath);
-        }
-        done(res);
-    });
+    const res = await luisRecognizer.recognize(context, telemetryProperties, telemetryMetrics);
+    res.v3 = {
+        response: res.luisResult,
+    };
+    res.v3.options = options;
+    delete res.luisResult;
+    if (!WithinDelta(oracle, res, 0.1, false) && res.v3 !== oldResponse) {
+        fs.outputJSONSync(newPath, res, { spaces: 2 });
+        assert(false, '\nReturned JSON\n  ' + newPath + '\n!= expected JSON\n  ' + expectedPath);
+    } else if (fs.existsSync(newPath)) {
+        fs.unlinkSync(newPath);
+    }
+    return res;
 }
 
 function GetExpected(oracle) {
@@ -100,17 +98,15 @@ function GetLuisRecognizer(application, options, includeApiResults) {
     return new LuisRecognizer(application, optsV3);
 }
 
-function throttle(callback) {
-    if (mockLuis) {
-        callback();
-    } else {
-        // If actually calling LUIS, need to throttle our requests
-        setTimeout(callback, 1000);
-    }
-}
-
 describe('LuisRecognizer V3', function () {
     this.timeout(15000);
+
+    afterEach(async function () {
+        if (!mockLuis) {
+            // If actually calling LUIS, need to throttle our requests
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+    });
 
     if (!mockLuis && endpointKey === 'MockedKey') {
         console.warn(
@@ -119,40 +115,73 @@ describe('LuisRecognizer V3', function () {
         return;
     }
 
-    it('Composite1', (done) => TestJson('Composite1.json', () => throttle(done)));
+    it('Composite1', async function () {
+        await TestJson('Composite1.json');
+    });
 
-    it('Composite2', (done) => TestJson('Composite2.json', () => throttle(done)));
+    it('Composite2', async function () {
+        await TestJson('Composite2.json');
+    });
 
-    it('Composite 3', (done) => TestJson('Composite3.json', () => throttle(done)));
+    it('Composite3', async function () {
+        await TestJson('Composite3.json');
+    });
 
-    it('DynamicLists', (done) => TestJson('DynamicListsAndList.json', () => throttle(done)));
+    it('DynamicListsAndList', async function () {
+        await TestJson('DynamicListsAndList.json');
+    });
 
-    it('ExternalEntitiesAndBuiltin', (done) => TestJson('ExternalEntitiesAndBuiltin.json', () => throttle(done)));
+    it('ExternalEntitiesAndBuiltin', async function () {
+        await TestJson('ExternalEntitiesAndBuiltin.json');
+    });
 
-    it('ExternalEntitiesAndComposite', (done) => TestJson('ExternalEntitiesAndComposite.json', () => throttle(done)));
+    it('ExternalEntitiesAndComposite', async function () {
+        await TestJson('ExternalEntitiesAndComposite.json');
+    });
 
-    it('ExternalEntitiesAndList', (done) => TestJson('ExternalEntitiesAndList.json', () => throttle(done)));
+    it('ExternalEntitiesAndList', async function () {
+        await TestJson('ExternalEntitiesAndList.json');
+    });
 
-    it('ExternalEntitiesAndRegex', (done) => TestJson('ExternalEntitiesAndRegex.json', () => throttle(done)));
+    it('ExternalEntitiesAndRegex', async function () {
+        await TestJson('ExternalEntitiesAndRegex.json');
+    });
 
-    it('ExternalEntitiesAndSimple', (done) => TestJson('ExternalEntitiesAndSimple.json', () => throttle(done)));
+    it('ExternalEntitiesAndSimple', async function () {
+        await TestJson('ExternalEntitiesAndSimple.json');
+    });
 
-    it('ExternalEntitiesAndSimpleOverride', (done) =>
-        TestJson('ExternalEntitiesAndSimpleOverride.json', () => throttle(done)));
+    it('ExternalEntitiesAndSimpleOverride', async function () {
+        await TestJson('ExternalEntitiesAndSimpleOverride.json');
+    });
 
-    it('GeoPeopleOrdinal', (done) => TestJson('GeoPeopleOrdinal.json', () => throttle(done)));
+    it('GeoPeopleOrdinal', async function () {
+        await TestJson('GeoPeopleOrdinal.json');
+    });
 
-    it('Minimal', (done) => TestJson('Minimal.json', () => throttle(done)));
+    it('Minimal', async function () {
+        await TestJson('Minimal.json');
+    });
 
-    it('Prebuilt', (done) => TestJson('Prebuilt.json', () => throttle(done)));
+    it('Prebuilt', async function () {
+        await TestJson('Prebuilt.json');
+    });
 
-    it('Patterns', (done) => TestJson('Patterns.json', () => throttle(done)));
+    it('Patterns', async function () {
+        await TestJson('Patterns.json');
+    });
 
-    it('roles', (done) => TestJson('roles.json', () => throttle(done)));
+    it('roles', async function () {
+        await TestJson('roles.json');
+    });
 
-    it('NoEntitiesInstanceTrue', (done) => TestJson('NoEntitiesInstanceTrue.json', () => throttle(done)));
+    it('NoEntitiesInstanceTrue', async function () {
+        await TestJson('NoEntitiesInstanceTrue.json');
+    });
 
-    it('DateTimeReference', (done) => TestJson('DateTimeReference.json', () => throttle(done)));
+    it('DateTimeReference', async function () {
+        await TestJson('DateTimeReference.json');
+    });
 });
 
 function WithinDelta(token1, token2, delta, compare) {

--- a/libraries/botbuilder-ai/tests/qnaMaker.test.js
+++ b/libraries/botbuilder-ai/tests/qnaMaker.test.js
@@ -47,7 +47,7 @@ describe('QnAMaker', function () {
         host: `https://${hostname}.azurewebsites.net/qnamaker`,
     };
 
-    beforeEach(function (done) {
+    beforeEach(function () {
         nock.cleanAll();
         if (mockQnA) {
             let fileName = replaceCharacters(this.currentTest.title);
@@ -63,12 +63,10 @@ describe('QnAMaker', function () {
                     .replyWithFile(200, filePath + file);
             });
         }
-        done();
     });
 
-    afterEach(function (done) {
+    afterEach(function () {
         nock.cleanAll();
-        done();
     });
 
     function replaceCharacters(testName, _testDesc) {
@@ -810,50 +808,45 @@ describe('QnAMaker', function () {
             );
         });
 
-        it('should emit trace info once per call to Answer', function (done) {
+        it('should emit trace info once per call to Answer', async function () {
             const context = new TestContext({ text: `how do I clean the stove?`, type: 'message' });
             const qna = new QnAMaker(endpoint, { top: 1 });
 
-            qna.answer(context).then((found) => {
-                assert.strictEqual(found, true, `Found answer should have returned 'true'.`);
-                let qnaMakerTraceActivies = context.sent.filter((s) => s.type === 'trace' && s.name === 'QnAMaker');
-                assert.strictEqual(qnaMakerTraceActivies.length, 1, 'Should have returned just one answer');
-                const traceActivity = qnaMakerTraceActivies[0];
-                assert.strictEqual(traceActivity.type, 'trace', `Should have returned 'trace'.`);
-                assert.strictEqual(traceActivity.name, 'QnAMaker', `Should have returned 'QnAMaker'.`);
-                assert.strictEqual(traceActivity.label, 'QnAMaker Trace', `Should have returned 'QnAMaker Trace'.`);
-                assert.strictEqual(
-                    traceActivity.valueType,
-                    'https://www.qnamaker.ai/schemas/trace',
-                    `Should have returned 'https://www.qnamaker.ai/schemas/trace'.`
-                );
-                assert(traceActivity['value'], `'traceActivity' should have 'value' property.`);
-                assert(traceActivity.value['message'], `'traceActivity.value' should have 'message' property.`);
-                assert(
-                    traceActivity.value['queryResults'],
-                    `'traceActivity.value' should have 'queryResults' property.'`
-                );
-                assert.strictEqual(
-                    traceActivity.value.knowledgeBaseId,
-                    knowledgeBaseId,
-                    `Should have returned '${knowledgeBaseId}'`
-                );
-                assert(
-                    traceActivity.value['scoreThreshold'],
-                    `'traceActivity.value' should have 'scoreThreshold' property.'`
-                );
-                done();
-            });
+            const found = await qna.answer(context);
+
+            assert.strictEqual(found, true, `Found answer should have returned 'true'.`);
+            let qnaMakerTraceActivies = context.sent.filter((s) => s.type === 'trace' && s.name === 'QnAMaker');
+            assert.strictEqual(qnaMakerTraceActivies.length, 1, 'Should have returned just one answer');
+            const traceActivity = qnaMakerTraceActivies[0];
+            assert.strictEqual(traceActivity.type, 'trace', `Should have returned 'trace'.`);
+            assert.strictEqual(traceActivity.name, 'QnAMaker', `Should have returned 'QnAMaker'.`);
+            assert.strictEqual(traceActivity.label, 'QnAMaker Trace', `Should have returned 'QnAMaker Trace'.`);
+            assert.strictEqual(
+                traceActivity.valueType,
+                'https://www.qnamaker.ai/schemas/trace',
+                `Should have returned 'https://www.qnamaker.ai/schemas/trace'.`
+            );
+            assert(traceActivity['value'], `'traceActivity' should have 'value' property.`);
+            assert(traceActivity.value['message'], `'traceActivity.value' should have 'message' property.`);
+            assert(traceActivity.value['queryResults'], `'traceActivity.value' should have 'queryResults' property.'`);
+            assert.strictEqual(
+                traceActivity.value.knowledgeBaseId,
+                knowledgeBaseId,
+                `Should have returned '${knowledgeBaseId}'`
+            );
+            assert(
+                traceActivity.value['scoreThreshold'],
+                `'traceActivity.value' should have 'scoreThreshold' property.'`
+            );
         });
 
-        it('should return "false" from answer() if no good answers found', function (done) {
+        it('should return "false" from answer() if no good answers found', async function () {
             const context = new TestContext({ text: `foo`, type: 'message' });
             const qna = new QnAMaker(endpoint, { top: 1 });
 
-            qna.answer(context).then((found) => {
-                assert.strictEqual(found, false, `Should have returned 'false' for questions with no good answers`);
-                done();
-            });
+            const found = await qna.answer(context);
+
+            assert.strictEqual(found, false, `Should have returned 'false' for questions with no good answers`);
         });
 
         it('should throw TypeError from answer() if no context', function () {

--- a/libraries/botbuilder-applicationinsights/tests/TelemetryWaterfallTest.test.js
+++ b/libraries/botbuilder-applicationinsights/tests/TelemetryWaterfallTest.test.js
@@ -241,7 +241,7 @@ describe('TelemetryWaterfall', function () {
         adapter.send({ text: 'hello' }).startTest();
     });
 
-    it('should set telemetryClient on dialogs inside a component dialog', function (done) {
+    it('should set telemetryClient on dialogs inside a component dialog', function () {
         const component = new ComponentDialog('id');
 
         component.addDialog(new WaterfallDialog('secondary'), [
@@ -303,7 +303,5 @@ describe('TelemetryWaterfall', function () {
             component.telemetryClient instanceof NullTelemetryClient,
             'component should be reset to nulltelemetryclient'
         );
-
-        done();
     });
 });


### PR DESCRIPTION
Partial fix for #3226. This will be done in multiple PRs.

## Covers

(Alphabetically such that `botbuilder` comes before `botbuilder-`)

* `botbuilder-ai` through `botbuilder-applicationinsights`, inclusive

## Excludes

* Many tests in [`TelemetryWaterfallTest.test.js`](https://github.com/microsoft/botbuilder-js/blob/main/libraries/botbuilder-applicationinsights/tests/TelemetryWaterfallTest.test.js)

## Description

Replaces the use of `done()` in tests with proper `async/await`.

## Specific Changes

  - `done` => `async/await`
  - Remove `done` completely when used in synchronous tests. For example, it was in some `beforeEach()` hooks, but it's not needed; [nock doesn't even use it there](https://github.com/nock/nock/blob/af7105c3c1731be5c0f2051b20bd44ead006e177/tests/setup.js#L12)
  - Remove some of the try/catches that are no longer needed since we don't need `done(err)`
  - [Avoid arrow function in mocha tests](https://mochajs.org/#arrow-functions)
  - A lot of no-op stuff auto-fixes with our prettier/eslint settings

## Notes (mostly for me)

* Regex for finding done usage: `(done =>)|\(done\)`
* Search in: `./libraries/**/**/tests/**/*.js`
* For adding `await` to `adapter.send()` calls: `(?<!(await)|(const))\sadapter`