### PR TITLE
fix: make useNamedPipe idempotent if already connected to pipeName

### DIFF
--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -1922,9 +1922,6 @@ export class BotFrameworkAdapter
         await this.startWebSocket(nodeWebSocket);
     }
 
-    /**
-     * @private
-     */
     private async startNamedPipeServer(pipeName: string): Promise<void> {
         this.namedPipeName = pipeName;
         this.streamingServer = new NamedPipeServer(pipeName, this);
@@ -1936,9 +1933,6 @@ export class BotFrameworkAdapter
         }
     }
 
-    /**
-     * @private
-     */
     private async authenticateConnection(req: WebRequest, channelService?: string): Promise<void> {
         if (!this.credentials.appId) {
             // auth is disabled
@@ -1969,17 +1963,11 @@ export class BotFrameworkAdapter
         await this.streamingServer.start();
     }
 
-    /**
-     * @private
-     */
     private async readRequestBodyAsString(request: IReceiveRequest): Promise<Activity> {
         const contentStream = request.streams[0];
         return await contentStream.readAsJson<Activity>();
     }
 
-    /**
-     * @private
-     */
     private async handleVersionRequest(
         request: IReceiveRequest,
         response: StreamingResponse

--- a/libraries/botbuilder/tests/streaming/botFrameworkAdapterStreaming.test.js
+++ b/libraries/botbuilder/tests/streaming/botFrameworkAdapterStreaming.test.js
@@ -51,9 +51,7 @@ describe('BotFrameworkAdapter Streaming tests', () => {
     it('starts and stops a namedpipe server', () => {
         const adapter = new BotFrameworkAdapter();
 
-        adapter.useNamedPipe('PipeyMcPipeface', async (_) => {
-            // no op
-        });
+        adapter.useNamedPipe(async (_) => {}, 'PipeyMcPipeface');
         expect(adapter.streamingServer.disconnect()).to.not.throw;
     });
 

--- a/libraries/botbuilder/tests/streaming/botFrameworkAdapterStreaming.test.js
+++ b/libraries/botbuilder/tests/streaming/botFrameworkAdapterStreaming.test.js
@@ -1,10 +1,11 @@
+const assert = require('assert');
 const { Socket } = require('net');
 
 const { expect } = require('chai');
 const { spy } = require('sinon');
 const { ActivityHandler, ActivityTypes, StatusCodes, TurnContext } = require('botbuilder-core');
 
-const { BotFrameworkAdapter} = require('../../');
+const { BotFrameworkAdapter } = require('../../');
 
 // Import Helper Classes
 const { MockHttpRequest } = require('./mockHttpRequest');
@@ -22,8 +23,14 @@ class TestAdapterSettings {
     }
 }
 
-describe('BotFrameworkAdapter Streaming tests', () => {
+class ConnectionTestAdapter extends BotFrameworkAdapter {
+    startNamedPipeServer(pipeName) {
+        this.namedPipeName = pipeName;
+        this.streamingServer = { isConnected: true };
+    }
+}
 
+describe('BotFrameworkAdapter Streaming tests', () => {
     it('has the correct status codes', () => {
         expect(StatusCodes.OK).to.equal(200);
         expect(StatusCodes.BAD_REQUEST).to.equal(400);
@@ -44,10 +51,50 @@ describe('BotFrameworkAdapter Streaming tests', () => {
     it('starts and stops a namedpipe server', () => {
         const adapter = new BotFrameworkAdapter();
 
-        adapter.useNamedPipe('PipeyMcPipeface', async (context) => {
-            await bot.run(context);
+        adapter.useNamedPipe('PipeyMcPipeface', async (_) => {
+            // no op
         });
         expect(adapter.streamingServer.disconnect()).to.not.throw;
+    });
+
+    it(`throws exception when trying to connect to a different named pipe than it's connected to`, async () => {
+        const adapter = new ConnectionTestAdapter();
+
+        try {
+            // Don't await to try and connect at the same time
+            await adapter.useNamedPipe(async (_) => {
+                // no op
+            }, 'NamedPipeTest');
+
+            // Try use same NamedPipe again to trigger error.
+            await adapter.useNamedPipe(async (_) => {
+                // no op
+            }, 'NotNamedPipeTest');
+
+            assert.fail('should have thrown error');
+        } catch (e) {
+            if (e instanceof assert.AssertionError) {
+                throw e;
+            }
+
+            expect(e.message).to.equal(
+                'This BotFrameworkAdapter instance is already connected to a different stream. Use a new instance to connect to the provided pipeName.'
+            );
+        }
+    });
+
+    it(`doesn't throw while trying to connect to named pipe it's connected to`, async () => {
+        const adapter = new ConnectionTestAdapter();
+        const namedPipeName = 'NamedPipeTest';
+
+        await adapter.useNamedPipe(async (_) => {
+            // no op
+        }, namedPipeName);
+
+        // Use same NamedPipeName to test scenario.
+        await adapter.useNamedPipe(async (_) => {
+            // no op
+        }, namedPipeName);
     });
 
     it('isStreamingConnectionOpen returns false without a streamingServer', () => {
@@ -143,7 +190,7 @@ describe('BotFrameworkAdapter Streaming tests', () => {
             const settings = new TestAdapterSettings('appId', 'password');
             const adapter = new BotFrameworkAdapter(settings);
             const requestWithoutAuthHeader = new MockHttpRequest();
-            
+
             const socket = new MockNetSocket();
             const writeSpy = spy(socket, 'write');
             const destroySpy = spy(socket, 'destroy');
@@ -171,7 +218,7 @@ describe('BotFrameworkAdapter Streaming tests', () => {
             const uncallableLogic = null;
 
             try {
-                await adapter.useWebSocket(request, socket, Buffer.from([]), uncallableLogic);    
+                await adapter.useWebSocket(request, socket, Buffer.from([]), uncallableLogic);
             } catch (err) {
                 expect(err.message).to.equal('Streaming logic needs to be provided to `useWebSocket`');
                 expect(useWebSocketSpy.called).to.be.true;

--- a/libraries/botbuilder/tests/streaming/botFrameworkAdapterStreaming.test.js
+++ b/libraries/botbuilder/tests/streaming/botFrameworkAdapterStreaming.test.js
@@ -60,41 +60,26 @@ describe('BotFrameworkAdapter Streaming tests', () => {
     it(`throws exception when trying to connect to a different named pipe than it's connected to`, async () => {
         const adapter = new ConnectionTestAdapter();
 
-        try {
-            // Don't await to try and connect at the same time
-            await adapter.useNamedPipe(async (_) => {
-                // no op
-            }, 'NamedPipeTest');
+        await adapter.useNamedPipe(async (_) => {}, 'NamedPipeTest');
 
-            // Try use same NamedPipe again to trigger error.
-            await adapter.useNamedPipe(async (_) => {
-                // no op
-            }, 'NotNamedPipeTest');
-
-            assert.fail('should have thrown error');
-        } catch (e) {
-            if (e instanceof assert.AssertionError) {
-                throw e;
+        // Try use same NamedPipe again to trigger error.
+        await assert.rejects(
+            adapter.useNamedPipe(async (_) => {}, 'NotNamedPipeTest'),
+            {
+                message:
+                    'This BotFrameworkAdapter instance is already connected to a different stream. Use a new instance to connect to the provided pipeName.',
             }
-
-            expect(e.message).to.equal(
-                'This BotFrameworkAdapter instance is already connected to a different stream. Use a new instance to connect to the provided pipeName.'
-            );
-        }
+        );
     });
 
     it(`doesn't throw while trying to connect to named pipe it's connected to`, async () => {
         const adapter = new ConnectionTestAdapter();
         const namedPipeName = 'NamedPipeTest';
 
-        await adapter.useNamedPipe(async (_) => {
-            // no op
-        }, namedPipeName);
+        await adapter.useNamedPipe(async (_) => {}, namedPipeName);
 
         // Use same NamedPipeName to test scenario.
-        await adapter.useNamedPipe(async (_) => {
-            // no op
-        }, namedPipeName);
+        await adapter.useNamedPipe(async (_) => {}, namedPipeName);
     });
 
     it('isStreamingConnectionOpen returns false without a streamingServer', () => {

--- a/libraries/botframework-streaming/src/namedPipe/namedPipeServer.ts
+++ b/libraries/botframework-streaming/src/namedPipe/namedPipeServer.ts
@@ -34,7 +34,7 @@ export class NamedPipeServer implements IStreamingTransportServer {
      *
      * @param baseName The named pipe to connect to.
      * @param requestHandler Optional [RequestHandler](xref:botframework-streaming.RequestHandler) to process incoming messages received by this client.
-     * @param autoReconnect Optional setting to determine if the client sould attempt to reconnect automatically on disconnection events. Defaults to true.
+     * @param autoReconnect Optional setting to determine if the client should attempt to reconnect automatically on disconnection events. Defaults to true.
      */
     public constructor(baseName: string, requestHandler?: RequestHandler, autoReconnect = true) {
         if (!baseName) {


### PR DESCRIPTION
Fixes #3449

## Specific Changes
  - Make BotFrameworkAdapter.useNamedPipe idempotent by checking for StreamingServer and new `namedPipeName` member
  - Add `private namedPipeName?: string` member to BotFrameworkAdapter
  - Minor docstring fix in `botframework-streaming.NamedPipeServer`

## Testing
Add new tests for new behavior in useNamedPipe