### PR TITLE
Fix dateReadBack test

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/dateReadBack.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dateReadBack.ts
@@ -34,7 +34,7 @@ export class DateReadBack extends ExpressionEvaluator {
             const dateFormat = 'YYYY-MM-DD';
             let error = InternalFunctionUtils.verifyISOTimestamp(args[0]);
             if (!error) {
-                const timestamp1 = new Date(args[0]);
+                const timestamp1 = dayjs(args[0]).toDate();
                 error = InternalFunctionUtils.verifyISOTimestamp(args[1]);
                 if (!error) {
                     const timestamp2 = dayjs(args[1]).format(dateFormat);

--- a/libraries/adaptive-expressions/src/builtinFunctions/dateReadBack.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dateReadBack.ts
@@ -34,7 +34,7 @@ export class DateReadBack extends ExpressionEvaluator {
             const dateFormat = 'YYYY-MM-DD';
             let error = InternalFunctionUtils.verifyISOTimestamp(args[0]);
             if (!error) {
-                const timestamp1 = new Date(dayjs(args[0]).format(dateFormat));
+                const timestamp1 = new Date(args[0]);
                 error = InternalFunctionUtils.verifyISOTimestamp(args[1]);
                 if (!error) {
                     const timestamp2 = dayjs(args[1]).format(dateFormat);


### PR DESCRIPTION
Fixes #3378

## Description

`dateReadBack` test was failing when run locally. Turns out, there was a bug in the code that only expressed itself when the machine running the code wasn't on UTC (or something like that).

## What WAS Happening

The issue is how `timestamp1` was getting set.

The code: `const timestamp1 = new Date(dayjs(args[0]).format(dateFormat));`

`args[0]` was a timestamp, `'2018-03-15T13:00:00.111Z'`

1. `dayjs()` call would convert the timestamp to a dayjs Date object (good so far)
2. It would then get formatted to `2018-03-15` (good so far)
3. But then, we'd call `new Date()` on `2018-03-15`, which interprets the input as UTC and creates a Date object in PST, so it would more or less become `2018-03-14` and be off a whole day

## Testing

It now passes, locally:

![image](https://user-images.githubusercontent.com/40401643/112546357-90cddd00-8d76-11eb-9f22-ec198aa1b3f8.png)
