### PR TITLE
fix: getSuggestionsCard() to set card title

### DIFF
--- a/libraries/botbuilder-ai/src/qnaCardBuilder.ts
+++ b/libraries/botbuilder-ai/src/qnaCardBuilder.ts
@@ -53,8 +53,8 @@ export class QnACardBuilder {
             title: cardNoMatchText,
         });
 
-        const promptsCard = CardFactory.heroCard('', undefined, buttonList);
-        const message = MessageFactory.attachment(promptsCard, cardTitle);
+        const promptsCard = CardFactory.heroCard(cardTitle, undefined, buttonList);
+        const message = MessageFactory.attachment(promptsCard);
 
         return message;
     }

--- a/libraries/botbuilder-ai/tests/qnaMakerDialog.test.js
+++ b/libraries/botbuilder-ai/tests/qnaMakerDialog.test.js
@@ -277,6 +277,7 @@ describe('QnAMakerDialog', function () {
             const convoState = new ConversationState(new MemoryStorage());
             const dm = new DialogManager();
             dm.conversationState = convoState;
+            const activeLearningCardTitle = 'Suggested questions';
             const cardNoMatchText = 'Not helpful.';
             const qnaDialog = new QnAMakerDialog(
                 kbId,
@@ -284,7 +285,7 @@ describe('QnAMakerDialog', function () {
                 HOSTNAME,
                 undefined,
                 undefined,
-                undefined,
+                activeLearningCardTitle,
                 cardNoMatchText
             );
 
@@ -300,8 +301,9 @@ describe('QnAMakerDialog', function () {
                     strictEqual(reply.attachments && reply.attachments.length, 1);
                     strictEqual(reply.attachments[0].contentType, CardFactory.contentTypes.heroCard);
 
-                    // Verify the suggestions match the values received from QnA Maker.
                     const heroCard = reply.attachments[0].content;
+                    strictEqual(heroCard.title, activeLearningCardTitle);
+                    // Verify the suggestions match the values received from QnA Maker.
                     strictEqual(heroCard.buttons.length, 4);
 
                     for (let idx = 0; idx < heroCard.buttons.length; idx++) {


### PR DESCRIPTION
Fixes #3431

## Description
This PR fixes QnACardBuilder.getSuggestionsCard() to correctly use `QnAMakerDialog.activeLearningCardTitle` as expected.

## Specific Changes
  - Fix call to CardFactory.heroCard() in QnACardBuilder.getSuggestionsCard()
  
## Testing
Add unit test coverage for fix.