### PR TITLE
fix: resolve bad runtime adapter/skill auth configuration

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBotAdapter.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBotAdapter.ts
@@ -6,6 +6,7 @@ import { AuthenticationConfiguration, ClaimsIdentity, SkillValidation } from 'bo
 import {
     ActivityEx,
     BotFrameworkAdapter,
+    BotFrameworkAdapterSettings,
     ConversationState,
     InputHints,
     MessageFactory,
@@ -16,11 +17,11 @@ import {
 
 export class CoreBotAdapter extends BotFrameworkAdapter {
     constructor(
-        authConfig: AuthenticationConfiguration,
+        settings: Partial<BotFrameworkAdapterSettings>,
         private readonly conversationState: ConversationState,
         userState: UserState
     ) {
-        super({ authConfig });
+        super(settings);
 
         // attach storage?
         useBotState(this, userState, conversationState);

--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBotAdapter.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBotAdapter.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AuthenticationConfiguration, ClaimsIdentity, SkillValidation } from 'botframework-connector';
+import { ClaimsIdentity, SkillValidation } from 'botframework-connector';
 
 import {
     ActivityEx,

--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/index.ts
@@ -448,7 +448,6 @@ export async function getRuntimeServices(
 
     const runtimeSettings = configuration.bind(['runtimeSettings']);
 
-    addCredentialProvider(services, configuration);
     addCoreBot(services, configuration);
     addFeatures(services, runtimeSettings.bind(['features']));
     addSkills(services, runtimeSettings.bind(['skills']));


### PR DESCRIPTION
Couple oversights:

- Hard coded dummy appId/appPassword for Skills
- Mis-port of CoreBotAdapter due to differences between .NET CloudAdapter and JS BotFrameworkAdapter