### PR TITLE
fix: lock runtypes to 5.1.x version range

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-runtime-core/package.json
+++ b/libraries/botbuilder-dialogs-adaptive-runtime-core/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "dependency-graph": "^0.10.0",
-    "runtypes": "^5.0.1"
+    "runtypes": "~5.1.0"
   },
   "devDependencies": {
     "mocha": "^8.2.1",

--- a/libraries/botbuilder-dialogs-adaptive-runtime-integration-express/package.json
+++ b/libraries/botbuilder-dialogs-adaptive-runtime-integration-express/package.json
@@ -31,6 +31,6 @@
     "botbuilder-dialogs-adaptive-runtime": "4.1.6",
     "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
     "express": "^4.17.1",
-    "runtypes": "^5.0.1"
+    "runtypes": "~5.1.0"
   }
 }

--- a/libraries/botbuilder-dialogs-adaptive-runtime-integration-restify/package.json
+++ b/libraries/botbuilder-dialogs-adaptive-runtime-integration-restify/package.json
@@ -25,7 +25,7 @@
     "botbuilder-dialogs-adaptive-runtime": "4.1.6",
     "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
     "restify": "^8.5.1",
-    "runtypes": "^5.0.1"
+    "runtypes": "~5.1.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/libraries/botbuilder-dialogs-adaptive-runtime/package.json
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/package.json
@@ -40,7 +40,7 @@
     "botframework-connector": "4.1.6",
     "dependency-graph": "^0.10.0",
     "nconf": "^0.11.2",
-    "runtypes": "^5.0.1",
+    "runtypes": "~5.1.0",
     "yargs-parser": "^20.2.7"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10825,10 +10825,10 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-runtypes@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/runtypes/-/runtypes-5.0.1.tgz#406d140410266f6ece17c3501a37234f91faa346"
-  integrity sha512-+TWVlCmFsgrG4Nd2u+ambpNFO8Yp4heAflGQi9oNj6GRkxZo8aSDBxO1Y0vlKIQCWKKFxato+8Hn67XeAqKhRA==
+runtypes@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/runtypes/-/runtypes-5.1.0.tgz#a1f2501b5ca8fda47d51ea15b6ccca45e924a8c3"
+  integrity sha512-OMHkz6dxysXj4E8Fj/HCGjtdJUhapQUN7puvqzuzvjaX28pd52PZmEMqQlkIzCfKdhXdM0ghx8PpvELprEnOLQ==
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"


### PR DESCRIPTION
Runtypes 5.2.0 has an issue and is deprecated. v6 is coming soon, but we should lock down to 5.1.x for R13.