### PR TITLE
port: dialog context dialog manager prop obsolete

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBot.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBot.ts
@@ -48,16 +48,12 @@ export class CoreBot extends ActivityHandler {
         ResourceExtensions.useResourceExplorer(dialogManager, resourceExplorer);
         LanguageGeneratorExtensions.useLanguageGeneration(dialogManager);
         LanguageGeneratorExtensions.useLanguagePolicy(dialogManager, new LanguagePolicy(defaultLocale));
+
+        // Inserts skills dependencies into initial turn state
         SkillExtensions.useSkillClient(dialogManager, skillClient);
         SkillExtensions.useSkillConversationIdFactory(dialogManager, skillConversationIdFactory);
-        useTelemetry(dialogManager, botTelemetryClient);
 
-        /* TODO(jgummersall) reconcile:
-         * _dialogManager.InitialTurnState.Set(botFrameworkClient);
-         * _dialogManager.InitialTurnState.Set(conversationIdfactory);
-         * _dialogManager.InitialTurnState.Set(_userState); (handled by useBotState?)
-         * _dialogManager.InitialTurnState.Set(_conversationState); (handled by useBotState?)
-         */
+        useTelemetry(dialogManager, botTelemetryClient);
 
         if (memoryScopes.length) {
             dialogManager.initialTurnState.set('memoryScopes', memoryScopes);

--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBotAdapter.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBotAdapter.ts
@@ -23,7 +23,6 @@ export class CoreBotAdapter extends BotFrameworkAdapter {
     ) {
         super(settings);
 
-        // attach storage?
         useBotState(this, userState, conversationState);
 
         this.onTurnError = async (turnContext, err) => {

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
@@ -12,7 +12,7 @@ import {
     StringExpression,
     StringExpressionConverter,
 } from 'adaptive-expressions';
-import { Activity, ActivityTypes, ConversationState, StringUtils, TurnContext } from 'botbuilder';
+import { Activity, ActivityTypes, StringUtils, TurnContext } from 'botbuilder';
 import {
     BeginSkillDialogOptions,
     Converter,
@@ -182,7 +182,7 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
             this.dialogOptions.connectionName = this.connectionName.getValue(dcState);
         }
         if (!this.dialogOptions.conversationState) {
-            this.dialogOptions.conversationState = dc.context.turnState.get<ConversationState>('ConversationState');
+            this.dialogOptions.conversationState = dc.context.turnState.get('ConversationState');
         }
         if (!this.dialogOptions.skillClient) {
             this.dialogOptions.skillClient = dc.context.turnState.get(skillClientKey);
@@ -329,6 +329,11 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
 
         this.dialogOptions.skillClient = context.turnState.get(skillClientKey);
         if (this.dialogOptions.skillClient == null) {
+            throw new ReferenceError('Unable to get an instance of skillHttpClient from turnState.');
+        }
+
+        this.dialogOptions.conversationState = context.turnState.get('ConversationState');
+        if (this.dialogOptions.conversationState == null) {
             throw new ReferenceError('Unable to get an instance of conversationState from turnState.');
         }
 

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
@@ -12,7 +12,7 @@ import {
     StringExpression,
     StringExpressionConverter,
 } from 'adaptive-expressions';
-import { Activity, ActivityTypes, StringUtils, TurnContext } from 'botbuilder';
+import { Activity, ActivityTypes, ConversationState, StringUtils, TurnContext } from 'botbuilder';
 import {
     BeginSkillDialogOptions,
     Converter,
@@ -182,7 +182,7 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
             this.dialogOptions.connectionName = this.connectionName.getValue(dcState);
         }
         if (!this.dialogOptions.conversationState) {
-            this.dialogOptions.conversationState = dc.dialogManager.conversationState;
+            this.dialogOptions.conversationState = dc.context.turnState.get<ConversationState>('ConversationState');
         }
         if (!this.dialogOptions.skillClient) {
             this.dialogOptions.skillClient = dc.context.turnState.get(skillClientKey);
@@ -217,9 +217,9 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
         // Call the base to invoke the skill
         return await super.beginDialog(dc, options);
     }
-    
+
     /**
-     * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is _continued_, where it is the active dialog and the 
+     * Called when the [Dialog](xref:botbuilder-dialogs.Dialog) is _continued_, where it is the active dialog and the
      * user replies with a new activity.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns A `Promise` representing the asynchronous operation.
@@ -253,7 +253,7 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
      * Called when a child [Dialog](xref:botbuilder-dialogs.Dialog) completed its turn, returning control to this dialog.
      * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @param reason [DialogReason](xref:botbuilder-dialogs.DialogReason), reason why the dialog resumed.
-     * @param result Optional. Value returned from the dialog that was called. The type 
+     * @param result Optional. Value returned from the dialog that was called. The type
      * of the value returned is dependent on the child dialog.
      * @returns A `Promise` representing the asynchronous operation.
      */

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -181,7 +181,9 @@ export class DialogContext {
     public services: TurnContextStateCollection = new TurnContextStateCollection();
 
     /**
-     * Returns the current dialog manager instance.
+     * Returns the current dialog manager instance. This property is obsolete.
+     *
+     * @obsolete This property serves no function.
      */
     public get dialogManager(): DialogManager {
         return this.context.turnState.get(DialogTurnStateConstants.dialogManager);
@@ -353,12 +355,12 @@ export class DialogContext {
      * ```JavaScript
      * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
      * ```
-     */  
+     */
     public async prompt(
         dialogId: string,
         promptOrOptions: string | Partial<Activity> | PromptOptions
     ): Promise<DialogTurnResult>;
-    
+
     /**
      * Helper function to simplify formatting the options for calling a prompt dialog.
      * @param dialogId ID of the prompt dialog to start.
@@ -374,13 +376,13 @@ export class DialogContext {
      * ```JavaScript
      * return await dc.prompt('confirmPrompt', `Are you sure you'd like to quit?`);
      * ```
-     */    
+     */
     public async prompt(
         dialogId: string,
         promptOrOptions: string | Partial<Activity> | PromptOptions,
         choices: (string | Choice)[]
     ): Promise<DialogTurnResult>;
-    
+
     /**
      * Helper function to simplify formatting the options for calling a prompt dialog.
      * @param dialogId ID of the prompt dialog to start.
@@ -630,8 +632,8 @@ export class DialogContext {
 
     /**
      * @private
-     * @param reason 
-     * @param result 
+     * @param reason
+     * @param result
      */
     private async endActiveDialog(reason: DialogReason, result?: any): Promise<void> {
         const instance: DialogInstance<any> = this.activeDialog;


### PR DESCRIPTION
Fixes #3512

Seems like we missed a change in `beginSkill` that fetches the conversation state from the turn context. @stevengum can you triple check that?