### PR TITLE
cherrypick: small runtime tweaks (#3519)

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-runtime-integration-azure-functions/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime-integration-azure-functions/src/index.ts
@@ -45,7 +45,7 @@ export function makeTriggers(
 
     return {
         messageTrigger: async (context: Context, req: HttpRequest) => {
-            context.log('Messages endpoint triggerd.');
+            context.log('Messages endpoint triggered.');
 
             try {
                 const { adapter, bot } = await instances();
@@ -57,8 +57,6 @@ export function makeTriggers(
                 context.log.error(err);
                 throw err;
             }
-
-            context.log('Done.');
         },
 
         skillsTrigger: async function (context: Context, req: HttpRequest) {
@@ -86,8 +84,6 @@ export function makeTriggers(
                 context.log.error(err);
                 throw err;
             }
-
-            context.log('Done.');
         },
     };
 }

--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/configurationResourceExplorer.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/configurationResourceExplorer.ts
@@ -14,7 +14,13 @@ export class ConfigurationResourceExporer extends ResourceExplorer {
         const applicationRoot = configuration.string(['applicationRoot']);
         ok(applicationRoot);
 
-        this.folderResourceProvider = new FolderResourceProvider(this, applicationRoot, true, true);
+        this.folderResourceProvider = new FolderResourceProvider(
+            this,
+            applicationRoot,
+            true,
+            configuration.string(['NODE_ENV']) === 'dev' // watch in dev only!
+        );
+
         this.addResourceProvider(this.folderResourceProvider);
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/index.ts
@@ -411,11 +411,16 @@ export async function getRuntimeServices(
     // Resolve configuration
     let configuration: Configuration;
     if (typeof configurationOrSettingsDirectory === 'string') {
-        configuration = new Configuration()
-            .argv()
-            .env()
-            .file(path.join(configurationOrSettingsDirectory, 'appsettings.Development.json'))
-            .file(path.join(configurationOrSettingsDirectory, 'appsettings.json'));
+        configuration = new Configuration().argv().env();
+
+        const files = ['appsettings.json'];
+
+        const { NODE_ENV: nodeEnv } = process.env;
+        if (nodeEnv) {
+            files.unshift(`appsettings.${nodeEnv}.json`);
+        }
+
+        files.forEach((file) => configuration.file(path.join(configurationOrSettingsDirectory, file)));
     } else {
         configuration = configurationOrSettingsDirectory;
     }


### PR DESCRIPTION
* fix: azure logs issues

Can't log after response is written for some reason.

* fix: watch files in dev only

* fix: load appsettings files based on NODE_ENV

Roughly maps to behavior added via https://github.com/microsoft/botbuilder-dotnet/pull/5421