### PR TITLE
fix: botbuilder core lint errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,7 +48,7 @@
     "@typescript-eslint/no-unused-vars": [
       "error",
       {
-        "args": "after-used",
+        "args": "none",
         "argsIgnorePattern": "^_",
         "caughtErrors": "all",
         "caughtErrorsIgnorePattern": "^_",

--- a/libraries/botbuilder-core/.eslintrc.json
+++ b/libraries/botbuilder-core/.eslintrc.json
@@ -1,4 +1,3 @@
 {
-    "extends": "../../.eslintrc.json",
-    "plugins": ["only-warn"]
+    "extends": "../../.eslintrc.json"
 }

--- a/libraries/botbuilder-core/src/activityFactory.ts
+++ b/libraries/botbuilder-core/src/activityFactory.ts
@@ -115,6 +115,7 @@ export class ActivityFactory {
 
     /**
      * Generate the activity.
+     *
      * @param lgResult string result from languageGenerator.
      */
     public static fromObject(lgResult: any): Partial<Activity> {
@@ -131,6 +132,7 @@ export class ActivityFactory {
 
     /**
      * Given a lg result, create a text activity. This method will create a MessageActivity from text.
+     *
      * @param text lg text output.
      */
     private static buildActivityFromText(text: string): Partial<Activity> {
@@ -148,6 +150,7 @@ export class ActivityFactory {
 
     /**
      * Given a structured lg result, create an activity. This method will create an MessageActivity from object
+     *
      * @param lgValue lg output.
      */
     private static buildActivityFromLGStructuredResult(lgValue: any): Partial<Activity> {
@@ -167,6 +170,7 @@ export class ActivityFactory {
 
     /**
      * Builds an [Activity](xref:botframework-schema.Activity) with a given message.
+     *
      * @param messageValue Message value on which to base the activity.
      * @returns [Activity](xref:botframework-schema.Activity) with the given message.
      */

--- a/libraries/botbuilder-core/src/activityFactory.ts
+++ b/libraries/botbuilder-core/src/activityFactory.ts
@@ -117,7 +117,9 @@ export class ActivityFactory {
      * Generate the activity.
      *
      * @param lgResult string result from languageGenerator.
+     * @returns activity from lg result
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public static fromObject(lgResult: any): Partial<Activity> {
         if (typeof lgResult === 'string') {
             return this.buildActivityFromText(lgResult.trim());
@@ -130,11 +132,7 @@ export class ActivityFactory {
         }
     }
 
-    /**
-     * Given a lg result, create a text activity. This method will create a MessageActivity from text.
-     *
-     * @param text lg text output.
-     */
+    // Given a lg result, create a text activity. This method will create a MessageActivity from text.
     private static buildActivityFromText(text: string): Partial<Activity> {
         const msg: Partial<Activity> = {
             type: ActivityTypes.Message,
@@ -148,12 +146,8 @@ export class ActivityFactory {
         return msg;
     }
 
-    /**
-     * Given a structured lg result, create an activity. This method will create an MessageActivity from object
-     *
-     * @param lgValue lg output.
-     */
-    private static buildActivityFromLGStructuredResult(lgValue: any): Partial<Activity> {
+    // Given a structured lg result, create an activity. This method will create an MessageActivity from object
+    private static buildActivityFromLGStructuredResult(lgValue: unknown): Partial<Activity> {
         let activity: Partial<Activity> = {};
 
         const type: string = this.getStructureType(lgValue);
@@ -171,10 +165,12 @@ export class ActivityFactory {
     /**
      * Builds an [Activity](xref:botframework-schema.Activity) with a given message.
      *
+     * @private
+     *
      * @param messageValue Message value on which to base the activity.
      * @returns [Activity](xref:botframework-schema.Activity) with the given message.
      */
-    private static buildActivity(messageValue: any): Partial<Activity> {
+    private static buildActivity(messageValue: unknown): Partial<Activity> {
         const activity: Partial<Activity> = { type: ActivityTypes.Message };
         for (const key of Object.keys(messageValue)) {
             const property: string = key.trim();
@@ -182,7 +178,7 @@ export class ActivityFactory {
                 continue;
             }
 
-            const value: any = messageValue[key];
+            const value = messageValue[key];
 
             switch (property.toLowerCase()) {
                 case 'attachments':
@@ -200,11 +196,8 @@ export class ActivityFactory {
         return activity;
     }
 
-    /**
-     * @private
-     */
-    private static getSuggestions(suggestionsValue: any): SuggestedActions {
-        const actions: any[] = this.normalizedToList(suggestionsValue);
+    private static getSuggestions(suggestionsValue: unknown): SuggestedActions {
+        const actions: unknown[] = this.normalizedToList(suggestionsValue);
 
         const suggestedActions: SuggestedActions = {
             actions: this.getCardActions(actions),
@@ -214,25 +207,16 @@ export class ActivityFactory {
         return suggestedActions;
     }
 
-    /**
-     * @private
-     */
-    private static getButtons(buttonsValue: any): CardAction[] {
-        const actions: any[] = this.normalizedToList(buttonsValue);
+    private static getButtons(buttonsValue: unknown): CardAction[] {
+        const actions: unknown[] = this.normalizedToList(buttonsValue);
         return this.getCardActions(actions);
     }
 
-    /**
-     * @private
-     */
-    private static getCardActions(actions: any[]): CardAction[] {
-        return actions.map((u: any): CardAction => this.getCardAction(u));
+    private static getCardActions(actions: unknown[]): CardAction[] {
+        return actions.map((u) => this.getCardAction(u));
     }
 
-    /**
-     * @private
-     */
-    private static getCardAction(action: any): CardAction {
+    private static getCardAction(action: unknown): CardAction {
         let cardAction: CardAction;
         if (typeof action === 'string') {
             cardAction = { type: ActionTypes.ImBack, value: action, title: action, channelData: undefined };
@@ -258,12 +242,9 @@ export class ActivityFactory {
         return cardAction;
     }
 
-    /**
-     * @private
-     */
-    private static getAttachments(input: any): Attachment[] {
+    private static getAttachments(input: unknown): Attachment[] {
         const attachments: Attachment[] = [];
-        const attachmentsJsonList: any[] = this.normalizedToList(input);
+        const attachmentsJsonList: unknown[] = this.normalizedToList(input);
 
         for (const attachmentsJson of attachmentsJsonList) {
             if (typeof attachmentsJson === 'object') {
@@ -274,10 +255,7 @@ export class ActivityFactory {
         return attachments;
     }
 
-    /**
-     * @private
-     */
-    private static getAttachment(input: any): Attachment {
+    private static getAttachment(input: unknown): Attachment {
         let attachment: Attachment = {
             contentType: '',
         };
@@ -295,18 +273,15 @@ export class ActivityFactory {
         return attachment;
     }
 
-    /**
-     * @private
-     */
-    private static getNormalAttachment(input: any): Attachment {
+    private static getNormalAttachment(input: unknown): Attachment {
         const attachment: Attachment = { contentType: '' };
 
         for (const key of Object.keys(input)) {
             const property: string = key.trim();
-            const value: any = input[key];
+            const value = input[key];
 
             switch (property.toLowerCase()) {
-                case 'contenttype':
+                case 'contenttype': {
                     const type: string = value.toString().toLowerCase();
                     if (this.genericCardTypeMapping.has(type)) {
                         attachment.contentType = this.genericCardTypeMapping.get(type);
@@ -316,6 +291,8 @@ export class ActivityFactory {
                         attachment.contentType = type;
                     }
                     break;
+                }
+
                 default:
                     attachment[this.realProperty(property, this.attachmentProperties)] = value;
                     break;
@@ -325,20 +302,18 @@ export class ActivityFactory {
         return attachment;
     }
 
-    /**
-     * @private
-     */
-    private static getCardAttachment(type: string, input: any): Attachment {
-        const card: any = {};
+    private static getCardAttachment(type: string, input: unknown): Attachment {
+        const card = {};
 
         for (const key of Object.keys(input)) {
             const property: string = key.trim().toLowerCase();
-            const value: any = input[key];
+            const value = input[key];
 
             switch (property) {
                 case 'tap':
                     card[property] = this.getCardAction(value);
                     break;
+
                 case 'image':
                 case 'images':
                     if (type === CardFactory.contentTypes.heroCard || type === CardFactory.contentTypes.thumbnailCard) {
@@ -347,37 +322,44 @@ export class ActivityFactory {
                         }
 
                         const imageList = this.normalizedToList(value);
-                        imageList.forEach((u): any => card['images'].push(this.normalizedToMediaOrImage(u)));
+                        imageList.forEach((u) => card['images'].push(this.normalizedToMediaOrImage(u)));
                     } else {
                         card['image'] = this.normalizedToMediaOrImage(value);
                     }
                     break;
-                case 'media':
+
+                case 'media': {
                     if (!('media' in card)) {
                         card['media'] = [];
                     }
 
                     const mediaList = this.normalizedToList(value);
-                    mediaList.forEach((u): any => card['media'].push(this.normalizedToMediaOrImage(u)));
+                    mediaList.forEach((u) => card['media'].push(this.normalizedToMediaOrImage(u)));
                     break;
-                case 'buttons':
+                }
+
+                case 'buttons': {
                     if (!('buttons' in card)) {
                         card['buttons'] = [];
                     }
 
-                    const buttons: any[] = this.getButtons(value);
-                    buttons.forEach((u): any => card[property].push(u));
+                    const buttons = this.getButtons(value);
+                    buttons.forEach((u) => card[property].push(u));
                     break;
+                }
+
                 case 'autostart':
                 case 'shareable':
-                case 'autoloop':
-                    const boolValue: boolean = this.getValidBooleanValue(value.toString());
+                case 'autoloop': {
+                    const boolValue = this.getValidBooleanValue(value.toString());
                     if (boolValue !== undefined) {
                         card[property] = boolValue;
                     } else {
                         card[property] = value;
                     }
                     break;
+                }
+
                 default:
                     card[this.realProperty(key.trim(), this.cardProperties)] = value;
                     break;
@@ -392,9 +374,6 @@ export class ActivityFactory {
         return attachment;
     }
 
-    /**
-     * @private
-     */
     private static realProperty(property: string, builtinProperties: string[]): string {
         const properties = builtinProperties.map((u: string): string => u.toLowerCase());
         if (properties.includes(property.toLowerCase())) {
@@ -404,10 +383,7 @@ export class ActivityFactory {
         }
     }
 
-    /**
-     * @private
-     */
-    private static normalizedToList(item: any): any[] {
+    private static normalizedToList(item: unknown): unknown[] {
         if (item === undefined) {
             return [];
         } else if (Array.isArray(item)) {
@@ -417,10 +393,7 @@ export class ActivityFactory {
         }
     }
 
-    /**
-     * @private
-     */
-    private static getStructureType(input: any): string {
+    private static getStructureType(input: unknown): string {
         let result = '';
 
         if (input && typeof input === 'object') {
@@ -435,21 +408,19 @@ export class ActivityFactory {
         return result.trim().toLowerCase();
     }
 
-    /**
-     * @private
-     */
-    private static normalizedToMediaOrImage(item: any): object {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    private static normalizedToMediaOrImage(item: unknown): object {
         if (!item) {
             return {};
         } else if (typeof item === 'string') {
             return { url: item };
-        } else return item;
+        } else {
+            // eslint-disable-next-line @typescript-eslint/ban-types
+            return item as object;
+        }
     }
 
-    /**
-     * @private
-     */
-    private static getValidBooleanValue(boolValue: any): boolean {
+    private static getValidBooleanValue(boolValue: string | boolean): boolean | undefined {
         if (typeof boolValue === 'boolean') {
             return boolValue;
         }

--- a/libraries/botbuilder-core/src/activityHandler.ts
+++ b/libraries/botbuilder-core/src/activityHandler.ts
@@ -3,12 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-    Activity,
-    AdaptiveCardInvokeResponse,
-    AdaptiveCardInvokeValue,
-    MessageReaction,
-} from 'botframework-schema';
+import { Activity, AdaptiveCardInvokeResponse, AdaptiveCardInvokeValue, MessageReaction } from 'botframework-schema';
 
 import { ActivityHandlerBase } from './activityHandlerBase';
 import { InvokeException } from './invokeException';
@@ -486,6 +481,7 @@ export class ActivityHandler extends ActivityHandlerBase {
 
     /**
      * Provides default behavior for invoke activities.
+     *
      * @param context The context object for the current turn.
      *
      * @remarks
@@ -977,6 +973,7 @@ export class ActivityHandler extends ActivityHandlerBase {
 
     /**
      * An [InvokeResponse](xref:botbuilder.InvokeResponse) factory that initializes the body to the parameter passed and status equal to OK.
+     *
      * @param body JSON serialized content from a POST response.
      * @returns A new [InvokeResponse](xref:botbuilder.InvokeResponse) object.
      */

--- a/libraries/botbuilder-core/src/adapterExtensions.ts
+++ b/libraries/botbuilder-core/src/adapterExtensions.ts
@@ -13,6 +13,7 @@ import { RegisterClassMiddleware } from './registerClassMiddleware';
 /**
  * Adds middleware to the adapter to register one or more BotState objects on the turn context.
  * The middleware registers the state objects on the turn context at the start of each turn.
+ *
  * @param botAdapter The adapter on which to register the state objects.
  * @param botStates The state objects to register.
  */

--- a/libraries/botbuilder-core/src/autoSaveStateMiddleware.ts
+++ b/libraries/botbuilder-core/src/autoSaveStateMiddleware.ts
@@ -50,6 +50,7 @@ export class AutoSaveStateMiddleware implements Middleware {
     public botStateSet: BotStateSet;
     /**
      * Creates a new AutoSaveStateMiddleware instance.
+     *
      * @param botStates One or more BotState plugins to automatically save at the end of the turn.
      */
     constructor(...botStates: BotState[]) {
@@ -59,6 +60,7 @@ export class AutoSaveStateMiddleware implements Middleware {
 
     /**
      * Called by the adapter (for example, a `BotFrameworkAdapter`) at runtime in order to process an inbound [Activity](xref:botframework-schema.Activity).
+     *
      * @param context The context object for this turn.
      * @param next {function} The next delegate function.
      */
@@ -69,6 +71,7 @@ export class AutoSaveStateMiddleware implements Middleware {
 
     /**
      * Adds additional `BotState` plugins to be saved.
+     *
      * @param botStates One or more BotState plugins to add.
      */
     public add(...botStates: BotState[]): this {

--- a/libraries/botbuilder-core/src/botAdapter.ts
+++ b/libraries/botbuilder-core/src/botAdapter.ts
@@ -131,9 +131,9 @@ export abstract class BotAdapter {
      * Adds middleware to the adapter's pipeline.
      *
      * @param middleware The middleware or middleware handlers to add.
-     *
-     * @remarks
-     * Middleware is added to the adapter at initialization time.
+     * @param {...any} middlewares
+     * @remarks 
+Middleware is added to the adapter at initialization time.
      * Each turn, the adapter calls its middleware in the order in which you added it.
      */
     public use(...middlewares: (MiddlewareHandler | Middleware)[]): this {

--- a/libraries/botbuilder-core/src/botState.ts
+++ b/libraries/botbuilder-core/src/botState.ts
@@ -41,6 +41,7 @@ export class BotState implements PropertyManager {
 
     /**
      * Creates a new BotState instance.
+     *
      * @param storage Storage provider to persist the state object to.
      * @param storageKey Function called anytime the storage key for a given turn needs to be calculated.
      */
@@ -49,6 +50,7 @@ export class BotState implements PropertyManager {
     /**
      * Creates a new property accessor for reading and writing an individual property to the bot
      * states storage object.
+     *
      * @param T (Optional) type of property to create. Defaults to `any` type.
      * @param name Name of the property to add.
      */

--- a/libraries/botbuilder-core/src/botStatePropertyAccessor.ts
+++ b/libraries/botbuilder-core/src/botStatePropertyAccessor.ts
@@ -84,6 +84,7 @@ export interface StatePropertyAccessor<T = any> {
 export class BotStatePropertyAccessor<T = any> implements StatePropertyAccessor<T> {
     /**
      * Creates a new BotStatePropertyAccessor instance.
+     *
      * @param state Parent BotState instance.
      * @param name Unique name of the property for the parent BotState.
      */
@@ -91,6 +92,7 @@ export class BotStatePropertyAccessor<T = any> implements StatePropertyAccessor<
 
     /**
      * Deletes the persisted property from its backing storage object.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      */
     public async delete(context: TurnContext): Promise<void> {
@@ -102,6 +104,7 @@ export class BotStatePropertyAccessor<T = any> implements StatePropertyAccessor<
 
     /**
      * Reads a persisted property from its backing storage object.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @returns A JSON representation of the cached state.
      */
@@ -109,6 +112,7 @@ export class BotStatePropertyAccessor<T = any> implements StatePropertyAccessor<
     public async get(context: TurnContext, defaultValue: T): Promise<T>;
     /**
      * Reads a persisted property from its backing storage object.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @param defaultValue Optional. Default value for the property.
      * @returns A JSON representation of the cached state.
@@ -128,6 +132,7 @@ export class BotStatePropertyAccessor<T = any> implements StatePropertyAccessor<
 
     /**
      * Assigns a new value to the properties backing storage object.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @param value Value to set on the property.
      */

--- a/libraries/botbuilder-core/src/botStateSet.ts
+++ b/libraries/botbuilder-core/src/botStateSet.ts
@@ -20,6 +20,7 @@ export class BotStateSet {
 
     /**
      * Creates a new BotStateSet instance.
+     *
      * @param botStates One or more BotState plugins to register.
      */
     public constructor(...botStates: BotState[]) {
@@ -28,6 +29,7 @@ export class BotStateSet {
 
     /**
      * Registers One or more `BotState` plugins with the set.
+     *
      * @param botStates One or more BotState plugins to register.
      */
     public add(...botStates: BotState[]): this {

--- a/libraries/botbuilder-core/src/botTelemetryClient.ts
+++ b/libraries/botbuilder-core/src/botTelemetryClient.ts
@@ -76,6 +76,7 @@ export interface TelemetryPageView {
 export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelemetryClient {
     /**
      * Creates a new instance of the [NullTelemetryClient](xref:botbuilder-core.NullTelemetryClient) class.
+     *
      * @param settings Optional. Settings for the telemetry client.
      */
     constructor(settings?: any) {
@@ -84,6 +85,7 @@ export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelem
 
     /**
      * Logs an Application Insights page view.
+     *
      * @param telemetry An object implementing [TelemetryPageView](xref:botbuilder-core.TelemetryPageView).
      */
     trackPageView(telemetry: TelemetryPageView) {
@@ -92,6 +94,7 @@ export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelem
 
     /**
      * Sends information about an external dependency (outgoing call) in the application.
+     *
      * @param telemetry An object implementing [TelemetryDependency](xref:botbuilder-core.TelemetryDependency).
      */
     trackDependency(telemetry: TelemetryDependency) {
@@ -100,6 +103,7 @@ export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelem
 
     /**
      * Logs custom events with extensible named fields.
+     *
      * @param telemetry An object implementing [TelemetryEvent](xref:botbuilder-core.TelemetryEvent).
      */
     trackEvent(telemetry: TelemetryEvent) {
@@ -108,6 +112,7 @@ export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelem
 
     /**
      * Logs a system exception.
+     *
      * @param telemetry An object implementing [TelemetryException](xref:botbuilder-core.TelemetryException).
      */
     trackException(telemetry: TelemetryException) {
@@ -116,6 +121,7 @@ export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelem
 
     /**
      * Sends a trace message.
+     *
      * @param telemetry An object implementing [TelemetryTrace](xref:botbuilder-core.TelemetryTrace).
      */
     trackTrace(telemetry: TelemetryTrace) {
@@ -133,6 +139,7 @@ export class NullTelemetryClient implements BotTelemetryClient, BotPageViewTelem
 /**
  * Logs a DialogView using the [trackPageView](xref:botbuilder-core.BotTelemetryClient.trackPageView) method on the [BotTelemetryClient](xref:botbuilder-core.BotTelemetryClient) if [BotPageViewTelemetryClient](xref:botbuilder-core.BotPageViewTelemetryClient) has been implemented.
  * Alternatively logs the information out via TrackTrace.
+ *
  * @param telemetryClient TelemetryClient that implements [BotTelemetryClient](xref:botbuilder-core.BotTelemetryClient).
  * @param dialogName Name of the dialog to log the entry / start for.
  * @param properties Named string values you can use to search and classify events.

--- a/libraries/botbuilder-core/src/cardFactory.ts
+++ b/libraries/botbuilder-core/src/cardFactory.ts
@@ -242,10 +242,10 @@ export class CardFactory {
      * @param title The title for the card's sign-in button.
      * @param text Optional. Additional text to include on the card.
      * @param link Optional. The sign-in link to use.
+     * @param tokenExchangeResource
      * @returns An [Attachment](xref:botframework-schema.Attachment).
-     *
-     * @remarks
-     * OAuth cards support the Bot Framework's single sign on (SSO) service.
+     * @remarks 
+OAuth cards support the Bot Framework's single sign on (SSO) service.
      */
     public static oauthCard(
         connectionName: string,
@@ -267,29 +267,29 @@ export class CardFactory {
     }
 
     /**
-    * Returns an attachment for an Office 365 connector card.
-    *
-    * @param card a description of the Office 365 connector card to return.
-    * @returns An [Attachment](xref:botframework-schema.Attachment).
-    *
-    * @remarks
-    * For example:
-    * ```JavaScript
-    * const card = CardFactory.o365ConnectorCard({
-    *   "title": "card title",
-    *   "text": "card text",
-    *   "summary": "O365 card summary",
-    *   "themeColor": "#E67A9E",
-    *   "sections": [
-    *       {
-    *           "title": "**section title**",
-    *           "text": "section text",
-    *           "activityTitle": "activity title",
-    *       }
-    *   ]
-    * });
-    * ```
-    */
+     * Returns an attachment for an Office 365 connector card.
+     *
+     * @param card a description of the Office 365 connector card to return.
+     * @returns An [Attachment](xref:botframework-schema.Attachment).
+     *
+     * @remarks
+     * For example:
+     * ```JavaScript
+     * const card = CardFactory.o365ConnectorCard({
+     *   "title": "card title",
+     *   "text": "card text",
+     *   "summary": "O365 card summary",
+     *   "themeColor": "#E67A9E",
+     *   "sections": [
+     *       {
+     *           "title": "**section title**",
+     *           "text": "section text",
+     *           "activityTitle": "activity title",
+     *       }
+     *   ]
+     * });
+     * ```
+     */
     public static o365ConnectorCard(card: O365ConnectorCard): Attachment {
         return { contentType: CardFactory.contentTypes.o365ConnectorCard, content: card };
     }

--- a/libraries/botbuilder-core/src/componentRegistration.ts
+++ b/libraries/botbuilder-core/src/componentRegistration.ts
@@ -14,6 +14,7 @@ export class ComponentRegistration {
 
     /**
      * Gets list of all ComponentRegistration objects registered.
+     *
      * @returns A list of ComponentRegistration objects.
      */
     public static get components(): ComponentRegistration[] {
@@ -22,6 +23,7 @@ export class ComponentRegistration {
 
     /**
      * Add a component, only one instance per type is allowed for components.
+     *
      * @param componentRegistration The component to be registered.
      */
     public static add(componentRegistration: ComponentRegistration): void {

--- a/libraries/botbuilder-core/src/conversationState.ts
+++ b/libraries/botbuilder-core/src/conversationState.ts
@@ -29,6 +29,7 @@ const NO_KEY = `ConversationState: overridden getStorageKey method did not retur
 export class ConversationState extends BotState {
     /**
      * Creates a new ConversationState instance.
+     *
      * @param storage Storage provider to persist conversation state to.
      * @param namespace (Optional) namespace to append to storage keys. Defaults to an empty string.
      */
@@ -43,6 +44,7 @@ export class ConversationState extends BotState {
 
     /**
      * Returns the storage key for the current conversation state.
+     *
      * @param context Context for current turn of conversation with the user.
      */
     public getStorageKey(context: TurnContext): string | undefined {

--- a/libraries/botbuilder-core/src/coreAppCredentials.ts
+++ b/libraries/botbuilder-core/src/coreAppCredentials.ts
@@ -18,6 +18,7 @@ interface CoreWebResource {
 
 /**
  * CoreAppCredentials
+ *
  * @remarks
  * Runtime-agnostic interface representing "ServiceClientCredentials" from @azure/ms-rest-js
  */

--- a/libraries/botbuilder-core/src/extendedUserTokenProvider.ts
+++ b/libraries/botbuilder-core/src/extendedUserTokenProvider.ts
@@ -17,6 +17,7 @@ import { SignInUrlResponse, TokenResponse, TokenExchangeRequest } from 'botframe
 export interface ExtendedUserTokenProvider extends IUserTokenProvider {
     /**
      * Retrieves the OAuth token for a user that is in a sign-in flow.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param magicCode (Optional) Optional user entered code to validate.
@@ -30,6 +31,7 @@ export interface ExtendedUserTokenProvider extends IUserTokenProvider {
 
     /**
      * Signs the user out with the token server.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param userId User id of user to sign out.
@@ -44,6 +46,7 @@ export interface ExtendedUserTokenProvider extends IUserTokenProvider {
 
     /**
      * Gets a signin link from the token server that can be sent as part of a SigninCard.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param oAuthAppCredentials AppCredentials for OAuth.
@@ -52,6 +55,7 @@ export interface ExtendedUserTokenProvider extends IUserTokenProvider {
 
     /**
      * Signs the user out with the token server.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param oAuthAppCredentials AppCredentials for OAuth.
@@ -67,6 +71,7 @@ export interface ExtendedUserTokenProvider extends IUserTokenProvider {
 
     /**
      * Get the raw signin resource to be sent to the user for signin for a connection name.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      */
@@ -74,6 +79,7 @@ export interface ExtendedUserTokenProvider extends IUserTokenProvider {
 
     /**
      * Get the raw signin resource to be sent to the user for signin for a connection name.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param userId The user id that will be associated with the token.
@@ -88,6 +94,7 @@ export interface ExtendedUserTokenProvider extends IUserTokenProvider {
 
     /**
      * Get the raw signin resource to be sent to the user for signin for a connection name.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param userId The user id that will be associated with the token.
@@ -103,6 +110,7 @@ export interface ExtendedUserTokenProvider extends IUserTokenProvider {
 
     /**
      * Performs a token exchange operation such as for single sign-on.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param userId The user id that will be associated with the token.
@@ -117,6 +125,7 @@ export interface ExtendedUserTokenProvider extends IUserTokenProvider {
 
     /**
      * Performs a token exchange operation such as for single sign-on.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param userId The user id that will be associated with the token.

--- a/libraries/botbuilder-core/src/memoryStorage.ts
+++ b/libraries/botbuilder-core/src/memoryStorage.ts
@@ -31,6 +31,7 @@ export class MemoryStorage implements Storage {
     protected etag: number;
     /**
      * Creates a new MemoryStorage instance.
+     *
      * @param memory (Optional) memory to use for storing items. By default it will create an empty JSON object `{}`.
      */
     public constructor(protected memory: { [k: string]: string } = {}) {
@@ -39,6 +40,7 @@ export class MemoryStorage implements Storage {
 
     /**
      * Reads storage items from storage.
+     *
      * @param keys Keys of the [StoreItems](xref:botbuilder-core.StoreItems) objects to read.
      * @returns The read items.
      */
@@ -60,6 +62,7 @@ export class MemoryStorage implements Storage {
 
     /**
      * Writes storage items to storage.
+     *
      * @param changes The [StoreItems](xref:botbuilder-core.StoreItems) to write, indexed by key.
      */
     public write(changes: StoreItems): Promise<void> {
@@ -94,6 +97,7 @@ export class MemoryStorage implements Storage {
 
     /**
      * Deletes storage items from storage.
+     *
      * @param keys Keys of the [StoreItems](xref:botbuilder-core.StoreItems) objects to delete.
      */
     public delete(keys: string[]): Promise<void> {

--- a/libraries/botbuilder-core/src/memoryTranscriptStore.ts
+++ b/libraries/botbuilder-core/src/memoryTranscriptStore.ts
@@ -23,6 +23,7 @@ export class MemoryTranscriptStore implements TranscriptStore {
 
     /**
      * Log an activity to the transcript.
+     *
      * @param activity Activity to log.
      */
     public logActivity(activity: Activity): void | Promise<void> {
@@ -55,6 +56,7 @@ export class MemoryTranscriptStore implements TranscriptStore {
 
     /**
      * Get activities from the memory transcript store
+     *
      * @param channelId Channel Id.
      * @param conversationId Conversation Id.
      * @param continuationToken Continuation token to page through results.
@@ -103,6 +105,7 @@ export class MemoryTranscriptStore implements TranscriptStore {
 
     /**
      * List conversations in the channelId.
+     *
      * @param channelId Channel Id.
      * @param continuationToken Continuation token to page through results.
      */
@@ -146,6 +149,7 @@ export class MemoryTranscriptStore implements TranscriptStore {
 
     /**
      * Delete a specific conversation and all of it's activities.
+     *
      * @param channelId Channel Id where conversation took place.
      * @param conversationId Id of the conversation to delete.
      */

--- a/libraries/botbuilder-core/src/messageFactory.ts
+++ b/libraries/botbuilder-core/src/messageFactory.ts
@@ -45,9 +45,11 @@ export class MessageFactory {
      * ```JavaScript
      * const message = MessageFactory.text('Greetings from example message');
      * ```
+     *
      * @param text Text to include in the message.
      * @param speak (Optional) SSML to include in the message.
      * @param inputHint (Optional) input hint for the message. Defaults to `acceptingInput`.
+     * @returns partial activity
      */
     public static text(text: string, speak?: string, inputHint?: InputHints | string): Partial<Activity> {
         const msg: Partial<Activity> = {
@@ -71,10 +73,12 @@ export class MessageFactory {
      * ```JavaScript
      * const message = MessageFactory.suggestedActions(['red', 'green', 'blue'], `Choose a color`);
      * ```
+     *
      * @param actions Array of card actions or strings to include. Strings will be converted to `messageBack` actions.
      * @param text (Optional) text of the message.
      * @param speak (Optional) SSML to include with the message.
      * @param inputHint (Optional) input hint for the message. Defaults to `acceptingInput`.
+     * @returns partial activity
      */
     public static suggestedActions(
         actions: (CardAction | string)[],
@@ -114,10 +118,12 @@ export class MessageFactory {
      *      )
      * );
      * ```
+     *
      * @param attachment Adaptive card to include in the message.
      * @param text (Optional) text of the message.
      * @param speak (Optional) SSML to include with the message.
      * @param inputHint (Optional) input hint for the message. Defaults to `acceptingInput`.
+     * @returns partial activity
      */
     public static attachment(
         attachment: Attachment,
@@ -141,10 +147,12 @@ export class MessageFactory {
      *    CardFactory.heroCard('title3', ['imageUrl3'], ['button3'])
      * ]);
      * ```
+     *
      * @param attachments Array of attachments to include in the message.
      * @param text (Optional) text of the message.
      * @param speak (Optional) SSML to include with the message.
      * @param inputHint (Optional) input hint for the message.
+     * @returns partial activity
      */
     public static list(
         attachments: Attachment[],
@@ -168,10 +176,12 @@ export class MessageFactory {
      *    CardFactory.heroCard('title3', ['imageUrl3'], ['button3'])
      * ]);
      * ```
+     *
      * @param attachments Array of attachments to include in the message.
      * @param text (Optional) text of the message.
      * @param speak (Optional) SSML to include with the message.
      * @param inputHint (Optional) input hint for the message.
+     * @returns partial activity
      */
     public static carousel(
         attachments: Attachment[],
@@ -191,12 +201,14 @@ export class MessageFactory {
      * ```JavaScript
      * const message = MessageFactory.contentUrl('https://example.com/hawaii.jpg', 'image/jpeg', 'Hawaii Trip', 'A photo from our family vacation.');
      * ```
+     *
      * @param url Url of the image/video to send.
      * @param contentType The MIME type of the image/video.
      * @param name (Optional) Name of the image/video file.
      * @param text (Optional) text of the message.
      * @param speak (Optional) SSML to include with the message.
      * @param inputHint (Optional) input hint for the message.
+     * @returns partial activity
      */
     public static contentUrl(
         url: string,

--- a/libraries/botbuilder-core/src/middlewareSet.ts
+++ b/libraries/botbuilder-core/src/middlewareSet.ts
@@ -72,8 +72,7 @@ export class MiddlewareSet implements Middleware {
     /**
      * Creates a new MiddlewareSet instance.
      *
-     * @param middleware One or more middleware handlers(s) to register.
-     * @param {...any} middlewares
+     * @param middlewares One or more middleware handlers(s) to register.
      */
     constructor(...middlewares: (MiddlewareHandler | Middleware)[]) {
         this.use(...middlewares);
@@ -84,6 +83,7 @@ export class MiddlewareSet implements Middleware {
      *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @param next Delegate to call to continue the bot middleware pipeline.
+     * @returns promise representing the async operation
      */
     public onTurn(context: TurnContext, next: () => Promise<void>): Promise<void> {
         return this.run(context, next);
@@ -92,9 +92,9 @@ export class MiddlewareSet implements Middleware {
     /**
      * Registers middleware handlers(s) with the set.
      *
-     * @remarks 
-This example adds a new piece of middleware to a set:
-     * 
+     * @remarks
+     * This example adds a new piece of middleware to a set:
+     *
      * ```JavaScript
      * set.use(async (context, next) => {
      * console.log(`Leading Edge`);
@@ -102,8 +102,9 @@ This example adds a new piece of middleware to a set:
      * console.log(`Trailing Edge`);
      * });
      * ```
-     * @param {...any} middlewares
-     * @param middleware One or more middleware handlers(s) to register.
+     *
+     * @param middlewares One or more middleware handlers(s) to register.
+     * @returns this for chaining
      */
     public use(...middlewares: (MiddlewareHandler | Middleware)[]): this {
         middlewares.forEach((plugin) => {

--- a/libraries/botbuilder-core/src/middlewareSet.ts
+++ b/libraries/botbuilder-core/src/middlewareSet.ts
@@ -71,7 +71,9 @@ export class MiddlewareSet implements Middleware {
 
     /**
      * Creates a new MiddlewareSet instance.
+     *
      * @param middleware One or more middleware handlers(s) to register.
+     * @param {...any} middlewares
      */
     constructor(...middlewares: (MiddlewareHandler | Middleware)[]) {
         this.use(...middlewares);
@@ -79,6 +81,7 @@ export class MiddlewareSet implements Middleware {
 
     /**
      * Processes an incoming activity.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext) object for this turn.
      * @param next Delegate to call to continue the bot middleware pipeline.
      */
@@ -89,16 +92,17 @@ export class MiddlewareSet implements Middleware {
     /**
      * Registers middleware handlers(s) with the set.
      *
-     * @remarks
-     * This example adds a new piece of middleware to a set:
-     *
+     * @remarks 
+This example adds a new piece of middleware to a set:
+     * 
      * ```JavaScript
      * set.use(async (context, next) => {
-     *    console.log(`Leading Edge`);
-     *    await next();
-     *    console.log(`Trailing Edge`);
+     * console.log(`Leading Edge`);
+     * await next();
+     * console.log(`Trailing Edge`);
      * });
      * ```
+     * @param {...any} middlewares
      * @param middleware One or more middleware handlers(s) to register.
      */
     public use(...middlewares: (MiddlewareHandler | Middleware)[]): this {
@@ -117,6 +121,7 @@ export class MiddlewareSet implements Middleware {
 
     /**
      * Executes a set of middleware in series.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param next Function to invoke at the end of the middleware chain.
      * @returns A promise that resolves after the handler chain is complete.

--- a/libraries/botbuilder-core/src/privateConversationState.ts
+++ b/libraries/botbuilder-core/src/privateConversationState.ts
@@ -29,6 +29,7 @@ const NO_KEY = `PrivateConversationState: overridden getStorageKey method did no
 export class PrivateConversationState extends BotState {
     /**
      * Creates a new PrivateConversationState instance.
+     *
      * @param storage Storage provider to persist PrivateConversation state to.
      * @param namespace (Optional) namespace to append to storage keys. Defaults to an empty string.
      */
@@ -43,6 +44,7 @@ export class PrivateConversationState extends BotState {
 
     /**
      * Returns the storage key for the current PrivateConversation state.
+     *
      * @param context Context for current turn of PrivateConversation with the user.
      */
     public getStorageKey(context: TurnContext): string | undefined {

--- a/libraries/botbuilder-core/src/privateConversationState.ts
+++ b/libraries/botbuilder-core/src/privateConversationState.ts
@@ -46,6 +46,7 @@ export class PrivateConversationState extends BotState {
      * Returns the storage key for the current PrivateConversation state.
      *
      * @param context Context for current turn of PrivateConversation with the user.
+     * @returns storage key or undefined
      */
     public getStorageKey(context: TurnContext): string | undefined {
         const activity: Activity = context.activity;

--- a/libraries/botbuilder-core/src/propertyManager.ts
+++ b/libraries/botbuilder-core/src/propertyManager.ts
@@ -14,6 +14,7 @@ export interface PropertyManager {
     /**
      * Creates a new property accessor for reading and writing an individual property to the bots
      * state management system.
+     *
      * @param T (Optional) type of property to create. Defaults to `any` type.
      * @param name Name of the property being created.
      */

--- a/libraries/botbuilder-core/src/propertyManager.ts
+++ b/libraries/botbuilder-core/src/propertyManager.ts
@@ -18,5 +18,6 @@ export interface PropertyManager {
      * @param T (Optional) type of property to create. Defaults to `any` type.
      * @param name Name of the property being created.
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     createProperty<T = any>(name: string): StatePropertyAccessor<T>;
 }

--- a/libraries/botbuilder-core/src/recognizerResult.ts
+++ b/libraries/botbuilder-core/src/recognizerResult.ts
@@ -56,7 +56,6 @@ export const getTopScoringIntent = (result: RecognizerResult): { intent: string;
         }
     }
 
-
     return {
         intent: topIntent,
         score: topScore,

--- a/libraries/botbuilder-core/src/recognizerResult.ts
+++ b/libraries/botbuilder-core/src/recognizerResult.ts
@@ -33,12 +33,12 @@ export interface RecognizerResult {
     /**
      * (Optional) entities recognized.
      */
-    entities?: any;
+    entities?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
     /**
      * (Optional) other properties
      */
-    [propName: string]: any;
+    [propName: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export const getTopScoringIntent = (result: RecognizerResult): { intent: string; score: number } => {

--- a/libraries/botbuilder-core/src/registerClassMiddleware.ts
+++ b/libraries/botbuilder-core/src/registerClassMiddleware.ts
@@ -17,6 +17,7 @@ export class RegisterClassMiddleware<T> implements Middleware {
 
     /**
      * Initialize a new instance of the RegisterClassMiddleware class.
+     *
      * @param service The object or service to add.
      * @param key The key for service object in turn state.
      */
@@ -32,6 +33,7 @@ export class RegisterClassMiddleware<T> implements Middleware {
 
     /**
      * Adds the associated object or service to the current turn context.
+     *
      * @param turnContext The context object for this turn.
      * @param next The delegate to call to continue the bot middleware pipeline.
      */

--- a/libraries/botbuilder-core/src/showTypingMiddleware.ts
+++ b/libraries/botbuilder-core/src/showTypingMiddleware.ts
@@ -23,6 +23,7 @@ import { TurnContext } from './turnContext';
 export class ShowTypingMiddleware implements Middleware {
     /**
      * Create the SendTypingIndicator middleware
+     *
      * @param delay {number} Number of milliseconds to wait before sending the first typing indicator.
      * @param period {number} Number of milliseconds to wait before sending each following indicator.
      */
@@ -38,6 +39,7 @@ export class ShowTypingMiddleware implements Middleware {
 
     /**
      * Processes an incoming activity.
+     *
      * @param context {TurnContext} An incoming TurnContext object.
      * @param next {function} The next delegate function.
      */

--- a/libraries/botbuilder-core/src/skills/botFrameworkClient.ts
+++ b/libraries/botbuilder-core/src/skills/botFrameworkClient.ts
@@ -22,7 +22,7 @@ export interface BotFrameworkClient {
      * @param conversationId A conversation ID to use for the conversation with the skill.
      * @param activity Activity to forward.
      */
-    postActivity: <T = any>(
+    postActivity: <T = any>( // eslint-disable-line @typescript-eslint/no-explicit-any
         fromBotId: string,
         toBotId: string,
         toUrl: string,

--- a/libraries/botbuilder-core/src/skills/botFrameworkClient.ts
+++ b/libraries/botbuilder-core/src/skills/botFrameworkClient.ts
@@ -12,6 +12,7 @@ import { InvokeResponse } from '../invokeResponse';
 export interface BotFrameworkClient {
     /**
      * Forwards an activity to a another bot.
+     *
      * @remarks
      *
      * @param fromBotId The MicrosoftAppId of the bot sending the activity.

--- a/libraries/botbuilder-core/src/skills/skillConversationIdFactoryBase.ts
+++ b/libraries/botbuilder-core/src/skills/skillConversationIdFactoryBase.ts
@@ -16,8 +16,10 @@ import { SkillConversationReference } from './skillConversationReference';
 export abstract class SkillConversationIdFactoryBase {
     /**
      * Creates a conversation ID for a skill conversation based on the caller's ConversationReference.
-     * @remarks
-     * It should be possible to use the returned string on a request URL and it should not contain special characters.
+     *
+     * @remarks 
+It should be possible to use the returned string on a request URL and it should not contain special characters.
+     * @param options
      * @param conversationReference The skill's caller ConversationReference.
      * @returns A unique conversation ID used to communicate with the skill.
      */
@@ -27,6 +29,7 @@ export abstract class SkillConversationIdFactoryBase {
 
     /**
      * Creates a conversation ID for a skill conversation based on the caller's ConversationReference.
+     *
      * @deprecated Method is deprecated, please use createSkillConversationIdWithOptions() with SkillConversationIdFactoryOptions instead.
      * @remarks
      * It should be possible to use the returned string on a request URL and it should not contain special characters.
@@ -39,6 +42,7 @@ export abstract class SkillConversationIdFactoryBase {
 
     /**
      * Gets the ConversationReference created using createSkillConversationId() for a skillConversationId.
+     *
      * @deprecated Method is deprecated, please use getSkillConversationReference() instead.
      * @param skillConversationId >A skill conversationId created using createSkillConversationId().
      * @returns The caller's ConversationReference for a skillConversationId. null if not found.
@@ -49,6 +53,7 @@ export abstract class SkillConversationIdFactoryBase {
 
     /**
      * Gets the SkillConversationReference created using createSkillConversationId() for a skillConversationId.
+     *
      * @param skillConversationId Gets the SkillConversationReference used during createSkillConversationId for a skillConversationId.
      */
     public getSkillConversationReference(skillConversationId: string): Promise<SkillConversationReference> {
@@ -57,6 +62,7 @@ export abstract class SkillConversationIdFactoryBase {
 
     /**
      * Deletes a ConversationReference.
+     *
      * @param skillConversationId A skill conversationId created using createSkillConversationId().
      */
     public abstract deleteConversationReference(skillConversationId: string): Promise<void>;

--- a/libraries/botbuilder-core/src/skills/skillConversationIdFactoryBase.ts
+++ b/libraries/botbuilder-core/src/skills/skillConversationIdFactoryBase.ts
@@ -17,10 +17,10 @@ export abstract class SkillConversationIdFactoryBase {
     /**
      * Creates a conversation ID for a skill conversation based on the caller's ConversationReference.
      *
-     * @remarks 
-It should be possible to use the returned string on a request URL and it should not contain special characters.
-     * @param options
-     * @param conversationReference The skill's caller ConversationReference.
+     * @remarks
+     * It should be possible to use the returned string on a request URL and it should not contain special characters.
+     *
+     * @param options options for creating a skill conversation ID
      * @returns A unique conversation ID used to communicate with the skill.
      */
     public createSkillConversationIdWithOptions(options: SkillConversationIdFactoryOptions): Promise<string> {
@@ -30,9 +30,12 @@ It should be possible to use the returned string on a request URL and it should 
     /**
      * Creates a conversation ID for a skill conversation based on the caller's ConversationReference.
      *
-     * @deprecated Method is deprecated, please use createSkillConversationIdWithOptions() with SkillConversationIdFactoryOptions instead.
+     * @deprecated Method is deprecated, please use createSkillConversationIdWithOptions() with
+     * SkillConversationIdFactoryOptions instead.
+     *
      * @remarks
      * It should be possible to use the returned string on a request URL and it should not contain special characters.
+     *
      * @param conversationReference The skill's caller ConversationReference.
      * @returns A unique conversation ID used to communicate with the skill.
      */
@@ -44,6 +47,7 @@ It should be possible to use the returned string on a request URL and it should 
      * Gets the ConversationReference created using createSkillConversationId() for a skillConversationId.
      *
      * @deprecated Method is deprecated, please use getSkillConversationReference() instead.
+     *
      * @param skillConversationId >A skill conversationId created using createSkillConversationId().
      * @returns The caller's ConversationReference for a skillConversationId. null if not found.
      */
@@ -55,6 +59,7 @@ It should be possible to use the returned string on a request URL and it should 
      * Gets the SkillConversationReference created using createSkillConversationId() for a skillConversationId.
      *
      * @param skillConversationId Gets the SkillConversationReference used during createSkillConversationId for a skillConversationId.
+     * @returns a promise resolving to the skill conversation reference
      */
     public getSkillConversationReference(skillConversationId: string): Promise<SkillConversationReference> {
         throw new Error('Not Implemented');

--- a/libraries/botbuilder-core/src/skypeMentionNormalizeMiddleware.ts
+++ b/libraries/botbuilder-core/src/skypeMentionNormalizeMiddleware.ts
@@ -23,6 +23,7 @@ import { TurnContext } from './turnContext';
 export class SkypeMentionNormalizeMiddleware implements Middleware {
     /**
      * Performs the normalization of Skype mention Entities.
+     *
      * @param activity [Activity](xref:botframework-schema.Activity) containing the mentions to normalize.
      */
     public static normalizeSkypeMentionText(activity: Activity): void {
@@ -42,6 +43,7 @@ export class SkypeMentionNormalizeMiddleware implements Middleware {
 
     /**
      * Middleware implementation which corrects the Entity text of type [Mention](xref:botframework-schema.Mention) to a value that [removeMentionText](xref:botbuilder-core.TurnContext.removeMentionText) can work with.
+     *
      * @param turnContext [TurnContext](xref:botbuilder-core.TurnContext) for the current turn of conversation.
      * @param next Delegate to call to continue the bot middleware pipeline.
      */

--- a/libraries/botbuilder-core/src/storage.ts
+++ b/libraries/botbuilder-core/src/storage.ts
@@ -72,7 +72,7 @@ export interface StoreItem {
     /**
      * Key/value pairs.
      */
-    [key: string]: any;
+    [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
     /**
      * (Optional) eTag field for stores that support optimistic concurrency.
@@ -87,7 +87,7 @@ export interface StoreItems {
     /**
      * List of store items indexed by key.
      */
-    [key: string]: any;
+    [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export const assertStoreItems: Assertion<StoreItems> = (val, path) => {
@@ -113,10 +113,12 @@ export const assertStoreItems: Assertion<StoreItems> = (val, path) => {
  *    await storage.write({ 'botState': state });
  * }
  * ```
+ *
  * @param item Item to calculate the change hash for.
+ * @returns a string representing the changes
  */
 export function calculateChangeHash(item: StoreItem): string {
-    const cpy: any = { ...item };
+    const cpy = { ...item };
     if (cpy.eTag) {
         delete cpy.eTag;
     }

--- a/libraries/botbuilder-core/src/storage.ts
+++ b/libraries/botbuilder-core/src/storage.ts
@@ -14,6 +14,7 @@ import { Assertion, assert } from 'botbuilder-stdlib';
  * ```TypeScript
  * type StorageKeyFactory = (context: TurnContext) => Promise<string>;
  * ```
+ *
  * @param StorageKeyFactory.context Context for the current turn of conversation with a user.
  */
 export type StorageKeyFactory = (context: TurnContext) => Promise<string>;

--- a/libraries/botbuilder-core/src/stringUtils.ts
+++ b/libraries/botbuilder-core/src/stringUtils.ts
@@ -12,6 +12,7 @@
 export class StringUtils {
     /**
      * Truncate string with ...
+     *
      * @param text Text.
      * @param length Length to truncate text.
      */
@@ -47,6 +48,7 @@ export class StringUtils {
 
     /**
      * EllipsisHash - create truncated string with unique hash for the truncated part.
+     *
      * @param text Text to truncate.
      * @param length Length to truncate at.
      */

--- a/libraries/botbuilder-core/src/stringUtils.ts
+++ b/libraries/botbuilder-core/src/stringUtils.ts
@@ -15,6 +15,7 @@ export class StringUtils {
      *
      * @param text Text.
      * @param length Length to truncate text.
+     * @returns truncated string with ellipsis
      */
     public static ellipsis(text: string, length: number): string {
         text = text || '';
@@ -34,6 +35,7 @@ export class StringUtils {
      * https://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/
      *
      * @param text Text to hash.
+     * @returns hashed text
      */
     public static hash(text: string): string {
         const length = text.length;
@@ -51,6 +53,7 @@ export class StringUtils {
      *
      * @param text Text to truncate.
      * @param length Length to truncate at.
+     * @returns truncated and hashed string
      */
     public static ellipsisHash(text: string, length: number): string {
         text = text || '';

--- a/libraries/botbuilder-core/src/telemetryLoggerMiddleware.ts
+++ b/libraries/botbuilder-core/src/telemetryLoggerMiddleware.ts
@@ -50,6 +50,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
 
     /**
      * Initializes a new instance of the TelemetryLoggerMiddleware class.
+     *
      * @param telemetryClient The BotTelemetryClient used for logging.
      * @param logPersonalInformation (Optional) Enable/Disable logging original message name within Application Insights.
      */
@@ -74,6 +75,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
 
     /**
      * Logs events based on incoming and outgoing activities using the botTelemetryClient class.
+     *
      * @param context The context object for this turn.
      * @param next The delegate to call to continue the bot middleware pipeline
      */
@@ -146,6 +148,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
      * Invoked when a message is received from the user.
      * Performs logging of telemetry data using the IBotTelemetryClient.TrackEvent() method.
      * The event name logged is "BotMessageReceived".
+     *
      * @param activity Current activity sent from user.
      */
     protected async onReceiveActivity(activity: Activity): Promise<void> {
@@ -159,6 +162,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
      * Invoked when the bot sends a message to the user.
      * Performs logging of telemetry data using the botTelemetryClient.trackEvent() method.
      * The event name logged is "BotMessageSend".
+     *
      * @param activity Last activity sent from user.
      */
     protected async onSendActivity(activity: Activity): Promise<void> {
@@ -172,6 +176,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
      * Invoked when the bot updates a message.
      * Performs logging of telemetry data using the botTelemetryClient.trackEvent() method.
      * The event name used is "BotMessageUpdate".
+     *
      * @param activity
      */
     protected async onUpdateActivity(activity: Activity): Promise<void> {
@@ -185,6 +190,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
      * Invoked when the bot deletes a message.
      * Performs logging of telemetry data using the botTelemetryClient.trackEvent() method.
      * The event name used is "BotMessageDelete".
+     *
      * @param activity
      */
     protected async onDeleteActivity(activity: Activity): Promise<void> {
@@ -197,6 +203,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
     /**
      * Fills the Application Insights Custom Event properties for BotMessageReceived.
      * These properties are logged in the custom event when a new message is received from the user.
+     *
      * @param activity Last activity sent from user.
      * @param telemetryProperties Additional properties to add to the event.
      * @returns A dictionary that is sent as "Properties" to botTelemetryClient.trackEvent method.
@@ -252,6 +259,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
     /**
      * Fills the Application Insights Custom Event properties for BotMessageSend.
      * These properties are logged in the custom event when a response message is sent by the Bot to the user.
+     *
      * @param activity - Last activity sent from user.
      * @param telemetryProperties Additional properties to add to the event.
      * @returns A dictionary that is sent as "Properties" to botTelemetryClient.trackEvent method.
@@ -305,6 +313,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
      * These properties are logged when an activity message is updated by the Bot.
      * For example, if a card is interacted with by the use, and the card needs to be updated to reflect
      * some interaction.
+     *
      * @param activity - Last activity sent from user.
      * @param telemetryProperties Additional properties to add to the event.
      * @returns A dictionary that is sent as "Properties" to botTelemetryClient.trackEvent method.
@@ -341,6 +350,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
     /**
      * Fills the Application Insights Custom Event properties for BotMessageDelete.
      * These properties are logged in the custom event when an activity message is deleted by the Bot.  This is a relatively rare case.
+     *
      * @param activity - Last activity sent from user.
      * @param telemetryProperties Additional properties to add to the event.
      * @returns A dictionary that is sent as "Properties" to botTelemetryClient.trackEvent method.

--- a/libraries/botbuilder-core/src/telemetryLoggerMiddleware.ts
+++ b/libraries/botbuilder-core/src/telemetryLoggerMiddleware.ts
@@ -61,6 +61,8 @@ export class TelemetryLoggerMiddleware implements Middleware {
 
     /**
      * Gets a value indicating whether determines whether to log personal information that came from the user.
+     *
+     * @returns log true if log personal information is enabled
      */
     public get logPersonalInformation(): boolean {
         return this._logPersonalInformation;
@@ -68,6 +70,8 @@ export class TelemetryLoggerMiddleware implements Middleware {
 
     /**
      * Gets the currently configured botTelemetryClient that logs the events.
+     *
+     * @returns bot telemetry client
      */
     public get telemetryClient(): BotTelemetryClient {
         return this._telemetryClient;
@@ -95,7 +99,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
         // hook up onSend pipeline
         context.onSendActivities(
             async (
-                ctx: TurnContext,
+                _ctx: TurnContext,
                 activities: Partial<Activity>[],
                 nextSend: () => Promise<ResourceResponse[]>
             ): Promise<ResourceResponse[]> => {
@@ -111,7 +115,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
 
         // hook up update activity pipeline
         context.onUpdateActivity(
-            async (ctx: TurnContext, activity: Partial<Activity>, nextUpdate: () => Promise<void>) => {
+            async (_ctx: TurnContext, activity: Partial<Activity>, nextUpdate: () => Promise<void>) => {
                 // run full pipeline
                 const response: void = await nextUpdate();
 
@@ -123,7 +127,7 @@ export class TelemetryLoggerMiddleware implements Middleware {
 
         // hook up delete activity pipeline
         context.onDeleteActivity(
-            async (ctx: TurnContext, reference: Partial<ConversationReference>, nextDelete: () => Promise<void>) => {
+            async (_ctx: TurnContext, reference: Partial<ConversationReference>, nextDelete: () => Promise<void>) => {
                 // run full pipeline
                 await nextDelete();
 
@@ -177,7 +181,8 @@ export class TelemetryLoggerMiddleware implements Middleware {
      * Performs logging of telemetry data using the botTelemetryClient.trackEvent() method.
      * The event name used is "BotMessageUpdate".
      *
-     * @param activity
+     * @param activity the activity to update
+     * @returns a promise representing the async operation
      */
     protected async onUpdateActivity(activity: Activity): Promise<void> {
         this.telemetryClient.trackEvent({
@@ -191,7 +196,8 @@ export class TelemetryLoggerMiddleware implements Middleware {
      * Performs logging of telemetry data using the botTelemetryClient.trackEvent() method.
      * The event name used is "BotMessageDelete".
      *
-     * @param activity
+     * @param activity the activity to delete
+     * @returns a promise representing the async operation
      */
     protected async onDeleteActivity(activity: Activity): Promise<void> {
         this.telemetryClient.trackEvent({

--- a/libraries/botbuilder-core/src/testAdapter.ts
+++ b/libraries/botbuilder-core/src/testAdapter.ts
@@ -33,6 +33,7 @@ import { TurnContext } from './turnContext';
  * ```TypeScript
  * type TestActivityInspector = (activity: Partial<Activity>, description: string) => void;
  * ```
+ *
  * @param TestActivityInspector.activity The activity being inspected.
  * @param TestActivityInspector.description Text to log in the event of an error.
  */
@@ -59,8 +60,10 @@ export type TestActivityInspector = (activity: Partial<Activity>, description?: 
 export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider {
     /**
      * Creates a new TestAdapter instance.
+     *
      * @param logicOrConversation The bots logic that's under test.
      * @param template (Optional) activity containing default values to assign to all test messages received.
+     * @param sendTraceActivity
      */
     public constructor(
         logicOrConversation?: ((context: TurnContext) => Promise<void>) | ConversationReference,
@@ -129,6 +132,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Create a ConversationReference.
+     *
      * @param name name of the conversation (also id).
      * @param user name of the user (also id) default: User1.
      * @param bot name of the bot (also id) default: Bot.
@@ -157,6 +161,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Creates a message activity from text and the current conversational context.
+     *
      * @param text The message text.
      */
     public makeActivity(text?: string): Partial<Activity> {
@@ -175,6 +180,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Processes a message activity from a user.
+     *
      * @param userSays The text of the user's message.
      * @param callback The bot logic to invoke.
      */
@@ -195,6 +201,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Receives an activity and runs it through the middleware pipeline.
+     *
      * @param activity The activity to process.
      * @param callback The bot logic to invoke.
      */
@@ -324,6 +331,9 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
     /**
      * The `TestAdapter` doesn't implement `continueConversation()` and will return an error if it's
      * called.
+     *
+     * @param reference
+     * @param logic
      */
     public continueConversation(
         reference: Partial<ConversationReference>,
@@ -422,6 +432,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Adds a fake user token so it can later be retrieved.
+     *
      * @param connectionName The connection name.
      * @param channelId The channel id.
      * @param userId The user id.
@@ -492,6 +503,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Retrieves the OAuth token for a user that is in a sign-in flow.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param magicCode (Optional) Optional user entered code to validate.
@@ -526,6 +538,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Signs the user out with the token server.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param userId User ID to sign out.
@@ -542,6 +555,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Gets a signin link from the token server that can be sent as part of a SigninCard.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      */
@@ -551,8 +565,10 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Signs the user out with the token server.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
+     * @param resourceUrls
      */
     public async getAadTokens(
         context: TurnContext,
@@ -568,6 +584,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Adds a fake exchangeable token so it can be exchanged later.
+     *
      * @param connectionName Name of the auth connection to use.
      * @param channelId Channel ID.
      * @param userId User ID.
@@ -592,6 +609,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Gets a sign-in resource.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext) for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param userId User ID
@@ -616,6 +634,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Performs a token exchange operation such as for single sign-on.
+     *
      * @param context [TurnContext](xref:botbuilder-core.TurnContext) for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param userId User id associated with the token.
@@ -654,6 +673,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
 
     /**
      * Adds an instruction to throw an exception during exchange requests.
+     *
      * @param connectionName The connection name.
      * @param channelId The channel id.
      * @param userId The user id.
@@ -767,6 +787,7 @@ export class TestFlow {
      * Send something to the bot and expects the bot to return with a given reply. This is simply a
      * wrapper around calls to `send()` and `assertReply()`. This is such a common pattern that a
      * helper is provided.
+     *
      * @param userSays Text or activity simulating user input.
      * @param expected Expected text or activity of the reply sent by the bot.
      * @param description (Optional) Description of the test case. If not provided one will be generated.
@@ -783,6 +804,7 @@ export class TestFlow {
 
     /**
      * Sends something to the bot.
+     *
      * @param userSays Text or activity simulating user input.
      */
     public send(userSays: string | Partial<Activity>): TestFlow {
@@ -813,6 +835,7 @@ export class TestFlow {
 
     /**
      * Generates an assertion if the bots response doesn't match the expected text/activity.
+     *
      * @param expected Expected text or activity from the bot. Can be a callback to inspect the response using custom logic.
      * @param description (Optional) Description of the test case. If not provided one will be generated.
      * @param timeout (Optional) number of milliseconds to wait for a response from bot. Defaults to a value of `3000`.
@@ -893,6 +916,7 @@ export class TestFlow {
 
     /**
      * Generates an assertion that the turn processing logic did not generate a reply from the bot, as expected.
+     *
      * @param description (Optional) Description of the test case. If not provided one will be generated.
      * @param timeout (Optional) number of milliseconds to wait for a response from bot. Defaults to a value of `3000`.
      */
@@ -935,6 +959,7 @@ export class TestFlow {
 
     /**
      * Generates an assertion if the bots response is not one of the candidate strings.
+     *
      * @param candidates List of candidate responses.
      * @param description (Optional) Description of the test case. If not provided one will be generated.
      * @param timeout (Optional) number of milliseconds to wait for a response from bot. Defaults to a value of `3000`.
@@ -960,6 +985,7 @@ export class TestFlow {
 
     /**
      * Inserts a delay before continuing.
+     *
      * @param ms ms to wait
      */
     public delay(ms: number): TestFlow {
@@ -976,6 +1002,7 @@ export class TestFlow {
 
     /**
      * Adds a `then()` step to the tests promise chain.
+     *
      * @param onFulfilled Code to run if the test is currently passing.
      */
     public then(onFulfilled?: () => void): TestFlow {
@@ -984,6 +1011,7 @@ export class TestFlow {
 
     /**
      * Adds a `catch()` clause to the tests promise chain.
+     *
      * @param onRejected Code to run if the test has thrown an error.
      */
     public catch(onRejected?: (reason: any) => void): TestFlow {

--- a/libraries/botbuilder-core/src/transcriptLogger.ts
+++ b/libraries/botbuilder-core/src/transcriptLogger.ts
@@ -56,7 +56,7 @@ export class TranscriptLoggerMiddleware implements Middleware {
 
         // hook up onSend pipeline
         context.onSendActivities(
-            async (ctx: TurnContext, activities: Partial<Activity>[], next: () => Promise<ResourceResponse[]>) => {
+            async (_ctx: TurnContext, activities: Partial<Activity>[], next: () => Promise<ResourceResponse[]>) => {
                 // Run full pipeline.
                 const responses = await next();
 
@@ -85,7 +85,7 @@ export class TranscriptLoggerMiddleware implements Middleware {
         );
 
         // hook up update activity pipeline
-        context.onUpdateActivity(async (ctx: TurnContext, activity: Partial<Activity>, next: () => Promise<void>) => {
+        context.onUpdateActivity(async (_ctx: TurnContext, activity: Partial<Activity>, next: () => Promise<void>) => {
             // run full pipeline
             const response: void = await next();
 
@@ -99,7 +99,7 @@ export class TranscriptLoggerMiddleware implements Middleware {
 
         // hook up delete activity pipeline
         context.onDeleteActivity(
-            async (ctx: TurnContext, reference: Partial<ConversationReference>, next: () => Promise<void>) => {
+            async (_ctx: TurnContext, reference: Partial<ConversationReference>, next: () => Promise<void>) => {
                 // run full pipeline
                 await next();
 
@@ -145,12 +145,7 @@ export class TranscriptLoggerMiddleware implements Middleware {
         }
     }
 
-    /**
-     * Logs the Activity.
-     *
-     * @param transcript
-     * @param activity Activity to log.
-     */
+    // Logs the Activity.
     private logActivity(transcript: Activity[], activity: Activity): void {
         if (!activity.timestamp) {
             activity.timestamp = new Date();
@@ -162,11 +157,7 @@ export class TranscriptLoggerMiddleware implements Middleware {
         }
     }
 
-    /**
-     * Clones the Activity entity.
-     *
-     * @param activity Activity to clone.
-     */
+    // Clones the Activity entity.
     private cloneActivity(activity: Partial<Activity>): Activity {
         return Object.assign(<Activity>{}, activity);
     }
@@ -176,6 +167,7 @@ export class TranscriptLoggerMiddleware implements Middleware {
      *
      * @param err Error or object to console.error out.
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private transcriptLoggerErrorHandler(err: Error | any): void {
         // tslint:disable:no-console
         if (err instanceof Error) {

--- a/libraries/botbuilder-core/src/transcriptLogger.ts
+++ b/libraries/botbuilder-core/src/transcriptLogger.ts
@@ -25,6 +25,7 @@ export class TranscriptLoggerMiddleware implements Middleware {
 
     /**
      * Middleware for logging incoming and outgoing activities to a transcript store.
+     *
      * @param logger Transcript logger
      */
     constructor(logger: TranscriptLogger) {
@@ -37,6 +38,7 @@ export class TranscriptLoggerMiddleware implements Middleware {
 
     /**
      * Initialization for middleware turn.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param next Function to call at the end of the middleware chain.
      */
@@ -145,6 +147,8 @@ export class TranscriptLoggerMiddleware implements Middleware {
 
     /**
      * Logs the Activity.
+     *
+     * @param transcript
      * @param activity Activity to log.
      */
     private logActivity(transcript: Activity[], activity: Activity): void {
@@ -160,6 +164,7 @@ export class TranscriptLoggerMiddleware implements Middleware {
 
     /**
      * Clones the Activity entity.
+     *
      * @param activity Activity to clone.
      */
     private cloneActivity(activity: Partial<Activity>): Activity {
@@ -168,6 +173,7 @@ export class TranscriptLoggerMiddleware implements Middleware {
 
     /**
      * Error logging helper function.
+     *
      * @param err Error or object to console.error out.
      */
     private transcriptLoggerErrorHandler(err: Error | any): void {
@@ -188,6 +194,7 @@ export class TranscriptLoggerMiddleware implements Middleware {
 export class ConsoleTranscriptLogger implements TranscriptLogger {
     /**
      * Log an activity to the transcript.
+     *
      * @param activity Activity being logged.
      */
     public logActivity(activity: Activity): void | Promise<void> {
@@ -206,6 +213,7 @@ export class ConsoleTranscriptLogger implements TranscriptLogger {
 export interface TranscriptLogger {
     /**
      * Log an activity to the transcript.
+     *
      * @param activity Activity being logged.
      */
     logActivity(activity: Activity): void | Promise<void>;
@@ -217,6 +225,7 @@ export interface TranscriptLogger {
 export interface TranscriptStore extends TranscriptLogger {
     /**
      * Get activities for a conversation (Aka the transcript)
+     *
      * @param channelId Channel Id.
      * @param conversationId Conversation Id.
      * @param continuationToken Continuation token to page through results.
@@ -231,6 +240,7 @@ export interface TranscriptStore extends TranscriptLogger {
 
     /**
      * List conversations in the channelId.
+     *
      * @param channelId Channel Id.
      * @param continuationToken Continuation token to page through results.
      */
@@ -238,6 +248,7 @@ export interface TranscriptStore extends TranscriptLogger {
 
     /**
      * Delete a specific conversation and all of its activities.
+     *
      * @param channelId Channel Id where conversation took place.
      * @param conversationId Id of the conversation to delete.
      */
@@ -266,6 +277,7 @@ export interface TranscriptInfo {
 
 /**
  * Page of results.
+ *
  * @param T type of items being paged in.
  */
 // tslint:disable-next-line:max-classes-per-file

--- a/libraries/botbuilder-core/src/turnContextStateCollection.ts
+++ b/libraries/botbuilder-core/src/turnContextStateCollection.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 const TURN_STATE_SCOPE_CACHE = Symbol('turnStateScopeCache');
 
 /**

--- a/libraries/botbuilder-core/src/turnContextStateCollection.ts
+++ b/libraries/botbuilder-core/src/turnContextStateCollection.ts
@@ -7,19 +7,21 @@ const TURN_STATE_SCOPE_CACHE = Symbol('turnStateScopeCache');
 
 /**
  * Values persisted for the lifetime of the turn as part of the [TurnContext](xref:botbuilder-core.TurnContext).
+ *
  * @remarks Typical values stored here are objects which are needed for the lifetime of a turn, such
  * as [Storage](xref:botbuilder-core.Storage), [BotState](xref:botbuilder-core.BotState), [ConversationState](xref:botbuilder-core.ConversationState), [LanguageGenerator](xref:botbuilder-dialogs-adaptive.LanguageGenerator), [ResourceExplorer](xref:botbuilder-dialogs-declarative.ResourceExplorer), etc.
  */
 export class TurnContextStateCollection extends Map<any, any> {
-
     /**
      * Gets a typed value from the [TurnContextStateCollection](xref:botbuilder-core.TurnContextStateCollection).
+     *
      * @param key The values key.
      */
     public get<T = any>(key: any): T;
 
     /**
      * Gets a value from the [TurnContextStateCollection](xref:botbuilder-core.TurnContextStateCollection).
+     *
      * @param key The values key.
      */
     public get(key: any): any;
@@ -29,6 +31,7 @@ export class TurnContextStateCollection extends Map<any, any> {
 
     /**
      * Push a value by key to the turn's context.
+     *
      * @remarks
      * The keys current value (if any) will be saved and can be restored by calling [pop()](#pop).
      * @param key The values key.
@@ -54,6 +57,7 @@ export class TurnContextStateCollection extends Map<any, any> {
 
     /**
      * Restores a keys previous value, and returns the value that was removed.
+     *
      * @param key The values key.
      * @returns The removed value.
      */

--- a/libraries/botbuilder-core/src/userState.ts
+++ b/libraries/botbuilder-core/src/userState.ts
@@ -28,6 +28,7 @@ const NO_KEY = `UserState: overridden getStorageKey method did not return a key.
 export class UserState extends BotState {
     /**
      * Creates a new UserState instance.
+     *
      * @param storage Storage provider to persist user state to.
      * @param namespace (Optional) namespace to append to storage keys. Defaults to an empty string.
      */
@@ -42,6 +43,7 @@ export class UserState extends BotState {
 
     /**
      * Returns the storage key for the current user state.
+     *
      * @param context Context for current turn of conversation with the user.
      */
     public getStorageKey(context: TurnContext): string | undefined {

--- a/libraries/botbuilder-core/src/userState.ts
+++ b/libraries/botbuilder-core/src/userState.ts
@@ -45,6 +45,7 @@ export class UserState extends BotState {
      * Returns the storage key for the current user state.
      *
      * @param context Context for current turn of conversation with the user.
+     * @returns storage key, or undefined
      */
     public getStorageKey(context: TurnContext): string | undefined {
         const activity: Activity = context.activity;

--- a/libraries/botbuilder-core/src/userTokenProvider.ts
+++ b/libraries/botbuilder-core/src/userTokenProvider.ts
@@ -43,8 +43,8 @@ export interface IUserTokenProvider {
         context: TurnContext,
         userId: string,
         includeFilter?: string,
-        oAuthAppCredentials?: any
-    ): Promise<any[]>;
+        oAuthAppCredentials?: any // eslint-disable-line @typescript-eslint/no-explicit-any
+    ): Promise<any[]>; // eslint-disable-line @typescript-eslint/no-explicit-any
 
     /**
      * Gets a signin link from the token server that can be sent as part of a SigninCard.

--- a/libraries/botbuilder-core/src/userTokenProvider.ts
+++ b/libraries/botbuilder-core/src/userTokenProvider.ts
@@ -15,6 +15,7 @@ import { TokenResponse } from 'botframework-schema';
 export interface IUserTokenProvider {
     /**
      * Retrieves the OAuth token for a user that is in a sign-in flow.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param magicCode (Optional) Optional user entered code to validate.
@@ -23,6 +24,7 @@ export interface IUserTokenProvider {
 
     /**
      * Signs the user out with the token server.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      * @param userId User id of user to sign out.
@@ -31,6 +33,7 @@ export interface IUserTokenProvider {
 
     /**
      * Retrieves the token status for each configured connection for the given user, using the bot's AppCredentials.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param userId The user Id for which token status is retrieved.
      * @param includeFilter Comma separated list of connection's to include. Blank will return token status for all configured connections.
@@ -45,6 +48,7 @@ export interface IUserTokenProvider {
 
     /**
      * Gets a signin link from the token server that can be sent as part of a SigninCard.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      */
@@ -52,6 +56,7 @@ export interface IUserTokenProvider {
 
     /**
      * Signs the user out with the token server.
+     *
      * @param context Context for the current turn of conversation with the user.
      * @param connectionName Name of the auth connection to use.
      */

--- a/libraries/botbuilder-core/tests/ActivityHandler.test.js
+++ b/libraries/botbuilder-core/tests/ActivityHandler.test.js
@@ -21,7 +21,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onTurnCalled = false;
-        bot.onTurn(async (context, next) => {
+        bot.onTurn(async (_context, next) => {
             onTurnCalled = true;
             await next();
         });
@@ -34,7 +34,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onMessageCalled = false;
-        bot.onMessage(async (context, next) => {
+        bot.onMessage(async (_context, next) => {
             onMessageCalled = true;
             await next();
         });
@@ -47,13 +47,13 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onTurnCalled = false;
-        bot.onTurn(async (context, next) => {
+        bot.onTurn(async (_context, next) => {
             onTurnCalled = true;
             await next();
         });
 
         let onMessageCalled = false;
-        bot.onMessage(async (context, next) => {
+        bot.onMessage(async (_context, next) => {
             onMessageCalled = true;
             await next();
         });
@@ -67,12 +67,12 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onTurnCalled = false;
-        bot.onTurn(async (context, next) => {
+        bot.onTurn(async (_context, _next) => {
             onTurnCalled = true;
         });
 
         let onMessageCalled = false;
-        bot.onMessage(async (context, next) => {
+        bot.onMessage(async (_context, next) => {
             onMessageCalled = false;
             await next();
         });
@@ -87,14 +87,14 @@ describe('ActivityHandler', function () {
         let count = 0;
 
         let onMessageCalled = false;
-        bot.onMessage(async (context, next) => {
+        bot.onMessage(async (_context, next) => {
             onMessageCalled = true;
             count++;
             await next();
         });
 
         let onMessageCalledAgain = false;
-        bot.onMessage(async (context, next) => {
+        bot.onMessage(async (_context, next) => {
             onMessageCalledAgain = true;
             count++;
             await next();
@@ -110,7 +110,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onConversationUpdateCalled = false;
-        bot.onConversationUpdate(async (context, next) => {
+        bot.onConversationUpdate(async (_context, next) => {
             onConversationUpdateCalled = true;
             await next();
         });
@@ -123,7 +123,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onMembersAddedCalled = false;
-        bot.onMembersAdded(async (context, next) => {
+        bot.onMembersAdded(async (_context, next) => {
             onMembersAddedCalled = true;
             await next();
         });
@@ -136,7 +136,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onMembersRemovedCalled = false;
-        bot.onMembersRemoved(async (context, next) => {
+        bot.onMembersRemoved(async (_context, next) => {
             onMembersRemovedCalled = true;
             await next();
         });
@@ -149,7 +149,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onMessageReactionCalled = false;
-        bot.onMessageReaction(async (context, next) => {
+        bot.onMessageReaction(async (_context, next) => {
             onMessageReactionCalled = true;
             await next();
         });
@@ -162,7 +162,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onReactionsAddedCalled = false;
-        bot.onReactionsAdded(async (context, next) => {
+        bot.onReactionsAdded(async (_context, next) => {
             onReactionsAddedCalled = true;
             await next();
         });
@@ -175,7 +175,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onReactionsRemovedCalled = false;
-        bot.onReactionsRemoved(async (context, next) => {
+        bot.onReactionsRemoved(async (_context, next) => {
             onReactionsRemovedCalled = true;
             await next();
         });
@@ -188,7 +188,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onEventCalled = false;
-        bot.onEvent(async (context, next) => {
+        bot.onEvent(async (_context, next) => {
             onEventCalled = true;
             await next();
         });
@@ -201,7 +201,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onEndConversationCalled = false;
-        bot.onEndOfConversation(async (context, next) => {
+        bot.onEndOfConversation(async (_context, next) => {
             onEndConversationCalled = true;
             await next();
         });
@@ -214,7 +214,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onTypingCalled = false;
-        bot.onTyping(async (context, next) => {
+        bot.onTyping(async (_context, next) => {
             onTypingCalled = true;
             await next();
         });
@@ -227,7 +227,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onInstallationUpdateCalled = false;
-        bot.onInstallationUpdate(async (context, next) => {
+        bot.onInstallationUpdate(async (_context, next) => {
             onInstallationUpdateCalled = true;
             await next();
         });
@@ -240,7 +240,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onInstallationUpdateAddCalled = false;
-        bot.onInstallationUpdateAdd(async (context, next) => {
+        bot.onInstallationUpdateAdd(async (_context, next) => {
             onInstallationUpdateAddCalled = true;
             await next();
         });
@@ -253,7 +253,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onInstallationUpdateAddCalled = false;
-        bot.onInstallationUpdateAdd(async (context, next) => {
+        bot.onInstallationUpdateAdd(async (_context, next) => {
             onInstallationUpdateAddCalled = true;
             await next();
         });
@@ -266,7 +266,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onInstallationUpdateRemoveCalled = false;
-        bot.onInstallationUpdateRemove(async (context, next) => {
+        bot.onInstallationUpdateRemove(async (_context, next) => {
             onInstallationUpdateRemoveCalled = true;
             await next();
         });
@@ -279,7 +279,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onInstallationUpdateRemoveCalled = false;
-        bot.onInstallationUpdateRemove(async (context, next) => {
+        bot.onInstallationUpdateRemove(async (_context, next) => {
             onInstallationUpdateRemoveCalled = true;
             await next();
         });
@@ -292,7 +292,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onUnrecognizedActivityTypeCalled = false;
-        bot.onUnrecognizedActivityType(async (context, next) => {
+        bot.onUnrecognizedActivityType(async (_context, next) => {
             onUnrecognizedActivityTypeCalled = true;
             await next();
         });
@@ -305,7 +305,7 @@ describe('ActivityHandler', function () {
         const bot = new ActivityHandler();
 
         let onDialogCalled = false;
-        bot.onDialog(async (context, next) => {
+        bot.onDialog(async (_context, next) => {
             onDialogCalled = true;
             await next();
         });

--- a/libraries/botbuilder-core/tests/activityHandlerBase.test.js
+++ b/libraries/botbuilder-core/tests/activityHandlerBase.test.js
@@ -160,7 +160,7 @@ describe('ActivityHandlerBase', function () {
         assert(onUnrecognizedActivity, 'onUnrecognizedActivity was not called');
     });
 
-    describe('onConversationUpdateActivity', () => {
+    describe('onConversationUpdateActivity', function () {
         class ConversationUpdateActivityHandler extends ActivityHandlerBase {
             async onTurnActivity(context) {
                 assert(context, 'context not found');
@@ -261,7 +261,7 @@ describe('ActivityHandlerBase', function () {
         });
     });
 
-    describe('onMessageReaction', () => {
+    describe('onMessageReaction', function () {
         class MessageReactionActivityHandler extends ActivityHandlerBase {
             async onTurnActivity(context) {
                 assert(context, 'context not found');

--- a/libraries/botbuilder-core/tests/autoSaveStateMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/autoSaveStateMiddleware.test.js
@@ -14,7 +14,7 @@ class BotStateMock {
         assert(context, `BotStateMock.load() not passed context.`);
         if (this.assertForce) assert(force, `BotStateMock.load(): force not set.`);
         this.readCalled = true;
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             setTimeout(() => resolve(this.state), Math.random() * 50);
         });
     }
@@ -23,7 +23,7 @@ class BotStateMock {
         assert(context, `BotStateMock.saveChanges() not passed context.`);
         if (this.assertForce) assert(force, `BotStateMock.saveChanges(): force not set.`);
         this.writeCalled = true;
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             setTimeout(() => resolve(), Math.random() * 50);
         });
     }
@@ -89,7 +89,7 @@ describe(`AutoSaveStateMiddleware`, function () {
 
     it(`should throw exception if invalid plugin passed in.`, function () {
         try {
-            const set = new AutoSaveStateMiddleware(fooState, { read: () => {} });
+            new AutoSaveStateMiddleware(fooState, { read: () => {} });
             assert.fail('bogus plugin added to set.');
         } catch (err) {
             assert.strictEqual(err.message, "BotStateSet: a object was added that isn't an instance of BotState.");

--- a/libraries/botbuilder-core/tests/botAdapter.test.js
+++ b/libraries/botbuilder-core/tests/botAdapter.test.js
@@ -12,13 +12,13 @@ class SimpleAdapter extends BotAdapter {
     }
 }
 
-describe('BotAdapter', () => {
+describe('BotAdapter', function () {
     let sandbox;
-    beforeEach(() => {
+    beforeEach(function () {
         sandbox = sinon.createSandbox();
     });
 
-    afterEach(() => {
+    afterEach(function () {
         sandbox.restore();
     });
 
@@ -26,18 +26,18 @@ describe('BotAdapter', () => {
 
     const getAdapter = () => new SimpleAdapter();
 
-    describe('middleware handling', () => {
-        it('should use() middleware individually', () => {
+    describe('middleware handling', function () {
+        it('should use() middleware individually', function () {
             const adapter = getAdapter();
             adapter.use(getNextFake()).use(getNextFake());
         });
 
-        it('should use() a list of middleware', () => {
+        it('should use() a list of middleware', function () {
             const adapter = getAdapter();
             adapter.use(getNextFake(), getNextFake(), getNextFake());
         });
 
-        it('should run all middleware', async () => {
+        it('should run all middleware', async function () {
             const adapter = getAdapter();
 
             const middlewares = [getNextFake(), getNextFake()];
@@ -57,8 +57,8 @@ describe('BotAdapter', () => {
         });
     });
 
-    describe('Get locale from activity', () => {
-        it('should have locale', async () => {
+    describe('Get locale from activity', function () {
+        it('should have locale', async function () {
             const adapter = getAdapter();
             const activity = testMessage;
             activity.locale = 'de-DE';
@@ -71,7 +71,7 @@ describe('BotAdapter', () => {
         });
     });
 
-    describe('onTurnError', () => {
+    describe('onTurnError', function () {
         const testCases = [
             { label: 'promise is rejected', logic: () => Promise.reject('error') },
             {
@@ -83,7 +83,7 @@ describe('BotAdapter', () => {
         ];
 
         testCases.forEach(({ label, logic }) => {
-            it(`should reach onTurnError when a ${label}`, async () => {
+            it(`should reach onTurnError when a ${label}`, async function () {
                 const adapter = getAdapter();
 
                 adapter.onTurnError = sandbox.fake((context, error) => {
@@ -99,7 +99,7 @@ describe('BotAdapter', () => {
                 assert(handler.called, 'handler was called');
             });
 
-            it(`should propagate error when onTurnError is not defined and a ${label}`, async () => {
+            it(`should propagate error when onTurnError is not defined and a ${label}`, async function () {
                 const adapter = getAdapter();
 
                 const handler = sandbox.fake(logic);
@@ -112,7 +112,7 @@ describe('BotAdapter', () => {
                 assert(handler.called, 'handler was called');
             });
 
-            it(`should propagate error if a ${label} in onTurnError when a ${label} in handler`, async () => {
+            it(`should propagate error if a ${label} in onTurnError when a ${label} in handler`, async function () {
                 const adapter = getAdapter();
 
                 adapter.onTurnError = sandbox.fake((context, error) => {
@@ -134,8 +134,8 @@ describe('BotAdapter', () => {
         });
     });
 
-    describe('proxy context revocation', () => {
-        it('should revoke after execution', async () => {
+    describe('proxy context revocation', function () {
+        it('should revoke after execution', async function () {
             const adapter = getAdapter();
 
             const handler = sandbox.fake((context) => {
@@ -149,7 +149,7 @@ describe('BotAdapter', () => {
             assert.throws(() => context.activity, 'accessing context property should throw since it has been revoked');
         });
 
-        it('should revoke after onTurnError', async () => {
+        it('should revoke after onTurnError', async function () {
             const adapter = getAdapter();
 
             adapter.onTurnError = sandbox.fake((context) => {
@@ -165,7 +165,7 @@ describe('BotAdapter', () => {
             assert.throws(() => context.activity, 'accessing context property should throw since it has been revoked');
         });
 
-        it('should revoke after unhandled error', async () => {
+        it('should revoke after unhandled error', async function () {
             const adapter = getAdapter();
 
             const handler = sandbox.fake(() => Promise.reject('error'));

--- a/libraries/botbuilder-core/tests/botAdapter.test.js
+++ b/libraries/botbuilder-core/tests/botAdapter.test.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const { uniqueId } = require('lodash');
 const sinon = require('sinon');
 const { BotAdapter, TurnContext } = require('../');
 

--- a/libraries/botbuilder-core/tests/botState.test.js
+++ b/libraries/botbuilder-core/tests/botState.test.js
@@ -26,7 +26,7 @@ describe(`BotState`, function () {
 
     it(`should load and save state from storage.`, async function () {
         await botState.load(context);
-        let state = cachedState(context, botState.stateKey);
+        const state = cachedState(context, botState.stateKey);
         assert(state, `State not loaded`);
         state.test = 'foo';
         await botState.saveChanges(context);
@@ -100,7 +100,7 @@ describe(`BotState`, function () {
     });
 
     it(`should create new PropertyAccessors`, async function () {
-        let count = botState.createProperty('count', 1);
+        const count = botState.createProperty('count', 1);
         assert(count !== undefined, `did not successfully create PropertyAccessor.`);
     });
 });

--- a/libraries/botbuilder-core/tests/botState.test.js
+++ b/libraries/botbuilder-core/tests/botState.test.js
@@ -32,7 +32,7 @@ describe(`BotState`, function () {
         await botState.saveChanges(context);
 
         const items = await storage.read([storageKey]);
-        assert(items.hasOwnProperty(storageKey), `Saved state not found in storage.`);
+        assert(items[storageKey], `Saved state not found in storage.`);
         assert(items[storageKey].test === 'foo', `Missing test value in stored state.`);
     });
 
@@ -49,12 +49,12 @@ describe(`BotState`, function () {
         await botState.load(context);
         assert(cachedState(context, botState.stateKey).test === 'foo', `invalid initial state`);
         await botState.clear(context);
-        assert(!cachedState(context, botState.stateKey).hasOwnProperty('test'), `state not cleared on context.`);
+        assert(!cachedState(context, botState.stateKey).test, `state not cleared on context.`);
         await botState.saveChanges(context);
 
         const items = await storage.read([storageKey]);
         assert(items[storageKey], `state removed from storage.`);
-        assert(!items[storageKey].hasOwnProperty('test'), `state not cleared from storage.`);
+        assert(!items[storageKey].test, `state not cleared from storage.`);
     });
 
     it(`should delete() state storage.`, async function () {
@@ -64,13 +64,13 @@ describe(`BotState`, function () {
         assert(!cachedState(context, botState.stateKey), `state not cleared on context.`);
 
         const items = await storage.read([storageKey]);
-        assert(!items.hasOwnProperty(storageKey), `state not removed from storage.`);
+        assert(!items[storageKey], `state not removed from storage.`);
     });
 
     it(`should force immediate saveChanges() of state to storage.`, async function () {
         await botState.load(context);
         const state = cachedState(context, botState.stateKey);
-        assert(!state.hasOwnProperty('foo'), `invalid initial state`);
+        assert(!state.foo, `invalid initial state`);
         state.test = 'foo';
         await botState.saveChanges(context, true);
         const items = await storage.read([storageKey]);

--- a/libraries/botbuilder-core/tests/botStatePropertyAccessor.test.js
+++ b/libraries/botbuilder-core/tests/botStatePropertyAccessor.test.js
@@ -69,7 +69,7 @@ describe(`BotStatePropertyAccessor`, function () {
             await booleanProperty.set(context, booleanValue);
 
             // Retrieve the property value which should be true.
-            const retrievedValue = await booleanProperty.get(context);
+            await booleanProperty.get(context);
             assert(booleanValue, `value for PropertyAccessor was not properly saved.`);
 
             // Delete the value from state, and verify that the value is now undefined.

--- a/libraries/botbuilder-core/tests/botStatePropertyAccessor.test.js
+++ b/libraries/botbuilder-core/tests/botStatePropertyAccessor.test.js
@@ -20,7 +20,7 @@ describe(`BotStatePropertyAccessor`, function () {
         const userProperty = botState.createProperty(USER_COUNT);
 
         const tAdapter = new TestAdapter(async (context) => {
-            let userCount = await userProperty.get(context, 100);
+            const userCount = await userProperty.get(context, 100);
             assert(userCount === 100, `default value for PropertyAccessor was not used.`);
             await botState.saveChanges(context);
         });
@@ -33,7 +33,7 @@ describe(`BotStatePropertyAccessor`, function () {
         const testProperty = botState.createProperty(NO_DEFAULT_VALUE);
 
         const tAdapter = new TestAdapter(async (context) => {
-            let testValue = await testProperty.get(context);
+            const testValue = await testProperty.get(context);
             assert(testValue === undefined, `PropertyAccessor's value was not undefined.`);
             await botState.saveChanges(context);
         });
@@ -69,12 +69,12 @@ describe(`BotStatePropertyAccessor`, function () {
             await booleanProperty.set(context, booleanValue);
 
             // Retrieve the property value which should be true.
-            let retrievedValue = await booleanProperty.get(context);
+            const retrievedValue = await booleanProperty.get(context);
             assert(booleanValue, `value for PropertyAccessor was not properly saved.`);
 
             // Delete the value from state, and verify that the value is now undefined.
             await booleanProperty.delete(context);
-            let noPropertyValue = await booleanProperty.get(context);
+            const noPropertyValue = await booleanProperty.get(context);
             assert(noPropertyValue === undefined, `value for PropertyAccessor was not properly deleted.`);
             await botState.saveChanges(context);
         });
@@ -101,7 +101,7 @@ describe(`BotStatePropertyAccessor`, function () {
         const numbersProperty = botState.createProperty(NUMBERS_PROPERTY);
 
         const tAdapter = new TestAdapter(async (context) => {
-            let numbersValue = await numbersProperty.get(context, [1]);
+            const numbersValue = await numbersProperty.get(context, [1]);
             assert(Array.isArray(numbersValue), `default value for PropertyAccessor was not properly set.`);
             assert(numbersValue.length === 1, `numbersValue.length should be 1, not ${numbersValue.length}.`);
             assert(numbersValue[0] === 1, `numbersValue[0] should be 1, not ${numbersValue[0]}.`);
@@ -116,7 +116,7 @@ describe(`BotStatePropertyAccessor`, function () {
         const addressProperty = botState.createProperty(ADDRESS_PROPERTY);
 
         const tAdapter = new TestAdapter(async (context) => {
-            let addressValue = await addressProperty.get(context, {
+            const addressValue = await addressProperty.get(context, {
                 street: '1 Microsoft Way',
                 zipCode: 98052,
                 state: 'WA',

--- a/libraries/botbuilder-core/tests/botStateSet.test.js
+++ b/libraries/botbuilder-core/tests/botStateSet.test.js
@@ -1,8 +1,22 @@
 const assert = require('assert');
 
-const { TurnContext, BotStateSet, BotState, MemoryStorage, UserState, ConversationState, TestAdapter } = require('../lib');
+const {
+    TurnContext,
+    BotStateSet,
+    BotState,
+    MemoryStorage,
+    UserState,
+    ConversationState,
+    TestAdapter,
+} = require('../lib');
 
-const receivedMessage = { text: 'received', type: 'message', channelId: 'test', from: { id: 'testuser' }, conversation: { id: 'conv' } };
+const receivedMessage = {
+    text: 'received',
+    type: 'message',
+    channelId: 'test',
+    from: { id: 'testuser' },
+    conversation: { id: 'conv' },
+};
 
 class BotStateMock {
     constructor(state) {
@@ -41,8 +55,7 @@ describe(`BotStateSet`, function () {
         const userState = new UserState(memoryStorage);
         const convState = new ConversationState(memoryStorage);
 
-        let botStateSet = new BotStateSet(userState)
-            .add(convState);
+        const botStateSet = new BotStateSet(userState).add(convState);
         assert.equal(botStateSet.botStates.length, 2);
     });
 
@@ -52,16 +65,16 @@ describe(`BotStateSet`, function () {
         {
             const userState = new UserState(memoryStorage);
             const convState = new ConversationState(memoryStorage);
-            let botStateSet = new BotStateSet(userState, convState);
+            const botStateSet = new BotStateSet(userState, convState);
 
-            let userProperty = userState.createProperty("userCount");
-            let convProperty = convState.createProperty("convCount");
+            const userProperty = userState.createProperty('userCount');
+            const convProperty = convState.createProperty('convCount');
 
             assert.equal(botStateSet.botStates.length, 2);
 
-            let userCount = await userProperty.get(turnContext, 0);
+            const userCount = await userProperty.get(turnContext, 0);
             assert.equal(userCount, 0);
-            let convCount = await convProperty.get(turnContext, 0);
+            const convCount = await convProperty.get(turnContext, 0);
             assert.equal(convCount, 0);
 
             await userProperty.set(turnContext, 10);
@@ -73,20 +86,19 @@ describe(`BotStateSet`, function () {
         {
             const userState = new UserState(memoryStorage);
             const convState = new ConversationState(memoryStorage);
-            let botStateSet = new BotStateSet(userState, convState);
+            const botStateSet = new BotStateSet(userState, convState);
 
-            let userProperty = userState.createProperty("userCount");
-            let convProperty = convState.createProperty("convCount");
+            const userProperty = userState.createProperty('userCount');
+            const convProperty = convState.createProperty('convCount');
 
             assert.equal(botStateSet.botStates.length, 2);
 
             await botStateSet.loadAll(turnContext);
 
-            let userCount = await userProperty.get(turnContext, 0);
+            const userCount = await userProperty.get(turnContext, 0);
             assert.equal(userCount, 10);
-            let convCount = await convProperty.get(turnContext, 0);
+            const convCount = await convProperty.get(turnContext, 0);
             assert.equal(convCount, 20);
         }
-
     });
 });

--- a/libraries/botbuilder-core/tests/botStateSet.test.js
+++ b/libraries/botbuilder-core/tests/botStateSet.test.js
@@ -1,14 +1,5 @@
 const assert = require('assert');
-
-const {
-    TurnContext,
-    BotStateSet,
-    BotState,
-    MemoryStorage,
-    UserState,
-    ConversationState,
-    TestAdapter,
-} = require('../lib');
+const { TurnContext, BotStateSet, MemoryStorage, UserState, ConversationState, TestAdapter } = require('../lib');
 
 const receivedMessage = {
     text: 'received',
@@ -17,32 +8,6 @@ const receivedMessage = {
     from: { id: 'testuser' },
     conversation: { id: 'conv' },
 };
-
-class BotStateMock {
-    constructor(state) {
-        this.state = state || {};
-        this.assertForce = false;
-        this.readCalled = false;
-        this.writeCalled = false;
-    }
-    load(context, force) {
-        assert(context, `BotStateMock.load() not passed context.`);
-        if (this.assertForce) assert(force, `BotStateMock.load(): force not set.`);
-        this.readCalled = true;
-        return new Promise((resolve, reject) => {
-            setTimeout(() => resolve(this.state), Math.random() * 50);
-        });
-    }
-
-    saveChanges(context, force) {
-        assert(context, `BotStateMock.saveChanges() not passed context.`);
-        if (this.assertForce) assert(force, `BotStateMock.saveChanges(): force not set.`);
-        this.writeCalled = true;
-        return new Promise((resolve, reject) => {
-            setTimeout(() => resolve(), Math.random() * 50);
-        });
-    }
-}
 
 describe(`BotStateSet`, function () {
     this.timeout(5000);

--- a/libraries/botbuilder-core/tests/botTelemetryClient.test.js
+++ b/libraries/botbuilder-core/tests/botTelemetryClient.test.js
@@ -1,46 +1,51 @@
 const { ok, strictEqual } = require('assert');
 const { Severity, telemetryTrackDialogView } = require('../');
 
-describe('BotTelemetryClient', function() {
+describe('BotTelemetryClient', function () {
     this.timeout(3000);
 
-    describe('"telemetryTrackDialogView" helper', () => {
-        it('should call client.trackPageView if it exists', () => {
+    describe('"telemetryTrackDialogView" helper', function () {
+        it('should call client.trackPageView if it exists', function () {
             const testClient = {
                 trackPageView({ name, properties, metrics }) {
                     ok(name);
                     ok(properties);
                     ok(metrics);
-                }
+                },
             };
             const testProps = { description: 'value' };
             const testMetrics = { duration: 1 };
             telemetryTrackDialogView(testClient, 'dialogName', testProps, testMetrics);
         });
 
-        it('should call client.trackTrace if trackPageView is not supported', () => {
+        it('should call client.trackTrace if trackPageView is not supported', function () {
             const testClient = {
                 trackTrace({ message, severityLevel }) {
                     ok(message);
                     strictEqual(severityLevel, Severity.Information);
-                }
+                },
             };
             telemetryTrackDialogView(testClient, 'dialogName');
         });
 
-        it('should throw TypeError if trackTrace and trackPageView do not exist', () => {
+        it('should throw TypeError if trackTrace and trackPageView do not exist', function () {
             try {
                 telemetryTrackDialogView(undefined, 'dialogName');
             } catch (err) {
-                strictEqual(err.message, '"telemetryClient" parameter does not have methods trackPageView() or trackTrace()');
+                strictEqual(
+                    err.message,
+                    '"telemetryClient" parameter does not have methods trackPageView() or trackTrace()'
+                );
             }
 
             try {
                 telemetryTrackDialogView({}, 'dialogName');
             } catch (err) {
-                strictEqual(err.message, '"telemetryClient" parameter does not have methods trackPageView() or trackTrace()');
+                strictEqual(
+                    err.message,
+                    '"telemetryClient" parameter does not have methods trackPageView() or trackTrace()'
+                );
             }
-
         });
     });
 });

--- a/libraries/botbuilder-core/tests/browserStorage.test.js
+++ b/libraries/botbuilder-core/tests/browserStorage.test.js
@@ -1,10 +1,10 @@
 const assert = require('assert');
 const { BrowserLocalStorage, BrowserSessionStorage } = require('../');
 
-
 function testStorage(storage) {
     it('read of unknown key', function () {
-        return storage.read(['unk'])
+        return storage
+            .read(['unk'])
             .catch((reson) => assert(false, 'should not throw on read of unknown key'))
             .then((result) => {
                 assert(result != null, 'result should be object');
@@ -13,7 +13,8 @@ function testStorage(storage) {
     });
 
     it('key creation', function () {
-        return storage.write({ keyCreate: { count: 1 } })
+        return storage
+            .write({ keyCreate: { count: 1 } })
             .then(() => storage.read(['keyCreate']))
             .then((result) => {
                 assert(result != null, 'result should be object');
@@ -24,69 +25,75 @@ function testStorage(storage) {
     });
 
     it('key update', function () {
-        return storage.write({ keyUpdate: { count: 1 } })
+        return storage
+            .write({ keyUpdate: { count: 1 } })
             .then(() => storage.read(['keyUpdate']))
             .then((result) => {
                 result.keyUpdate.count = 2;
-                return storage.write(result)
+                return storage
+                    .write(result)
                     .then(() => storage.read(['keyUpdate']))
                     .then((updated) => {
                         assert(updated.keyUpdate.count == 2, 'object should be updated');
                         assert(updated.keyUpdate.eTag != result.keyUpdate.eTag, 'Etag should be updated on write');
                     });
-            })
+            });
     });
 
     it('invalid eTag', function () {
-        return storage.write({ keyUpdate2: { count: 1 } })
+        return storage
+            .write({ keyUpdate2: { count: 1 } })
             .then(() => storage.read(['keyUpdate2']))
             .then((result) => {
                 result.keyUpdate2.count = 2;
                 return storage.write(result).then(() => {
                     result.keyUpdate2.count = 3;
-                    return storage.write(result)
+                    return storage
+                        .write(result)
                         .then(() => assert(false, 'should throw an exception on second write with same etag'))
-                        .catch((reason) => { });
+                        .catch((reason) => {});
                 });
             });
     });
 
     it('wildcard eTag', function () {
-        return storage.write({ keyUpdate3: { count: 1 } })
+        return storage
+            .write({ keyUpdate3: { count: 1 } })
             .then(() => storage.read(['keyUpdate3']))
             .then((result) => {
                 result.keyUpdate3.eTag = '*';
                 result.keyUpdate3.count = 2;
                 return storage.write(result).then(() => {
                     result.keyUpdate3.count = 3;
-                    return storage.write(result)
+                    return storage
+                        .write(result)
                         .catch((reason) => assert(false, 'should NOT fail on etag writes with wildcard'));
                 });
             });
     });
 
     it('delete unknown', function () {
-        return storage.delete(['unknown'])
-            .catch((reason) => assert(false, 'should not fail delete of unknown key'));
+        return storage.delete(['unknown']).catch((reason) => assert(false, 'should not fail delete of unknown key'));
     });
 
     it('delete known', function () {
-        return storage.write({ delete1: { count: 1 } })
+        return storage
+            .write({ delete1: { count: 1 } })
             .then(() => storage.delete(['delete1']))
             .then(() => storage.read(['delete1']))
-            .then(result => {
-                if (result.delete1)
-                    console.log(JSON.stringify(result.delete1));
+            .then((result) => {
+                if (result.delete1) console.log(JSON.stringify(result.delete1));
                 assert(!result.delete1, 'delete1 should not be found');
             });
     });
 
     it('batch operations', function () {
-        return storage.write({
-            batch1: { count: 10 },
-            batch2: { count: 20 },
-            batch3: { count: 30 },
-        })
+        return storage
+            .write({
+                batch1: { count: 10 },
+                batch2: { count: 20 },
+                batch3: { count: 30 },
+            })
             .then(() => storage.read(['batch1', 'batch2', 'batch3']))
             .then((result) => {
                 assert(result.batch1 != null, 'batch1 should exist and doesnt');
@@ -109,10 +116,11 @@ function testStorage(storage) {
     });
 
     it('crazy keys work', function () {
-        let obj = { };
-        let crazyKey = '!@#$%^&*()_+??><":QASD~`';
-        obj[crazyKey] = { count: 1};
-        return storage.write(obj)
+        const obj = {};
+        const crazyKey = '!@#$%^&*()_+??><":QASD~`';
+        obj[crazyKey] = { count: 1 };
+        return storage
+            .write(obj)
             .then(() => storage.read([crazyKey]))
             .then((result) => {
                 assert(result != null, 'result should be object');
@@ -121,7 +129,6 @@ function testStorage(storage) {
                 assert(result[crazyKey].eTag, 'ETag should be defined');
             });
     });
-
 }
 
 global.localStorage = {};

--- a/libraries/botbuilder-core/tests/browserStorage.test.js
+++ b/libraries/botbuilder-core/tests/browserStorage.test.js
@@ -5,7 +5,7 @@ function testStorage(storage) {
     it('read of unknown key', function () {
         return storage
             .read(['unk'])
-            .catch((reson) => assert(false, 'should not throw on read of unknown key'))
+            .catch(() => assert(false, 'should not throw on read of unknown key'))
             .then((result) => {
                 assert(result != null, 'result should be object');
                 assert(!result.unk, 'key should be undefined');
@@ -51,7 +51,7 @@ function testStorage(storage) {
                     return storage
                         .write(result)
                         .then(() => assert(false, 'should throw an exception on second write with same etag'))
-                        .catch((reason) => {});
+                        .catch(() => {});
                 });
             });
     });
@@ -67,13 +67,13 @@ function testStorage(storage) {
                     result.keyUpdate3.count = 3;
                     return storage
                         .write(result)
-                        .catch((reason) => assert(false, 'should NOT fail on etag writes with wildcard'));
+                        .catch(() => assert(false, 'should NOT fail on etag writes with wildcard'));
                 });
             });
     });
 
     it('delete unknown', function () {
-        return storage.delete(['unknown']).catch((reason) => assert(false, 'should not fail delete of unknown key'));
+        return storage.delete(['unknown']).catch(() => assert(false, 'should not fail delete of unknown key'));
     });
 
     it('delete known', function () {

--- a/libraries/botbuilder-core/tests/cardFactory.test.js
+++ b/libraries/botbuilder-core/tests/cardFactory.test.js
@@ -11,12 +11,12 @@ function assertActions(actions, count, titles) {
     assert(Array.isArray(actions), `actions not array.`);
     assert(actions.length === count, `wrong number of actions returned.`);
     for (let i = 0; i < count; i++) {
-        assert(actions[i].title, `title[${ i }] missing`);
+        assert(actions[i].title, `title[${i}] missing`);
         if (titles) {
-            assert(actions[i].title === titles[i], `title[${ i }] invalid`);
+            assert(actions[i].title === titles[i], `title[${i}] invalid`);
         }
-        assert(actions[i].type, `type[${ i }] missing`);
-        assert(actions[i].value, `value[${ i }] missing`);
+        assert(actions[i].type, `type[${i}] missing`);
+        assert(actions[i].value, `value[${i}] missing`);
     }
 }
 
@@ -24,9 +24,9 @@ function assertImages(images, count, links) {
     assert(Array.isArray(images), `images not array.`);
     assert(images.length === count, `wrong number of images returned.`);
     for (let i = 0; i < count; i++) {
-        assert(images[i].url, `image url[${ i }] missing`);
+        assert(images[i].url, `image url[${i}] missing`);
         if (links) {
-            assert(images[i].url === links[i], `image url[${ i }] invalid`);
+            assert(images[i].url === links[i], `image url[${i}] invalid`);
         }
     }
 }
@@ -35,9 +35,9 @@ function assertMedia(media, count, links) {
     assert(Array.isArray(media), `media not array.`);
     assert(media.length === count, `wrong number of media returned.`);
     for (let i = 0; i < count; i++) {
-        assert(media[i].url, `media url[${ i }] missing`);
+        assert(media[i].url, `media url[${i}] missing`);
         if (links) {
-            assert(media[i].url === links[i], `media url[${ i }] invalid`);
+            assert(media[i].url === links[i], `media url[${i}] invalid`);
         }
     }
 }
@@ -47,7 +47,7 @@ function assertOAuthActions(actions, title) {
     assert(actions.length === 1, `should have received only one action.`);
     const button = actions[0];
     assert(button.value === undefined, `OAuthCard actions' value should be undefined.`);
-    assert(button.title === title, `action's title [${ button.title }] is not expected "${ title }".`);
+    assert(button.title === title, `action's title [${button.title}] is not expected "${title}".`);
     assert(button.type === 'signin', `action's type [${button.type}] is not expected "signin".`);
 }
 
@@ -60,11 +60,13 @@ describe(`CardFactory`, function () {
     });
 
     it(`should support an array of CardAction options passed to actions().`, function () {
-        const actions = CardFactory.actions([{
-            title: 'foo',
-            type: 'postBack',
-            value: 'bar'
-        }]);
+        const actions = CardFactory.actions([
+            {
+                title: 'foo',
+                type: 'postBack',
+                value: 'bar',
+            },
+        ]);
         assertActions(actions, 1, ['foo']);
         assert(actions[0].type === 'postBack', `invalid action type`);
         assert(actions[0].value === 'bar', `invalid action value.`);
@@ -81,11 +83,13 @@ describe(`CardFactory`, function () {
     });
 
     it(`should support an array of CardImage options passed to images().`, function () {
-        const images = CardFactory.images([{
-            url: 'foo',
-            alt: 'bar',
-            tap: {}
-        }]);
+        const images = CardFactory.images([
+            {
+                url: 'foo',
+                alt: 'bar',
+                tap: {},
+            },
+        ]);
         assertImages(images, 1, ['foo']);
         assert(images[0].alt === 'bar', `invalid image.alt property.`);
         assert(typeof images[0].tap === 'object', `invalid image.type property.`);
@@ -102,10 +106,12 @@ describe(`CardFactory`, function () {
     });
 
     it(`should support an array of CardMedia options passed to media().`, function () {
-        const media = CardFactory.media([{
-            url: 'foo',
-            profile: 'bar'
-        }]);
+        const media = CardFactory.media([
+            {
+                url: 'foo',
+                profile: 'bar',
+            },
+        ]);
         assertMedia(media, 1, ['foo']);
         assert(media[0].profile === 'bar', `invalid media.profile property.`);
     });
@@ -345,21 +351,19 @@ describe(`CardFactory`, function () {
     });
 
     it(`should create an o365ConnectorCard.`, function () {
-        const attachment = CardFactory.o365ConnectorCard(
-            {
-                "title": "card title",
-                "text": "card text",
-                "summary": "O365 card summary",
-                "themeColor": "#E67A9E",
-                "sections": [
-                    {
-                        "title": "**section title**",
-                        "text": "section text",
-                        "activityTitle": "activity title",
-                     }
-                ]
-            }
-        );
+        const attachment = CardFactory.o365ConnectorCard({
+            title: 'card title',
+            text: 'card text',
+            summary: 'O365 card summary',
+            themeColor: '#E67A9E',
+            sections: [
+                {
+                    title: '**section title**',
+                    text: 'section text',
+                    activityTitle: 'activity title',
+                },
+            ],
+        });
         assertAttachment(attachment, CardFactory.contentTypes.o365ConnectorCard);
         const content = attachment.content;
         assert(content.title === 'card title', `wrong title.`);

--- a/libraries/botbuilder-core/tests/conversationState.test.js
+++ b/libraries/botbuilder-core/tests/conversationState.test.js
@@ -13,12 +13,10 @@ describe(`ConversationState`, function () {
     const context = new TurnContext(adapter, receivedMessage);
     const conversationState = new ConversationState(storage);
     it(`should load and save state from storage.`, async function () {
-        let key;
-
         // Simulate a "Turn" in a conversation by loading the state,
         // changing it and then saving the changes to state.
         await conversationState.load(context);
-        key = conversationState.getStorageKey(context);
+        const key = conversationState.getStorageKey(context);
         const state = conversationState.get(context);
         assert(state, `State not loaded`);
         assert(key, `Key not found`);
@@ -27,19 +25,18 @@ describe(`ConversationState`, function () {
 
         // Check the storage to see if the changes to state were saved.
         const items = await storage.read([key]);
-        assert(items.hasOwnProperty(key), `Saved state not found in storage.`);
+        assert(items[key], `Saved state not found in storage.`);
         assert(items[key].test === 'foo', `Missing test value in stored state.`);
     });
 
     it(`should ignore any activities that aren't "endOfConversation".`, async function () {
-        let key;
         await conversationState.load(context);
-        key = conversationState.getStorageKey(context);
+        const key = conversationState.getStorageKey(context);
         assert(conversationState.get(context).test === 'foo', `invalid initial state`);
         await context.sendActivity({ type: ActivityTypes.Message, text: 'foo' });
 
         const items = await storage.read([key]);
-        assert(items[key].hasOwnProperty('test'), `state cleared and shouldn't have been.`);
+        assert(items[key].test, `state cleared and shouldn't have been.`);
     });
 
     it(`should reject with error if channelId missing.`, async function () {
@@ -65,7 +62,8 @@ describe(`ConversationState`, function () {
     });
 
     it(`should throw NO_KEY error if getStorageKey() returns falsey value.`, async function () {
-        conversationState.getStorageKey = (turnContext) => undefined;
+        conversationState.getStorageKey = () => undefined;
+
         try {
             await conversationState.load(context, true);
         } catch (err) {

--- a/libraries/botbuilder-core/tests/memoryStorage.test.js
+++ b/libraries/botbuilder-core/tests/memoryStorage.test.js
@@ -3,83 +3,83 @@ const { MemoryStorage } = require('../');
 const { StorageBaseTests } = require('../../botbuilder-core/tests/storageBaseTests');
 
 function testStorage(storage) {
-    it('return empty object when reading unknown key', async function() {
+    it('return empty object when reading unknown key', async function () {
         const testRan = await StorageBaseTests.returnEmptyObjectWhenReadingUnknownKey(storage);
-        
+
         assert.strictEqual(testRan, true);
     });
 
-    it('throws when reading null keys', async function() {
+    it('throws when reading null keys', async function () {
         const testRan = await StorageBaseTests.handleNullKeysWhenReading(storage);
 
         assert.strictEqual(testRan, true);
     });
 
-    it('throws when writing null keys', async function() {
+    it('throws when writing null keys', async function () {
         const testRan = await StorageBaseTests.handleNullKeysWhenWriting(storage);
-        
+
         assert.strictEqual(testRan, true);
     });
 
-    it('does not throw when writing no items', async function() {
+    it('does not throw when writing no items', async function () {
         const testRan = await StorageBaseTests.doesNotThrowWhenWritingNoItems(storage);
-        
+
         assert.strictEqual(testRan, true);
     });
 
-    it('create an object', async function() {
+    it('create an object', async function () {
         const testRan = await StorageBaseTests.createObject(storage);
 
         assert.strictEqual(testRan, true);
     });
 
-    it('handle crazy keys', async function() {
+    it('handle crazy keys', async function () {
         const testRan = await StorageBaseTests.handleCrazyKeys(storage);
 
         assert.strictEqual(testRan, true);
     });
 
-    it('update an object', async function() {
+    it('update an object', async function () {
         const testRan = await StorageBaseTests.updateObject(storage);
 
         assert.strictEqual(testRan, true);
     });
 
-    it('delete an object', async function() {
+    it('delete an object', async function () {
         const testRan = await StorageBaseTests.deleteObject(storage);
 
         assert.strictEqual(testRan, true);
     });
 
-    it('does not throw when deleting an unknown object', async function() {
+    it('does not throw when deleting an unknown object', async function () {
         const testRan = await StorageBaseTests.deleteUnknownObject(storage);
 
         assert.strictEqual(testRan, true);
     });
 
-    it('performs batch operations', async function() {
+    it('performs batch operations', async function () {
         const testRan = await StorageBaseTests.performBatchOperations(storage);
 
         assert.strictEqual(testRan, true);
     });
 
-    it('proceeds through a waterfall dialog', async function() {
+    it('proceeds through a waterfall dialog', async function () {
         const testRan = await StorageBaseTests.proceedsThroughWaterfall(storage);
 
         assert.strictEqual(testRan, true);
     });
 }
 
-describe('MemoryStorage - Empty', function() {
+describe('MemoryStorage - Empty', function () {
     testStorage(new MemoryStorage());
 });
 
-describe('MemoryStorage - PreExisting', function() {
-    const dictionary = { 'test': JSON.stringify({counter:12})};
+describe('MemoryStorage - PreExisting', function () {
+    const dictionary = { test: JSON.stringify({ counter: 12 }) };
     const storage = new MemoryStorage(dictionary);
     testStorage(storage);
 
-    it('should still have test', function() {
+    it('should still have test', function () {
         return storage.read(['test']).then((result) => {
             assert(result.test.counter == 12, 'read()  test.counter should be 12');
         });

--- a/libraries/botbuilder-core/tests/memoryTranscriptStore.test.js
+++ b/libraries/botbuilder-core/tests/memoryTranscriptStore.test.js
@@ -7,62 +7,62 @@ const print = (o) => {
     return JSON.stringify(o, null, '  ');
 };
 
-testStorage = function() {
+testStorage = function () {
     const storage = new MemoryTranscriptStore();
 
-    it('bad args', function() {
-        return base._badArgs(storage)
-            .then(messages => {
-                assert(messages.every(message => message.startsWith('expected error')));
+    it('bad args', function () {
+        return base
+            ._badArgs(storage)
+            .then((messages) => {
+                assert(messages.every((message) => message.startsWith('expected error')));
             })
-            .catch(reason =>
-                assert(false, `should not throw: ${ print(reason) }`));
+            .catch((reason) => assert(false, `should not throw: ${print(reason)}`));
     });
 
-    it('log activity', function() {
-        return base._logActivity(storage)
+    it('log activity', function () {
+        return base
+            ._logActivity(storage)
             .then(() => assert(true))
-            .catch(reason =>
-                assert(false, `should not throw: ${ print(reason) }`));
+            .catch((reason) => assert(false, `should not throw: ${print(reason)}`));
     });
 
-    it('logs multiple activities', function() {
-        return base._logMultipleActivities(storage)
+    it('logs multiple activities', function () {
+        return base
+            ._logMultipleActivities(storage)
             .then(() => assert(true))
-            .catch(reason =>
-                assert(false, `should not throw: ${ print(reason) }`));
+            .catch((reason) => assert(false, `should not throw: ${print(reason)}`));
     });
 
-    it('delete transcript', function() {
-        return base._deleteTranscript(storage)
+    it('delete transcript', function () {
+        return base
+            ._deleteTranscript(storage)
             .then(() => assert(true))
-            .catch(reason =>
-                assert(false, `should not throw: ${ print(reason) }`));
+            .catch((reason) => assert(false, `should not throw: ${print(reason)}`));
     });
 
-    it('get transcript activities', function() {
-        return base._getTranscriptActivities(storage)
+    it('get transcript activities', function () {
+        return base
+            ._getTranscriptActivities(storage)
             .then(() => assert(true))
-            .catch(reason =>
-                assert(false, `should not throw: ${ print(reason) }`));
+            .catch((reason) => assert(false, `should not throw: ${print(reason)}`));
     });
 
-    it('get transcript activities with state date', function() {
-        return base._getTranscriptActivitiesStartDate(storage)
+    it('get transcript activities with state date', function () {
+        return base
+            ._getTranscriptActivitiesStartDate(storage)
             .then(() => assert(true))
-            .catch(reason =>
-                assert(false, `should not throw: ${ print(reason) }`));
+            .catch((reason) => assert(false, `should not throw: ${print(reason)}`));
     });
 
-    it('list transcripts', function() {
-        return base._listTranscripts(storage)
+    it('list transcripts', function () {
+        return base
+            ._listTranscripts(storage)
             .then(() => assert(true))
-            .catch(reason =>
-                assert(false, `should not throw: ${ print(reason) }`));
+            .catch((reason) => assert(false, `should not throw: ${print(reason)}`));
     });
 };
 
-describe('MemoryTranscriptStore', function() {
+describe('MemoryTranscriptStore', function () {
     this.timeout(10000);
     testStorage();
 });

--- a/libraries/botbuilder-core/tests/memoryTranscriptStore.test.js
+++ b/libraries/botbuilder-core/tests/memoryTranscriptStore.test.js
@@ -7,7 +7,7 @@ const print = (o) => {
     return JSON.stringify(o, null, '  ');
 };
 
-testStorage = function () {
+function testStorage() {
     const storage = new MemoryTranscriptStore();
 
     it('bad args', function () {
@@ -60,7 +60,7 @@ testStorage = function () {
             .then(() => assert(true))
             .catch((reason) => assert(false, `should not throw: ${print(reason)}`));
     });
-};
+}
 
 describe('MemoryTranscriptStore', function () {
     this.timeout(10000);

--- a/libraries/botbuilder-core/tests/mention.test.js
+++ b/libraries/botbuilder-core/tests/mention.test.js
@@ -4,8 +4,9 @@ const { MessageFactory, SkypeMentionNormalizeMiddleware, TurnContext } = require
 describe(`Mention`, function () {
     this.timeout(5000);
 
-    it('should not change activity text when entity type is not a mention', async function() {
-        const mentionJson = '{\"mentioned\": {\"id\": \"recipientid\"},\"text\": \"<at id=\\\"28: 841caffa-9e92-425d-8d84-b503b3ded285\\\">botname</at>\"}';
+    it('should not change activity text when entity type is not a mention', async function () {
+        const mentionJson =
+            '{"mentioned": {"id": "recipientid"},"text": "<at id=\\"28: 841caffa-9e92-425d-8d84-b503b3ded285\\">botname</at>"}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'test';
 
@@ -18,8 +19,8 @@ describe(`Mention`, function () {
         assert(activity.text === 'botname sometext');
     });
 
-    it('should not change activity text when mention text is empty', async function() {
-        const mentionJson = '{\"mentioned\": {\"id\": \"recipientid\"},\"text\": \""}';
+    it('should not change activity text when mention text is empty', async function () {
+        const mentionJson = '{"mentioned": {"id": "recipientid"},"text": ""}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'mention';
 
@@ -32,8 +33,8 @@ describe(`Mention`, function () {
         assert(activity.text === 'botname sometext');
     });
 
-    it('should not change activity text when there is no matching mention', async function() {
-        const mentionJson = '{\"mentioned\": {\"id\": \"foo bar"},\"text\": \""}';
+    it('should not change activity text when there is no matching mention', async function () {
+        const mentionJson = '{"mentioned": {"id": "foo bar"},"text": ""}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'mention';
 
@@ -47,7 +48,8 @@ describe(`Mention`, function () {
     });
 
     it(`should remove skype mention`, async function () {
-        const mentionJson = '{\"mentioned\": {\"id\": \"recipientid\"},\"text\": \"<at id=\\\"28: 841caffa-9e92-425d-8d84-b503b3ded285\\\">botname</at>\"}';
+        const mentionJson =
+            '{"mentioned": {"id": "recipientid"},"text": "<at id=\\"28: 841caffa-9e92-425d-8d84-b503b3ded285\\">botname</at>"}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'mention';
 
@@ -62,7 +64,7 @@ describe(`Mention`, function () {
     });
 
     it(`should remove teams mention`, async function () {
-        const mentionJson = '{\"mentioned\": {\"id\": \"recipientid\"},\"text\": \"<at>botname</at>\"}';
+        const mentionJson = '{"mentioned": {"id": "recipientid"},"text": "<at>botname</at>"}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'mention';
 
@@ -76,7 +78,7 @@ describe(`Mention`, function () {
     });
 
     it(`should remove slack mention`, async function () {
-        const mentionJson = '{\"mentioned\": {\"id\": \"recipientid\"},\"text\": \"@botname\"}';
+        const mentionJson = '{"mentioned": {"id": "recipientid"},"text": "@botname"}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'mention';
 
@@ -90,7 +92,7 @@ describe(`Mention`, function () {
     });
 
     it(`should remove GroupMe mention`, async function () {
-        const mentionJson = '{\"mentioned\": {\"id\": \"recipientid\"},\"text\": \"@bot name\"}';
+        const mentionJson = '{"mentioned": {"id": "recipientid"},"text": "@bot name"}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'mention';
 
@@ -104,7 +106,7 @@ describe(`Mention`, function () {
     });
 
     it(`should remove Telegram mention`, async function () {
-        const mentionJson = '{\"mentioned\": {\"id\": \"recipientid\"},\"text\": \"botname\"}';
+        const mentionJson = '{"mentioned": {"id": "recipientid"},"text": "botname"}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'mention';
 

--- a/libraries/botbuilder-core/tests/messageFactory.test.js
+++ b/libraries/botbuilder-core/tests/messageFactory.test.js
@@ -118,20 +118,19 @@ describe(`MessageFactory`, function () {
     });
 
     it(`should return a list().`, function () {
-        const activity = MessageFactory.list([
-            { contentType: 'a' },
-            { contentType: 'b' }
-        ]);
+        const activity = MessageFactory.list([{ contentType: 'a' }, { contentType: 'b' }]);
         assertMessage(activity);
         assertAttachments(activity, 2, ['a', 'b']);
         assert(activity.attachmentLayout === AttachmentLayoutTypes.List, `invalid attachmentLayout.`);
     });
 
     it(`should return list() with text, speak, and inputHint.`, function () {
-        const activity = MessageFactory.list([
-            { contentType: 'a' },
-            { contentType: 'b' }
-        ], 'foo', 'bar', InputHints.IgnoringInput);
+        const activity = MessageFactory.list(
+            [{ contentType: 'a' }, { contentType: 'b' }],
+            'foo',
+            'bar',
+            InputHints.IgnoringInput
+        );
         assertMessage(activity);
         assertAttachments(activity, 2, ['a', 'b']);
         assert(activity.attachmentLayout === AttachmentLayoutTypes.List, `invalid attachmentLayout.`);
@@ -141,20 +140,19 @@ describe(`MessageFactory`, function () {
     });
 
     it(`should return a carousel().`, function () {
-        const activity = MessageFactory.carousel([
-            { contentType: 'a' },
-            { contentType: 'b' }
-        ]);
+        const activity = MessageFactory.carousel([{ contentType: 'a' }, { contentType: 'b' }]);
         assertMessage(activity);
         assertAttachments(activity, 2, ['a', 'b']);
         assert(activity.attachmentLayout === AttachmentLayoutTypes.Carousel, `invalid attachmentLayout.`);
     });
 
     it(`should return carousel() with text, speak, and inputHint.`, function () {
-        const activity = MessageFactory.carousel([
-            { contentType: 'a' },
-            { contentType: 'b' }
-        ], 'foo', 'bar', InputHints.IgnoringInput);
+        const activity = MessageFactory.carousel(
+            [{ contentType: 'a' }, { contentType: 'b' }],
+            'foo',
+            'bar',
+            InputHints.IgnoringInput
+        );
         assertMessage(activity);
         assertAttachments(activity, 2, ['a', 'b']);
         assert(activity.attachmentLayout === AttachmentLayoutTypes.Carousel, `invalid attachmentLayout.`);
@@ -167,22 +165,38 @@ describe(`MessageFactory`, function () {
         const activity = MessageFactory.contentUrl('https://example.com/content', 'content-type');
         assertMessage(activity);
         assertAttachments(activity, 1, ['content-type']);
-        assert(activity.attachments[0].contentUrl === 'https://example.com/content', `invalid attachment[0].contentUrl.`);
+        assert(
+            activity.attachments[0].contentUrl === 'https://example.com/content',
+            `invalid attachment[0].contentUrl.`
+        );
     });
 
     it(`should return a contentUrl() with a name.`, function () {
         const activity = MessageFactory.contentUrl('https://example.com/content', 'content-type', 'file name');
         assertMessage(activity);
         assertAttachments(activity, 1, ['content-type']);
-        assert(activity.attachments[0].contentUrl === 'https://example.com/content', `invalid attachment[0].contentUrl.`);
+        assert(
+            activity.attachments[0].contentUrl === 'https://example.com/content',
+            `invalid attachment[0].contentUrl.`
+        );
         assert(activity.attachments[0].name === 'file name', `invalid attachment[0].name.`);
     });
 
     it(`should return a contentUrl() with a name, text, speak, and inputHint.`, function () {
-        const activity = MessageFactory.contentUrl('https://example.com/content', 'content-type', 'file name', 'foo', 'bar', InputHints.IgnoringInput);
+        const activity = MessageFactory.contentUrl(
+            'https://example.com/content',
+            'content-type',
+            'file name',
+            'foo',
+            'bar',
+            InputHints.IgnoringInput
+        );
         assertMessage(activity);
         assertAttachments(activity, 1, ['content-type']);
-        assert(activity.attachments[0].contentUrl === 'https://example.com/content', `invalid attachment[0].contentUrl.`);
+        assert(
+            activity.attachments[0].contentUrl === 'https://example.com/content',
+            `invalid attachment[0].contentUrl.`
+        );
         assert(activity.attachments[0].name === 'file name', `invalid attachment[0].name.`);
         assert(activity.text === 'foo', `invalid text field.`);
         assert(activity.speak === 'bar', `invalid speak field.`);

--- a/libraries/botbuilder-core/tests/middlewareSet.test.js
+++ b/libraries/botbuilder-core/tests/middlewareSet.test.js
@@ -11,7 +11,7 @@ const noop = () => {
     // no-op
 };
 
-describe(`MiddlewareSet`, () => {
+describe(`MiddlewareSet`, function () {
     // Generates middleware helper that itself generates middleware that pushes a value
     // on a stack. Returns the middleware generator function, the stack, and a clean
     // MiddlewareSet instance for testing
@@ -28,12 +28,12 @@ describe(`MiddlewareSet`, () => {
         };
     };
 
-    it(`should use() middleware individually.`, () => {
+    it(`should use() middleware individually.`, function () {
         const { middleware, set } = stackMiddleware();
         set.use(middleware('a')).use(middleware('b'));
     });
 
-    it(`should use() a list of middleware.`, () => {
+    it(`should use() a list of middleware.`, function () {
         const { middleware, set } = stackMiddleware();
         set.use(middleware('a'), middleware('b'), middleware('c'));
     });
@@ -58,7 +58,7 @@ describe(`MiddlewareSet`, () => {
         });
     });
 
-    it(`should run middleware with a leading and trailing edge.`, async () => {
+    it(`should run middleware with a leading and trailing edge.`, async function () {
         const { set, stack } = stackMiddleware();
 
         set.use(async (_, next) => {
@@ -110,7 +110,7 @@ describe(`MiddlewareSet`, () => {
         }
     });
 
-    it(`should throw an error if an invalid plugin type is added.`, () => {
+    it(`should throw an error if an invalid plugin type is added.`, function () {
         assert.throws(() => new MiddlewareSet().use('bogus'));
     });
 

--- a/libraries/botbuilder-core/tests/privateConversationState.test.js
+++ b/libraries/botbuilder-core/tests/privateConversationState.test.js
@@ -32,7 +32,7 @@ describe(`PrivateConversationState`, function () {
 
         // Check the storage to see if the changes to state were saved.
         const items = await storage.read([key]);
-        assert(items.hasOwnProperty(key), `Saved state not found in storage.`);
+        assert(items[key], `Saved state not found in storage.`);
         assert(items[key].test === 'foo', `Missing test value in stored state.`);
     });
 
@@ -43,7 +43,7 @@ describe(`PrivateConversationState`, function () {
         await context.sendActivity({ type: ActivityTypes.Message, text: 'foo' });
 
         const items = await storage.read([key]);
-        assert(items[key].hasOwnProperty('test'), `state cleared and shouldn't have been.`);
+        assert(items[key].test, `state cleared and shouldn't have been.`);
     });
 
     it(`should reject with error if channelId missing.`, async function () {
@@ -80,7 +80,7 @@ describe(`PrivateConversationState`, function () {
     });
 
     it(`should throw NO_KEY error if getStorageKey() returns falsey value.`, async function () {
-        privateConversationState.getStorageKey = (turnContext) => undefined;
+        privateConversationState.getStorageKey = () => undefined;
         try {
             await privateConversationState.load(context, true);
         } catch (err) {

--- a/libraries/botbuilder-core/tests/storageBaseTests.js
+++ b/libraries/botbuilder-core/tests/storageBaseTests.js
@@ -94,7 +94,7 @@ class StorageBaseTests {
     }
 
     static async handleCrazyKeys(storage) {
-        const key = `!@#$%^&*()~/\\><,.?';\"\`~`;
+        const key = `!@#$%^&*()~/\\><,.?';"\`~`;
         const storeItem = { id: 1 };
         const storeItems = { [key]: storeItem };
 
@@ -145,7 +145,7 @@ class StorageBaseTests {
             updatePocoItem.count = 123;
 
             await storage.write({ pocoItem: updatePocoItem });
-        } catch (err) {
+        } catch (_err) {
             assert.fail('Should not throw exception on write with pocoItem');
         }
 
@@ -155,7 +155,9 @@ class StorageBaseTests {
 
             await storage.write({ pocoStoreItem: updatePocoStoreItem });
             assert.fail('Should have thrown exception on write with store item because of old eTag');
-        } catch (err) {}
+        } catch (_err) {
+            // no-op
+        }
 
         const reloadedStoreItems2 = await storage.read(['pocoItem', 'pocoStoreItem']);
 
@@ -196,7 +198,9 @@ class StorageBaseTests {
             await storage.write(dict2);
 
             assert.fail('Should have thrown exception on write with storeItem because of empty eTag');
-        } catch (err) {}
+        } catch (_err) {
+            // no-op
+        }
 
         const finalStoreItems = await storage.read(['pocoItem', 'pocoStoreItem']);
         assert.strictEqual(finalStoreItems.pocoItem.count, 100);

--- a/libraries/botbuilder-core/tests/storageBaseTests.js
+++ b/libraries/botbuilder-core/tests/storageBaseTests.js
@@ -6,13 +6,13 @@ const { BlobStorage, CosmosDbPartitionedStorage } = require('../../botbuilder-az
 /**
  * Base tests that all storage providers should implement in their own tests.
  * They handle the storage-based assertions, internally.
- * 
+ *
  * All tests return true if assertions pass to indicate that the code ran to completion, passing internal assertions.
  * Therefore, all tests using theses static tests should strictly check that the method returns true.
- * 
+ *
  * @example
  * const testRan = await StorageBaseTests.returnEmptyObjectWhenReadingUnknownKey(storage);
- * assert.strictEqual(testRan, true); 
+ * assert.strictEqual(testRan, true);
  */
 class StorageBaseTests {
     static async returnEmptyObjectWhenReadingUnknownKey(storage) {
@@ -31,10 +31,16 @@ class StorageBaseTests {
 
     static async handleNullKeysWhenReading(storage) {
         if (storage instanceof BlobStorage) {
-            await assert.rejects(async () => await storage.read(null), Error('Please provide at least one key to read from storage.'));
-        } else if (storage instanceof CosmosDbPartitionedStorage || storage instanceof MemoryStorage){
-            await assert.rejects(async () => await storage.read(null), ReferenceError('Keys are required when reading.'));
-        // CosmosDbStorage and catch-all
+            await assert.rejects(
+                async () => await storage.read(null),
+                Error('Please provide at least one key to read from storage.')
+            );
+        } else if (storage instanceof CosmosDbPartitionedStorage || storage instanceof MemoryStorage) {
+            await assert.rejects(
+                async () => await storage.read(null),
+                ReferenceError('Keys are required when reading.')
+            );
+            // CosmosDbStorage and catch-all
         } else {
             const result = await storage.read(null);
             assert.strictEqual(Object.keys(result).length, 0);
@@ -45,10 +51,16 @@ class StorageBaseTests {
 
     static async handleNullKeysWhenWriting(storage) {
         if (storage instanceof BlobStorage) {
-            await assert.rejects(async () => await storage.write(null), Error('Please provide a StoreItems with changes to persist.'));
-        } else if (storage instanceof CosmosDbPartitionedStorage || storage instanceof MemoryStorage){
-            await assert.rejects(async () => await storage.write(null), ReferenceError('Changes are required when writing.'));
-        // CosmosDbStorage and catch-all
+            await assert.rejects(
+                async () => await storage.write(null),
+                Error('Please provide a StoreItems with changes to persist.')
+            );
+        } else if (storage instanceof CosmosDbPartitionedStorage || storage instanceof MemoryStorage) {
+            await assert.rejects(
+                async () => await storage.write(null),
+                ReferenceError('Changes are required when writing.')
+            );
+            // CosmosDbStorage and catch-all
         } else {
             const result = await storage.write(null);
             assert.strictEqual(result, undefined);
@@ -133,7 +145,7 @@ class StorageBaseTests {
             updatePocoItem.count = 123;
 
             await storage.write({ pocoItem: updatePocoItem });
-        } catch(err) {
+        } catch (err) {
             assert.fail('Should not throw exception on write with pocoItem');
         }
 
@@ -143,7 +155,7 @@ class StorageBaseTests {
 
             await storage.write({ pocoStoreItem: updatePocoStoreItem });
             assert.fail('Should have thrown exception on write with store item because of old eTag');
-        } catch(err) { }
+        } catch (err) {}
 
         const reloadedStoreItems2 = await storage.read(['pocoItem', 'pocoStoreItem']);
 
@@ -161,7 +173,7 @@ class StorageBaseTests {
 
         const wildcardEtagdict = {
             pocoItem: reloadedPocoItem2,
-            pocoStoreItem: reloadedPocoStoreItem2
+            pocoStoreItem: reloadedPocoStoreItem2,
         };
 
         await storage.write(wildcardEtagdict);
@@ -184,7 +196,7 @@ class StorageBaseTests {
             await storage.write(dict2);
 
             assert.fail('Should have thrown exception on write with storeItem because of empty eTag');
-        } catch (err) { }
+        } catch (err) {}
 
         const finalStoreItems = await storage.read(['pocoItem', 'pocoStoreItem']);
         assert.strictEqual(finalStoreItems.pocoItem.count, 100);
@@ -192,10 +204,10 @@ class StorageBaseTests {
 
         return true;
     }
-    
+
     static async deleteObject(storage) {
         const storeItems = {
-            delete1: { id: 1, count: 1 }
+            delete1: { id: 1, count: 1 },
         };
 
         await storage.write(storeItems);
@@ -213,7 +225,7 @@ class StorageBaseTests {
 
         return true;
     }
-    
+
     static async deleteUnknownObject(storage) {
         await assert.doesNotReject(async () => {
             await storage.delete(['unknown_key']);
@@ -237,8 +249,8 @@ class StorageBaseTests {
         assert(result.batch1.count > 0);
         assert(result.batch2.count > 0);
         assert(result.batch3.count > 0);
-        assert.notStrictEqual(result.batch1.eTag, null);	
-        assert.notStrictEqual(result.batch2.eTag, null);	
+        assert.notStrictEqual(result.batch1.eTag, null);
+        assert.notStrictEqual(result.batch2.eTag, null);
         assert.notStrictEqual(result.batch3.eTag, null);
 
         await storage.delete(['batch1', 'batch2', 'batch3']);
@@ -265,34 +277,39 @@ class StorageBaseTests {
             if (!turnContext.responded) {
                 await dc.beginDialog('waterfallDialog');
             }
-        })
-            .use(new AutoSaveStateMiddleware(convoState));
+        }).use(new AutoSaveStateMiddleware(convoState));
 
-        dialogs.add(new TextPrompt('textPrompt', async (promptContext) => {
-            const result = promptContext.recognized.value;
-            if (result.length > 3) {
-                const succeededMessage = MessageFactory.text(`You got it at the ${ promptContext.attemptCount }th try!`);
-                await promptContext.context.sendActivity(succeededMessage);
-                return true;
-            }
+        dialogs.add(
+            new TextPrompt('textPrompt', async (promptContext) => {
+                const result = promptContext.recognized.value;
+                if (result.length > 3) {
+                    const succeededMessage = MessageFactory.text(
+                        `You got it at the ${promptContext.attemptCount}th try!`
+                    );
+                    await promptContext.context.sendActivity(succeededMessage);
+                    return true;
+                }
 
-            const reply = MessageFactory.text(`Please send a name that is longer than 3 characters. ${ promptContext.attemptCount }`);
-            await promptContext.context.sendActivity(reply);
-            return false;
-        }));
+                const reply = MessageFactory.text(
+                    `Please send a name that is longer than 3 characters. ${promptContext.attemptCount}`
+                );
+                await promptContext.context.sendActivity(reply);
+                return false;
+            })
+        );
 
         const steps = [
             async (stepContext) => {
-                assert.strictEqual(typeof(stepContext.activeDialog.state['stepIndex']), 'number');
+                assert.strictEqual(typeof stepContext.activeDialog.state['stepIndex'], 'number');
                 await stepContext.context.sendActivity('step1');
                 return Dialog.EndOfTurn;
             },
             async (stepContext) => {
-                assert.strictEqual(typeof(stepContext.activeDialog.state['stepIndex']), 'number');
+                assert.strictEqual(typeof stepContext.activeDialog.state['stepIndex'], 'number');
                 await stepContext.prompt('textPrompt', { prompt: MessageFactory.text('Please type your name.') });
             },
             async (stepContext) => {
-                assert.strictEqual(typeof(stepContext.activeDialog.state['stepIndex']), 'number');
+                assert.strictEqual(typeof stepContext.activeDialog.state['stepIndex'], 'number');
                 await stepContext.context.sendActivity('step3');
                 return Dialog.EndOfTurn;
             },

--- a/libraries/botbuilder-core/tests/stringUtils.test.js
+++ b/libraries/botbuilder-core/tests/stringUtils.test.js
@@ -7,7 +7,7 @@ const test2 = 'alskjdf lksjfd laksjdf lksjdfasdlfkjasdflkjasdlfkjasldkfjasdf';
 describe(`StringUtils`, function () {
     this.timeout(5000);
 
-    it('test hash', () => {
+    it('test hash', function () {
         let hash1 = StringUtils.hash(test1);
         let hash2 = StringUtils.hash(test1);
         assert(hash1);
@@ -30,16 +30,16 @@ describe(`StringUtils`, function () {
         assert.notEqual(hash1, hash2, 'case changes string should be different');
     });
 
-    it('test ellipsis', () => {
+    it('test ellipsis', function () {
         assert.equal(StringUtils.ellipsis(test1, 0), '...');
-        assert.equal(StringUtils.ellipsis(test1, 5), `${ test1.substr(0, 5) }...`);
+        assert.equal(StringUtils.ellipsis(test1, 5), `${test1.substr(0, 5)}...`);
         assert.equal(StringUtils.ellipsis(test1, 1000), test1);
     });
 
-    it('test ellipsis hash', () => {
+    it('test ellipsis hash', function () {
         const hash1 = StringUtils.hash(test1);
-        assert.equal(StringUtils.ellipsisHash(test1, 0), `...${ hash1 }`);
-        assert.equal(StringUtils.ellipsisHash(test1, 5), `${ test1.substr(0, 5) }...${ hash1 }`);
+        assert.equal(StringUtils.ellipsisHash(test1, 0), `...${hash1}`);
+        assert.equal(StringUtils.ellipsisHash(test1, 5), `${test1.substr(0, 5)}...${hash1}`);
         assert.equal(StringUtils.ellipsisHash(test1, 1000), test1);
     });
 });

--- a/libraries/botbuilder-core/tests/telemetryMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/telemetryMiddleware.test.js
@@ -21,13 +21,13 @@ const createReply = (activity, text, locale = null) => ({
     locale: locale || activity.locale,
 });
 
-describe(`TelemetryMiddleware`, () => {
+describe(`TelemetryMiddleware`, function () {
     let sandbox;
-    beforeEach(() => {
+    beforeEach(function () {
         sandbox = sinon.createSandbox();
     });
 
-    afterEach(() => {
+    afterEach(function () {
         sandbox.restore();
     });
 
@@ -88,7 +88,7 @@ describe(`TelemetryMiddleware`, () => {
             new TelemetryLoggerMiddleware(telemetryClient, logPersonalInformation),
     }) => new TestAdapter(adapterLogic).use(makeLogger());
 
-    it(`should log send and receive activities`, async () => {
+    it(`should log send and receive activities`, async function () {
         const { client, expectReceiveEvent, expectSendEvent } = makeTelemetryClient();
 
         expectReceiveEvent({
@@ -127,7 +127,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`should work with null telemetryClient`, async () => {
+    it(`should work with null telemetryClient`, async function () {
         const adapter = makeAdapter({
             makeLogger: () => new TelemetryLoggerMiddleware(null, true),
         });
@@ -144,7 +144,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`should not log PII properties for send and receive activities`, async () => {
+    it(`should not log PII properties for send and receive activities`, async function () {
         const { client, expectReceiveEvent, expectSendEvent } = makeTelemetryClient();
 
         expectReceiveEvent({ fromName: undefined, text: undefined });
@@ -164,7 +164,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`telemetry should log update activities`, async () => {
+    it(`telemetry should log update activities`, async function () {
         const { client, expectReceiveEvent, expectSendEvent, expectTrackEvent } = makeTelemetryClient();
 
         expectReceiveEvent({ text: 'foo' });
@@ -193,7 +193,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`telemetry should log delete activities`, async () => {
+    it(`telemetry should log delete activities`, async function () {
         const { client, expectReceiveEvent, expectSendEvent, expectTrackEvent } = makeTelemetryClient();
 
         expectReceiveEvent({ text: 'foo' });
@@ -220,7 +220,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`telemetry override RECEIVE with custom derived logger class`, async () => {
+    it(`telemetry override RECEIVE with custom derived logger class`, async function () {
         class OverrideLogger extends TelemetryLoggerMiddleware {
             async onReceiveActivity(activity) {
                 this.telemetryClient.trackEvent({
@@ -262,7 +262,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`telemetry override SEND with custom derived logger class`, async () => {
+    it(`telemetry override SEND with custom derived logger class`, async function () {
         class OverrideLogger extends TelemetryLoggerMiddleware {
             async onSendActivity(activity) {
                 this.telemetryClient.trackEvent({
@@ -309,7 +309,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`telemetry override UPDATE with custom derived logger class`, async () => {
+    it(`telemetry override UPDATE with custom derived logger class`, async function () {
         class OverrideLogger extends TelemetryLoggerMiddleware {
             async onUpdateActivity() {
                 this.telemetryClient.trackEvent({
@@ -350,7 +350,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`telemetry should log channel specific properties`, async () => {
+    it(`telemetry should log channel specific properties`, async function () {
         const { client, expectReceiveEvent } = makeTelemetryClient();
 
         expectReceiveEvent({

--- a/libraries/botbuilder-core/tests/testAdapter.test.js
+++ b/libraries/botbuilder-core/tests/testAdapter.test.js
@@ -1,10 +1,9 @@
 const assert = require('assert');
-const { TestAdapter, ActivityTypes, TestFlow, ActivityFactory, TurnContext } = require('../');
+const { TestAdapter, ActivityTypes, ActivityFactory, TurnContext } = require('../');
 
 const receivedMessage = { text: 'received', type: 'message' };
 const originalActivity = { text: 'original', type: 'message' };
 const updatedActivity = { text: 'update', type: 'message' };
-const deletedActivityId = '1234';
 
 describe(`TestAdapter`, function () {
     this.timeout(5000);
@@ -52,7 +51,7 @@ describe(`TestAdapter`, function () {
 
     it(`should call bot logic when send() is called.`, async function () {
         let called = false;
-        const adapter = new TestAdapter((context) => {
+        const adapter = new TestAdapter(() => {
             called = true;
         });
 
@@ -149,7 +148,7 @@ describe(`TestAdapter`, function () {
         });
         await adapter
             .send('test')
-            .assertReply((reply, description) => {
+            .assertReply((reply) => {
                 assert(reply, `reply not passed`);
                 called = true;
             })
@@ -158,11 +157,7 @@ describe(`TestAdapter`, function () {
     });
 
     it(`should timeout waiting for assertReply() when a string is expected.`, async function () {
-        const adapter = new TestAdapter((context) => {
-            return new Promise((resolve, reject) => {
-                setTimeout(() => resolve(), 600);
-            });
-        });
+        const adapter = new TestAdapter(() => new Promise((resolve) => setTimeout(resolve, 600)));
         await assert.rejects(
             async () => await adapter.send('test').assertReply('received', 'received failed', 500).startTest(),
             /.*Timed out after.*/
@@ -170,11 +165,7 @@ describe(`TestAdapter`, function () {
     });
 
     it(`should timeout waiting for assertReply() when an Activity is expected.`, async function () {
-        const adapter = new TestAdapter((context) => {
-            return new Promise((resolve, reject) => {
-                setTimeout(() => resolve(), 600);
-            });
-        });
+        const adapter = new TestAdapter(() => new Promise((resolve) => setTimeout(resolve, 600)));
         await assert.rejects(
             async () =>
                 await adapter.send('test').assertReply({ text: 'received' }, 'received failed', 500).startTest(),
@@ -183,11 +174,7 @@ describe(`TestAdapter`, function () {
     });
 
     it(`should timeout waiting for assertReply() when a custom inspector is expected.`, async function () {
-        const adapter = new TestAdapter((context) => {
-            return new Promise((resolve, reject) => {
-                setTimeout(() => resolve(), 600);
-            });
-        });
+        const adapter = new TestAdapter(() => new Promise((resolve) => setTimeout(resolve, 600)));
         await assert.rejects(
             async () =>
                 await adapter
@@ -199,11 +186,7 @@ describe(`TestAdapter`, function () {
     });
 
     it(`should timeout waiting for assertNoReply() when an Activity is not expected.`, async function () {
-        const adapter = new TestAdapter((context) => {
-            return new Promise((resolve, reject) => {
-                setTimeout(() => resolve(), 600);
-            });
-        });
+        const adapter = new TestAdapter(() => new Promise((resolve) => setTimeout(resolve, 600)));
         await assert.doesNotReject(
             async () => await adapter.send('test').assertNoReply('no message received', 500).startTest()
         );
@@ -253,7 +236,7 @@ describe(`TestAdapter`, function () {
     });
 
     it(`should return an error from continueConversation().`, async function () {
-        const adapter = new TestAdapter((context) => {
+        const adapter = new TestAdapter(() => {
             assert.fail("shouldn't run bot logic.");
         });
         await assert.rejects(async () => await adapter.continueConversation(), {
@@ -314,7 +297,7 @@ describe(`TestAdapter`, function () {
 
     it(`should run the bot's logic to activities without a from property via testActivities().`, async function () {
         let counter = 0;
-        const adapter = new TestAdapter((context) => {
+        const adapter = new TestAdapter(() => {
             counter++;
         });
 

--- a/libraries/botbuilder-core/tests/transcriptMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/transcriptMiddleware.test.js
@@ -175,7 +175,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
                     // In SendActivitiesHandlers developers are supposed to call:
                     //      return next();
                     // If this is not returned, then the next handler will not have the ResourceResponses[].
-                    const responses = await next();
+                    await next();
                 });
 
                 // Run the bot's application logic.
@@ -229,7 +229,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
                     // In SendActivitiesHandlers developers are supposed to call:
                     //      return next();
                     // If this is not returned, then the next handler will not have the ResourceResponses[].
-                    const responses = await next();
+                    await next();
 
                     return {};
                 });
@@ -282,7 +282,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
                     // In SendActivitiesHandlers developers are supposed to call:
                     //      return next();
                     // If this is not returned, then the next handler will not have the ResourceResponses[].
-                    const responses = await next();
+                    await next();
 
                     return 1;
                 });

--- a/libraries/botbuilder-core/tests/transcriptMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/transcriptMiddleware.test.js
@@ -18,7 +18,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         const transcriptStore = new MemoryTranscriptStore();
         const adapter = new TestAdapter(async (context) => {
             conversationId = context.activity.conversation.id;
-            var typingActivity = {
+            const typingActivity = {
                 type: ActivityTypes.Typing,
                 relatesTo: context.activity.relatesTo,
             };
@@ -59,7 +59,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
                 activityToUpdate.text = 'new response';
                 await context.updateActivity(activityToUpdate);
             } else {
-                var activity = createReply(context.activity, 'response');
+                const activity = createReply(context.activity, 'response');
                 const response = await context.sendActivity(activity);
                 activity.id = response.id;
 
@@ -104,7 +104,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         assert(pagedResult.items[3].type, ActivityTypes.MessageDelete);
     });
 
-    it('should filter continueConversation events', async () => {
+    it('should filter continueConversation events', async function () {
         let conversationId;
         const transcriptStore = new MemoryTranscriptStore();
         const adapter = new TestAdapter(async (context) => {
@@ -121,7 +121,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         assert.strictEqual(pagedResult.items.length, 2, 'only the two message activities should be logged');
     });
 
-    it(`should not error for sent activities if no ResourceResponses are received`, async () => {
+    it(`should not error for sent activities if no ResourceResponses are received`, async function () {
         class NoResourceResponseAdapter extends TestAdapter {
             constructor(logic) {
                 super(logic);
@@ -168,7 +168,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         });
     });
 
-    it(`should not error for sent activities if another handler does not return next()`, async () => {
+    it(`should not error for sent activities if another handler does not return next()`, async function () {
         class NoResourceResponseMiddleware {
             async onTurn(context, next) {
                 context.onSendActivities(async (context, activities, next) => {
@@ -222,7 +222,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         });
     });
 
-    it(`should not error for sent activities if another handler does not return an array`, async () => {
+    it(`should not error for sent activities if another handler does not return an array`, async function () {
         class NoResourceResponseMiddleware {
             async onTurn(context, next) {
                 context.onSendActivities(async (context, activities, next) => {
@@ -262,7 +262,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         });
     });
 
-    it(`should not error when logging sent activities and return the actual value from next()`, async () => {
+    it(`should not error when logging sent activities and return the actual value from next()`, async function () {
         // This middleware should receive 1 from `next()`
         class AssertionMiddleware {
             async onTurn(context, next) {
@@ -316,11 +316,11 @@ describe(`TranscriptLoggerMiddleware`, function () {
 
     describe("'s error handling", function () {
         let sandbox;
-        beforeEach(() => {
+        beforeEach(function () {
             sandbox = sinon.createSandbox();
         });
 
-        afterEach(() => {
+        afterEach(function () {
             sandbox.restore();
         });
 
@@ -414,7 +414,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         });
     });
 
-    it(`should use outgoing activity's timestamp for activity id when activity id and resourceResponse is empty`, async () => {
+    it(`should use outgoing activity's timestamp for activity id when activity id and resourceResponse is empty`, async function () {
         let conversationId, timestamp;
         const transcriptStore = new MemoryTranscriptStore();
 

--- a/libraries/botbuilder-core/tests/transcriptStoreBaseTest.js
+++ b/libraries/botbuilder-core/tests/transcriptStoreBaseTest.js
@@ -3,13 +3,14 @@ const { ActivityTypes } = require('../');
 
 function uuid() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-        var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+        const r = (Math.random() * 16) | 0,
+            v = c == 'x' ? r : (r & 0x3) | 0x8;
         return v.toString(16);
     });
 }
 
 function createActivities(conversationId, ts, count = 5) {
-    var activities = [];
+    const activities = [];
     for (let i = 1; i <= count; i++) {
         activities.push({
             type: ActivityTypes.Message,
@@ -20,7 +21,7 @@ function createActivities(conversationId, ts, count = 5) {
             from: { id: `User${i}` },
             conversation: { id: conversationId },
             recipient: { id: 'Bot1', name: '2' },
-            serviceUrl: 'http://foo.com/api/messages'
+            serviceUrl: 'http://foo.com/api/messages',
         });
         ts = new Date(ts.getTime() + 60000);
 
@@ -33,7 +34,7 @@ function createActivities(conversationId, ts, count = 5) {
             from: { id: 'Bot1', name: '2' },
             conversation: { id: conversationId },
             recipient: { id: `User${i}` },
-            serviceUrl: 'http://foo.com/api/messages'
+            serviceUrl: 'http://foo.com/api/messages',
         });
         ts = new Date(ts.getTime() + 60000);
     }
@@ -53,16 +54,12 @@ function group(array, size) {
 
 function promiseSeq(promiseFuncArray) {
     return promiseFuncArray.reduce((chain, promiseFunc) => {
-        return chain.then(chainResult =>
-            promiseFunc().then(currentResult =>
-                [ ...chainResult, currentResult ]
-            )
-        );
+        return chain.then((chainResult) => promiseFunc().then((currentResult) => [...chainResult, currentResult]));
     }, Promise.resolve([]));
 }
 
 function promiseParallel(promiseFuncArray) {
-    return Promise.all(promiseFuncArray.map(promiseFunc => promiseFunc()));
+    return Promise.all(promiseFuncArray.map((promiseFunc) => promiseFunc()));
 }
 
 function resolvePromises(promiseFuncArray, useParallel = true) {
@@ -74,16 +71,17 @@ function dateSorter(a, b) {
 }
 
 exports._badArgs = function _badArgs(store) {
-    var assertPromise = (promiseFunc, errMessage) => new Promise((resolve, reject) => {
-        try { promiseFunc().then(() => reject(errMessage)) }
-        catch (error) { resolve('expected error') }
-    });
+    const assertPromise = (promiseFunc, errMessage) =>
+        new Promise((resolve, reject) => {
+            try {
+                promiseFunc().then(() => reject(errMessage));
+            } catch (error) {
+                resolve('expected error');
+            }
+        });
 
     return Promise.all([
-        assertPromise(
-            () => store.logActivity(null),
-            'logActivity should have thrown error about missing activity'
-        ),
+        assertPromise(() => store.logActivity(null), 'logActivity should have thrown error about missing activity'),
         assertPromise(
             () => store.getTranscriptActivities(null, null),
             'getTranscriptActivities should have thrown error about missing channelId'
@@ -103,214 +101,248 @@ exports._badArgs = function _badArgs(store) {
         assertPromise(
             () => store.deleteTranscript('foo', null),
             'deleteTranscript should have thrown error about missing conversationId'
-        )
+        ),
     ]);
-}
+};
 
 exports._logActivity = function _logActivity(store) {
-        var conversationId = '_logActivity';
-        var date = new Date();
-        var activity = createActivities(conversationId, date, 1).pop();
+    const conversationId = '_logActivity';
+    const date = new Date();
+    const activity = createActivities(conversationId, date, 1).pop();
 
-        return store.logActivity(activity)
-            .then(() => store.getTranscriptActivities('test', conversationId))
-            .then((result) => {
-                assert.equal(result.items.length, 1);
-                assert.equal(JSON.stringify(result.items[0]), JSON.stringify(activity));
-            });
-}
+    return store
+        .logActivity(activity)
+        .then(() => store.getTranscriptActivities('test', conversationId))
+        .then((result) => {
+            assert.equal(result.items.length, 1);
+            assert.equal(JSON.stringify(result.items[0]), JSON.stringify(activity));
+        });
+};
 
 exports._logMultipleActivities = function _logMultipleActivities(store, useParallel = true) {
-    var conversationId = '_logMultipleActivities';
-    var start = new Date();
-    var activities = createActivities(conversationId, start);
+    const conversationId = '_logMultipleActivities';
+    const start = new Date();
+    const activities = createActivities(conversationId, start);
 
     // log activities
-    var writes = activities.map(a => () => store.logActivity(a));
+    const writes = activities.map((a) => () => store.logActivity(a));
 
     // wait for all logs
     return resolvePromises(writes, useParallel).then(() => {
         // group the different queries into promises
         return Promise.all([
             // make sure other channels and conversations don't return results
-            store.getTranscriptActivities('bogus', conversationId).then(pagedResult => {
+            store.getTranscriptActivities('bogus', conversationId).then((pagedResult) => {
                 assert(!pagedResult.continuationToken);
                 assert.equal(pagedResult.items.length, 0);
             }),
             // make sure other channels and conversations don't return results
-            store.getTranscriptActivities('test', 'bogus').then(pagedResult => {
+            store.getTranscriptActivities('test', 'bogus').then((pagedResult) => {
                 assert(!pagedResult.continuationToken);
                 assert.equal(pagedResult.items.length, 0);
             }),
             // make sure all created activities where persisted
-            store.getTranscriptActivities('test', conversationId).then(pagedResult => {
+            store.getTranscriptActivities('test', conversationId).then((pagedResult) => {
                 assert(!pagedResult.continuationToken);
                 assert.equal(pagedResult.items.length, activities.length);
 
                 // assert all are equal
-                assert.equal(
-                    JSON.stringify(pagedResult.items.sort(dateSorter)),
-                    JSON.stringify(activities)
-                );
+                assert.equal(JSON.stringify(pagedResult.items.sort(dateSorter)), JSON.stringify(activities));
             }),
             // assert half page, get activities +5 minutes
-            store.getTranscriptActivities('test', conversationId, null, new Date(start.getTime() + 60000 * 5)).then(pagedResult => {
-                assert.equal(activities.length / 2, pagedResult.items.length);
-                var expected = activities.slice(5);
-                assert.equal(
-                    JSON.stringify(pagedResult.items.sort(dateSorter)),
-                    JSON.stringify(expected));
-            })
+            store
+                .getTranscriptActivities('test', conversationId, null, new Date(start.getTime() + 60000 * 5))
+                .then((pagedResult) => {
+                    assert.equal(activities.length / 2, pagedResult.items.length);
+                    const expected = activities.slice(5);
+                    assert.equal(JSON.stringify(pagedResult.items.sort(dateSorter)), JSON.stringify(expected));
+                }),
         ]);
     });
-}
+};
 
 exports._deleteTranscript = function _deleteTranscript(store, useParallel = true) {
-    var conversationId = '_deleteConversation';
-    var conversationId2 = '_deleteConversation2';
-    var start = new Date();
-    var activities = createActivities(conversationId, start);
-    var activities2 = createActivities(conversationId2, start);
+    const conversationId = '_deleteConversation';
+    const conversationId2 = '_deleteConversation2';
+    const start = new Date();
+    const activities = createActivities(conversationId, start);
+    const activities2 = createActivities(conversationId2, start);
 
     // log all activities
-    var writes = activities.concat(activities2)
-        .map(a => () => store.logActivity(a));
+    const writes = activities.concat(activities2).map((a) => () => store.logActivity(a));
 
     // wait for all writes
     return resolvePromises(writes, useParallel).then(() => {
         return Promise.all([
             // test A
-            store.getTranscriptActivities('test', conversationId).then(pagedResult => {
+            store.getTranscriptActivities('test', conversationId).then((pagedResult) => {
                 assert.equal(pagedResult.items.length, activities.length);
                 // delete!
                 store.deleteTranscript('test', conversationId).then(() => {
                     return Promise.all([
                         // check deleted
-                        store.getTranscriptActivities('test', conversationId).then(pagedResult => {
+                        store.getTranscriptActivities('test', conversationId).then((pagedResult) => {
                             assert.equal(pagedResult.items.length, 0);
                         }),
                         // check second transcript still exists
-                        store.getTranscriptActivities('test', conversationId2).then(pagedResult => {
+                        store.getTranscriptActivities('test', conversationId2).then((pagedResult) => {
                             assert.equal(pagedResult.items.length, activities2.length);
-                        })
-                    ])
-                })
+                        }),
+                    ]);
+                });
             }),
             // test B
-            store.getTranscriptActivities('test', conversationId2).then(pagedResult => {
+            store.getTranscriptActivities('test', conversationId2).then((pagedResult) => {
                 assert.equal(pagedResult.items.length, activities2.length);
-            })
+            }),
         ]);
     });
-}
+};
 
 exports._getTranscriptActivities = function _getTranscriptActivities(store, useParallel = true) {
     return new Promise((resolve, reject) => {
-        var conversationId = '_getTranscriptActivitiesPaging';
-        var date = new Date();
-        var activities = createActivities(conversationId, date, 50);
+        const conversationId = '_getTranscriptActivitiesPaging';
+        const date = new Date();
+        const activities = createActivities(conversationId, date, 50);
         // log in parallel batches of 10
-        var groups = group(activities, 10);
-        return promiseSeq(groups.map(group => () => resolvePromises(group.map(item => () => store.logActivity(item)), useParallel)))
-        .then(async () => {
-            var actualPageSize = 0;
-            var pagedResult = {};
-            var seen = [];
-            do {
-                pagedResult = await store.getTranscriptActivities('test', conversationId, pagedResult.continuationToken);
-                assert(pagedResult);
-                assert(pagedResult.items);
+        const groups = group(activities, 10);
+        return promiseSeq(
+            groups.map((group) => () =>
+                resolvePromises(
+                    group.map((item) => () => store.logActivity(item)),
+                    useParallel
+                )
+            )
+        )
+            .then(async () => {
+                let actualPageSize = 0;
+                let pagedResult = {};
+                const seen = [];
+                do {
+                    pagedResult = await store.getTranscriptActivities(
+                        'test',
+                        conversationId,
+                        pagedResult.continuationToken
+                    );
+                    assert(pagedResult);
+                    assert(pagedResult.items);
 
-                if (!actualPageSize) {
-                    actualPageSize = pagedResult.items.length;
-                } else if (actualPageSize === pagedResult.items.length) {
-                    assert(pagedResult.continuationToken)
-                }
-                pagedResult.items.forEach(item => {
-                    assert(!seen.includes(item.id));
-                    seen.push(item.id);
-                });
-            } while (pagedResult.continuationToken);
-            assert.equal(seen.length, activities.length);
-            activities.forEach(activity => assert(seen.includes(activity.id)));
-            resolve();
-        }).catch(error => reject(error));
+                    if (!actualPageSize) {
+                        actualPageSize = pagedResult.items.length;
+                    } else if (actualPageSize === pagedResult.items.length) {
+                        assert(pagedResult.continuationToken);
+                    }
+                    pagedResult.items.forEach((item) => {
+                        assert(!seen.includes(item.id));
+                        seen.push(item.id);
+                    });
+                } while (pagedResult.continuationToken);
+                assert.equal(seen.length, activities.length);
+                activities.forEach((activity) => assert(seen.includes(activity.id)));
+                resolve();
+            })
+            .catch((error) => reject(error));
     });
-}
+};
 
 exports._getTranscriptActivitiesStartDate = function _getTranscriptActivitiesStartDate(store, useParallel = true) {
     return new Promise((resolve, reject) => {
-        var conversationId = '_getTranscriptActivitiesStartDate';
-        var date = new Date();
-        var activities = createActivities(conversationId, date, 50);
+        const conversationId = '_getTranscriptActivitiesStartDate';
+        const date = new Date();
+        const activities = createActivities(conversationId, date, 50);
         // log in parallel batches of 10
-        var groups = group(activities, 10);
-        return promiseSeq(groups.map(group => () => resolvePromises(group.map(item => () => store.logActivity(item)), useParallel)))
-        .then(async () => {
-            var actualPageSize = 0;
-            var pagedResult = {};
-            var seen = [];
-            var referenceDate = new Date(date.getTime() + (50 * 60 * 1000));
-            do {
-                pagedResult = await store.getTranscriptActivities('test', conversationId, pagedResult.continuationToken, referenceDate);
-                assert(pagedResult);
-                assert(pagedResult.items);
+        const groups = group(activities, 10);
+        return promiseSeq(
+            groups.map((group) => () =>
+                resolvePromises(
+                    group.map((item) => () => store.logActivity(item)),
+                    useParallel
+                )
+            )
+        )
+            .then(async () => {
+                let actualPageSize = 0;
+                let pagedResult = {};
+                const seen = [];
+                const referenceDate = new Date(date.getTime() + 50 * 60 * 1000);
+                do {
+                    pagedResult = await store.getTranscriptActivities(
+                        'test',
+                        conversationId,
+                        pagedResult.continuationToken,
+                        referenceDate
+                    );
+                    assert(pagedResult);
+                    assert(pagedResult.items);
 
-                if (!actualPageSize) {
-                    actualPageSize = pagedResult.items.length;
-                } else if (actualPageSize === pagedResult.items.length) {
-                    assert(pagedResult.continuationToken)
-                }
-                pagedResult.items.forEach(item => {
-                    assert(!seen.includes(item.id));
-                    seen.push(item.id);
-                });
-            } while (pagedResult.continuationToken);
-            assert.equal(seen.length, activities.length / 2);
-            activities.filter(a => a.timestamp.getTime() >= referenceDate.getTime()).forEach(activity => assert(seen.includes(activity.id)));
-            activities.filter(a => a.timestamp.getTime() < referenceDate.getTime()).forEach(activity => assert(!seen.includes(activity.id)));
-            resolve();
-        }).catch(error => reject(error));
+                    if (!actualPageSize) {
+                        actualPageSize = pagedResult.items.length;
+                    } else if (actualPageSize === pagedResult.items.length) {
+                        assert(pagedResult.continuationToken);
+                    }
+                    pagedResult.items.forEach((item) => {
+                        assert(!seen.includes(item.id));
+                        seen.push(item.id);
+                    });
+                } while (pagedResult.continuationToken);
+                assert.equal(seen.length, activities.length / 2);
+                activities
+                    .filter((a) => a.timestamp.getTime() >= referenceDate.getTime())
+                    .forEach((activity) => assert(seen.includes(activity.id)));
+                activities
+                    .filter((a) => a.timestamp.getTime() < referenceDate.getTime())
+                    .forEach((activity) => assert(!seen.includes(activity.id)));
+                resolve();
+            })
+            .catch((error) => reject(error));
     });
-}
+};
 
 exports._listTranscripts = function _listTranscripts(store, useParallel = true) {
     return new Promise((resolve, reject) => {
-        var conversationIds = [];
-        var start = new Date();
+        const conversationIds = [];
+        const start = new Date();
         for (let i = 1; i <= 100; i++) {
-            conversationIds.push(`_ListConversations${i}`)
+            conversationIds.push(`_ListConversations${i}`);
         }
 
-        var activities = [].concat(...conversationIds.map(cId => createActivities(cId, start, 1)));
+        const activities = [].concat(...conversationIds.map((cId) => createActivities(cId, start, 1)));
 
         // log in parallel batches of 10
-        var groups = group(activities, 10);
-        return promiseSeq(groups.map(group => () => resolvePromises(group.map(item => () => store.logActivity(item)), useParallel)))
-        .then(async () => {
-            var actualPageSize = 0;
-            var pagedResult = {};
-            var seen = [];
-            do {
-                pagedResult = await store.listTranscripts('test', pagedResult.continuationToken);
-                assert(pagedResult);
-                assert(pagedResult.items);
+        const groups = group(activities, 10);
+        return promiseSeq(
+            groups.map((group) => () =>
+                resolvePromises(
+                    group.map((item) => () => store.logActivity(item)),
+                    useParallel
+                )
+            )
+        )
+            .then(async () => {
+                let actualPageSize = 0;
+                let pagedResult = {};
+                const seen = [];
+                do {
+                    pagedResult = await store.listTranscripts('test', pagedResult.continuationToken);
+                    assert(pagedResult);
+                    assert(pagedResult.items);
 
-                if (!actualPageSize) {
-                    actualPageSize = pagedResult.items.length;
-                } else if (actualPageSize === pagedResult.items.length) {
-                    assert(pagedResult.continuationToken)
-                }
-                pagedResult.items.forEach(item => {
-                    assert(!seen.includes(item.id));
-                    if (item.id.startsWith('_ListConversations')) {
-                        seen.push(item.id);
+                    if (!actualPageSize) {
+                        actualPageSize = pagedResult.items.length;
+                    } else if (actualPageSize === pagedResult.items.length) {
+                        assert(pagedResult.continuationToken);
                     }
-                });
-            } while (pagedResult.continuationToken);
-            assert.equal(seen.length, conversationIds.length);
-            conversationIds.forEach(cId => assert(seen.includes(cId)));
-            resolve();
-        }).catch(error => reject(error));
+                    pagedResult.items.forEach((item) => {
+                        assert(!seen.includes(item.id));
+                        if (item.id.startsWith('_ListConversations')) {
+                            seen.push(item.id);
+                        }
+                    });
+                } while (pagedResult.continuationToken);
+                assert.equal(seen.length, conversationIds.length);
+                conversationIds.forEach((cId) => assert(seen.includes(cId)));
+                resolve();
+            })
+            .catch((error) => reject(error));
     });
-}
+};

--- a/libraries/botbuilder-core/tests/transcriptStoreBaseTest.js
+++ b/libraries/botbuilder-core/tests/transcriptStoreBaseTest.js
@@ -75,7 +75,7 @@ exports._badArgs = function _badArgs(store) {
         new Promise((resolve, reject) => {
             try {
                 promiseFunc().then(() => reject(errMessage));
-            } catch (error) {
+            } catch (_error) {
                 resolve('expected error');
             }
         });

--- a/libraries/botbuilder-core/tests/transcriptUtilities.js
+++ b/libraries/botbuilder-core/tests/transcriptUtilities.js
@@ -58,9 +58,9 @@ function getActivitiesFromChat(chatFilePath) {
  * Creates a Mocha Test definition (Mocha.ITestDefinition) that will use the TestAdapter to test a bot logic against the specified transcript file.
  * Optionally, pass a third parameter (as function) to register middleware into the TestAdapter.
  *
- * @param {string} transcriptPath Path to the transcript file. Can be a .chat or .transcript file.
- * @param {Function} botLogicFactoryFun Function which accepts conversationState and userState and should return the bots logic to test.
- * @param {Function} middlewareRegistrationFun (Optional) Function which accepts the testAdapter, conversationState and userState.
+ * @param relativeTranscriptPath {string} transcriptPath Path to the transcript file. Can be a .chat or .transcript file.
+ * @param botLogicFactoryFun {Function} botLogicFactoryFun Function which accepts conversationState and userState and should return the bots logic to test.
+ * @param middlewareRegistrationFun {Function} middlewareRegistrationFun (Optional) Function which accepts the testAdapter, conversationState and userState.
  */
 function assertBotLogicWithBotBuilderTranscript(relativeTranscriptPath, botLogicFactoryFun, middlewareRegistrationFun) {
     return function (mochaDoneCallback) {
@@ -176,7 +176,7 @@ const isUrl = (possibleUrl) => {
     try {
         new url.URL(possibleUrl);
         return true;
-    } catch (e) {
+    } catch (_e) {
         return false;
     }
 };

--- a/libraries/botbuilder-core/tests/turnContext.test.js
+++ b/libraries/botbuilder-core/tests/turnContext.test.js
@@ -180,7 +180,7 @@ describe(`TurnContext`, function () {
 
     it(`should send a text message with speak and inputHint added.`, async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        context.onSendActivities((ctx, activities, next) => {
+        context.onSendActivities((_ctx, activities, _next) => {
             assert(Array.isArray(activities), `activities not array.`);
             assert(activities.length === 1, `invalid count of activities.`);
             assert(activities[0].text === 'test', `text wrong.`);
@@ -193,7 +193,7 @@ describe(`TurnContext`, function () {
 
     it(`should send a trace activity.`, async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        context.onSendActivities((ctx, activities, next) => {
+        context.onSendActivities((_ctx, activities, _next) => {
             assert(Array.isArray(activities), `activities not array.`);
             assert(activities.length === 1, `invalid count of activities.`);
             assert(activities[0].type === ActivityTypes.Trace, `type wrong.`);
@@ -230,7 +230,7 @@ describe(`TurnContext`, function () {
 
     it(`should allow interception of delivery in onSendActivity() hook.`, async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        context.onSendActivities((ctx, activities, next) => {
+        context.onSendActivities((_ctx, _activities, _next) => {
             return [];
         });
         const response = await context.sendActivity(testMessage);
@@ -285,7 +285,7 @@ describe(`TurnContext`, function () {
     it(`should call onDeleteActivity() hook before delete by "reference".`, async function () {
         let called = false;
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        context.onDeleteActivity((ctx, reference, next) => {
+        context.onDeleteActivity((_ctx, reference, next) => {
             assert(reference, `missing reference`);
             assert(reference.activityId === '1234', `invalid activityId passed to hook`);
             called = true;
@@ -297,7 +297,7 @@ describe(`TurnContext`, function () {
 
     it(`should map an exception raised by a hook to a rejection.`, async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        context.onDeleteActivity((ctx, reference, next) => {
+        context.onDeleteActivity((_ctx, _reference, _next) => {
             throw new Error('failed');
         });
         await assert.rejects(async () => await context.deleteActivity('1234'), {
@@ -349,12 +349,12 @@ describe(`TurnContext`, function () {
         // Round trip outgoing activity without a replyToId
         delete reference.activityId;
         const activity3 = TurnContext.applyConversationReference({ text: 'foo', type: 'message' }, reference);
-        assert(!activity3.hasOwnProperty('replyToId'), `activity3 has replyToId`);
+        assert(!activity3.replyToId, `activity3 has replyToId`);
 
         // Round trip incoming activity without an id
         delete reference.activityId;
         const activity4 = TurnContext.applyConversationReference({ text: 'foo', type: 'message' }, reference, true);
-        assert(!activity4.hasOwnProperty('id'), `activity4 has id`);
+        assert(!activity4.id, `activity4 has id`);
     });
 
     it(`should not set TurnContext.responded to true if Trace activity is sent.`, async function () {

--- a/libraries/botbuilder-core/tests/turnContext.test.js
+++ b/libraries/botbuilder-core/tests/turnContext.test.js
@@ -421,7 +421,7 @@ describe(`TurnContext`, function () {
         assert(response.id === undefined, `invalid response id of "${response.id}" sent back. Should be 'undefined'`);
     });
 
-    it('should add to bufferedReplyActivities if TurnContext.activity.deliveryMode === DeliveryModes.ExpectReplies', async () => {
+    it('should add to bufferedReplyActivities if TurnContext.activity.deliveryMode === DeliveryModes.ExpectReplies', async function () {
         const activity = JSON.parse(JSON.stringify(testMessage));
         activity.deliveryMode = DeliveryModes.ExpectReplies;
         const context = new TurnContext(new SimpleAdapter(), activity);

--- a/libraries/botbuilder-core/tests/userState.test.js
+++ b/libraries/botbuilder-core/tests/userState.test.js
@@ -13,12 +13,10 @@ describe(`UserState`, function () {
     const context = new TurnContext(adapter, receivedMessage);
     const userState = new UserState(storage);
     it(`should load and save state from storage.`, async function () {
-        let key;
-
         // Simulate a "Turn" in a conversation by loading the state,
         // changing it and then saving the changes to state.
         await userState.load(context);
-        key = userState.getStorageKey(context);
+        const key = userState.getStorageKey(context);
         const state = userState.get(context);
         assert(state, `State not loaded`);
         assert(key, `Key not found`);
@@ -27,7 +25,7 @@ describe(`UserState`, function () {
 
         // Check the storage to see if the changes to state were saved.
         const items = await storage.read([key]);
-        assert(items.hasOwnProperty(key), `Saved state not found in storage.`);
+        assert(items[key], `Saved state not found in storage.`);
         assert(items[key].test === 'foo', `Missing test value in stored state.`);
     });
 
@@ -54,7 +52,7 @@ describe(`UserState`, function () {
     });
 
     it(`should throw NO_KEY error if getStorageKey() returns falsey value.`, async function () {
-        userState.getStorageKey = (turnContext) => undefined;
+        userState.getStorageKey = () => undefined;
         try {
             await userState.load(context, true);
         } catch (err) {


### PR DESCRIPTION
Note: I decided that the unused var linting was a bit aggressive with respect to function parameters. In many cases, we write abstract functions with documentation where including leading underscores for unused parameters looks a bit clunky. As it's not possible to contextually turn off (in eslint config) we just need to drop it.

#minor