### PR TITLE
fix: cleanup lint errors in bf-connector

### DIFF
--- a/libraries/botframework-connector/src/auth/appCredentials.ts
+++ b/libraries/botframework-connector/src/auth/appCredentials.ts
@@ -7,7 +7,6 @@
  */
 
 import * as msrest from '@azure/ms-rest-js';
-import * as url from 'url';
 import * as adal from 'adal-node';
 import { AuthenticationConstants } from './authenticationConstants';
 
@@ -47,6 +46,8 @@ export abstract class AppCredentials implements msrest.ServiceClientCredentials 
 
     /**
      * Gets tenant to be used for channel authentication.
+     *
+     * @returns The channel auth token tenant for this credential.
      */
     private get tenant(): string {
         return this._tenant;
@@ -61,6 +62,8 @@ export abstract class AppCredentials implements msrest.ServiceClientCredentials 
 
     /**
      * Gets the OAuth scope to use.
+     *
+     * @returns The OAuth scope to use.
      */
     public get oAuthScope(): string {
         return this._oAuthScope;
@@ -76,6 +79,8 @@ export abstract class AppCredentials implements msrest.ServiceClientCredentials 
 
     /**
      * Gets the OAuth endpoint to use.
+     *
+     * @returns The OAuthEndpoint to use.
      */
     public get oAuthEndpoint(): string {
         return this._oAuthEndpoint;

--- a/libraries/botframework-connector/src/auth/authenticationError.ts
+++ b/libraries/botframework-connector/src/auth/authenticationError.ts
@@ -22,10 +22,12 @@ export class AuthenticationError extends Error implements IStatusCodeError {
     }
 
     /**
-     * Corroborates that the error is of type [IStatusCodeError](xref:botbuilder.IStatusCodeError).
+     * Corroborates that the error is of type [IStatusCodeError](xref:botframework-schema.IStatusCodeError).
      *
      * @param err The error to validate.
+     * @returns If `err` is an [IStatusCodeError](xref:botframework-schema.IStatusCodeError), the result is true; otherwise false.
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
     public static isStatusCodeError(err: any): err is IStatusCodeError {
         return !!(err && typeof err.statusCode === 'number');
     }
@@ -34,7 +36,9 @@ export class AuthenticationError extends Error implements IStatusCodeError {
      * Used to determine a status code from the error message for non-`IStatusCodeError`'s.
      *
      * @param err The error thrown, used to determine an appropriate status code.
+     * @returns The error message to be sent as a response.
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
     public static determineStatusCodeAndBuildMessage(err: any): string {
         const errMessage: string = err && err.message ? err.message : 'Internal Server Error';
         const code: number = AuthenticationError.determineStatusCode(errMessage);

--- a/libraries/botframework-connector/src/auth/certificateAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/certificateAppCredentials.ts
@@ -37,9 +37,6 @@ export class CertificateAppCredentials extends AppCredentials {
         this.certificatePrivateKey = certificatePrivateKey;
     }
 
-    /**
-     * @protected
-     */
     protected async refreshToken(): Promise<adal.TokenResponse> {
         if (!this.refreshingToken) {
             this.refreshingToken = new Promise<adal.TokenResponse>((resolve, reject) => {

--- a/libraries/botframework-connector/src/auth/channelValidation.ts
+++ b/libraries/botframework-connector/src/auth/channelValidation.ts
@@ -15,6 +15,7 @@ import { JwtTokenExtractor } from './jwtTokenExtractor';
 import { AuthenticationError } from './authenticationError';
 import { StatusCodes } from 'botframework-schema';
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace ChannelValidation {
     export let OpenIdMetadataEndpoint: string;
 
@@ -35,8 +36,8 @@ export namespace ChannelValidation {
      * @param  {string} authHeader The raw HTTP header in the format: "Bearer [longString]"
      * @param  {ICredentialProvider} credentials The user defined set of valid credentials, such as the AppId.
      * @param  {string} serviceUrl The ServiceUrl Claim value that must match in the identity.
-     * @param  {string} channelId
-     * @param  {AuthenticationConfiguration} authConfig
+     * @param  {string} channelId The ID of the channel to validate.
+     * @param  {AuthenticationConfiguration} authConfig The authentication configuration.
      * @returns {Promise<ClaimsIdentity>} A valid ClaimsIdentity.
      */
     export async function authenticateChannelTokenWithServiceUrl(
@@ -63,8 +64,8 @@ export namespace ChannelValidation {
      *
      * @param  {string} authHeader The raw HTTP header in the format: "Bearer [longString]"
      * @param  {ICredentialProvider} credentials The user defined set of valid credentials, such as the AppId.
-     * @param  {string} channelId
-     * @param  {AuthenticationConfiguration} authConfig
+     * @param  {string} channelId The ID of the channel to validate.
+     * @param  {AuthenticationConfiguration} authConfig The authentication configuration.
      * @returns {Promise<ClaimsIdentity>} A valid ClaimsIdentity.
      */
     export async function authenticateChannelToken(

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -75,6 +75,7 @@ export namespace EmulatorValidation {
         }
 
         // Parse the Big Long String into an actual token.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const token: any = decode(bearerToken, { complete: true });
         if (!token) {
             return false;
@@ -107,8 +108,8 @@ export namespace EmulatorValidation {
      * @param  {string} authHeader The raw HTTP header in the format: "Bearer [longString]"
      * @param  {ICredentialProvider} credentials The user defined set of valid credentials, such as the AppId.
      * @param  {string} channelService The channelService value that distinguishes public Azure from US Government Azure.
-     * @param  {string} channelId
-     * @param  {AuthenticationConfiguration} authConfig
+     * @param  {string} channelId The ID of the channel to validate.
+     * @param  {AuthenticationConfiguration} authConfig The authentication configuration.
      * @returns {Promise<ClaimsIdentity>} A valid ClaimsIdentity.
      */
     export async function authenticateEmulatorToken(

--- a/libraries/botframework-connector/src/auth/enterpriseChannelValidation.ts
+++ b/libraries/botframework-connector/src/auth/enterpriseChannelValidation.ts
@@ -16,6 +16,7 @@ import { JwtTokenExtractor } from './jwtTokenExtractor';
 import { AuthenticationError } from './authenticationError';
 import { StatusCodes } from 'botframework-schema';
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace EnterpriseChannelValidation {
     /**
      * TO BOT FROM CHANNEL: Token validation parameters when connecting to a bot
@@ -30,9 +31,12 @@ export namespace EnterpriseChannelValidation {
     /**
      * Validate the incoming Auth Header as a token sent from the Bot Framework Service.
      * A token issued by the Bot Framework emulator will FAIL this check.
+     *
      * @param {string} authHeader The raw HTTP header in the format: "Bearer [longString]"
      * @param {ICredentialProvider} credentials The user defined set of valid credentials, such as the AppId.
      * @param {string} serviceUrl The ServiceUrl Claim value that must match in the identity.
+     * @param channelId The ID of the channel to validate.
+     * @param channelService The channelService value that distinguishes public Azure from US Government Azure.
      * @returns {Promise<ClaimsIdentity>} A valid ClaimsIdentity.
      */
     export async function authenticateChannelTokenWithServiceUrl(
@@ -61,8 +65,12 @@ export namespace EnterpriseChannelValidation {
     /**
      * Validate the incoming Auth Header as a token sent from the Bot Framework Service.
      * A token issued by the Bot Framework emulator will FAIL this check.
+     *
      * @param {string} authHeader The raw HTTP header in the format: "Bearer [longString]"
      * @param {ICredentialProvider} credentials The user defined set of valid credentials, such as the AppId.
+     * @param channelId The ID of the channel to validate.
+     * @param channelService The channelService value that distinguishes public Azure from US Government Azure.
+     * @param authConfig The authentication configuration.
      * @returns {Promise<ClaimsIdentity>} A valid ClaimsIdentity.
      */
     export async function authenticateChannelToken(
@@ -94,6 +102,7 @@ export namespace EnterpriseChannelValidation {
 
     /**
      * Validate the ClaimsIdentity to ensure it came from the channel service.
+     *
      * @param  {ClaimsIdentity} identity The identity to validate
      * @param  {ICredentialProvider} credentials The user defined set of valid credentials, such as the AppId.
      * @returns {Promise<ClaimsIdentity>} A valid ClaimsIdentity.

--- a/libraries/botframework-connector/src/auth/governmentChannelValidation.ts
+++ b/libraries/botframework-connector/src/auth/governmentChannelValidation.ts
@@ -65,7 +65,7 @@ export namespace GovernmentChannelValidation {
      * @param  {string} authHeader The raw HTTP header in the format: "Bearer [longString]"
      * @param  {ICredentialProvider} credentials The user defined set of valid credentials, such as the AppId.
      * @param  {string} channelId The ID of the channel to validate.
-     * @param  {AuthenticationConfiguration} authConfig
+     * @param  {AuthenticationConfiguration} authConfig The authentication configuration.
      * @returns {Promise<ClaimsIdentity>} A valid ClaimsIdentity.
      */
     export async function authenticateChannelToken(

--- a/libraries/botframework-connector/src/auth/governmentConstants.ts
+++ b/libraries/botframework-connector/src/auth/governmentConstants.ts
@@ -6,6 +6,7 @@
  * Licensed under the MIT License.
  */
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace GovernmentConstants {
     /**
      * Government Channel Service property value

--- a/libraries/botframework-connector/src/auth/jwtTokenValidation.ts
+++ b/libraries/botframework-connector/src/auth/jwtTokenValidation.ts
@@ -116,7 +116,7 @@ export namespace JwtTokenValidation {
         return identity;
     }
 
-    // eslint-disable-next-line no-inner-declarations
+    // eslint-disable-next-line jsdoc/require-jsdoc, no-inner-declarations
     async function authenticateToken(
         authHeader: string,
         credentials: ICredentialProvider,
@@ -194,7 +194,7 @@ export namespace JwtTokenValidation {
     /**
      * Validates the identity claims against the ClaimsValidator in AuthenticationConfiguration if present.
      *
-     * @param authConfig
+     * @param authConfig The authentication configuration.
      * @param claims The list of claims to validate.
      */
     // eslint-disable-next-line no-inner-declarations
@@ -257,7 +257,7 @@ export namespace JwtTokenValidation {
         return appId;
     }
 
-    // eslint-disable-next-line no-inner-declarations
+    // eslint-disable-next-line jsdoc/require-jsdoc, no-inner-declarations
     function isPublicAzure(channelService: string): boolean {
         return !channelService || channelService.length === 0;
     }

--- a/libraries/botframework-connector/src/auth/openIdMetadata.ts
+++ b/libraries/botframework-connector/src/auth/openIdMetadata.ts
@@ -16,7 +16,6 @@ import { StatusCodes } from 'botframework-schema';
  * Class in charge of manage OpenId metadata.
  */
 export class OpenIdMetadata {
-    private url: string;
     private lastUpdated = 0;
     private keys: IKey[];
 
@@ -25,9 +24,7 @@ export class OpenIdMetadata {
      *
      * @param url Metadata Url.
      */
-    constructor(url: string) {
-        this.url = url;
-    }
+    constructor(private url: string) {}
 
     /**
      * Gets the Signing key.
@@ -38,20 +35,14 @@ export class OpenIdMetadata {
     public async getKey(keyId: string): Promise<IOpenIdMetadataKey | null> {
         // If keys are more than 24 hours old, refresh them
         if (this.lastUpdated < Date.now() - 1000 * 60 * 60 * 24) {
-            try {
-                await this.refreshCache();
+            await this.refreshCache();
 
-                // Search the cache even if we failed to refresh
-                const key: IOpenIdMetadataKey = this.findKey(keyId);
-                return key;
-            } catch (err) {
-                //logger.error('Error retrieving OpenId metadata at ' + this.url + ', error: ' + err.toString());
-                // fall through and return cached key on error
-                throw err;
-            }
+            // Search the cache even if we failed to refresh
+            const key = this.findKey(keyId);
+            return key;
         } else {
             // Otherwise read from cache
-            const key: IOpenIdMetadataKey = this.findKey(keyId);
+            const key = this.findKey(keyId);
             // Refresh the cache if a key is not found (max once per hour)
             if (!key && this.lastUpdated < Date.now() - 1000 * 60 * 60) {
                 await this.refreshCache();
@@ -103,8 +94,8 @@ export class OpenIdMetadata {
                     return null;
                 }
 
-                const modulus: any = base64url.toBase64(key.n);
-                const exponent: string = key.e;
+                const modulus = base64url.toBase64(key.n);
+                const exponent = key.e;
 
                 return {
                     key: getPem(modulus, exponent),

--- a/libraries/botframework-connector/src/auth/serviceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/serviceClientCredentialsFactory.ts
@@ -18,6 +18,7 @@ export abstract class ServiceClientCredentialsFactory {
 
     /**
      * Checks whether bot authentication is disabled.
+     *
      * @returns {Promise<boolean>} If bot authentication is disabled, the result is true; otherwise, false.
      */
     abstract isAuthenticationDisabled(): Promise<boolean>;

--- a/libraries/botframework-connector/src/auth/skillValidation.ts
+++ b/libraries/botframework-connector/src/auth/skillValidation.ts
@@ -242,6 +242,8 @@ export namespace SkillValidation {
 
     /**
      * Creates a set of claims that represent an anonymous skill. Useful for testing bots locally in the emulator
+     *
+     * @returns A [ClaimsIdentity](xref.botframework-connector.ClaimsIdentity) instance with authentication type set to [AuthenticationConstants.AnonymousAuthType](xref.botframework-connector.AuthenticationConstants) and a reserved [AuthenticationConstants.AnonymousSkillAppId](xref.botframework-connector.AuthenticationConstants) claim.
      */
     export function createAnonymousSkillClaim(): ClaimsIdentity {
         return new ClaimsIdentity(

--- a/libraries/botframework-connector/src/emulatorApiClient.ts
+++ b/libraries/botframework-connector/src/emulatorApiClient.ts
@@ -16,9 +16,12 @@ export class EmulatorApiClient {
     /**
      * OAuth card emulation.
      *
+     * @remarks If the emulation fails, an error containing the status code from the server is thrown.
+     *
      * @param credentials [AppCredentials](xref:botframework-connector.AppCredentials) for OAuth.
      * @param emulatorUrl The URL of the emulator.
      * @param emulate `true` to send an emulated OAuth card to the emulator; or `false` to not send the card.
+     * @returns `true` on a successful emulation of OAuthCards.
      */
     public static async emulateOAuthCards(
         credentials: AppCredentials,


### PR DESCRIPTION
#minor

## Description
Addresses lint errors in `botframework-connector`, the new doc strings are either a verbatim port from .NET or derived from examples in the JS SDK.