### PR TITLE
fix: clean command should ignore missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "browser-functional-test": "yarn workspace browser-functional-tests test",
     "build": "wsrun -e -m -t build",
     "build-docs": "wsrun -e -m build-docs",
-    "clean": "wsrun clean",
+    "clean": "wsrun -m clean",
     "functional-test": "yarn build && yarn workspace functional-tests test",
     "lint": "wsrun -m -l lint --quiet",
     "package": "wsrun -e -t -l --if is-not-private --bin yarn pack",


### PR DESCRIPTION
#minor