### PR TITLE
feat: allow wildcard in mock paths

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/src/httpRequestMocks/httpRequestSequenceMock.ts
+++ b/libraries/botbuilder-dialogs-adaptive-testing/src/httpRequestMocks/httpRequestSequenceMock.ts
@@ -81,8 +81,12 @@ export class HttpRequestSequenceMock extends HttpRequestMock implements HttpRequ
         }
         const response = new SequenceResponseManager(this.responses);
         const url = parse(this.url);
-        let path = this.url.substr(url.origin.length);
+        let path: string | RegExp = this.url.substr(url.origin.length);
         path = path.startsWith('/') ? path : '/' + path;
+        if (path.includes('*')) {
+            // eslint-disable-next-line security/detect-non-literal-regexp
+            path = new RegExp(path.replace('*', '.*'));
+        }
         if (this.method) {
             nock(url.origin)
                 .intercept(path, this.method, this._matchContent.bind(this))

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ChooseEntityTests/LuisChooseEntity-wheat.mock.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ChooseEntityTests/LuisChooseEntity-wheat.mock.dialog
@@ -2,7 +2,7 @@
   "$schema": "../../../tests.schema",
   "$kind": "Microsoft.Test.HttpRequestSequenceMock",
   "method": "POST",
-  "url": "https://westus.api.cognitive.microsoft.com/luis/prediction/v3.0/apps/00000000-0000-0000-0000-000000000000/slots/production/predict?verbose=false&log=true&show-all-intents=false",
+  "url": "https://westus.api.cognitive.microsoft.com/luis/prediction/v3.0/apps/00000000-0000-0000-0000-000000000000/*",
   "body": "\"query\": \"wheat\"",
   "responses": [
     {


### PR DESCRIPTION
Fixes #3712 

## Description
See linked issue for more details, but this is for parity w/ .NET.

## Specific Changes
Allow wildcards in URL paths by replacing the path with a RegExp and replacing `*` with `.*`.

## Testing
Changed 1 test, which passes. Others will change as part of another PR.

![image](https://user-images.githubusercontent.com/40401643/119882712-8f8a6f00-bee3-11eb-96ac-ecc2e4b31a4f.png)
