### PR TITLE
chore: bump chromedriver to ^90.0.1 in browser-functional-tests

### DIFF
--- a/libraries/browser-functional-tests/package.json
+++ b/libraries/browser-functional-tests/package.json
@@ -5,7 +5,7 @@
   "description": "Test to check browser compatibility",
   "main": "",
   "devDependencies": {
-    "chromedriver": "^89.0.0",
+    "chromedriver": "^90.0.1",
     "dotenv": "^8.2.0",
     "geckodriver": "^1.19.1",
     "nightwatch": "^1.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3518,17 +3518,16 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^89.0.0:
-  version "89.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-89.0.0.tgz#a6f27aa306400651a20dc04976fe5b2c4e65d61a"
-  integrity sha512-+DVYp3+m6tZUYTMl9fEgCZIDk9YBTcHws82nIV1JYwusu51zRITA0oeNzuPyFhuK7ageFnnKCDviH2BL5I4M0w==
+chromedriver@^90.0.1:
+  version "90.0.1"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-90.0.1.tgz#e322d9fcab28da124a25fd4469a8683b00f69e09"
+  integrity sha512-jvyhin0I/Bacxfet7eg29B1j+5mKR35XwWGbgcCOUALeE3mqcCKJY8xUW9cVrqVqTK9/iUOq8/kar7qrTVshPA==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.21.1"
     del "^6.0.0"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.0"
-    mkdirp "^1.0.4"
     proxy-from-env "^1.1.0"
     tcp-port-used "^1.0.1"
 


### PR DESCRIPTION
#minor

Should fix: https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=248670&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9

Edit: [_Does_ fix](https://fuselabs.visualstudio.com/86659c66-c9df-418a-a371-7de7aed35064/_build/results?buildId=248682)