### PR TITLE
fix: adjust adaptiveCard/action handling

### DIFF
--- a/libraries/botbuilder-core/tests/ActivityHandler.test.js
+++ b/libraries/botbuilder-core/tests/ActivityHandler.test.js
@@ -288,6 +288,22 @@ describe('ActivityHandler', function () {
         assert(onInstallationUpdateRemoveCalled);
     });
 
+    it(`should fire onAdaptiveCardInvoke`, async function () {
+        const bot = new ActivityHandler();
+
+        let onAdpativeCardInvokeCalled = false;
+        bot.onAdaptiveCardInvoke = async () => {
+            onAdpativeCardInvokeCalled = true;
+            return { statusCode: 200, value: 'called' };
+        };
+
+        await processActivity(
+            { type: ActivityTypes.Invoke, name: 'adaptiveCard/action', value: 'Action.Execute' },
+            bot
+        );
+        assert(onAdpativeCardInvokeCalled);
+    });
+
     it(`should fire onUnrecognizedActivityType`, async function () {
         const bot = new ActivityHandler();
 

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -133,9 +133,6 @@ export class TeamsActivityHandler extends ActivityHandler {
                             await this.handleTeamsTabSubmit(context, context.activity.value)
                         );
 
-                    case 'adaptiveCard/action':
-                        return ActivityHandler.createInvokeResponse(await this.handleAdaptiveCardAction(context));
-
                     default:
                         runEvents = false;
                         return super.onInvokeActivity(context);

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -192,13 +192,6 @@ export enum ActivityTypes {
 }
 
 // @public
-export interface AdaptiveCardAuthentication {
-    connectionName: string;
-    id: string;
-    token: string;
-}
-
-// @public
 export interface AdaptiveCardInvokeAction {
     data: Record<string, unknown>;
     id: string;
@@ -216,7 +209,7 @@ export interface AdaptiveCardInvokeResponse {
 // @public
 export interface AdaptiveCardInvokeValue {
     action: AdaptiveCardInvokeAction;
-    authentication: AdaptiveCardAuthentication;
+    authentication: TokenExchangeInvokeRequest;
     state: string;
 }
 

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -192,6 +192,10 @@ export enum ActivityTypes {
 }
 
 // @public
+export interface AdaptiveCardAuthentication extends TokenExchangeInvokeRequest {
+}
+
+// @public
 export interface AdaptiveCardInvokeAction {
     data: Record<string, unknown>;
     id: string;
@@ -209,7 +213,7 @@ export interface AdaptiveCardInvokeResponse {
 // @public
 export interface AdaptiveCardInvokeValue {
     action: AdaptiveCardInvokeAction;
-    authentication: TokenExchangeInvokeRequest;
+    authentication: AdaptiveCardAuthentication;
     state: string;
 }
 

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -2190,7 +2190,7 @@ export interface IStatusCodeError {
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface AdaptiveCardAuthentication extends TokenExchangeInvokeRequest {
-    // No-op. This class was accidentally created as a duplicate of TokenExchangeInvokeRequest but must remain for backwards-compatibility.
+    // No-op. This interface was accidentally created as a duplicate of TokenExchangeInvokeRequest but must remain for backwards-compatibility.
 }
 
 /**

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { Assertion, Nil, assert, Test } from 'botbuilder-stdlib';
+import { TokenExchangeInvokeRequest } from './tokenExchangeInvokeRequest';
 
 export * from './activityInterfaces';
 export * from './activityEx';
@@ -2184,25 +2185,6 @@ export interface IStatusCodeError {
 }
 
 /**
- * Defines the structure that arrives in the Activity.Value.Authentication for Invoke
- * activity with Name of 'adaptiveCard/action'.
- */
-export interface AdaptiveCardAuthentication {
-    /**
-     * The id of this adaptive card invoke action value's 'authentication'.
-     */
-    id: string;
-    /**
-     * The connection name of the adaptive card authentication.
-     */
-    connectionName: string;
-    /**
-     * The token of the adaptive card authentication.
-     */
-    token: string;
-}
-
-/**
  * Defines the structure that arrives in the Activity.Value.Action for Invoke
  * activity with Name of 'adaptiveCard/action'.
  */
@@ -2255,10 +2237,10 @@ export interface AdaptiveCardInvokeValue {
      */
     action: AdaptiveCardInvokeAction;
     /**
-     * The [AdaptiveCardAuthentication](xref:botframework-schema.AdaptiveCardAuthentication)
+     * The [TokenExchangeInvokeRequest](xref:botframework-schema.TokenExchangeInvokeRequest)
      * for this adaptive card invoke action value.
      */
-    authentication: AdaptiveCardAuthentication;
+    authentication: TokenExchangeInvokeRequest;
     /**
      * The 'state' or magic code for an OAuth flow.
      */

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -2185,6 +2185,15 @@ export interface IStatusCodeError {
 }
 
 /**
+ * Defines the structure that arrives in the Activity.Value.Authentication for Invoke
+ * activity with Name of 'adaptiveCard/action'.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface AdaptiveCardAuthentication extends TokenExchangeInvokeRequest {
+    // No-op. This class was accidentally created as a duplicate of TokenExchangeInvokeRequest but must remain for backwards-compatibility.
+}
+
+/**
  * Defines the structure that arrives in the Activity.Value.Action for Invoke
  * activity with Name of 'adaptiveCard/action'.
  */
@@ -2237,10 +2246,10 @@ export interface AdaptiveCardInvokeValue {
      */
     action: AdaptiveCardInvokeAction;
     /**
-     * The [TokenExchangeInvokeRequest](xref:botframework-schema.TokenExchangeInvokeRequest)
+     * The [AdaptiveCardAuthentication](xref:botframework-schema.AdaptiveCardAuthentication)
      * for this adaptive card invoke action value.
      */
-    authentication: TokenExchangeInvokeRequest;
+    authentication: AdaptiveCardAuthentication;
     /**
      * The 'state' or magic code for an OAuth flow.
      */


### PR DESCRIPTION
#minor

## Description
Per [the OBI](https://github.com/microsoft/botframework-obi/blob/jeffders/adaptiveCards2/protocols/botframework-protocol/botframework-action-execute.md#authentication-field), `AdaptiveCardInvokeValue.authentication` should actually be a `TokenExchangeInvokeRequest`, which has the same properties as `AdaptiveCardAuthentication`, which is now superfluous.

In working on this, I also noticed that [this PR](https://github.com/microsoft/botbuilder-js/pull/3716) was actually already covered.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Remove `AdaptiveCardAuthentication` and replace with `TokenExchangeInvokeRequest`
  - Revert [this PR](https://github.com/microsoft/botbuilder-js/pull/3716) (manually, because I didn't realize I should've just called `git revert` until I had already manually removed it.
  - Added tests