### PR TITLE
chore: remove unnecessary public access modifier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -123,6 +123,17 @@
       "rules": {
         "@typescript-eslint/no-var-requires": "off"
       }
-    }
+    },
+    {
+      "files": [
+        "libraries/botbuilder-ai*/**/*.ts",
+        "libraries/botbuilder-applicationinsights/**/*.ts",
+        "libraries/botbuilder-azure*/**/*.ts",
+        "libraries/botbuilder-dialogs-adaptive-runtime*/**/*.ts"
+      ],
+      "rules": {
+          "@typescript-eslint/explicit-member-accessibility": ["error", {"accessibility": "no-public"}]
+      }
+  }
   ]
 }

--- a/libraries/botbuilder-ai-orchestrator/src/orchestratorRecognizer.ts
+++ b/libraries/botbuilder-ai-orchestrator/src/orchestratorRecognizer.ts
@@ -66,55 +66,55 @@ interface Orchestrator {
  * Class that represents an adaptive Orchestrator recognizer.
  */
 export class OrchestratorRecognizer extends AdaptiveRecognizer implements OrchestratorRecognizerConfiguration {
-    public static $kind = 'Microsoft.OrchestratorRecognizer';
+    static $kind = 'Microsoft.OrchestratorRecognizer';
 
     /**
      * Path to Orchestrator base model folder.
      */
-    public modelFolder: StringExpression = new StringExpression('=settings.orchestrator.modelFolder');
+    modelFolder: StringExpression = new StringExpression('=settings.orchestrator.modelFolder');
 
     /**
      * Path to the snapshot (.blu file) to load.
      */
-    public snapshotFile: StringExpression = new StringExpression('=settings.orchestrator.snapshotFile');
+    snapshotFile: StringExpression = new StringExpression('=settings.orchestrator.snapshotFile');
 
     /**
      * Threshold value to use for ambiguous intent detection. Defaults to 0.05.
      * Recognizer returns ChooseIntent (disambiguation) if other intents are classified within this threshold of the top scoring intent.
      */
-    public disambiguationScoreThreshold: NumberExpression = new NumberExpression(0.05);
+    disambiguationScoreThreshold: NumberExpression = new NumberExpression(0.05);
 
     /**
      * Enable ambiguous intent detection. Defaults to false.
      */
-    public detectAmbiguousIntents: BoolExpression = new BoolExpression(false);
+    detectAmbiguousIntents: BoolExpression = new BoolExpression(false);
 
     /**
      * The external entity recognizer.
      */
-    public externalEntityRecognizer: Recognizer;
+    externalEntityRecognizer: Recognizer;
 
     /**
      * Enable entity detection if entity model exists inside modelFolder. Defaults to false.
      */
-    public scoreEntities = false;
+    scoreEntities = false;
 
     /**
      * Intent name if ambiguous intents are detected.
      */
-    public readonly chooseIntent = 'ChooseIntent';
+    readonly chooseIntent = 'ChooseIntent';
 
     /**
      * Full intent recognition results are available under this property
      */
-    public readonly resultProperty = 'result';
+    readonly resultProperty = 'result';
 
     /**
      * Full entity recognition results are available under this property
      */
-    public readonly entityProperty = 'entityResult';
+    readonly entityProperty = 'entityResult';
 
-    public getConverter(property: keyof OrchestratorRecognizerConfiguration): Converter | ConverterFactory {
+    getConverter(property: keyof OrchestratorRecognizerConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'modelFolder':
                 return new StringExpressionConverter();
@@ -142,7 +142,7 @@ export class OrchestratorRecognizer extends AdaptiveRecognizer implements Orches
      * @param {string} snapshotFile Path to snapshot.
      * @param {any} resolver Orchestrator resolver to use.
      */
-    public constructor(modelFolder?: string, snapshotFile?: string, resolver?: LabelResolver) {
+    constructor(modelFolder?: string, snapshotFile?: string, resolver?: LabelResolver) {
         super();
         if (modelFolder) {
             this._modelFolder = modelFolder;
@@ -162,7 +162,7 @@ export class OrchestratorRecognizer extends AdaptiveRecognizer implements Orches
      * @param {Record<string, number>} telemetryMetrics Additional metrics to be logged to telemetry with event.
      * @returns {Promise<RecognizerResult>} Recognized result.
      */
-    public async recognize(
+    async recognize(
         dc: DialogContext,
         activity: Partial<Activity>,
         telemetryProperties?: Record<string, string>,

--- a/libraries/botbuilder-ai/src/luisAdaptivePredictionOptions.ts
+++ b/libraries/botbuilder-ai/src/luisAdaptivePredictionOptions.ts
@@ -62,7 +62,7 @@ export interface LuisAdaptivePredictionOptionsConfiguration {
 
 export class LuisAdaptivePredictionOptionsConverter
     implements Converter<LuisAdaptivePredictionOptionsConfiguration, LuisAdaptivePredictionOptions> {
-    public convert(config: LuisAdaptivePredictionOptionsConfiguration): LuisAdaptivePredictionOptions {
+    convert(config: LuisAdaptivePredictionOptionsConfiguration): LuisAdaptivePredictionOptions {
         const options = Object.entries(config).reduce((options: LuisAdaptivePredictionOptions, [key, value]) => {
             switch (key) {
                 case 'includeAllIntents':

--- a/libraries/botbuilder-ai/src/luisAdaptiveRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisAdaptiveRecognizer.ts
@@ -55,17 +55,17 @@ export interface LuisAdaptiveRecognizerConfiguration extends RecognizerConfigura
  * Class that represents an adaptive LUIS recognizer.
  */
 export class LuisAdaptiveRecognizer extends Recognizer implements LuisAdaptiveRecognizerConfiguration {
-    public static $kind = 'Microsoft.LuisRecognizer';
+    static $kind = 'Microsoft.LuisRecognizer';
 
     /**
      * LUIS application ID.
      */
-    public applicationId: StringExpression;
+    applicationId: StringExpression;
 
     /**
      * LUIS application version.
      */
-    public version: StringExpression;
+    version: StringExpression;
 
     /**
      * LUIS endpoint to query.
@@ -73,12 +73,12 @@ export class LuisAdaptiveRecognizer extends Recognizer implements LuisAdaptiveRe
      * @summary
      * For example: "https://westus.api.cognitive.microsoft.com"
      */
-    public endpoint: StringExpression;
+    endpoint: StringExpression;
 
     /**
      * Key used to talk to a LUIS endpoint.
      */
-    public endpointKey: StringExpression;
+    endpointKey: StringExpression;
 
     /**
      * External entity recognizer.
@@ -86,26 +86,26 @@ export class LuisAdaptiveRecognizer extends Recognizer implements LuisAdaptiveRe
      * @summary
      * This recognizer is run before calling LUIS and the results are passed to LUIS.
      */
-    public externalEntityRecognizer: Recognizer;
+    externalEntityRecognizer: Recognizer;
 
     /**
      * LUIS dynamic list.
      */
-    public dynamicLists: ArrayExpression<DynamicList>;
+    dynamicLists: ArrayExpression<DynamicList>;
 
     /**
      * LUIS prediction options.
      */
-    public predictionOptions: LuisAdaptivePredictionOptions;
+    predictionOptions: LuisAdaptivePredictionOptions;
 
     /**
      * The flag to indicate in personal information should be logged in telemetry.
      */
-    public logPersonalInformation: BoolExpression = new BoolExpression(
+    logPersonalInformation: BoolExpression = new BoolExpression(
         '=settings.runtimeSettings.telemetry.logPersonalInformation'
     );
 
-    public getConverter(property: keyof LuisAdaptiveRecognizerConfiguration): Converter | ConverterFactory {
+    getConverter(property: keyof LuisAdaptiveRecognizerConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'applicationId':
             case 'version':
@@ -132,7 +132,7 @@ export class LuisAdaptiveRecognizer extends Recognizer implements LuisAdaptiveRe
      * @param {object} telemetryMetrics Optional. Additional metrics to be logged to telemetry with event.
      * @returns {Promise<RecognizerResult>} A promise resolving to the recognizer result.
      */
-    public async recognize(
+    async recognize(
         dialogContext: DialogContext,
         activity: Activity,
         telemetryProperties?: Record<string, string>,
@@ -175,7 +175,7 @@ export class LuisAdaptiveRecognizer extends Recognizer implements LuisAdaptiveRe
      * @param {DialogContext} dialogContext Current dialog context.
      * @returns {LuisRecognizerOptionsV3} luis recognizer options
      */
-    public recognizerOptions(dialogContext: DialogContext): LuisRecognizerOptionsV3 {
+    recognizerOptions(dialogContext: DialogContext): LuisRecognizerOptionsV3 {
         const options: LuisRecognizerOptionsV3 = {
             apiVersion: 'v3',
             externalEntityRecognizer: this.externalEntityRecognizer,

--- a/libraries/botbuilder-ai/src/luisComponentRegistration.ts
+++ b/libraries/botbuilder-ai/src/luisComponentRegistration.ts
@@ -31,7 +31,7 @@ export class LuisComponentRegistration extends ComponentRegistration {
      * @param _resourceExplorer resource explorer
      * @returns component registrations
      */
-    public getDeclarativeTypes(_resourceExplorer: unknown): ComponentDeclarativeTypes[] {
+    getDeclarativeTypes(_resourceExplorer: unknown): ComponentDeclarativeTypes[] {
         return this.services.mustMakeInstance<ComponentDeclarativeTypes[]>('declarativeTypes');
     }
 }

--- a/libraries/botbuilder-ai/src/luisRecognizer.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizer.ts
@@ -343,12 +343,12 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
     }
 
     // Gets a value indicating whether determines whether to log personal information that came from the user.
-    public get logPersonalInformation(): boolean {
+    get logPersonalInformation(): boolean {
         return this._logPersonalInformation;
     }
 
     // Gets the currently configured botTelemetryClient that logs the events.
-    public get telemetryClient(): BotTelemetryClient {
+    get telemetryClient(): BotTelemetryClient {
         return this._telemetryClient;
     }
 
@@ -360,7 +360,7 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
      * @param {number} minScore (Optional) minimum score needed for an intent to be considered as a top intent. If all intents in the set are below this threshold then the `defaultIntent` will be returned.  Defaults to a value of `0.0`.
      * @returns {string} the top intent
      */
-    public static topIntent(results?: RecognizerResult, defaultIntent = 'None', minScore = 0): string {
+    static topIntent(results?: RecognizerResult, defaultIntent = 'None', minScore = 0): string {
         const sortedIntents = this.sortedIntents(results, minScore);
         const topIntent = sortedIntents[0];
         return topIntent?.intent || defaultIntent; // Note: `||` is intentionally not `??` and is covered by tests
@@ -374,7 +374,7 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
      * @param {number} minScore minimum score threshold, lower score results will be filtered
      * @returns {Array<{intent: string; score: number}>} sorted result intents
      */
-    public static sortedIntents(result?: RecognizerResult, minScore = 0): Array<{ intent: string; score: number }> {
+    static sortedIntents(result?: RecognizerResult, minScore = 0): Array<{ intent: string; score: number }> {
         return Object.entries(result?.intents ?? {})
             .map(([intent, { score = 0 }]) => ({ intent, score }))
             .filter(({ score }) => score > minScore)
@@ -423,7 +423,7 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
      * @param {LuisRecognizerOptionsV2 | LuisRecognizerOptionsV3 | LuisPredictionOptions} options (Optional) options object used to override control predictions. Should conform to the [LuisRecognizerOptionsV2] or [LuisRecognizerOptionsV3] definition.
      * @returns {Promise<RecognizerResult>} A promise that resolved to the recognizer result.
      */
-    public async recognize(
+    async recognize(
         context: DialogContext | TurnContext,
         telemetryProperties?: Record<string, string>,
         telemetryMetrics?: Record<string, number>,
@@ -436,7 +436,7 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
      * @param {string} utterance The utterance to be recognized.
      * @param {LuisRecognizerOptionsV2 | LuisRecognizerOptionsV3 | LuisPredictionOptions} options (Optional) options object used to override control predictions. Should conform to the [LuisRecognizerOptionsV2] or [LuisRecognizerOptionsV3] definition.
      */
-    public async recognize(
+    async recognize(
         utterance: string,
         options?: LuisRecognizerOptionsV2 | LuisRecognizerOptionsV3 | LuisPredictionOptions
     ): Promise<RecognizerResult>;
@@ -444,7 +444,7 @@ export class LuisRecognizer implements LuisRecognizerTelemetryClient {
     /**
      * @internal
      */
-    public async recognize(
+    async recognize(
         contextOrUtterance: DialogContext | TurnContext | string,
         maybeTelemetryPropertiesOrOptions?:
             | Record<string, string>

--- a/libraries/botbuilder-ai/src/luisRecognizerOptionsV2.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizerOptionsV2.ts
@@ -71,7 +71,7 @@ export class LuisRecognizerV2 extends LuisRecognizerInternal {
         };
     }
 
-    public options: LuisRecognizerOptionsV2;
+    options: LuisRecognizerOptionsV2;
 
     private luisClient: LuisClient;
 

--- a/libraries/botbuilder-ai/src/luisRecognizerOptionsV3.ts
+++ b/libraries/botbuilder-ai/src/luisRecognizerOptionsV3.ts
@@ -62,7 +62,7 @@ export class LuisRecognizerV3 extends LuisRecognizerInternal {
         };
     }
 
-    public predictionOptions: LuisRecognizerOptionsV3;
+    predictionOptions: LuisRecognizerOptionsV3;
 
     /**
      * Calls LUIS to recognize intents and entities in a users utterance.

--- a/libraries/botbuilder-ai/src/luisTelemetryConstants.ts
+++ b/libraries/botbuilder-ai/src/luisTelemetryConstants.ts
@@ -9,16 +9,16 @@
  * The BotTelemetryClient event and property names that logged by default.
  */
 export class LuisTelemetryConstants {
-    public static readonly luisResultEvent = 'LuisResult'; // Event name
-    public static readonly applicationIdProperty = 'applicationId';
-    public static readonly intentProperty = 'intent';
-    public static readonly intentScoreProperty = 'intentScore';
-    public static readonly intent2Property = 'intent2';
-    public static readonly intentScore2Property = 'intentScore2';
-    public static readonly entitiesProperty = 'entities';
-    public static readonly questionProperty = 'question';
-    public static readonly activityIdProperty = 'activityId';
-    public static readonly sentimentLabelProperty = 'sentimentLabel';
-    public static readonly sentimentScoreProperty = 'sentimentScore';
-    public static readonly fromIdProperty = 'fromId';
+    static readonly luisResultEvent = 'LuisResult'; // Event name
+    static readonly applicationIdProperty = 'applicationId';
+    static readonly intentProperty = 'intent';
+    static readonly intentScoreProperty = 'intentScore';
+    static readonly intent2Property = 'intent2';
+    static readonly intentScore2Property = 'intentScore2';
+    static readonly entitiesProperty = 'entities';
+    static readonly questionProperty = 'question';
+    static readonly activityIdProperty = 'activityId';
+    static readonly sentimentLabelProperty = 'sentimentLabel';
+    static readonly sentimentScoreProperty = 'sentimentScore';
+    static readonly fromIdProperty = 'fromId';
 }

--- a/libraries/botbuilder-ai/src/qnaCardBuilder.ts
+++ b/libraries/botbuilder-ai/src/qnaCardBuilder.ts
@@ -20,7 +20,7 @@ export class QnACardBuilder {
      * @param {string} cardNoMatchText Text for button to be added to card to allow user to select 'no match'.
      * @returns {Partial<Activity>} Activity representing the suggestions as a card
      */
-    public static getSuggestionsCard(
+    static getSuggestionsCard(
         suggestionsList: string[],
         cardTitle: string,
         cardNoMatchText: string
@@ -65,7 +65,7 @@ export class QnACardBuilder {
      * @param {QnAMakerResult} result QnAMaker result containing the answer text and multi turn prompts to be displayed.
      * @returns {Partial<Activity>} Activity representing the prompts as a card
      */
-    public static getQnAPromptsCard(result: QnAMakerResult): Partial<Activity> {
+    static getQnAPromptsCard(result: QnAMakerResult): Partial<Activity> {
         if (!result) {
             throw new Error('Missing QnAMaker result');
         }

--- a/libraries/botbuilder-ai/src/qnaMaker.ts
+++ b/libraries/botbuilder-ai/src/qnaMaker.ts
@@ -178,12 +178,12 @@ export class QnAMaker implements QnAMakerClient, QnAMakerTelemetryClient {
     }
 
     // Gets a value indicating whether determines whether to log personal information that came from the user.
-    public get logPersonalInformation(): boolean {
+    get logPersonalInformation(): boolean {
         return this._logPersonalInformation;
     }
 
     // Gets the currently configured botTelemetryClient that logs the events.
-    public get telemetryClient(): BotTelemetryClient {
+    get telemetryClient(): BotTelemetryClient {
         return this._telemetryClient;
     }
 
@@ -202,7 +202,7 @@ export class QnAMaker implements QnAMakerClient, QnAMakerTelemetryClient {
      * @param {object} telemetryMetrics Additional metrics to be logged to telemetry with the QnaMessage event.
      * @returns {Promise<QnAMakerResult>} A promise resolving to the QnAMaker result
      */
-    public async getAnswers(
+    async getAnswers(
         context: TurnContext,
         options?: QnAMakerOptions,
         telemetryProperties?: { [key: string]: string },
@@ -230,7 +230,7 @@ export class QnAMaker implements QnAMakerClient, QnAMakerTelemetryClient {
      * @param {object} telemetryMetrics Optional. Additional metrics to be logged to telemetry with the QnaMessage event.
      * @returns {Promise<QnAMakerResults>} A list of answers for the user query, sorted in decreasing order of ranking score.
      */
-    public async getAnswersRaw(
+    async getAnswersRaw(
         context: TurnContext,
         options?: QnAMakerOptions,
         telemetryProperties?: { [key: string]: string },
@@ -287,7 +287,7 @@ export class QnAMaker implements QnAMakerClient, QnAMakerTelemetryClient {
      * @param {TurnContext} context Context for the current turn of conversation with the user.
      * @returns {Promise<boolean>} A promise resolving to true if an answer was sent
      */
-    public async answer(context: TurnContext): Promise<boolean> {
+    async answer(context: TurnContext): Promise<boolean> {
         if (!context) {
             throw new TypeError('QnAMaker.answer() requires a TurnContext.');
         }
@@ -320,7 +320,7 @@ export class QnAMaker implements QnAMakerClient, QnAMakerTelemetryClient {
      * @param {number} scoreThreshold (Optional) minimum answer score needed to be considered a match to questions. Defaults to a value of `0.001`.
      * @returns {Promise<QnAMakerResult[]>} A promise resolving to the QnAMaker results
      */
-    public async generateAnswer(
+    async generateAnswer(
         question: string | undefined,
         top?: number,
         scoreThreshold?: number
@@ -351,7 +351,7 @@ export class QnAMaker implements QnAMakerClient, QnAMakerTelemetryClient {
      * @param {QnAMakerResult[]} queryResult User query output.
      * @returns {QnAMakerResult[]} the filtered results
      */
-    public getLowScoreVariation(queryResult: QnAMakerResult[]): QnAMakerResult[] {
+    getLowScoreVariation(queryResult: QnAMakerResult[]): QnAMakerResult[] {
         return ActiveLearningUtils.getLowScoreVariation(queryResult);
     }
 
@@ -361,7 +361,7 @@ export class QnAMaker implements QnAMakerClient, QnAMakerTelemetryClient {
      * @param {FeedbackRecords} feedbackRecords Feedback records.
      * @returns {Promise<void>} A promise representing the async operation
      */
-    public callTrain(feedbackRecords: FeedbackRecords): Promise<void> {
+    callTrain(feedbackRecords: FeedbackRecords): Promise<void> {
         return this.trainUtils.callTrain(feedbackRecords);
     }
 

--- a/libraries/botbuilder-ai/src/qnaMakerComponentRegistration.ts
+++ b/libraries/botbuilder-ai/src/qnaMakerComponentRegistration.ts
@@ -31,7 +31,7 @@ export class QnAMakerComponentRegistration extends ComponentRegistration {
      * @param _resourceExplorer resource explorer
      * @returns component registrations
      */
-    public getDeclarativeTypes(_resourceExplorer: unknown): ComponentDeclarativeTypes[] {
+    getDeclarativeTypes(_resourceExplorer: unknown): ComponentDeclarativeTypes[] {
         return this.services.mustMakeInstance<ComponentDeclarativeTypes[]>('declarativeTypes');
     }
 }

--- a/libraries/botbuilder-ai/src/qnaMakerDialog.ts
+++ b/libraries/botbuilder-ai/src/qnaMakerDialog.ts
@@ -52,7 +52,7 @@ import { ActiveLearningUtils, BindToActivity } from './qnamaker-utils';
 
 class QnAMakerDialogActivityConverter
     implements Converter<string, TemplateInterface<Partial<Activity>, DialogStateManager>> {
-    public convert(
+    convert(
         value: string | TemplateInterface<Partial<Activity>, DialogStateManager>
     ): TemplateInterface<Partial<Activity>, DialogStateManager> {
         if (typeof value === 'string') {
@@ -137,7 +137,7 @@ const isSuggestionsFactory: Test<QnASuggestionsActivityFactory> = (val): val is 
  * The dialog will also present user with appropriate multi-turn prompt or active learning options.
  */
 export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogConfiguration {
-    public static $kind = 'Microsoft.QnAMakerDialog';
+    static $kind = 'Microsoft.QnAMakerDialog';
 
     // state and step value key constants
 
@@ -195,32 +195,32 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
     /**
      * Gets or sets the QnA Maker knowledge base ID to query.
      */
-    public knowledgeBaseId: StringExpression;
+    knowledgeBaseId: StringExpression;
 
     /**
      * Gets or sets the QnA Maker host URL for the knowledge base.
      */
-    public hostname: StringExpression;
+    hostname: StringExpression;
 
     /**
      * Gets or sets the QnA Maker endpoint key to use to query the knowledge base.
      */
-    public endpointKey: StringExpression;
+    endpointKey: StringExpression;
 
     /**
      * Gets or sets the threshold for answers returned, based on score.
      */
-    public threshold: NumberExpression = new NumberExpression(this.defaultThreshold);
+    threshold: NumberExpression = new NumberExpression(this.defaultThreshold);
 
     /**
      * Gets or sets the maximum number of answers to return from the knowledge base.
      */
-    public top: IntExpression = new IntExpression(this.defaultTopN);
+    top: IntExpression = new IntExpression(this.defaultTopN);
 
     /**
      * Gets or sets the template to send to the user when QnA Maker does not find an answer.
      */
-    public noAnswer: TemplateInterface<Partial<Activity>, DialogStateManager> = new BindToActivity(
+    noAnswer: TemplateInterface<Partial<Activity>, DialogStateManager> = new BindToActivity(
         MessageFactory.text(this.defaultNoAnswer)
     );
 
@@ -229,7 +229,7 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
      *
      * _Note: If suggestionsActivityFactory is passed in, this member is unused._
      */
-    public activeLearningCardTitle: StringExpression;
+    activeLearningCardTitle: StringExpression;
 
     /**
      * Gets or sets the button text to use with active learning options, allowing a user to
@@ -237,13 +237,13 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
      *
      * _Note: If suggestionsActivityFactory is passed in, this member is required._
      */
-    public cardNoMatchText: StringExpression;
+    cardNoMatchText: StringExpression;
 
     /**
      * Gets or sets the template to send to the user if they select the no match option on an
      * active learning card.
      */
-    public cardNoMatchResponse: TemplateInterface<Partial<Activity>, DialogStateManager> = new BindToActivity(
+    cardNoMatchResponse: TemplateInterface<Partial<Activity>, DialogStateManager> = new BindToActivity(
         MessageFactory.text(this.defaultCardNoMatchResponse)
     );
 
@@ -251,7 +251,7 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
      * Gets or sets the QnA Maker metadata with which to filter or boost queries to the knowledge base,
      * or null to apply none.
      */
-    public strictFilters: ArrayExpression<QnAMakerMetadata>;
+    strictFilters: ArrayExpression<QnAMakerMetadata>;
 
     /**
      * Gets or sets the flag to determine if personal information should be logged in telemetry.
@@ -260,17 +260,17 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
      * Defaults to a value of `=settings.telemetry.logPersonalInformation`, which retrieves
      * `logPersonalInformation` flag from settings.
      */
-    public logPersonalInformation = new BoolExpression('=settings.runtimeSettings.telemetry.logPersonalInformation');
+    logPersonalInformation = new BoolExpression('=settings.runtimeSettings.telemetry.logPersonalInformation');
 
     /**
      * Gets or sets a value indicating whether gets or sets environment of knowledgebase to be called.
      */
-    public isTest = false;
+    isTest = false;
 
     /**
      * Gets or sets the QnA Maker ranker type to use.
      */
-    public rankerType: EnumExpression<RankerTypes> = new EnumExpression(RankerTypes.default);
+    rankerType: EnumExpression<RankerTypes> = new EnumExpression(RankerTypes.default);
 
     // TODO: Add Expressions support
     private suggestionsActivityFactory?: QnASuggestionsActivityFactory;
@@ -293,7 +293,7 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
      * @param {string} dialogId (Optional) Id of the created dialog. Default is 'QnAMakerDialog'.
      * @param {string} strictFiltersJoinOperator join operator for strict filters
      */
-    public constructor(
+    constructor(
         knowledgeBaseId?: string,
         endpointKey?: string,
         hostname?: string,
@@ -324,7 +324,7 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
      * @param {string} dialogId (Optional) Id of the created dialog. Default is 'QnAMakerDialog'.
      * @param {string} strictFiltersJoinOperator join operator for strict filters
      */
-    public constructor(
+    constructor(
         knowledgeBaseId?: string,
         endpointKey?: string,
         hostname?: string,
@@ -407,7 +407,7 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
         this.addStep(this.displayQnAResult.bind(this));
     }
 
-    public getConverter(property: keyof QnAMakerDialogConfiguration): Converter | ConverterFactory {
+    getConverter(property: keyof QnAMakerDialogConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'knowledgeBaseId':
                 return new StringExpressionConverter();
@@ -454,7 +454,7 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
      * @returns {Promise<DialogTurnResult>} A promise resolving to the turn result
      */
     // eslint-disable-next-line @typescript-eslint/ban-types
-    public async beginDialog(dc: DialogContext, options?: object): Promise<DialogTurnResult> {
+    async beginDialog(dc: DialogContext, options?: object): Promise<DialogTurnResult> {
         if (!dc) {
             throw new Error('Missing DialogContext');
         }
@@ -482,7 +482,7 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
      * @param {DialogContext} dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
      * @returns {DialogContext} A Promise representing the asynchronous operation.
      */
-    public continueDialog(dc: DialogContext): Promise<DialogTurnResult> {
+    continueDialog(dc: DialogContext): Promise<DialogTurnResult> {
         const interrupted = dc.state.getValue<boolean>(TurnPath.interrupted, false);
         if (interrupted) {
             // if qnamaker was interrupted then end the qnamaker dialog

--- a/libraries/botbuilder-ai/src/qnaMakerRecognizer.ts
+++ b/libraries/botbuilder-ai/src/qnaMakerRecognizer.ts
@@ -57,77 +57,77 @@ export interface QnAMakerRecognizerConfiguration extends RecognizerConfiguration
  * A recognizer which uses QnAMaker KB to recognize intents.
  */
 export class QnAMakerRecognizer extends Recognizer implements QnAMakerRecognizerConfiguration {
-    public static $kind = 'Microsoft.QnAMakerRecognizer';
-    public static readonly qnaMatchIntent = 'QnAMatch';
+    static $kind = 'Microsoft.QnAMakerRecognizer';
+    static readonly qnaMatchIntent = 'QnAMatch';
 
     /**
      * Knowledgebase id of your QnA maker knowledgebase.
      */
-    public knowledgeBaseId: StringExpression;
+    knowledgeBaseId: StringExpression;
 
     /**
      * Host name of the QnA maker knowledgebase.
      */
-    public hostname: StringExpression;
+    hostname: StringExpression;
 
     /**
      * Endpoint key for the QnA service.
      */
-    public endpointKey: StringExpression;
+    endpointKey: StringExpression;
 
     /**
      * Number of results you want.
      */
-    public top: IntExpression = new IntExpression(3);
+    top: IntExpression = new IntExpression(3);
 
     /**
      * Threshold for the results.
      */
-    public threshold: NumberExpression = new NumberExpression(0.3);
+    threshold: NumberExpression = new NumberExpression(0.3);
 
     /**
      * A value indicating whether to call test or prod environment of knowledgebase.
      */
-    public isTest: boolean;
+    isTest: boolean;
 
     /**
      * Desired RankerType.
      */
-    public rankerType: StringExpression = new StringExpression(RankerTypes.default);
+    rankerType: StringExpression = new StringExpression(RankerTypes.default);
 
     /**
      * A value used for Join operation of Metadata.
      */
-    public strictFiltersJoinOperator: JoinOperator;
+    strictFiltersJoinOperator: JoinOperator;
 
     /**
      * Whether to include the dialog name metadata for QnA context.
      */
-    public includeDialogNameInMetadata: BoolExpression = new BoolExpression(true);
+    includeDialogNameInMetadata: BoolExpression = new BoolExpression(true);
 
     /**
      * An expression to evaluate to set additional metadata name value pairs.
      */
-    public metadata: ArrayExpression<QnAMakerMetadata>;
+    metadata: ArrayExpression<QnAMakerMetadata>;
 
     /**
      * An expression to evaluate to set the context.
      */
-    public context: ObjectExpression<QnARequestContext>;
+    context: ObjectExpression<QnARequestContext>;
 
     /**
      * An expression to evaluate to set QnAId parameter.
      */
-    public qnaId: IntExpression = new IntExpression(0);
+    qnaId: IntExpression = new IntExpression(0);
 
     /**
      * The flag to indicate if personal information should be logged in telemetry.
      */
-    public logPersonalInformation: BoolExpression = new BoolExpression(
+    logPersonalInformation: BoolExpression = new BoolExpression(
         '=settings.runtimeSettings.telemetry.logPersonalInformation'
     );
 
-    public getConverter(property: keyof QnAMakerRecognizerConfiguration): Converter | ConverterFactory {
+    getConverter(property: keyof QnAMakerRecognizerConfiguration): Converter | ConverterFactory {
         switch (property) {
             case 'knowledgeBaseId':
                 return new StringExpressionConverter();
@@ -163,7 +163,7 @@ export class QnAMakerRecognizer extends Recognizer implements QnAMakerRecognizer
      * @param {string} knowledgeBaseId Id of QnAMaker KB.
      * @param {string} endpointKey Endpoint key of QnAMaker KB.
      */
-    public constructor(hostname?: string, knowledgeBaseId?: string, endpointKey?: string) {
+    constructor(hostname?: string, knowledgeBaseId?: string, endpointKey?: string) {
         super();
         if (hostname) {
             this.hostname = new StringExpression(hostname);
@@ -185,7 +185,7 @@ export class QnAMakerRecognizer extends Recognizer implements QnAMakerRecognizer
      * @param {object} telemetryMetrics Additional metrics to be logged to telemetry.
      * @returns {Promise<RecognizerResult>} A promise resolving to the recognizer result
      */
-    public async recognize(
+    async recognize(
         dc: DialogContext,
         activity: Activity,
         telemetryProperties?: { [key: string]: string },

--- a/libraries/botbuilder-ai/src/qnaTelemetryConstants.ts
+++ b/libraries/botbuilder-ai/src/qnaTelemetryConstants.ts
@@ -5,15 +5,15 @@
  * The BotTelemetryClient event, property and metric names that logged by default.
  */
 export class QnATelemetryConstants {
-    public static readonly qnaMessageEvent: string = 'QnaMessage'; // Event name
-    public static readonly knowledgeBaseIdProperty: string = 'knowledgeBaseId';
-    public static readonly answerProperty: string = 'answer';
-    public static readonly articleFoundProperty: string = 'articleFound';
-    public static readonly channelIdProperty: string = 'channelId';
-    public static readonly conversationIdProperty: string = 'conversationId';
-    public static readonly questionProperty: string = 'question';
-    public static readonly matchedQuestionProperty: string = 'matchedQuestion';
-    public static readonly questionIdProperty: string = 'questionId';
-    public static readonly scoreMetric: string = 'score';
-    public static readonly usernameProperty: string = 'username';
+    static readonly qnaMessageEvent: string = 'QnaMessage'; // Event name
+    static readonly knowledgeBaseIdProperty: string = 'knowledgeBaseId';
+    static readonly answerProperty: string = 'answer';
+    static readonly articleFoundProperty: string = 'articleFound';
+    static readonly channelIdProperty: string = 'channelId';
+    static readonly conversationIdProperty: string = 'conversationId';
+    static readonly questionProperty: string = 'question';
+    static readonly matchedQuestionProperty: string = 'matchedQuestion';
+    static readonly questionIdProperty: string = 'questionId';
+    static readonly scoreMetric: string = 'score';
+    static readonly usernameProperty: string = 'username';
 }

--- a/libraries/botbuilder-ai/src/qnamaker-utils/activeLearningUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/activeLearningUtils.ts
@@ -22,10 +22,10 @@ const MaxLowScoreVariationMultiplier = 1.0;
  */
 export class ActiveLearningUtils {
     /** Minimum Score For Low Score Variation. */
-    public static MinimumScoreForLowScoreVariation = 20;
+    static MinimumScoreForLowScoreVariation = 20;
 
     /** Maximum Score For Low Score Variation. */
-    public static MaximumScoreForLowScoreVariation = 95.0;
+    static MaximumScoreForLowScoreVariation = 95.0;
 
     /**
      * Returns list of qnaSearch results which have low score variation.
@@ -33,7 +33,7 @@ export class ActiveLearningUtils {
      * @param {QnAMakerResult[]} qnaSearchResults A list of results returned from the QnA getAnswer call.
      * @returns {QnAMakerResult[]} List of filtered qnaSearch results.
      */
-    public static getLowScoreVariation(qnaSearchResults: QnAMakerResult[]): QnAMakerResult[] {
+    static getLowScoreVariation(qnaSearchResults: QnAMakerResult[]): QnAMakerResult[] {
         if (qnaSearchResults == null || qnaSearchResults.length == 0) {
             return [];
         }

--- a/libraries/botbuilder-ai/src/qnamaker-utils/bindToActivity.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/bindToActivity.ts
@@ -10,14 +10,11 @@ import { Activity } from 'botbuilder-core';
 import { DialogContext, TemplateInterface } from 'botbuilder-dialogs';
 
 export class BindToActivity implements TemplateInterface<Partial<Activity>> {
-    private _activity: Partial<Activity>;
-
-    public constructor(activity: Partial<Activity>) {
-        this._activity = activity;
+    constructor(private readonly activity: Partial<Activity>) {
     }
 
     // eslint-disable-next-line @typescript-eslint/ban-types
-    public async bind(_context: DialogContext, _data?: object): Promise<Partial<Activity>> {
-        return this._activity;
+    async bind(_context: DialogContext, _data?: object): Promise<Partial<Activity>> {
+        return this.activity;
     }
 }

--- a/libraries/botbuilder-ai/src/qnamaker-utils/bindToActivity.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/bindToActivity.ts
@@ -10,8 +10,7 @@ import { Activity } from 'botbuilder-core';
 import { DialogContext, TemplateInterface } from 'botbuilder-dialogs';
 
 export class BindToActivity implements TemplateInterface<Partial<Activity>> {
-    constructor(private readonly activity: Partial<Activity>) {
-    }
+    constructor(private readonly activity: Partial<Activity>) {}
 
     // eslint-disable-next-line @typescript-eslint/ban-types
     async bind(_context: DialogContext, _data?: object): Promise<Partial<Activity>> {

--- a/libraries/botbuilder-ai/src/qnamaker-utils/generateAnswerUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/generateAnswerUtils.ts
@@ -47,7 +47,7 @@ export class GenerateAnswerUtils {
      * @param {QnAMakerOptions} options (Optional) The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.
      * @returns {Promise<QnAMakerResult[]>} a promise that resolves to the query results
      */
-    public async queryQnaService(
+    async queryQnaService(
         endpoint: QnAMakerEndpoint,
         question: string,
         options?: QnAMakerOptions
@@ -65,7 +65,7 @@ export class GenerateAnswerUtils {
      * @param {QnAMakerOptions} options (Optional) The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.
      * @returns {Promise<QnAMakerResult[]>} a promise that resolves to the raw query results
      */
-    public async queryQnaServiceRaw(
+    async queryQnaServiceRaw(
         endpoint: QnAMakerEndpoint,
         question: string,
         options?: QnAMakerOptions
@@ -104,7 +104,7 @@ export class GenerateAnswerUtils {
      * @param {QnAMakerOptions} queryOptions (Optional) The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.
      * @returns {Promise<any>} a promise representing the async operation
      */
-    public async emitTraceInfo(
+    async emitTraceInfo(
         turnContext: TurnContext,
         answers: QnAMakerResult[],
         queryOptions?: QnAMakerOptions
@@ -139,7 +139,7 @@ export class GenerateAnswerUtils {
      *
      * @param {QnAMakerOptions} options The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.
      */
-    public validateOptions(options: QnAMakerOptions): void {
+    validateOptions(options: QnAMakerOptions): void {
         const { scoreThreshold, top } = options;
 
         if (scoreThreshold) {
@@ -159,7 +159,7 @@ export class GenerateAnswerUtils {
      * @param {QnAMakerOptions} queryOptions (Optional) The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.
      * @returns {QnAMakerResult[]} the sorted and filtered results
      */
-    public static sortAnswersWithinThreshold(
+    static sortAnswersWithinThreshold(
         answers: QnAMakerResult[] = [] as QnAMakerResult[],
         queryOptions: QnAMakerOptions
     ): QnAMakerResult[] {

--- a/libraries/botbuilder-ai/src/qnamaker-utils/httpRequestUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/httpRequestUtils.ts
@@ -33,7 +33,7 @@ export class HttpRequestUtils {
      * @param {number} timeout (Optional)Timeout for http call
      * @returns {QnAMakerResults} a promise that resolves to the QnAMakerResults
      */
-    public async executeHttpRequest(
+    async executeHttpRequest(
         requestUrl: string,
         payloadBody: string,
         endpoint: QnAMakerEndpoint,

--- a/libraries/botbuilder-ai/src/qnamaker-utils/trainUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/trainUtils.ts
@@ -33,7 +33,7 @@ export class TrainUtils {
      *
      * @param {FeedbackRecords} feedbackRecords Feedback record list.
      */
-    public async callTrain(feedbackRecords: FeedbackRecords): Promise<void> {
+    async callTrain(feedbackRecords: FeedbackRecords): Promise<void> {
         if (!feedbackRecords) {
             throw new TypeError('Feedback records can not be null.');
         }

--- a/libraries/botbuilder-applicationinsights/src/applicationInsightsTelemetryClient.ts
+++ b/libraries/botbuilder-applicationinsights/src/applicationInsightsTelemetryClient.ts
@@ -144,7 +144,7 @@ export class ApplicationInsightsTelemetryClient implements BotTelemetryClient, B
      *
      * @param telemetry The [TelemetryDependency](xref:botbuilder-core.TelemetryDependency) to track.
      */
-    public trackDependency(telemetry: TelemetryDependency): void {
+    trackDependency(telemetry: TelemetryDependency): void {
         this.defaultClient.trackDependency(telemetry);
     }
 
@@ -153,7 +153,7 @@ export class ApplicationInsightsTelemetryClient implements BotTelemetryClient, B
      *
      * @param telemetry The [TelemetryEvent](xref:botbuilder-core.TelemetryEvent) to track.
      */
-    public trackEvent(telemetry: TelemetryEvent): void {
+    trackEvent(telemetry: TelemetryEvent): void {
         const { name, properties, metrics: measurements } = telemetry;
         this.defaultClient.trackEvent({ name, properties, measurements });
     }
@@ -163,7 +163,7 @@ export class ApplicationInsightsTelemetryClient implements BotTelemetryClient, B
      *
      * @param telemetry The [TelemetryException](xref:botbuilder-core.TelemetryException) to track.
      */
-    public trackException(telemetry: TelemetryException): void {
+    trackException(telemetry: TelemetryException): void {
         this.defaultClient.trackException(telemetry);
     }
 
@@ -172,7 +172,7 @@ export class ApplicationInsightsTelemetryClient implements BotTelemetryClient, B
      *
      * @param telemetry The [TelemetryTrace](xref:botbuilder-core.TelemetryTrace) to track.
      */
-    public trackTrace(telemetry: TelemetryTrace): void {
+    trackTrace(telemetry: TelemetryTrace): void {
         this.defaultClient.trackTrace(telemetry);
     }
 
@@ -181,14 +181,14 @@ export class ApplicationInsightsTelemetryClient implements BotTelemetryClient, B
      *
      * @param telemetry The [TelemetryPageView](xref:botbuilder-core.TelemetryPageView) to track.
      */
-    public trackPageView(telemetry: TelemetryPageView): void {
+    trackPageView(telemetry: TelemetryPageView): void {
         this.defaultClient.trackPageView(telemetry);
     }
 
     /**
      * Flushes the in-memory buffer and any metrics being pre-aggregated.
      */
-    public flush(): void {
+    flush(): void {
         this.defaultClient.flush();
     }
 }

--- a/libraries/botbuilder-applicationinsights/src/telemetryInitializerMiddleware.ts
+++ b/libraries/botbuilder-applicationinsights/src/telemetryInitializerMiddleware.ts
@@ -32,7 +32,7 @@ export class TelemetryInitializerMiddleware implements Middleware {
      *
      * @returns whether or not to log activity telemetry
      */
-    public get logActivityTelemetry(): boolean {
+    get logActivityTelemetry(): boolean {
         return this._logActivityTelemetry;
     }
 
@@ -41,7 +41,7 @@ export class TelemetryInitializerMiddleware implements Middleware {
      *
      * @returns telemetry logger middleware
      */
-    public get telemetryClient(): TelemetryLoggerMiddleware {
+    get telemetryClient(): TelemetryLoggerMiddleware {
         return this._telemetryLoggerMiddleware;
     }
 
@@ -67,7 +67,7 @@ export class TelemetryInitializerMiddleware implements Middleware {
      * @param context The context object for this turn.
      * @param next The delegate to call to continue the bot middleware pipeline
      */
-    public async onTurn(context: TurnContext, next: () => Promise<void>): Promise<void> {
+    async onTurn(context: TurnContext, next: () => Promise<void>): Promise<void> {
         if (context === null) {
             throw new Error('context is null');
         }

--- a/libraries/botbuilder-azure-queues/src/azureQueueStorage.ts
+++ b/libraries/botbuilder-azure-queues/src/azureQueueStorage.ts
@@ -17,7 +17,7 @@ export class AzureQueueStorage extends QueueStorage {
      * @param {string} queuesStorageConnectionString Azure storage connection string.
      * @param {string} queueName Name of the storage queue where entities will be queued.
      */
-    public constructor(queuesStorageConnectionString: string, queueName: string) {
+    constructor(queuesStorageConnectionString: string, queueName: string) {
         super();
         if (!queuesStorageConnectionString) {
             throw new Error(`queuesStorageConnectionString cannot be empty`);
@@ -39,7 +39,7 @@ export class AzureQueueStorage extends QueueStorage {
      * @param {number} messageTimeToLive Specifies the time-to-live interval for the message.
      * @returns {Promise<string>} [QueueSendMessageResponse](xref:@azure/storage-queue.QueueSendMessageResponse) as a JSON string.
      */
-    public async queueActivity(
+    async queueActivity(
         activity: Partial<Activity>,
         visibilityTimeout?: number,
         messageTimeToLive?: number

--- a/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
+++ b/libraries/botbuilder-azure/src/azureBlobTranscriptStore.ts
@@ -45,7 +45,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
      *
      * @param settings Settings required for configuring an instance of BlobStorage
      */
-    public constructor(settings: BlobStorageSettings) {
+    constructor(settings: BlobStorageSettings) {
         if (!settings) {
             throw new Error('The settings parameter is required.');
         }
@@ -67,7 +67,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
      *
      * @param activity Activity being logged.
      */
-    public async logActivity(activity: Activity): Promise<void> {
+    async logActivity(activity: Activity): Promise<void> {
         if (!activity) {
             throw new Error('Missing activity.');
         }
@@ -98,7 +98,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
      * @param continuationToken Continuation token to page through results.
      * @param startDate Earliest time to include.
      */
-    public async getTranscriptActivities(
+    async getTranscriptActivities(
         channelId: string,
         conversationId: string,
         continuationToken?: string,
@@ -144,7 +144,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
      * @param channelId Channel Id.
      * @param continuationToken ContinuationToken token to page through results.
      */
-    public async listTranscripts(channelId: string, continuationToken?: string): Promise<PagedResult<TranscriptInfo>> {
+    async listTranscripts(channelId: string, continuationToken?: string): Promise<PagedResult<TranscriptInfo>> {
         if (!channelId) {
             throw new Error('Missing channelId');
         }
@@ -177,7 +177,7 @@ export class AzureBlobTranscriptStore implements TranscriptStore {
      * @param channelId Channel Id where conversation took place.
      * @param conversationId Id of the conversation to delete.
      */
-    public async deleteTranscript(channelId: string, conversationId: string): Promise<void> {
+    async deleteTranscript(channelId: string, conversationId: string): Promise<void> {
         if (!channelId) {
             throw new Error('Missing channelId');
         }

--- a/libraries/botbuilder-azure/src/blobStorage.ts
+++ b/libraries/botbuilder-azure/src/blobStorage.ts
@@ -116,7 +116,7 @@ export class BlobStorage implements Storage {
      *
      * @param settings Settings for configuring an instance of BlobStorage.
      */
-    public constructor(settings: BlobStorageSettings) {
+    constructor(settings: BlobStorageSettings) {
         if (!settings) {
             throw new Error('The settings parameter is required.');
         }
@@ -144,7 +144,7 @@ export class BlobStorage implements Storage {
      * @param keys An array of entity keys.
      * @returns The read items.
      */
-    public read(keys: string[]): Promise<StoreItems> {
+    read(keys: string[]): Promise<StoreItems> {
         if (!keys) {
             throw new Error('Please provide at least one key to read from storage.');
         }
@@ -205,7 +205,7 @@ export class BlobStorage implements Storage {
      *
      * @param changes The changes to write to storage.
      */
-    public write(changes: StoreItems): Promise<void> {
+    write(changes: StoreItems): Promise<void> {
         if (!changes) {
             throw new Error('Please provide a StoreItems with changes to persist.');
         }
@@ -269,7 +269,7 @@ export class BlobStorage implements Storage {
      *
      * @param keys An array of entity keys.
      */
-    public delete(keys: string[]): Promise<void> {
+    delete(keys: string[]): Promise<void> {
         if (!keys) {
             throw new Error('Please provide at least one key to delete from storage.');
         }

--- a/libraries/botbuilder-azure/src/cosmosDbPartitionedStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbPartitionedStorage.ts
@@ -73,42 +73,42 @@ class DocumentStoreItem {
      *
      * @returns {string} the partition key path
      */
-    public static get partitionKeyPath(): string {
+    static get partitionKeyPath(): string {
         return '/id';
     }
 
     /**
      * Gets or sets the sanitized Id/Key used as PrimaryKey.
      */
-    public id: string;
+    id: string;
 
     /**
      * Gets or sets the un-sanitized Id/Key.
      *
      */
-    public realId: string;
+    realId: string;
 
     /**
      * Gets or sets the persisted object.
      */
-    public document: object;
+    document: object;
 
     /**
      * Gets or sets the ETag information for handling optimistic concurrency updates.
      */
-    public eTag: string;
+    eTag: string;
 
     /**
      * Gets the PartitionKey value for the document.
      *
      * @returns {string} the partition key
      */
-    public get partitionKey(): string {
+    get partitionKey(): string {
         return this.id;
     }
 
     // We can't make the partitionKey optional AND have it auto-get this.realId, so we'll use a constructor
-    public constructor(storeItem: { id: string; realId: string; document: object; eTag?: string }) {
+    constructor(storeItem: { id: string; realId: string; document: object; eTag?: string }) {
         this.id = storeItem.id;
         this.realId = storeItem.realId;
         this.document = storeItem.document;
@@ -130,7 +130,7 @@ export class CosmosDbPartitionedStorage implements Storage {
      *
      * @param {CosmosDbPartitionedStorageOptions} cosmosDbStorageOptions Cosmos DB partitioned storage configuration options.
      */
-    public constructor(private readonly cosmosDbStorageOptions: CosmosDbPartitionedStorageOptions) {
+    constructor(private readonly cosmosDbStorageOptions: CosmosDbPartitionedStorageOptions) {
         if (!cosmosDbStorageOptions) {
             throw new ReferenceError('CosmosDbPartitionedStorageOptions is required.');
         }
@@ -178,7 +178,7 @@ export class CosmosDbPartitionedStorage implements Storage {
      * @param {string[]} keys A collection of Ids for each item to be retrieved.
      * @returns {Promise<StoreItems>} The read items.
      */
-    public async read(keys: string[]): Promise<StoreItems> {
+    async read(keys: string[]): Promise<StoreItems> {
         if (!keys) {
             throw new ReferenceError(`Keys are required when reading.`);
         } else if (keys.length === 0) {
@@ -237,7 +237,7 @@ export class CosmosDbPartitionedStorage implements Storage {
      *
      * @param {StoreItems} changes Dictionary of items to be inserted or updated indexed by key.
      */
-    public async write(changes: StoreItems): Promise<void> {
+    async write(changes: StoreItems): Promise<void> {
         if (!changes) {
             throw new ReferenceError(`Changes are required when writing.`);
         } else if (changes.length === 0) {
@@ -287,7 +287,7 @@ export class CosmosDbPartitionedStorage implements Storage {
      *
      * @param {string[]} keys Array of Ids for the items to be deleted.
      */
-    public async delete(keys: string[]): Promise<void> {
+    async delete(keys: string[]): Promise<void> {
         await this.initialize();
 
         await Promise.all(
@@ -316,7 +316,7 @@ export class CosmosDbPartitionedStorage implements Storage {
     /**
      * Connects to the CosmosDB database and creates / gets the container.
      */
-    public async initialize(): Promise<void> {
+    async initialize(): Promise<void> {
         if (!this.container) {
             if (!this.client) {
                 this.client = new CosmosClient({

--- a/libraries/botbuilder-azure/src/cosmosDbStorage.ts
+++ b/libraries/botbuilder-azure/src/cosmosDbStorage.ts
@@ -101,7 +101,7 @@ export class CosmosDbStorage implements Storage {
      * @param settings Setting to configure the provider.
      * @param connectionPolicyConfigurator (Optional) An optional delegate that accepts a ConnectionPolicy for customizing policies. More information at http://azure.github.io/azure-documentdb-node/global.html#ConnectionPolicy
      */
-    public constructor(
+    constructor(
         settings: CosmosDbStorageSettings,
         connectionPolicyConfigurator: (policy: ConnectionPolicy) => void = null
     ) {
@@ -153,7 +153,7 @@ export class CosmosDbStorage implements Storage {
      * @param keys Keys of the items to read from the store.
      * @returns The read items.
      */
-    public read(keys: string[]): Promise<StoreItems> {
+    read(keys: string[]): Promise<StoreItems> {
         if (!keys || keys.length === 0) {
             // No keys passed in, no result to return.
             return Promise.resolve({});
@@ -224,7 +224,7 @@ export class CosmosDbStorage implements Storage {
      *
      * @param changes Items to write to storage, indexed by key.
      */
-    public write(changes: StoreItems): Promise<void> {
+    write(changes: StoreItems): Promise<void> {
         if (!changes || Object.keys(changes).length === 0) {
             return Promise.resolve();
         }
@@ -285,7 +285,7 @@ export class CosmosDbStorage implements Storage {
      *
      * @param keys Keys of the items to remove from the store.
      */
-    public delete(keys: string[]): Promise<void> {
+    delete(keys: string[]): Promise<void> {
         if (!keys || keys.length === 0) {
             return Promise.resolve();
         }

--- a/libraries/botbuilder-azure/src/doOnce.ts
+++ b/libraries/botbuilder-azure/src/doOnce.ts
@@ -20,7 +20,7 @@ export class DoOnce<T> {
      * @param key Key of the task.
      * @param fn Function to perform.
      */
-    public waitFor(key: string, fn: () => Promise<T>): Promise<T> {
+    waitFor(key: string, fn: () => Promise<T>): Promise<T> {
         if (!this.task[key]) {
             this.task[key] = fn();
         }


### PR DESCRIPTION
Part 1 of #3518
#minor

## Description:
Removed `public` access modifier from following packages:
- botbuilder-ai-orchestrator
- botbuilder-ai
- botbuilder-applicationinsights
- botbuilder-azure-queues
- botbuilder-azure