### PR TITLE
feat: add getMeetingInfo to TeamsInfo

### DIFF
--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -368,7 +368,7 @@ export function teamsGetTenant(activity: Activity): TenantInfo | null;
 
 // @public
 export class TeamsInfo {
-    static getMeetingDetails(context: TurnContext, meetingId?: string): Promise<TeamsMeetingInfo>;
+    static getMeetingInfo(context: TurnContext, meetingId?: string): Promise<TeamsMeetingInfo>;
     static getMeetingParticipant(context: TurnContext, meetingId?: string, participantId?: string, tenantId?: string): Promise<TeamsMeetingParticipant>;
     static getMember(context: TurnContext, userId: string): Promise<TeamsChannelAccount>;
     static getMembers(context: TurnContext): Promise<TeamsChannelAccount[]>;

--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -368,6 +368,7 @@ export function teamsGetTenant(activity: Activity): TenantInfo | null;
 
 // @public
 export class TeamsInfo {
+    static getMeetingDetails(context: TurnContext, meetingId?: string): Promise<TeamsMeetingInfo>;
     static getMeetingParticipant(context: TurnContext, meetingId?: string, participantId?: string, tenantId?: string): Promise<TeamsMeetingParticipant>;
     static getMember(context: TurnContext, userId: string): Promise<TeamsChannelAccount>;
     static getMembers(context: TurnContext): Promise<TeamsChannelAccount[]>;

--- a/libraries/botbuilder/src/teamsInfo.ts
+++ b/libraries/botbuilder/src/teamsInfo.ts
@@ -83,12 +83,12 @@ export class TeamsInfo {
     }
 
     /**
-     * Gets the details for the given meeting id.
+     * Gets the information for the given meeting id.
      * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * @param meetingId The BASE64-encoded id of the Teams meeting.
      * @returns The [TeamsMeetingInfo](xref:botbuilder-core.TeamsMeetingInfo) fetched
      */
-    public static async getMeetingDetails(context: TurnContext, meetingId?: string): Promise<TeamsMeetingInfo> {
+    public static async getMeetingInfo(context: TurnContext, meetingId?: string): Promise<TeamsMeetingInfo> {
         if (!context) {
             throw new Error('context is required.');
         }
@@ -104,7 +104,7 @@ export class TeamsInfo {
             throw new Error('meetingId is required.');
         }
 
-        return this.getTeamsConnectorClient(context).teams.fetchMeetingDetails(meetingId);
+        return this.getTeamsConnectorClient(context).teams.fetchMeetingInfo(meetingId);
     }
 
     /**

--- a/libraries/botbuilder/src/teamsInfo.ts
+++ b/libraries/botbuilder/src/teamsInfo.ts
@@ -54,7 +54,7 @@ export class TeamsInfo {
 
         if (meetingId == null) {
             const meeting = teamsGetTeamMeetingInfo(activity);
-            meetingId = meeting ? meeting.id : undefined;
+            meetingId = meeting?.id;
         }
 
         if (!meetingId) {
@@ -63,7 +63,7 @@ export class TeamsInfo {
 
         if (participantId == null) {
             const from = activity.from;
-            participantId = from ? from.aadObjectId : undefined;
+            participantId = from?.aadObjectId;
         }
 
         if (!participantId) {
@@ -74,7 +74,7 @@ export class TeamsInfo {
         // wants to disable defaulting of tenant ID they can pass `null`.
         if (tenantId === undefined) {
             const tenant = teamsGetTenant(activity);
-            tenantId = tenant ? tenant.id : undefined;
+            tenantId = tenant?.id;
         }
 
         return this.getTeamsConnectorClient(context).teams.fetchMeetingParticipant(meetingId, participantId, {
@@ -97,11 +97,11 @@ export class TeamsInfo {
 
         if (meetingId == null) {
             const meeting = teamsGetTeamMeetingInfo(activity);
-            meetingId = meeting ? meeting.id : undefined;
+            meetingId = meeting?.id;
         }
 
         if (!meetingId) {
-            throw new Error('meetingId is required.');
+            throw new Error('meetingId or TurnContext containing meetingId is required.');
         }
 
         return this.getTeamsConnectorClient(context).teams.fetchMeetingInfo(meetingId);

--- a/libraries/botbuilder/src/teamsInfo.ts
+++ b/libraries/botbuilder/src/teamsInfo.ts
@@ -20,6 +20,7 @@ import {
     ConversationParameters,
     ConversationReference,
     TeamsMeetingParticipant,
+    TeamsMeetingInfo,
 } from 'botbuilder-core';
 import { ConnectorClient, TeamsConnectorClient, TeamsConnectorModels } from 'botframework-connector';
 
@@ -79,6 +80,31 @@ export class TeamsInfo {
         return this.getTeamsConnectorClient(context).teams.fetchMeetingParticipant(meetingId, participantId, {
             tenantId,
         });
+    }
+
+    /**
+     * Gets the details for the given meeting id.
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
+     * @param meetingId The BASE64-encoded id of the Teams meeting.
+     * @returns The [TeamsMeetingInfo](xref:botbuilder-core.TeamsMeetingInfo) fetched
+     */
+    public static async getMeetingDetails(context: TurnContext, meetingId?: string): Promise<TeamsMeetingInfo> {
+        if (!context) {
+            throw new Error('context is required.');
+        }
+
+        const activity = context.activity;
+
+        if (meetingId == null) {
+            const meeting = teamsGetTeamMeetingInfo(activity);
+            meetingId = meeting ? meeting.id : undefined;
+        }
+
+        if (!meetingId) {
+            throw new Error('meetingId is required.');
+        }
+
+        return this.getTeamsConnectorClient(context).teams.fetchMeetingDetails(meetingId);
     }
 
     /**

--- a/libraries/botbuilder/tests/teamsInfo.test.js
+++ b/libraries/botbuilder/tests/teamsInfo.test.js
@@ -661,7 +661,7 @@ describe('TeamsInfo', function () {
         });
     });
 
-    describe('getMeetingDetails', function () {
+    describe('getMeetingInfo', function () {
         const context = new TestContext(teamActivity);
 
         it('should work with correct arguments-meetingId in context', async function () {
@@ -697,7 +697,7 @@ describe('TeamsInfo', function () {
                 .matchHeader('Authorization', expectedAuthHeader)
                 .reply(200, details);
 
-            const fetchedDetails = await TeamsInfo.getMeetingDetails(context);
+            const fetchedDetails = await TeamsInfo.getMeetingInfo(context);
 
             assert(fetchOauthToken.isDone());
             assert(fetchExpectation.isDone());
@@ -738,7 +738,7 @@ describe('TeamsInfo', function () {
                 .matchHeader('Authorization', expectedAuthHeader)
                 .reply(200, details);
 
-            const fetchedDetails = await TeamsInfo.getMeetingDetails(context, details.details.id);
+            const fetchedDetails = await TeamsInfo.getMeetingInfo(context, details.details.id);
 
             assert(fetchOauthToken.isDone());
             assert(fetchExpectation.isDone());
@@ -747,7 +747,7 @@ describe('TeamsInfo', function () {
         });
 
         it('should throw error for missing context', async function () {
-            await assert.rejects(TeamsInfo.getMeetingDetails(), Error('context is required.'));
+            await assert.rejects(TeamsInfo.getMeetingInfo(), Error('context is required.'));
         });
     });
 

--- a/libraries/botbuilder/tests/teamsInfo.test.js
+++ b/libraries/botbuilder/tests/teamsInfo.test.js
@@ -661,6 +661,96 @@ describe('TeamsInfo', function () {
         });
     });
 
+    describe('getMeetingDetails', function () {
+        const context = new TestContext(teamActivity);
+
+        it('should work with correct arguments-meetingId in context', async function () {
+            const details = {
+                organizer: {
+                    id: teamActivity.from.id,
+                    name: teamActivity.from.name,
+                    objectId: 'User-One-Object-Id',
+                    givenName: 'User',
+                    surname: 'One',
+                    email: 'User.One@microsoft.com',
+                    userPrincipalName: 'user1@microsoft.com',
+                    tenantId: teamActivity.conversation.tenantId,
+                },
+                details: {
+                    id: 'meeting-id',
+                    msGraphResourceId: 'msGraph-id',
+                    scheduledStartTime: new Date('Thu Jun 10 2021 15:02:32 GMT-0700'),
+                    scheduledEndTime: new Date('Thu Jun 10 2021 16:02:32 GMT-0700'),
+                    joinUrl: 'https://teams.microsoft.com/l/meetup-join/someEncodedMeetingString',
+                    title: 'Fake meeting',
+                    type: 'Scheduled',
+                },
+                conversation: {
+                    id: teamActivity.conversation.id,
+                },
+            };
+
+            const { expectedAuthHeader, expectation: fetchOauthToken } = nockOauth();
+
+            const fetchExpectation = nock('https://smba.trafficmanager.net/amer')
+                .get('/v1/meetings/19%3AmeetingId')
+                .matchHeader('Authorization', expectedAuthHeader)
+                .reply(200, details);
+
+            const fetchedDetails = await TeamsInfo.getMeetingDetails(context);
+
+            assert(fetchOauthToken.isDone());
+            assert(fetchExpectation.isDone());
+
+            assert.deepStrictEqual(fetchedDetails, details);
+        });
+
+        it('should work with correct arguments-meetingId passed in', async function () {
+            const details = {
+                organizer: {
+                    id: teamActivity.from.id,
+                    name: teamActivity.from.name,
+                    objectId: 'User-One-Object-Id',
+                    givenName: 'User',
+                    surname: 'One',
+                    email: 'User.One@microsoft.com',
+                    userPrincipalName: 'user1@microsoft.com',
+                    tenantId: teamActivity.conversation.tenantId,
+                },
+                details: {
+                    id: 'meeting-id',
+                    msGraphResourceId: 'msGraph-id',
+                    scheduledStartTime: new Date('Thu Jun 10 2021 15:02:32 GMT-0700'),
+                    scheduledEndTime: new Date('Thu Jun 10 2021 16:02:32 GMT-0700'),
+                    joinUrl: 'https://teams.microsoft.com/l/meetup-join/someEncodedMeetingString',
+                    title: 'Fake meeting',
+                    type: 'Scheduled',
+                },
+                conversation: {
+                    id: teamActivity.conversation.id,
+                },
+            };
+
+            const { expectedAuthHeader, expectation: fetchOauthToken } = nockOauth();
+
+            const fetchExpectation = nock('https://smba.trafficmanager.net/amer')
+                .get('/v1/meetings/meeting-id')
+                .matchHeader('Authorization', expectedAuthHeader)
+                .reply(200, details);
+
+            const fetchedDetails = await TeamsInfo.getMeetingDetails(context, details.details.id);
+
+            assert(fetchOauthToken.isDone());
+            assert(fetchExpectation.isDone());
+
+            assert.deepStrictEqual(fetchedDetails, details);
+        });
+
+        it('should throw error for missing context', async function () {
+            await assert.rejects(TeamsInfo.getMeetingDetails(), Error('context is required.'));
+        });
+    });
+
     describe('getTeamMembers()', function () {
         it('should error in 1-on-1 chat', async function () {
             const context = new TestContext(oneOnOneActivity);

--- a/libraries/botbuilder/tests/teamsInfo.test.js
+++ b/libraries/botbuilder/tests/teamsInfo.test.js
@@ -749,6 +749,10 @@ describe('TeamsInfo', function () {
         it('should throw error for missing context', async function () {
             await assert.rejects(TeamsInfo.getMeetingInfo(), Error('context is required.'));
         });
+
+        it('should throw error for missing meetingId', async function () {
+            await assert.rejects(TeamsInfo.getMeetingInfo({ activity: {} }), Error('meetingId or TurnContext containing meetingId is required.'));
+        });
     });
 
     describe('getTeamMembers()', function () {

--- a/libraries/botframework-connector/src/teams/models/index.ts
+++ b/libraries/botframework-connector/src/teams/models/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { HttpResponse, ServiceClientOptions, RequestOptionsBase } from '@azure/ms-rest-js';
-import { ConversationList, TeamDetails, TeamsMeetingParticipant } from 'botframework-schema';
+import { ConversationList, TeamDetails, TeamsMeetingInfo, TeamsMeetingParticipant } from 'botframework-schema';
 
 /**
  * @interface
@@ -99,3 +99,22 @@ export interface TeamsFetchMeetingParticipantOptionalParams extends RequestOptio
      */
     tenantId?: string;
 }
+
+/**
+ * Contains response data for the fetchMeetingDetails operation.
+ */
+export type TeamsMeetingInfoResponse = TeamsMeetingInfo & {
+    /**
+     * The underlying HTTP response.
+     */
+    _response: HttpResponse & {
+        /**
+         * The response body as text (string format)
+         */
+        bodyAsText: string;
+        /**
+         * The response body as parsed JSON or XML
+         */
+        parsedBody: TeamsMeetingParticipant;
+    };
+};

--- a/libraries/botframework-connector/src/teams/models/index.ts
+++ b/libraries/botframework-connector/src/teams/models/index.ts
@@ -101,7 +101,7 @@ export interface TeamsFetchMeetingParticipantOptionalParams extends RequestOptio
 }
 
 /**
- * Contains response data for the fetchMeetingDetails operation.
+ * Contains response data for the fetchMeetingInfo operation.
  */
 export type TeamsMeetingInfoResponse = TeamsMeetingInfo & {
     /**

--- a/libraries/botframework-connector/src/teams/models/mappers.ts
+++ b/libraries/botframework-connector/src/teams/models/mappers.ts
@@ -315,6 +315,89 @@ export const TeamsMeetingParticipant: msRest.CompositeMapper = {
     },
 };
 
+export const TeamsMeetingInfo: msRest.CompositeMapper = {
+    serializedName: 'TeamsMeetingInfo',
+    type: {
+        name: 'Composite',
+        className: 'TeamsMeetingInfo',
+        modelProperties: {
+            details: {
+                serializedName: 'details',
+                type: {
+                    name: 'Composite',
+                    className: 'TeamsMeetingDetails',
+                },
+            },
+            conversation: {
+                serializedName: 'conversation',
+                type: {
+                    name: 'Composite',
+                    className: 'MessageActionsPayloadConversation',
+                },
+            },
+            organizer: {
+                serializedName: 'organizer',
+                type: {
+                    name: 'Composite',
+                    className: 'TeamsChannelAccount',
+                },
+            },
+        },
+    },
+};
+
+export const TeamsMeetingDetails: msRest.CompositeMapper = {
+    serializedName: 'TeamsMeetingDetails',
+    type: {
+        name: 'Composite',
+        className: 'TeamsMeetingDetails',
+        modelProperties: {
+            id: {
+                serializedName: 'id',
+                type: {
+                    name: 'String',
+                },
+            },
+            msGraphResourceId: {
+                serializedName: 'msGraphResourceId',
+                type: {
+                    name: 'String',
+                },
+            },
+            scheduledStartTime: {
+                serializedName: 'scheduledStartTime',
+                type: {
+                    name: 'DateTime',
+                },
+            },
+            scheduledEndTime: {
+                serializedName: 'scheduledEndTime',
+                type: {
+                    name: 'DateTime',
+                },
+            },
+            joinUrl: {
+                serializedName: 'joinUrl',
+                type: {
+                    name: 'String',
+                },
+            },
+            title: {
+                serializedName: 'title',
+                type: {
+                    name: 'String',
+                },
+            },
+            type: {
+                serializedName: 'type',
+                type: {
+                    name: 'String',
+                },
+            },
+        },
+    },
+};
+
 export const CardAction: msRest.CompositeMapper = {
     serializedName: 'CardAction',
     type: {

--- a/libraries/botframework-connector/src/teams/models/teamsMappers.ts
+++ b/libraries/botframework-connector/src/teams/models/teamsMappers.ts
@@ -10,5 +10,7 @@ export {
     Meeting,
     TeamDetails,
     TeamsChannelAccount,
+    TeamsMeetingDetails,
+    TeamsMeetingInfo,
     TeamsMeetingParticipant,
 } from './mappers';

--- a/libraries/botframework-connector/src/teams/operations/teams.ts
+++ b/libraries/botframework-connector/src/teams/operations/teams.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 /**
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
@@ -8,7 +9,7 @@ import * as Models from '../models';
 import * as Mappers from '../models/teamsMappers';
 import * as Parameters from '../models/parameters';
 import { TeamsConnectorClientContext } from '../';
-import { ConversationList, TeamDetails, TeamsMeetingParticipant } from 'botframework-schema';
+import { ConversationList, TeamDetails, TeamsMeetingInfo, TeamsMeetingParticipant } from 'botframework-schema';
 
 /** Class representing a Teams. */
 export class Teams {
@@ -181,6 +182,51 @@ export class Teams {
             callback
         ) as Promise<Models.TeamsFetchMeetingParticipantResponse>;
     }
+
+    /**
+     * Fetch meeting details.
+     *
+     * @summary Fetches details of a Teams meeting.
+     * @param meetingId Meeting Id, encoded as a BASE64 string.
+     * @param [options] The optional parameters
+     * @returns Promise<Models.TeamsFetchMeetingDetailsResponse>
+     */
+    fetchMeetingDetails(
+        meetingId: string,
+        options?: msRest.RequestOptionsBase | msRest.ServiceCallback<TeamDetails>
+    ): Promise<Models.TeamsMeetingInfoResponse>;
+    /**
+     * @param meetingId Meeting Id, encoded as a BASE64 string.
+     * @param callback The callback
+     */
+     fetchMeetingDetails(
+        meetingId: string,
+        callback: msRest.ServiceCallback<TeamsMeetingInfo>
+    ): void;
+    /**
+     * @param meetingId Meeting Id, encoded as a BASE64 string.
+     * @param options The optional parameters
+     * @param callback The callback
+     */
+     fetchMeetingDetails(
+        meetingId: string,
+        options: msRest.RequestOptionsBase | msRest.ServiceCallback<TeamDetails>,
+        callback: msRest.ServiceCallback<TeamsMeetingInfo>
+    ): void;
+    fetchMeetingDetails(
+        meetingId: string,
+        options?: msRest.RequestOptionsBase | msRest.ServiceCallback<TeamDetails>,
+        callback?: msRest.ServiceCallback<TeamsMeetingInfo>
+    ): Promise<Models.TeamsMeetingInfoResponse> {
+        return this.client.sendOperationRequest(
+            {
+                meetingId,
+                options,
+            },
+            fetchMeetingDetailsOperationSpec,
+            callback
+        ) as Promise<Models.TeamsMeetingInfoResponse>;
+    }
 }
 
 // Operation Specifications
@@ -219,6 +265,19 @@ const fetchMeetingParticipantOperationSpec: msRest.OperationSpec = {
     responses: {
         200: {
             bodyMapper: Mappers.TeamsMeetingParticipant,
+        },
+        default: {},
+    },
+    serializer,
+};
+
+const fetchMeetingDetailsOperationSpec: msRest.OperationSpec = {
+    httpMethod: 'GET',
+    path: 'v1/meetings/{meetingId}',
+    urlParameters: [Parameters.meetingId],
+    responses: {
+        200: {
+            bodyMapper: Mappers.TeamsMeetingInfo,
         },
         default: {},
     },

--- a/libraries/botframework-connector/src/teams/operations/teams.ts
+++ b/libraries/botframework-connector/src/teams/operations/teams.ts
@@ -184,14 +184,14 @@ export class Teams {
     }
 
     /**
-     * Fetch meeting details.
+     * Fetch meeting information.
      *
-     * @summary Fetches details of a Teams meeting.
+     * @summary Fetches information of a Teams meeting.
      * @param meetingId Meeting Id, encoded as a BASE64 string.
      * @param [options] The optional parameters
-     * @returns Promise<Models.TeamsFetchMeetingDetailsResponse>
+     * @returns Promise<Models.TeamsFetchMeetingInfoResponse>
      */
-    fetchMeetingDetails(
+    fetchMeetingInfo(
         meetingId: string,
         options?: msRest.RequestOptionsBase | msRest.ServiceCallback<TeamDetails>
     ): Promise<Models.TeamsMeetingInfoResponse>;
@@ -199,7 +199,7 @@ export class Teams {
      * @param meetingId Meeting Id, encoded as a BASE64 string.
      * @param callback The callback
      */
-     fetchMeetingDetails(
+     fetchMeetingInfo(
         meetingId: string,
         callback: msRest.ServiceCallback<TeamsMeetingInfo>
     ): void;
@@ -208,12 +208,12 @@ export class Teams {
      * @param options The optional parameters
      * @param callback The callback
      */
-     fetchMeetingDetails(
+     fetchMeetingInfo(
         meetingId: string,
         options: msRest.RequestOptionsBase | msRest.ServiceCallback<TeamDetails>,
         callback: msRest.ServiceCallback<TeamsMeetingInfo>
     ): void;
-    fetchMeetingDetails(
+    fetchMeetingInfo(
         meetingId: string,
         options?: msRest.RequestOptionsBase | msRest.ServiceCallback<TeamDetails>,
         callback?: msRest.ServiceCallback<TeamsMeetingInfo>
@@ -223,7 +223,7 @@ export class Teams {
                 meetingId,
                 options,
             },
-            fetchMeetingDetailsOperationSpec,
+            fetchMeetingInfoOperationSpec,
             callback
         ) as Promise<Models.TeamsMeetingInfoResponse>;
     }
@@ -271,7 +271,7 @@ const fetchMeetingParticipantOperationSpec: msRest.OperationSpec = {
     serializer,
 };
 
-const fetchMeetingDetailsOperationSpec: msRest.OperationSpec = {
+const fetchMeetingInfoOperationSpec: msRest.OperationSpec = {
     httpMethod: 'GET',
     path: 'v1/meetings/{meetingId}',
     urlParameters: [Parameters.meetingId],

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -876,6 +876,24 @@ export interface Meeting {
 }
 
 // @public
+export interface MeetingDetails {
+    id: string;
+    joinUrl: string;
+    msGraphResourceId: string;
+    scheduledEndTime: Date;
+    scheduledStartTime: Date;
+    title: string;
+    type: string;
+}
+
+// @public
+export interface MeetingInfo {
+    conversation: ConversationAccount;
+    details: MeetingDetails;
+    organizer: TeamsChannelAccount;
+}
+
+// @public
 export interface Mention {
     mentioned: ChannelAccount;
     text: string;

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -1687,3 +1687,57 @@ export type Type3 = MessagingExtensionResultType;
  * @enum {string}
  */
 export type Action = 'accept' | 'decline';
+
+/**
+ * @interface
+ * Specific details of a Teams meeting.
+ */
+export interface MeetingDetails {
+    /**
+     * @member {string} [id] The meeting's Id, encoded as a BASE64 string.
+     */
+    id: string;
+    /**
+     * @member {string} [msGraphResourceId] The MsGraphResourceId, used specifically for MS Graph API calls.
+     */
+    msGraphResourceId: string;
+    /**
+     * @member {Date} [scheduledStartTime] The meeting's scheduled start time, in UTC.
+     */
+    scheduledStartTime: Date;
+    /**
+     * @member {Date} [scheduledEndTime] The meeting's scheduled end time, in UTC.
+     */
+    scheduledEndTime: Date;
+    /**
+     * @member {string} [joinUrl] The URL used to join the meeting.
+     */
+    joinUrl: string;
+    /**
+     * @member {string} [title] The title of the meeting.
+     */
+    title: string;
+    /**
+     * @member {string} [type] The meeting's type.
+     */
+    type: string;
+}
+
+/**
+ * @interface
+ * General information about a Teams meeting.
+ */
+export interface MeetingInfo {
+    /**
+     * @member {MeetingDetails} [details] The specific details of a Teams meeting.
+     */
+    details: MeetingDetails;
+    /**
+     * @member {ConversationAccount} [conversation] The Conversation Account for the meeting.
+     */
+    conversation: ConversationAccount;
+    /**
+     * @member {TeamsChannelAccount} [organizer] The organizer's user information.
+     */
+    organizer: TeamsChannelAccount;
+}


### PR DESCRIPTION
Fixes #3723 

## Description
Adds a `getMeetingInfo` method to `TeamsInfo`.

## Notes

Bots implementing this must add this to their `manifest.json`:

```json
"webApplicationInfo": {
        "id": "<MicrosoftAppId>",
        "resource": "<urlToApp>",
        "applicationPermissions": [
            "OnlineMeeting.ReadBasic.Chat"
        ]
    }
```

Per Teams, this is currently only available for:

1. Tenets who have the RSC permission for `OnlineMeeting.ReadBasic.Chat` set to Allowed. This won't be available for the Graph API permissions set until 6/17, or
2. Developers with the bot AppId whitelisted by the Teams Team (currently only available for Microsoft partner teams


## Testing
![image](https://user-images.githubusercontent.com/40401643/121605492-554fc000-ca01-11eb-9bf3-37877d04e44a.png)
