### PR TITLE
fix: make enum lookup case insensitive

### DIFF
--- a/libraries/adaptive-expressions/src/converters/enumExpressionConverter.ts
+++ b/libraries/adaptive-expressions/src/converters/enumExpressionConverter.ts
@@ -15,31 +15,45 @@ type Input<T> = T | string | Expression;
  * `string` to json [EnumExpression](xref:adaptive-expressions.EnumExpression) converter.
  */
 export class EnumExpressionConverter<T> {
-    private _enumValue: unknown;
+    private readonly lowercaseIndex: Record<string, string>;
 
     /**
      * Initializes a new instance of the [EnumExpressionConverter](xref:adaptive-expressions.EnumExpressionConverter) class.
+     *
      * @param enumValue The enum value of the `string` to convert.
      */
-    public constructor(enumValue: unknown) {
-        this._enumValue = enumValue;
+    constructor(private readonly enumValue: unknown) {
+        this.lowercaseIndex = Object.keys(enumValue || {}).reduce((acc, key) => {
+            acc[key.toLowerCase()] = key;
+
+            return acc;
+        }, {});
     }
 
     /**
      * Converts a `string` into an [EnumExpression](xref:adaptive-expressions.EnumExpression).
+     *
      * @param value `string` to convert.
      * @returns The [EnumExpression](xref:adaptive-expressions.EnumExpression).
      */
-    public convert(value: Input<T> | EnumExpression<T>): EnumExpression<T> {
+    convert(value: Input<T> | EnumExpression<T>): EnumExpression<T> {
         if (value instanceof EnumExpression) {
             return value;
         }
-        if (typeof value == 'string') {
-            if (Object.prototype.hasOwnProperty.call(this._enumValue, value)) {
-                return new EnumExpression<T>(this._enumValue[value as string]);
+
+        if (typeof value === 'string') {
+            let enumValue = this.enumValue[value];
+            if (enumValue === undefined) {
+                enumValue = this.enumValue[this.lowercaseIndex[value]];
             }
+
+            if (enumValue !== undefined) {
+                return new EnumExpression<T>(enumValue as Input<T>);
+            }
+
             return new EnumExpression<T>(`=${value}`);
         }
+
         return new EnumExpression<T>(value);
     }
 }


### PR DESCRIPTION
I tested the HTTP action in Composer with the .NET runtime, and it appears that enum resolution is case insensitive, so this PR replicates that behavior. I tested this by linking against a Composer bot and manually editing the enum value in the dialog to different casing variations.

Fixes https://github.com/microsoft/BotFramework-Composer/issues/7834
Fixes https://github.com/microsoft/botbuilder-js/issues/3744