### PR TITLE
feat: add support for Teams meeting start/end events

### DIFF
--- a/libraries/botbuilder-core/src/activityHandler.ts
+++ b/libraries/botbuilder-core/src/activityHandler.ts
@@ -457,7 +457,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to use custom logic for emitting events.
+     * Override this method to use custom logic for emitting events.
      *
      * The default logic is to call any handlers registered via [onTurn](xref:botbuilder-core.ActivityHandler.onTurn),
      * and then continue by calling [ActivityHandlerBase.onTurnActivity](xref:botbuilder-core.ActivityHandlerBase.onTurnActivity).
@@ -474,7 +474,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels.
+     * Override this method to support channel-specific behavior across multiple channels.
      *
      * The default logic is to call any handlers registered via
      * [onMessage](xref:botbuilder-core.ActivityHandler.onMessage),
@@ -489,7 +489,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels.
+     * Override this method to support channel-specific behavior across multiple channels.
      * The default logic is to check for a signIn invoke and handle that
      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
      */
@@ -531,7 +531,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels.
+     * Override this method to support channel-specific behavior across multiple channels.
      */
     protected async onSignInInvoke(context: TurnContext): Promise<void> {
         throw new InvokeException(StatusCodes.NOT_IMPLEMENTED);
@@ -556,7 +556,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels.
+     * Override this method to support channel-specific behavior across multiple channels.
      *
      * The default logic is to call any handlers registered via
      * [onEndOfConversationActivity](xref:botbuilder-core.ActivityHandler.onMessage),
@@ -572,7 +572,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels.
+     * Override this method to support channel-specific behavior across multiple channels.
      *
      * The default logic is to call any handlers registered via
      * [onTypingActivity](xref:botbuilder-core.ActivityHandler.onTypingActivity),
@@ -588,7 +588,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels.
+     * Override this method to support channel-specific behavior across multiple channels.
      *
      * The default logic is to call any handlers registered via
      * [onInstallationUpdateActivity](xref:botbuilder-core.ActivityHandler.onInstallationUpdateActivity),
@@ -624,7 +624,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels or to add
+     * Override this method to support channel-specific behavior across multiple channels or to add
      * custom conversation update sub-type events.
      *
      * The default logic is:
@@ -651,7 +651,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels.
+     * Override this method to support channel-specific behavior across multiple channels.
      *
      * The default logic is to call any handlers registered via
      * [onInstallationUpdateAdd](xref:botbuilder-core.ActivityHandler.onInstallationUpdateAdd),
@@ -667,7 +667,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels.
+     * Override this method to support channel-specific behavior across multiple channels.
      *
      * The default logic is to call any handlers registered via
      * [onInstallationUpdateRemove](xref:botbuilder-core.ActivityHandler.onInstallationUpdateRemove),
@@ -683,7 +683,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels.
+     * Override this method to support channel-specific behavior across multiple channels.
      *
      * The default logic is to call any handlers registered via
      * [onUnrecognizedActivityType](xref:botbuilder-core.ActivityHandler.onUnrecognizedActivityType),
@@ -743,7 +743,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels.
+     * Override this method to support channel-specific behavior across multiple channels.
      *
      * The default logic is to call any handlers registered via
      * [onConversationUpdate](xref:botbuilder-core.ActivityHandler.onConversationUpdate),
@@ -762,7 +762,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels or to add
+     * Override this method to support channel-specific behavior across multiple channels or to add
      * custom conversation update sub-type events.
      *
      * The default logic is:
@@ -786,7 +786,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels.
+     * Override this method to support channel-specific behavior across multiple channels.
      *
      * The default logic is to call any handlers registered via
      * [onMessageReaction](xref:botbuilder-core.ActivityHandler.onMessageReaction),
@@ -806,7 +806,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels.
+     * Override this method to support channel-specific behavior across multiple channels.
      *
      * The default logic is to call any handlers registered via
      * [onReactionsAdded](xref:botbuilder-core.ActivityHandler.onReactionsAdded),
@@ -823,7 +823,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels.
+     * Override this method to support channel-specific behavior across multiple channels.
      *
      * The default logic is to call any handlers registered via
      * [onReactionsRemoved](xref:botbuilder-core.ActivityHandler.onReactionsRemoved),
@@ -842,7 +842,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels or to add
+     * Override this method to support channel-specific behavior across multiple channels or to add
      * custom message reaction sub-type events.
      *
      * The default logic is:
@@ -864,7 +864,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels.
+     * Override this method to support channel-specific behavior across multiple channels.
      *
      * The default logic is to call any handlers registered via
      * [onEvent](xref:botbuilder-core.ActivityHandler.onEvent),
@@ -883,7 +883,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to support channel-specific behavior across multiple channels or to add custom event sub-type events.
+     * Override this method to support channel-specific behavior across multiple channels or to add custom event sub-type events.
      * For certain channels, such as  Web Chat and custom Direct Line clients, developers can emit custom event activities from the client.
      *
      * The default logic is:
@@ -905,7 +905,7 @@ export class ActivityHandler extends ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to use custom logic for emitting events.
+     * Override this method to use custom logic for emitting events.
      *
      * The default logic is to call any handlers registered via [onDialog](xref:botbuilder-core.ActivityHandler.onDialog),
      * and then complete the event emission process.

--- a/libraries/botbuilder-core/src/activityHandlerBase.ts
+++ b/libraries/botbuilder-core/src/activityHandlerBase.ts
@@ -6,7 +6,7 @@ import { ActivityTypes, ChannelAccount, MessageReaction, TurnContext } from '.';
 import { InvokeResponse } from './invokeResponse';
 import { StatusCodes } from './statusCodes';
 
-// This key is exported internally so that subclassed ActivityHandlers and BotAdapters will not overwrite any already set InvokeResponses.
+// This key is exported internally so that subclassed ActivityHandlers and BotAdapters will not override any already set InvokeResponses.
 export const INVOKE_RESPONSE_KEY = Symbol('invokeResponse');
 
 /**
@@ -37,7 +37,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to use custom logic for emitting events.
+     * Override this method to use custom logic for emitting events.
      *
      * The default logic is to call any type-specific and sub-type handlers registered via
      * the various _on event_ methods. Type-specific events are defined for:
@@ -97,7 +97,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to run registered _message_ handlers and then continue the event
+     * Override this method to run registered _message_ handlers and then continue the event
      * emission process.
      */
     protected async onMessageActivity(context: TurnContext): Promise<void> {
@@ -110,7 +110,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to run registered _conversation update_ handlers and then continue the event
+     * Override this method to run registered _conversation update_ handlers and then continue the event
      * emission process.
      *
      * The default logic is:
@@ -145,7 +145,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to run registered _message reaction_ handlers and then continue the event
+     * Override this method to run registered _message reaction_ handlers and then continue the event
      * emission process.
      *
      * The default logic is:
@@ -168,7 +168,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to run registered _event_ handlers and then continue the event
+     * Override this method to run registered _event_ handlers and then continue the event
      * emission process.
      */
     protected async onEventActivity(context: TurnContext): Promise<void> {
@@ -181,7 +181,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to handle particular invoke calls.
+     * Override this method to handle particular invoke calls.
      */
     protected async onInvokeActivity(context: TurnContext): Promise<InvokeResponse> {
         return { status: StatusCodes.NOT_IMPLEMENTED };
@@ -193,7 +193,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to run registered _end of conversation_ handlers and then continue the event
+     * Override this method to run registered _end of conversation_ handlers and then continue the event
      * emission process.
      */
     protected async onEndOfConversationActivity(context: TurnContext): Promise<void> {
@@ -206,7 +206,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to run registered _typing_ handlers and then continue the event
+     * Override this method to run registered _typing_ handlers and then continue the event
      * emission process.
      */
     protected async onTypingActivity(context: TurnContext): Promise<void> {
@@ -219,7 +219,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to run registered _installationupdate_ handlers and then continue the event
+     * Override this method to run registered _installationupdate_ handlers and then continue the event
      * emission process.
      */
     protected async onInstallationUpdateActivity(context: TurnContext): Promise<void> {
@@ -241,7 +241,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to run registered _installationupdateadd_ handlers and then continue the event
+     * Override this method to run registered _installationupdateadd_ handlers and then continue the event
      * emission process.
      */
     protected async onInstallationUpdateAddActivity(context: TurnContext): Promise<void> {
@@ -254,7 +254,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to run registered _installationupdateremove_ handlers and then continue the event
+     * Override this method to run registered _installationupdateremove_ handlers and then continue the event
      * emission process.
      */
     protected async onInstallationUpdateRemoveActivity(context: TurnContext): Promise<void> {
@@ -267,7 +267,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to run registered _unrecognized_ handlers and then continue the event
+     * Override this method to run registered _unrecognized_ handlers and then continue the event
      * emission process.
      */
     protected async onUnrecognizedActivity(context: TurnContext): Promise<void> {
@@ -282,7 +282,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to run registered _members added_ handlers and then continue the event
+     * Override this method to run registered _members added_ handlers and then continue the event
      * emission process.
      */
     protected async onMembersAddedActivity(membersAdded: ChannelAccount[], context: TurnContext): Promise<void> {
@@ -297,7 +297,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to run registered _members removed_ handlers and then continue the event
+     * Override this method to run registered _members removed_ handlers and then continue the event
      * emission process.
      */
     protected async onMembersRemovedActivity(membersRemoved: ChannelAccount[], context: TurnContext): Promise<void> {
@@ -312,7 +312,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to run registered _reactions added_ handlers and then continue the event
+     * Override this method to run registered _reactions added_ handlers and then continue the event
      * emission process.
      */
     protected async onReactionsAddedActivity(reactionsAdded: MessageReaction[], context: TurnContext): Promise<void> {
@@ -327,7 +327,7 @@ export class ActivityHandlerBase {
      * @param context The context object for the current turn.
      *
      * @remarks
-     * Overwrite this method to run registered _reactions removed_ handlers and then continue the event
+     * Override this method to run registered _reactions removed_ handlers and then continue the event
      * emission process.
      */
     protected async onReactionsRemovedActivity(

--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -38,6 +38,8 @@ import { INodeSocket } from 'botframework-streaming';
 import { InvokeResponse } from 'botbuilder-core';
 import { IReceiveRequest } from 'botframework-streaming';
 import { IStreamingTransportServer } from 'botframework-streaming';
+import { MeetingEndEventDetails } from 'botbuilder-core';
+import { MeetingStartEventDetails } from 'botbuilder-core';
 import { MessagingExtensionAction } from 'botbuilder-core';
 import { MessagingExtensionActionResponse } from 'botbuilder-core';
 import { MessagingExtensionQuery } from 'botbuilder-core';
@@ -299,6 +301,7 @@ export class StreamingHttpClient implements HttpClient {
 // @public
 export class TeamsActivityHandler extends ActivityHandler {
     protected dispatchConversationUpdateActivity(context: TurnContext): Promise<void>;
+    protected dispatchEventActivity(context: TurnContext): Promise<void>;
     protected handleAdaptiveCardAction(context: TurnContext): Promise<AdaptiveCardInvokeResponse>;
     protected handleTeamsAppBasedLinkQuery(context: TurnContext, query: AppBasedLinkQuery): Promise<MessagingExtensionResponse>;
     protected handleTeamsCardActionInvoke(context: TurnContext): Promise<InvokeResponse>;
@@ -333,6 +336,10 @@ export class TeamsActivityHandler extends ActivityHandler {
     // (undocumented)
     protected onTeamsChannelRestored(context: any): Promise<void>;
     onTeamsChannelRestoredEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
+    protected onTeamsMeetingEnd(context: TurnContext): Promise<void>;
+    onTeamsMeetingEndEvent(handler: (meeting: MeetingEndEventDetails, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
+    protected onTeamsMeetingStart(context: TurnContext): Promise<void>;
+    onTeamsMeetingStartEvent(handler: (meeting: MeetingStartEventDetails, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsMembersAdded(context: TurnContext): Promise<void>;
     onTeamsMembersAddedEvent(handler: (membersAdded: TeamsChannelAccount[], teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsMembersRemoved(context: TurnContext): Promise<void>;

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -38,6 +38,7 @@
     "filenamify": "^4.1.0",
     "fs-extra": "^7.0.1",
     "htmlparser2": "^6.0.1",
+    "runtypes": "6.3.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -38,7 +38,7 @@
     "filenamify": "^4.1.0",
     "fs-extra": "^7.0.1",
     "htmlparser2": "^6.0.1",
-    "runtypes": "6.3.0",
+    "runtypes": "~6.3.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -944,11 +944,9 @@ export class TeamsActivityHandler extends ActivityHandler {
             if (context.activity.channelId == Channels.Msteams) {
                 switch (context.activity.name) {
                     case 'application/vnd.microsoft.meetingStart':
-                        await this.onTeamsMeetingStart(context);
-                        break;
+                        return this.onTeamsMeetingStart(context);
                     case 'application/vnd.microsoft.meetingEnd':
-                        await this.onTeamsMeetingEnd(context);
-                        break;
+                        return this.onTeamsMeetingEnd(context);
                 }
             }
 

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -1024,8 +1024,12 @@ export class TeamsActivityHandler extends ActivityHandler {
 
         if (meeting.StartTime) {
             (convertedMeeting as MeetingStartEventDetails).startTime = new Date(meeting.StartTime);
-        } else {
+        } else if (meeting.EndTime) {
             (convertedMeeting as MeetingEndEventDetails).endTime = new Date(meeting.EndTime);
+        } else {
+            throw new Error(
+                `Invalid meeting. It does not include StartTime or EndTime: ${JSON.stringify(meeting, null, 2)}`
+            );
         }
 
         return convertedMeeting as T;

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -944,9 +944,11 @@ export class TeamsActivityHandler extends ActivityHandler {
             if (context.activity.channelId == Channels.Msteams) {
                 switch (context.activity.name) {
                     case 'application/vnd.microsoft.meetingStart':
-                        return this.onTeamsMeetingStart(context);
+                        await this.onTeamsMeetingStart(context);
+                        break;
                     case 'application/vnd.microsoft.meetingEnd':
-                        return this.onTeamsMeetingEnd(context);
+                        await this.onTeamsMeetingEnd(context);
+                        break;
                 }
             }
 

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -1008,6 +1008,8 @@ export class TeamsActivityHandler extends ActivityHandler {
         });
     }
 
+    // The payload from Teams comes in with TitleCase keys, so we'll convert them to camelCase
+    // to maintain JSON and JS standard practices.
     private convertMeetingEventDetailsToCamelCase<T extends MeetingStartEventDetails | MeetingEndEventDetails>(
         meeting: Record<string, string>
     ): T {

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -2188,7 +2188,7 @@ describe('TeamsActivityHandler', function () {
                 Id: 'meetingId',
                 JoinUrl: 'https://joinUrl',
                 MeetingType: 'Scheduled',
-                title: 'someTitle'
+                Title: 'someTitle',
             };
             onEventCalled = false;
             onDialogCalled = false;

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -2160,21 +2160,22 @@ describe('TeamsActivityHandler', function () {
     });
 
     describe('onEventActivity()', function () {
-        const expectedMeeting = { id: 'meetingId' };
+        let meetingPayload = { id: 'meetingId' };
 
+        // Note: Teams payload is TitleCase.
         function createMeetingEventActivity(start = true) {
             const activity = {
                 channelId: Channels.Msteams,
                 type: 'event',
-                value: expectedMeeting,
+                value: meetingPayload,
             };
 
             if (start) {
                 activity.name = 'application/vnd.microsoft.meetingStart';
-                activity.value.startTime = '2021-06-05T00:01:02.0Z';
+                activity.value.StartTime = '2021-06-05T00:01:02.0Z';
             } else {
                 activity.name = 'application/vnd.microsoft.meetingEnd';
-                activity.value.endTime = '2021-06-05T01:02:03.0Z';
+                activity.value.EndTime = '2021-06-05T01:02:03.0Z';
             }
 
             return activity;
@@ -2183,6 +2184,7 @@ describe('TeamsActivityHandler', function () {
         let onEventCalled;
         let onDialogCalled;
         this.beforeEach(function () {
+            meetingPayload = { id: 'meetingId' };
             onEventCalled = false;
             onDialogCalled = false;
         });
@@ -2227,7 +2229,8 @@ describe('TeamsActivityHandler', function () {
                 assert(meeting, 'teamsInfo not found');
                 assert(context, 'context not found');
                 assert(next, 'next not found');
-                assert.strictEqual(meeting, expectedMeeting);
+                assert.strictEqual(meeting.id, meetingPayload.Id);
+                assert.strictEqual(meeting.startTime.toString(), new Date(meetingPayload.StartTime).toString());
                 onTeamsMeetingStartCalled = true;
                 await next();
             });
@@ -2271,7 +2274,8 @@ describe('TeamsActivityHandler', function () {
                 assert(meeting, 'teamsInfo not found');
                 assert(context, 'context not found');
                 assert(next, 'next not found');
-                assert.strictEqual(meeting, expectedMeeting);
+                assert.strictEqual(meeting.id, meetingPayload.Id);
+                assert.strictEqual(meeting.endTime.toString(), new Date(meetingPayload.EndTime).toString());
                 onTeamsMeetingEndCalled = true;
                 await next();
             });

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -2160,7 +2160,7 @@ describe('TeamsActivityHandler', function () {
     });
 
     describe('onEventActivity()', function () {
-        let meetingPayload = { id: 'meetingId' };
+        let meetingPayload;
 
         // Note: Teams payload is TitleCase.
         function createMeetingEventActivity(start = true) {
@@ -2184,7 +2184,7 @@ describe('TeamsActivityHandler', function () {
         let onEventCalled;
         let onDialogCalled;
         this.beforeEach(function () {
-            meetingPayload = { id: 'meetingId' };
+            meetingPayload = { Id: 'meetingId' };
             onEventCalled = false;
             onDialogCalled = false;
         });

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -2184,7 +2184,12 @@ describe('TeamsActivityHandler', function () {
         let onEventCalled;
         let onDialogCalled;
         this.beforeEach(function () {
-            meetingPayload = { Id: 'meetingId' };
+            meetingPayload = {
+                Id: 'meetingId',
+                JoinUrl: 'https://joinUrl',
+                MeetingType: 'Scheduled',
+                title: 'someTitle'
+            };
             onEventCalled = false;
             onDialogCalled = false;
         });

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -885,11 +885,14 @@ export interface MeetingDetails extends MeetingDetailsBase {
     type: string;
 }
 
-// Warning: (ae-forgotten-export) The symbol "MeetingEventDetails" needs to be exported by the entry point index.d.ts
-//
 // @public
 export interface MeetingEndEventDetails extends MeetingEventDetails {
     endTime: Date;
+}
+
+// @public (undocumented)
+export interface MeetingEventDetails extends MeetingDetailsBase {
+    meetingType: string;
 }
 
 // @public

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -875,15 +875,21 @@ export interface Meeting {
     role?: string;
 }
 
+// Warning: (ae-forgotten-export) The symbol "MeetingDetailsBase" needs to be exported by the entry point index.d.ts
+//
 // @public
-export interface MeetingDetails {
-    id: string;
-    joinUrl: string;
+export interface MeetingDetails extends MeetingDetailsBase {
     msGraphResourceId: string;
     scheduledEndTime: Date;
     scheduledStartTime: Date;
-    title: string;
     type: string;
+}
+
+// Warning: (ae-forgotten-export) The symbol "MeetingEventDetails" needs to be exported by the entry point index.d.ts
+//
+// @public
+export interface MeetingEndEventDetails extends MeetingEventDetails {
+    endTime: Date;
 }
 
 // @public
@@ -891,6 +897,11 @@ export interface MeetingInfo {
     conversation: ConversationAccount;
     details: MeetingDetails;
     organizer: TeamsChannelAccount;
+}
+
+// @public
+export interface MeetingStartEventDetails extends MeetingEventDetails {
+    startTime: Date;
 }
 
 // @public

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -1690,13 +1690,27 @@ export type Action = 'accept' | 'decline';
 
 /**
  * @interface
- * Specific details of a Teams meeting.
  */
-export interface MeetingDetails {
+interface MeetingDetailsBase {
     /**
      * @member {string} [id] The meeting's Id, encoded as a BASE64 string.
      */
     id: string;
+    /**
+     * @member {string} [joinUrl] The URL used to join the meeting.
+     */
+    joinUrl: string;
+    /**
+     * @member {string} [title] The title of the meeting.
+     */
+    title: string;
+}
+
+/**
+ * @interface
+ * Specific details of a Teams meeting.
+ */
+export interface MeetingDetails extends MeetingDetailsBase {
     /**
      * @member {string} [msGraphResourceId] The MsGraphResourceId, used specifically for MS Graph API calls.
      */
@@ -1709,14 +1723,6 @@ export interface MeetingDetails {
      * @member {Date} [scheduledEndTime] The meeting's scheduled end time, in UTC.
      */
     scheduledEndTime: Date;
-    /**
-     * @member {string} [joinUrl] The URL used to join the meeting.
-     */
-    joinUrl: string;
-    /**
-     * @member {string} [title] The title of the meeting.
-     */
-    title: string;
     /**
      * @member {string} [type] The meeting's type.
      */
@@ -1740,4 +1746,36 @@ export interface MeetingInfo {
      * @member {TeamsChannelAccount} [organizer] The organizer's user information.
      */
     organizer: TeamsChannelAccount;
+}
+
+/**
+ * @interface
+ */
+interface MeetingEventDetails extends MeetingDetailsBase {
+    /**
+     * @member {string} [type] The meeting's type.
+     */
+    meetingType: string;
+}
+
+/**
+ * @interface
+ * Specific details of a Teams meeting start event.
+ */
+export interface MeetingStartEventDetails extends MeetingEventDetails {
+    /**
+     * @member {Date} [startTime] Timestamp for meeting start, in UTC.
+     */
+    startTime: Date;
+}
+
+/**
+ * @interface
+ * Specific details of a Teams meeting end event.
+ */
+export interface MeetingEndEventDetails extends MeetingEventDetails {
+    /**
+     * @member {Date} [endTime] Timestamp for meeting end, in UTC.
+     */
+    endTime: Date;
 }

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -1751,7 +1751,7 @@ export interface MeetingInfo {
 /**
  * @interface
  */
-interface MeetingEventDetails extends MeetingDetailsBase {
+export interface MeetingEventDetails extends MeetingDetailsBase {
     /**
      * @member {string} [type] The meeting's type.
      */

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -1753,7 +1753,7 @@ export interface MeetingInfo {
  */
 export interface MeetingEventDetails extends MeetingDetailsBase {
     /**
-     * @member {string} [type] The meeting's type.
+     * @member {string} [meetingType] The meeting's type.
      */
     meetingType: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10876,7 +10876,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-runtypes@~6.3.0:
+runtypes@6.3.0, runtypes@~6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/runtypes/-/runtypes-6.3.0.tgz#bd88392c21f471bd45591d5eabaa4644ca7cdf3c"
   integrity sha512-FTNUs13CIrCTjReBOaeY/8EY1LYIQVkkwyE9z5MCjZe9uew9/8TRbWF1PcTczgTFfGBjkjUKeedFWU2O3ExjPg==


### PR DESCRIPTION
Fixes #3724 

## Description
Adds support to TeamsActivityHandler for meeting start/end events.

## Notes

Bots implementing this must add this to their `manifest.json`:

```json
"webApplicationInfo": {
        "id": "<MicrosoftAppId>",
        "resource": "<urlToApp>",
        "applicationPermissions": [
            "OnlineMeeting.ReadBasic.Chat"
        ]
    }
```

Note that somebody needs to actually start/join the meeting for this to work. The scheduled start/end times mean nothing for this event.

## Testing
![image](https://user-images.githubusercontent.com/40401643/122273761-a7c42d00-ce96-11eb-8cec-4c84a10b4fca.png)