### PR TITLE
port: Support iteration for object in ForEach action

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
@@ -282,6 +282,10 @@ describe('ActionTests', function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_Foreach_Empty');
     });
 
+    it('Foreach_Object', async () => {
+        await TestUtils.runTestScript(resourceExplorer, 'Action_Foreach_Object');
+    });
+
     it('ForeachPage_Empty', async () => {
         await TestUtils.runTestScript(resourceExplorer, 'Action_ForeachPage_Empty');
     });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_Foreach_Object.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_Foreach_Object.test.dialog
@@ -1,0 +1,62 @@
+{
+    "$schema": "../../../../schemas/sdk.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "root",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "dialog.items",
+                        "value": "=[['item1', 'item2'], {'k1':'v1', 'k2':'v2'}]"
+                    },
+                    {
+                        "$kind": "Microsoft.Foreach",
+                        "itemsProperty": "dialog.items",
+                        "actions": [
+                            {
+                                "$kind": "Microsoft.Foreach",
+                                "index": "dialog.foreach.inner.index",
+                                "value": "dialog.foreach.inner.value",
+                                "itemsProperty": "dialog.foreach.value",
+                                "actions": [
+                                    {
+                                        "$kind": "Microsoft.SendActivity",
+                                        "activity": "index is: ${dialog.foreach.inner.index} and value is: ${dialog.foreach.inner.value}"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "autoEndDialog": true,
+        "defaultResultProperty": "dialog.result"
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "index is: 0 and value is: item1"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "index is: 1 and value is: item2"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "index is: k1 and value is: v1"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "index is: k2 and value is: v2"
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/forEach.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/forEach.ts
@@ -163,8 +163,8 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
         const items = this.convertToList(result);
 
         if (++this.currentIndex < items.length) {
-            dc.state.setValue(this.index.getValue(dc.state), items[this.currentIndex].index);
             dc.state.setValue(this.value.getValue(dc.state), items[this.currentIndex].value);
+            dc.state.setValue(this.index.getValue(dc.state), items[this.currentIndex].index);
             return await this.beginAction(dc, 0);
         } else {
             return await dc.endDialog();

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/forEach.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/forEach.ts
@@ -32,6 +32,7 @@ export interface ForEachConfiguration extends ActionScopeConfiguration {
  */
 export class ForEach<O extends object = {}> extends ActionScope<O> implements ForEachPageConfiguration {
     public static $kind = 'Microsoft.Foreach';
+    private currentIndex: number;
 
     public constructor();
 
@@ -110,7 +111,7 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
         if (this.disabled && this.disabled.getValue(dc.state)) {
             return await dc.endDialog();
         }
-        dc.state.setValue(this.index.getValue(dc.state), -1);
+        this.currentIndex = -1;
         return await this.nextItem(dc);
     }
 
@@ -158,12 +159,12 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
      */
     protected async nextItem(dc: DialogContext): Promise<DialogTurnResult> {
         const itemsProperty = this.itemsProperty.getValue(dc.state);
-        const items: any[] = dc.state.getValue(itemsProperty, []);
-        let index = dc.state.getValue(this.index.getValue(dc.state));
+        const result = dc.state.getValue(itemsProperty, []);
+        const items = this.convertToList(result);
 
-        if (++index < items.length) {
-            dc.state.setValue(this.value.getValue(dc.state), items[index]);
-            dc.state.setValue(this.index.getValue(dc.state), index);
+        if (++this.currentIndex < items.length) {
+            dc.state.setValue(this.index.getValue(dc.state), items[this.currentIndex].index);
+            dc.state.setValue(this.value.getValue(dc.state), items[this.currentIndex].value);
             return await this.beginAction(dc, 0);
         } else {
             return await dc.endDialog();
@@ -177,5 +178,16 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
      */
     protected onComputeId(): string {
         return `ForEach[${this.itemsProperty.toString()}]`;
+    }
+
+    private convertToList(value: unknown) {
+        let result: { index: string | number, value: unknown }[] = [];
+        if (Array.isArray(value)) {
+            value.forEach((item, index) => result.push({ index: index, value: item }));
+        } else if (typeof value === 'object') {
+            Object.entries(value).forEach(([key, value]) => result.push({ index: key, value: value }))
+        }
+
+        return result;
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/forEach.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/forEach.ts
@@ -159,8 +159,7 @@ export class ForEach<O extends object = {}> extends ActionScope<O> implements Fo
      */
     protected async nextItem(dc: DialogContext): Promise<DialogTurnResult> {
         const itemsProperty = this.itemsProperty.getValue(dc.state);
-        const result = dc.state.getValue(itemsProperty, []);
-        const items = this.convertToList(result);
+        const items = this.convertToList(dc.state.getValue(itemsProperty, []));
 
         if (++this.currentIndex < items.length) {
             dc.state.setValue(this.value.getValue(dc.state), items[this.currentIndex].value);


### PR DESCRIPTION
Fixes #3769
## Description
Make it possible for Microsoft.ForEach action to  traverse its keys and values.

## Changes
There is no change while the value of `itemsProperty` is array.
If the property value is Object, user could use the "index" property to get the current key, and use "value" value to get current value.
For example:
given such object for property `dialog.item`:
```
{
  "k1":"v1",
  "K2":"v2"
}
```
and the action:
```
{
    "$kind": "Microsoft.Foreach",
    "itemsProperty": "dialog.item",
    "actions": [
        {
            "$kind": "Microsoft.SendActivity",
            "activity": "index is: ${dialog.foreach.index}, and value is: ${dialog.foreach.value}"
        }
    ]
}
```

The result would be:
`index is: k1 and value is v1` and `index is: k2 and value is v2`

## two other object traverse comparison
### 1. built-in function `indicesAndValues`
[indicesAndValues](https://docs.microsoft.com/en-us/azure/bot-service/adaptive-expressions/adaptive-expressions-prebuilt-functions?view=azure-bot-service-4.0#indicesAndValues) is same with the above logic.

### 2. `foreach`, `where` and `select` builtin functions
These three functions would convert the key into  "key" property, and convert value into "value" property. And there is no index property.
For example:
```
foreach(dialog.item, u, concat(u.key, ':', u.value))
```
Get:
```
["k1:v1", "k2:v2"]
```