### PR TITLE
fix: first activity from bot to user has fake replyToId value

### DIFF
--- a/libraries/botbuilder-core/src/turnContext.ts
+++ b/libraries/botbuilder-core/src/turnContext.ts
@@ -10,6 +10,7 @@ import {
     InputHints,
     ResourceResponse,
     Mention,
+    Channels,
 } from 'botframework-schema';
 import { INVOKE_RESPONSE_KEY } from '.';
 import { BotAdapter } from './botAdapter';
@@ -118,6 +119,17 @@ export type DeleteActivityHandler = (
 ) => Promise<void>;
 
 export const BotCallbackHandlerKey = 'botCallbackHandler';
+
+function getAppropriateReplyToId(source: Partial<Activity>): string | undefined {
+    if (
+        source.type !== ActivityTypes.ConversationUpdate ||
+        (source.channelId !== Channels.Directline && source.channelId !== Channels.Webchat)
+    ) {
+        return source.id;
+    }
+
+    return undefined;
+}
 
 // tslint:disable-next-line:no-empty-interface
 export interface TurnContext {}
@@ -279,7 +291,7 @@ export class TurnContext {
      */
     public static getConversationReference(activity: Partial<Activity>): Partial<ConversationReference> {
         return {
-            activityId: activity.id,
+            activityId: getAppropriateReplyToId(activity),
             user: shallowCopy(activity.from),
             bot: shallowCopy(activity.recipient),
             conversation: shallowCopy(activity.conversation),

--- a/libraries/botbuilder-dialogs-declarative/tests/jsonLoad.test.js
+++ b/libraries/botbuilder-dialogs-declarative/tests/jsonLoad.test.js
@@ -14,6 +14,7 @@ const {
     TestAdapter,
     useBotState,
     ActivityTypes,
+    Channels,
 } = require('botbuilder-core');
 
 const {
@@ -398,6 +399,34 @@ describe('Json load tests', function () {
             .assertReply('Now try to specify the id of your pet, and I will help your find it out from the store.')
             .send('12121')
             .assertReply('Great! I found your pet named "TestPetName"')
+            .startTest();
+    });
+
+    it('NoReplyToIdForFirstConversationActivityFromBotToUser', async function () {
+        // The ReplyToId should be null if the activity from bot to user is the first one of the conversation.
+        await buildTestFlow(resourceExplorer, 'ReplyToId.main.dialog', this.test.title)
+            .send({
+                type: ActivityTypes.ConversationUpdate,
+                membersAdded: [
+                    {
+                        id: 'bot',
+                    },
+                ],
+                channelId: Channels.Webchat,
+            })
+            .assertReply((activity) => {
+                assert.strictEqual(activity.replyToId, undefined);
+            })
+            .assertReply((activity) => {
+                assert.strictEqual(activity.replyToId, undefined);
+            })
+            .assertReply((activity) => {
+                assert.strictEqual(activity.replyToId, undefined);
+            })
+            .send('Tom')
+            .assertReply((activity) => {
+                assert.notStrictEqual(activity.replyToId, undefined);
+            })
             .startTest();
     });
 

--- a/libraries/botbuilder-dialogs-declarative/tests/resources/JsonDialog/ReplyToId.main.dialog
+++ b/libraries/botbuilder-dialogs-declarative/tests/resources/JsonDialog/ReplyToId.main.dialog
@@ -1,0 +1,27 @@
+{
+    "$schema": "../../testbot.schema",
+    "$kind": "Microsoft.AdaptiveDialog",
+    "triggers": [
+        {
+            "$kind": "Microsoft.OnBeginDialog",
+            "actions": [
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "Action 1"
+                },
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "Action 2"
+                },
+                {
+                    "$kind": "Microsoft.TextInput",
+                    "prompt": "Hello, what is your name?"
+                },
+                {
+                    "$kind": "Microsoft.SendActivity",
+                    "activity": "Action 3"
+                }
+            ]
+        }
+    ]
+}

--- a/libraries/botframework-schema/src/activityEx.ts
+++ b/libraries/botframework-schema/src/activityEx.ts
@@ -28,6 +28,7 @@ import {
     ConversationAccount,
     ICommandActivity,
     ICommandResultActivity,
+    Channels,
 } from './index';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -149,7 +150,7 @@ export namespace ActivityEx {
                 id: source.from ? source.from.id : null,
                 name: source.from ? source.from.name : null,
             } as ChannelAccount,
-            replyToId: source.id,
+            replyToId: getAppropriateReplyToId(source),
             serviceUrl: source.serviceUrl,
             channelId: source.channelId,
             conversation: {
@@ -196,7 +197,7 @@ export namespace ActivityEx {
                 id: source.from ? source.from.id : null,
                 name: source.from ? source.from.name : null,
             } as ChannelAccount,
-            replyToId: source.id,
+            replyToId: getAppropriateReplyToId(source),
             serviceUrl: source.serviceUrl,
             channelId: source.channelId,
             conversation: source.conversation,
@@ -418,7 +419,7 @@ export namespace ActivityEx {
      */
     export function getConversationReference(source: Partial<Activity>): ConversationReference {
         return {
-            activityId: source.id,
+            activityId: getAppropriateReplyToId(source),
             bot: source.recipient,
             channelId: source.channelId,
             conversation: source.conversation,
@@ -482,4 +483,15 @@ export namespace ActivityEx {
 
         return result;
     }
+}
+
+function getAppropriateReplyToId(source: Partial<Activity>): string | undefined {
+    if (
+        source.type !== ActivityTypes.ConversationUpdate ||
+        (source.channelId !== Channels.Directline && source.channelId !== Channels.Webchat)
+    ) {
+        return source.id;
+    }
+
+    return undefined;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10876,7 +10876,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-runtypes@6.3.0, runtypes@~6.3.0:
+runtypes@~6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/runtypes/-/runtypes-6.3.0.tgz#bd88392c21f471bd45591d5eabaa4644ca7cdf3c"
   integrity sha512-FTNUs13CIrCTjReBOaeY/8EY1LYIQVkkwyE9z5MCjZe9uew9/8TRbWF1PcTczgTFfGBjkjUKeedFWU2O3ExjPg==


### PR DESCRIPTION
Fixes #3732

## Description
When the activity is the first one of the conversation and it's sent from bot to user, the ReplyToId was assigned to the bogus ConversationUpdate activity's id. The fix is to not assign the bogus ReplyToId if previous activity is the ConversationUpdate activity

## Specific Changes
  - Do not assign ReplyToId if conversantionReference is from ConversationUpdate activity
  - Add test tests to test the changes

## Testing
Tests are added