### PR TITLE
chore: remove public access modifier in botframework-streaming

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -129,11 +129,12 @@
         "libraries/botbuilder-ai*/**/*.ts",
         "libraries/botbuilder-applicationinsights/**/*.ts",
         "libraries/botbuilder-azure*/**/*.ts",
-        "libraries/botbuilder-dialogs-adaptive-runtime*/**/*.ts"
+        "libraries/botbuilder-dialogs-adaptive-runtime*/**/*.ts",
+        "libraries/botframework-streaming/**/*.ts"
       ],
       "rules": {
-          "@typescript-eslint/explicit-member-accessibility": ["error", {"accessibility": "no-public"}]
+          "@typescript-eslint/explicit-member-accessibility": ["error", { "accessibility": "no-public" }]
       }
-  }
+    }
   ]
 }

--- a/libraries/botframework-streaming/.eslintrc.json
+++ b/libraries/botframework-streaming/.eslintrc.json
@@ -1,5 +1,4 @@
 {
     "extends": "../../.eslintrc.json",
-    "plugins": ["only-warn"],
     "ignorePatterns": ["es5/"]
 }

--- a/libraries/botframework-streaming/etc/botframework-streaming.api.md
+++ b/libraries/botframework-streaming/etc/botframework-streaming.api.md
@@ -13,7 +13,8 @@ export class ContentStream {
     // Warning: (ae-forgotten-export) The symbol "PayloadAssembler" needs to be exported by the entry point index.d.ts
     constructor(id: string, assembler: PayloadAssembler);
     cancel(): void;
-    get contentType(): string;
+    // Warning: (ae-forgotten-export) The symbol "PayloadTypes" needs to be exported by the entry point index.d.ts
+    get contentType(): string | PayloadTypes;
     getStream(): SubscribableStream;
     // (undocumented)
     id: string;
@@ -370,11 +371,8 @@ export interface INodeSocket {
 
 // @public
 export interface IReceiveRequest {
-    // (undocumented)
     path?: string;
-    // (undocumented)
     streams: ContentStream[];
-    // (undocumented)
     verb?: string;
 }
 
@@ -447,7 +445,7 @@ export class NamedPipeServer implements IStreamingTransportServer {
 export class NodeWebSocket implements ISocket {
     constructor(wsSocket?: WebSocket_2);
     close(code?: number, data?: string): void;
-    connect(serverAddress: any, port?: number): Promise<void>;
+    connect(serverAddress: string, port?: number): Promise<void>;
     create(req: INodeIncomingMessage, socket: INodeSocket, head: INodeBuffer): Promise<void>;
     get isConnected(): boolean;
     setOnCloseHandler(handler: (x: any) => void): void;
@@ -504,15 +502,15 @@ export class SubscribableStream extends Duplex {
     length: number;
     _read(size: number): void;
     subscribe(onData: (chunk: any) => void): void;
-    _write(chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
+    _write(chunk: any, _encoding: string, callback: (error?: Error | null) => void): void;
 }
 
 // @public
 export class WebSocketClient implements IStreamingTransportClient {
-    constructor({ url, requestHandler, disconnectionHandler }: {
-        url: any;
-        requestHandler: any;
-        disconnectionHandler?: any;
+    constructor({ url, requestHandler, disconnectionHandler, }: {
+        url: string;
+        requestHandler: RequestHandler;
+        disconnectionHandler: (message: string) => void;
     });
     connect(): Promise<void>;
     disconnect(): void;

--- a/libraries/botframework-streaming/src/assemblers/payloadAssembler.ts
+++ b/libraries/botframework-streaming/src/assemblers/payloadAssembler.ts
@@ -5,16 +5,18 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+
 import { SubscribableStream } from '../subscribableStream';
 import { StreamManager, PayloadTypes } from '../payloads';
 import { ContentStream } from '../contentStream';
-import { IHeader, IResponsePayload, IReceiveResponse, IReceiveRequest, IRequestPayload } from '../interfaces';
-
-interface AssemblerParams {
-    header?: IHeader;
-    id?: string;
-    onCompleted?: (id: string, receiveResponse: IReceiveResponse | IReceiveRequest) => Promise<void>;
-}
+import {
+    IAssemblerParams,
+    IHeader,
+    IResponsePayload,
+    IReceiveResponse,
+    IReceiveRequest,
+    IRequestPayload,
+} from '../interfaces';
 
 /**
  * Assembles payloads for streaming library.
@@ -37,7 +39,7 @@ export class PayloadAssembler {
      * @param streamManager The [StreamManager](xref:botframework-streaming.StreamManager) managing the stream being assembled.
      * @param params Parameters for a streaming assembler.
      */
-    constructor(private readonly streamManager: StreamManager, params: AssemblerParams) {
+    constructor(private readonly streamManager: StreamManager, params: IAssemblerParams) {
         if (params.header) {
             this.id = params.header.id;
             this.payloadType = params.header.payloadType;

--- a/libraries/botframework-streaming/src/disassemblers/cancelDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/cancelDisassembler.ts
@@ -5,35 +5,36 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IHeader } from '../interfaces/IHeader';
-import { PayloadTypes } from '../payloads/payloadTypes';
-import { PayloadSender } from '../payloadTransport/payloadSender';
+import { PayloadTypes } from '../payloads';
+import type { PayloadSender } from '../payloadTransport';
 
 /**
  * Streaming cancel disassembler.
  */
 export class CancelDisassembler {
-    private readonly sender: PayloadSender;
-    private readonly id: string;
-    private readonly payloadType: PayloadTypes;
-
     /**
      * Initializes a new instance of the [CancelDisassembler](xref:botframework-streaming.CancelDisassembler) class.
+     *
      * @param sender The [PayloadSender](xref:botframework-streaming.PayloadSender) that this Cancel request will be sent by.
      * @param id The ID of the Stream to cancel.
      * @param payloadType The type of the Stream that is being cancelled.
      */
-    public constructor(sender: PayloadSender, id: string, payloadType: PayloadTypes) {
-        this.sender = sender;
-        this.id = id;
-        this.payloadType = payloadType;
-    }
+    constructor(
+        private readonly sender: PayloadSender,
+        private readonly id: string,
+        private readonly payloadType: PayloadTypes
+    ) {}
 
     /**
      * Initiates the process of disassembling the request and signals the [PayloadSender](xref:botframework-streaming.PayloadSender) to begin sending.
      */
-    public disassemble(): void {
-        const header: IHeader = { payloadType: this.payloadType, payloadLength: 0, id: this.id, end: true };
+    disassemble(): void {
+        const header = {
+            payloadType: this.payloadType,
+            payloadLength: 0,
+            id: this.id,
+            end: true,
+        };
         this.sender.sendPayload(header);
     }
 }

--- a/libraries/botframework-streaming/src/disassemblers/httpContentStreamDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/httpContentStreamDisassembler.ts
@@ -5,35 +5,37 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { HttpContentStream } from '../httpContentStream';
-import { PayloadSender } from '../payloadTransport/payloadSender';
-import { SubscribableStream } from '../subscribableStream';
-import { PayloadTypes } from '../payloads/payloadTypes';
+import type { HttpContentStream } from '../httpContentStream';
+import { IStreamWrapper } from '../interfaces';
 import { PayloadDisassembler } from './payloadDisassembler';
-import { IStreamWrapper } from '../interfaces/IStreamWrapper';
+import { PayloadTypes } from '../payloads';
+import type { PayloadSender } from '../payloadTransport';
+import type { SubscribableStream } from '../subscribableStream';
 
 /**
  * Disassembler for Http content stream
  */
 export class HttpContentStreamDisassembler extends PayloadDisassembler {
-    public readonly contentStream: HttpContentStream;
-    public payloadType: PayloadTypes = PayloadTypes.stream;
+    readonly contentStream: HttpContentStream;
+    payloadType: PayloadTypes = PayloadTypes.stream;
 
     /**
      * Initializes a new instance of the [HttpContentStreamDisassembler](xref:botframework-streaming.HttpContentStreamDisassembler) class.
+     *
      * @param sender The [PayloadSender](xref:botframework-streaming.PayloadSender) to send the disassembled data to.
      * @param contentStream The [HttpContentStream](xref:botframework-streaming.HttpContentStream) to be disassembled.
      */
-    public constructor(sender: PayloadSender, contentStream: HttpContentStream) {
+    constructor(sender: PayloadSender, contentStream: HttpContentStream) {
         super(sender, contentStream.id);
         this.contentStream = contentStream;
     }
 
     /**
      * Gets the stream this disassembler is operating on.
+     *
      * @returns An [IStreamWrapper](xref:botframework-streaming.IStreamWrapper) with a Subscribable Strea.
      */
-    public async getStream(): Promise<IStreamWrapper> {
+    async getStream(): Promise<IStreamWrapper> {
         const stream: SubscribableStream = this.contentStream.content.getStream();
 
         return { stream, streamLength: stream.length };

--- a/libraries/botframework-streaming/src/disassemblers/payloadDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/payloadDisassembler.ts
@@ -5,35 +5,32 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IHeader } from '../interfaces/IHeader';
-import { PayloadTypes } from '../payloads/payloadTypes';
-import { PayloadSender } from '../payloadTransport/payloadSender';
+import { PayloadTypes } from '../payloads';
+import { PayloadSender } from '../payloadTransport';
 import { SubscribableStream } from '../subscribableStream';
-import { IStreamWrapper } from '../interfaces/IStreamWrapper';
+import { IStreamWrapper } from '../interfaces';
 
 /**
  * Base class streaming payload disassembling.
  */
 export abstract class PayloadDisassembler {
-    public abstract payloadType: PayloadTypes;
-    private readonly sender: PayloadSender;
+    abstract payloadType: PayloadTypes;
     private stream: SubscribableStream;
     private streamLength?: number;
-    private readonly id: string;
 
     /**
      * Initializes a new instance of the [PayloadDisassembler](xref:botframework-streaming.PayloadDisassembler) class.
+     *
      * @param sender The [PayloadSender](xref:botframework-streaming.PayloadSender) used to send the disassembled payload chunks.
      * @param id The ID of this disassembler.
      */
-    public constructor(sender: PayloadSender, id: string) {
-        this.sender = sender;
-        this.id = id;
-    }
+    constructor(private readonly sender: PayloadSender, private readonly id: string) {}
 
     /**
      * Serializes the item into the [IStreamWrapper](xref:botframework-streaming.IStreamWrapper) that exposes the stream and length of the result.
+     *
      * @param item The item to be serialized.
+     * @returns The stream containing the serialized item and the length of the stream.
      */
     protected static serialize<T>(item: T): IStreamWrapper {
         const stream: SubscribableStream = new SubscribableStream();
@@ -46,15 +43,18 @@ export abstract class PayloadDisassembler {
 
     /**
      * Gets the stream this disassembler is operating on.
+     *
      * @returns An [IStreamWrapper](xref:botframework-streaming.IStreamWrapper) with a Subscribable Stream.
      */
-    public abstract getStream(): Promise<IStreamWrapper>;
+    abstract getStream(): Promise<IStreamWrapper>;
 
     /**
      * Begins the process of disassembling a payload and sending the resulting chunks to the [PayloadSender](xref:botframework-streaming.PayloadSender) to dispatch over the transport.
+     *
+     * @returns A completed Promise after the disassembled payload has been sent.
      */
-    public async disassemble(): Promise<void> {
-        const { stream, streamLength }: IStreamWrapper = await this.getStream();
+    async disassemble(): Promise<void> {
+        const { stream, streamLength } = await this.getStream();
 
         this.stream = stream;
         this.streamLength = streamLength;
@@ -66,7 +66,7 @@ export abstract class PayloadDisassembler {
      * Begins the process of disassembling a payload and signals the [PayloadSender](xref:botframework-streaming.PayloadSender).
      */
     private async send(): Promise<void> {
-        const header: IHeader = {
+        const header = {
             payloadType: this.payloadType,
             payloadLength: this.streamLength,
             id: this.id,

--- a/libraries/botframework-streaming/src/disassemblers/requestDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/requestDisassembler.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { IRequestPayload, IStreamWrapper } from '../interfaces';
+import { IStreamWrapper } from '../interfaces';
 import { PayloadTypes } from '../payloads/payloadTypes';
 import type { PayloadSender } from '../payloadTransport/payloadSender';
 import type { StreamingRequest } from '../streamingRequest';
@@ -35,12 +35,11 @@ export class RequestDisassembler extends PayloadDisassembler {
      * @returns An [IStreamWrapper](xref:botframework-streaming.IStreamWrapper) with a Subscribable Stream.
      */
     async getStream(): Promise<IStreamWrapper> {
-        const payload: IRequestPayload = { verb: this.request?.verb, path: this.request?.path, streams: [] };
-        if (this.request?.streams) {
-            this.request.streams.forEach(function (stream) {
-                payload.streams.push(stream.description);
-            });
-        }
+        const payload = { verb: this.request?.verb, path: this.request?.path, streams: [] };
+        this.request?.streams?.forEach(function (stream) {
+            payload.streams.push(stream.description);
+        });
+
         return PayloadDisassembler.serialize(payload);
     }
 }

--- a/libraries/botframework-streaming/src/disassemblers/requestDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/requestDisassembler.ts
@@ -5,38 +5,38 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+
+import { IRequestPayload, IStreamWrapper } from '../interfaces';
 import { PayloadTypes } from '../payloads/payloadTypes';
-import { PayloadSender } from '../payloadTransport/payloadSender';
-import { StreamingRequest } from '../streamingRequest';
+import type { PayloadSender } from '../payloadTransport/payloadSender';
+import type { StreamingRequest } from '../streamingRequest';
 import { PayloadDisassembler } from './payloadDisassembler';
-import { IStreamWrapper } from '../interfaces/IStreamWrapper';
-import { IRequestPayload } from '../interfaces/IRequestPayload';
 
 /**
  * Streaming request disassembler.
  */
 export class RequestDisassembler extends PayloadDisassembler {
-    public request: StreamingRequest;
-    public payloadType: PayloadTypes = PayloadTypes.request;
+    payloadType: PayloadTypes = PayloadTypes.request;
 
     /**
      * Initializes a new instance of the [RequestDisassembler](xref:botframework-streaming.RequestDisassembler) class.
+     *
      * @param sender The [PayloadSender](xref:botframework-streaming.PayloadSender) to send the disassembled data to.
      * @param id The ID of this disassembler.
      * @param request The request to be disassembled.
      */
-    public constructor(sender: PayloadSender, id: string, request?: StreamingRequest) {
+    constructor(sender: PayloadSender, id: string, public request?: StreamingRequest) {
         super(sender, id);
-        this.request = request;
     }
 
     /**
      * Gets the stream this disassembler is operating on.
+     *
      * @returns An [IStreamWrapper](xref:botframework-streaming.IStreamWrapper) with a Subscribable Stream.
      */
-    public async getStream(): Promise<IStreamWrapper> {
-        const payload: IRequestPayload = { verb: this.request.verb, path: this.request.path, streams: [] };
-        if (this.request.streams) {
+    async getStream(): Promise<IStreamWrapper> {
+        const payload: IRequestPayload = { verb: this.request?.verb, path: this.request?.path, streams: [] };
+        if (this.request?.streams) {
             this.request.streams.forEach(function (stream) {
                 payload.streams.push(stream.description);
             });

--- a/libraries/botframework-streaming/src/disassemblers/responseDisassembler.ts
+++ b/libraries/botframework-streaming/src/disassemblers/responseDisassembler.ts
@@ -9,32 +9,33 @@ import { PayloadTypes } from '../payloads/payloadTypes';
 import { PayloadSender } from '../payloadTransport/payloadSender';
 import { StreamingResponse } from '../streamingResponse';
 import { PayloadDisassembler } from './payloadDisassembler';
-import { IStreamWrapper } from '../interfaces/IStreamWrapper';
-import { IResponsePayload } from '../interfaces/IResponsePayload';
+import { IResponsePayload, IStreamWrapper } from '../interfaces';
 
 /**
  * Streaming response disassembler.
  */
 export class ResponseDisassembler extends PayloadDisassembler {
-    public readonly response: StreamingResponse;
-    public readonly payloadType: PayloadTypes = PayloadTypes.response;
+    readonly response: StreamingResponse;
+    readonly payloadType: PayloadTypes = PayloadTypes.response;
 
     /**
      * Initializes a new instance of the [ResponseDisassembler](xref:botframework-streaming.ResponseDisassembler) class.
+     *
      * @param sender The [PayloadSender](xref:botframework-streaming.PayloadSender) to send the disassembled data to.
      * @param id The ID of this disassembler.
      * @param response The response to be disassembled.
      */
-    public constructor(sender: PayloadSender, id: string, response: StreamingResponse) {
+    constructor(sender: PayloadSender, id: string, response: StreamingResponse) {
         super(sender, id);
         this.response = response;
     }
 
     /**
      * Gets the stream this disassembler is operating on.
+     *
      * @returns An [IStreamWrapper](xref:botframework-streaming.IStreamWrapper) with a Subscribable Stream.
      */
-    public async getStream(): Promise<IStreamWrapper> {
+    async getStream(): Promise<IStreamWrapper> {
         const payload: IResponsePayload = { statusCode: this.response.statusCode, streams: [] };
         if (this.response.streams) {
             this.response.streams.forEach(function (stream) {

--- a/libraries/botframework-streaming/src/httpContentStream.ts
+++ b/libraries/botframework-streaming/src/httpContentStream.ts
@@ -25,8 +25,8 @@ export class HttpContentStream {
         this.id = generateGuid();
         this.description = {
             id: this.id,
-            type: this.content?.headers ? this.content?.headers.type : 'unknown',
-            length: this.content?.headers ? this.content?.headers.contentLength : 0,
+            type: this.content?.headers?.type ?? 'unknown',
+            length: this.content?.headers?.contentLength ?? 0,
         };
     }
 }

--- a/libraries/botframework-streaming/src/httpContentStream.ts
+++ b/libraries/botframework-streaming/src/httpContentStream.ts
@@ -5,30 +5,28 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { SubscribableStream } from './subscribableStream';
 import { generateGuid } from './utilities/protocol-base';
-import { IHttpContentHeaders } from './interfaces/IHttpContentHeaders';
+import { IHttpContentHeaders } from './interfaces';
+import type { SubscribableStream } from './subscribableStream';
 
 /**
- * An attachment contained within a StreamingRequest's stream collection,
- * which itself contains any form of media item.
+ * An attachment contained within a StreamingRequest's stream collection, which itself contains any form of media item.
  */
 export class HttpContentStream {
-    public readonly id: string;
-    public readonly content: HttpContent;
-    public description: { id: string; type: string; length: number };
+    readonly id: string;
+    description: { id: string; type: string; length: number };
 
     /**
      * Initializes a new instance of the [HttpContentStream](xref:botframework-streaming.HttpContentStream) class.
+     *
      * @param content The [HttpContent](xref:botframework-streaming.HttpContent) to assign to the [HttpContentStream](xref:botframework-streaming.HttpContentStream).
      */
-    public constructor(content: HttpContent) {
+    constructor(readonly content: HttpContent) {
         this.id = generateGuid();
-        this.content = content;
         this.description = {
             id: this.id,
-            type: this.content.headers ? this.content.headers.type : 'unknown',
-            length: this.content.headers ? this.content.headers.contentLength : 0,
+            type: this.content?.headers ? this.content?.headers.type : 'unknown',
+            length: this.content?.headers ? this.content?.headers.contentLength : 0,
         };
     }
 }
@@ -37,23 +35,20 @@ export class HttpContentStream {
  * The HttpContent class that contains a [SubscribableStream](xref:botframework-streaming.SubscribableStream).
  */
 export class HttpContent {
-    public headers: IHttpContentHeaders;
-    private readonly stream: SubscribableStream;
-
     /**
      * Initializes a new instance of the [HttpContent](xref:botframework-streaming.HttpContent) class.
+     *
      * @param headers The Streaming Http content header definition.
      * @param stream The stream of buffered data.
      */
-    public constructor(headers: IHttpContentHeaders, stream: SubscribableStream) {
-        this.headers = headers;
-        this.stream = stream;
-    }
+    constructor(public headers: IHttpContentHeaders, private readonly stream: SubscribableStream) {}
 
     /**
      * Gets the data contained within this [HttpContent](xref:botframework-streaming.HttpContent).
+     *
+     * @returns This [HttpContent's](xref:botframework-streaming.HttpContent) [SubscribableStream](xref:botframework-streaming.SubscribableStream) member.
      */
-    public getStream(): SubscribableStream {
+    getStream(): SubscribableStream {
         return this.stream;
     }
 }

--- a/libraries/botframework-streaming/src/interfaces/IAssemblerParams.ts
+++ b/libraries/botframework-streaming/src/interfaces/IAssemblerParams.ts
@@ -9,9 +9,10 @@ import { IHeader } from './IHeader';
 
 /**
  * Parameters for a streaming assembler.
+ * @internal
  */
 export interface IAssemblerParams {
     header?: IHeader;
     id?: string;
-    onCompleted?: Function;
+    onCompleted?: (id: string, receiveResponse: unknown) => Promise<void>;
 }

--- a/libraries/botframework-streaming/src/interfaces/IAssemblerParams.ts
+++ b/libraries/botframework-streaming/src/interfaces/IAssemblerParams.ts
@@ -5,14 +5,18 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+
 import { IHeader } from './IHeader';
+import { IReceiveRequest } from './IReceiveRequest';
+import { IReceiveResponse } from './IReceiveResponse';
 
 /**
  * Parameters for a streaming assembler.
+ *
  * @internal
  */
 export interface IAssemblerParams {
     header?: IHeader;
     id?: string;
-    onCompleted?: (id: string, receiveResponse: unknown) => Promise<void>;
+    onCompleted?: (id: string, receiveResponse: IReceiveResponse | IReceiveRequest) => Promise<void>;
 }

--- a/libraries/botframework-streaming/src/interfaces/IBrowserFileReader.ts
+++ b/libraries/botframework-streaming/src/interfaces/IBrowserFileReader.ts
@@ -13,7 +13,9 @@
  * This interface supports the framework and is not intended to be called directly for your code.
  */
 export interface IBrowserFileReader {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     result: any;
     onload: (event: any) => void;
     readAsArrayBuffer: (blobOrFile: any) => void;
+    /* eslint-enable @typescript-eslint/no-explicit-any */
 }

--- a/libraries/botframework-streaming/src/interfaces/IBrowserWebSocket.ts
+++ b/libraries/botframework-streaming/src/interfaces/IBrowserWebSocket.ts
@@ -13,12 +13,13 @@
  * This interface supports the framework and is not intended to be called directly for your code.
  */
 export interface IBrowserWebSocket {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     onclose: (event: any) => void;
     onerror: (event: any) => void;
     onmessage: (event: any) => void;
     onopen: (event: any) => void;
-    readyState: number;
-
-    close(): void;
     send(buffer: any): void;
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    readyState: number;
+    close(): void;
 }

--- a/libraries/botframework-streaming/src/interfaces/IEventEmitter.ts
+++ b/libraries/botframework-streaming/src/interfaces/IEventEmitter.ts
@@ -12,20 +12,23 @@
  * This interface supports the framework and is not intended to be called directly for your code.
  */
 export interface IEventEmitter {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-    on(event: string | symbol, listener: (...args: any[]) => void): this;
-    once(event: string | symbol, listener: (...args: any[]) => void): this;
-    removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    emit(event: string | symbol, ...args: any[]): boolean;
     off(event: string | symbol, listener: (...args: any[]) => void): this;
+    once(event: string | symbol, listener: (...args: any[]) => void): this;
+    on(event: string | symbol, listener: (...args: any[]) => void): this;
+    removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+    /* eslint-enable @typescript-eslint/no-explicit-any */
     removeAllListeners(event?: string | symbol): this;
     setMaxListeners(n: number): this;
     getMaxListeners(): number;
+    /* eslint-disable  @typescript-eslint/ban-types */
     listeners(event: string | symbol): Function[];
     rawListeners(event: string | symbol): Function[];
-    emit(event: string | symbol, ...args: any[]): boolean;
+    /* eslint-enable  @typescript-eslint/ban-types */
     listenerCount(type: string | symbol): number;
-    // Added in Node 6...
-    prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
-    prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
     eventNames(): Array<string | symbol>;
 }

--- a/libraries/botframework-streaming/src/interfaces/INodeBuffer.ts
+++ b/libraries/botframework-streaming/src/interfaces/INodeBuffer.ts
@@ -26,9 +26,11 @@ export type BufferEncoding =
  * This interface supports the framework and is not intended to be called directly for your code.
  */
 export interface INodeBuffer extends Uint8Array {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     constructor: any;
     write(string: string, offset?: number, length?: number, encoding?: string): number;
     toString(encoding?: string, start?: number, end?: number): string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     toJSON(): { type: 'Buffer'; data: any[] };
     equals(otherBuffer: Uint8Array): boolean;
     compare(
@@ -90,6 +92,7 @@ export interface INodeBuffer extends Uint8Array {
     writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
     writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fill(value: any, offset?: number, end?: number): this;
     indexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: string): number;
     lastIndexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: string): number;

--- a/libraries/botframework-streaming/src/interfaces/INodeIncomingMessage.ts
+++ b/libraries/botframework-streaming/src/interfaces/INodeIncomingMessage.ts
@@ -12,13 +12,15 @@
  * This interface supports the framework and is not intended to be called directly for your code.
  */
 export interface INodeIncomingMessage {
-    /***
+    /**
      * Optional. The request headers.
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     headers?: any;
 
-    /***
+    /**
      * Optional. The request method.
      */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     method?: any;
 }

--- a/libraries/botframework-streaming/src/interfaces/INodeSocket.ts
+++ b/libraries/botframework-streaming/src/interfaces/INodeSocket.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types */
 /**
  * @module botframework-streaming
  */

--- a/libraries/botframework-streaming/src/interfaces/IReceiveRequest.ts
+++ b/libraries/botframework-streaming/src/interfaces/IReceiveRequest.ts
@@ -8,20 +8,21 @@
 import { ContentStream } from '../contentStream';
 
 /**
- * Streaming receive request definition
+ * Streaming receive request definition.
  */
 export interface IReceiveRequest {
-    /// Request verb, null on responses
-    /// </summary>
+    /**
+     * Request verb; null on responses.
+     */
     verb?: string;
 
-    /// <summary>
-    /// Request path; null on responses
-    /// </summary>
+    /**
+     * Request path; null on responses.
+     */
     path?: string;
 
-    /// <summary>
-    /// Gets or sets the collection of stream attachments included in this request.
-    /// </summary>
+    /**
+     * Gets or sets the collection of stream attachments included in this request.
+     */
     streams: ContentStream[];
 }

--- a/libraries/botframework-streaming/src/interfaces/ISocket.ts
+++ b/libraries/botframework-streaming/src/interfaces/ISocket.ts
@@ -18,7 +18,10 @@ export interface ISocket {
     write(buffer: INodeBuffer);
     connect(serverAddress: string): Promise<void>;
     close();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setOnMessageHandler(handler: (x: any) => void);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setOnErrorHandler(handler: (x: any) => void);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setOnCloseHandler(handler: (x: any) => void);
 }

--- a/libraries/botframework-streaming/src/interfaces/index.ts
+++ b/libraries/botframework-streaming/src/interfaces/index.ts
@@ -16,6 +16,7 @@ export * from './IStreamingTransportClient';
 export * from './IStreamingTransportServer';
 
 // Internal
+export * from './IAssemblerParams';
 export * from './IBrowserFileReader';
 export * from './IBrowserWebSocket';
 export * from './IEventEmitter';

--- a/libraries/botframework-streaming/src/interfaces/index.ts
+++ b/libraries/botframework-streaming/src/interfaces/index.ts
@@ -6,15 +6,26 @@
  * Licensed under the MIT License.
  */
 
-export * from './IBrowserFileReader';
-export * from './IBrowserWebSocket';
-export * from './IEventEmitter';
 export * from './INodeBuffer';
 export * from './INodeIncomingMessage';
-export * from './INodeServer';
 export * from './INodeSocket';
 export * from './IReceiveRequest';
 export * from './IReceiveResponse';
 export * from './ISocket';
 export * from './IStreamingTransportClient';
 export * from './IStreamingTransportServer';
+
+// Internal
+export * from './IBrowserFileReader';
+export * from './IBrowserWebSocket';
+export * from './IEventEmitter';
+export * from './IHeader';
+export * from './IHttpContentHeaders';
+export * from './INodeServer';
+export * from './IRequestPayload';
+export * from './IResponsePayload';
+export * from './ISendPacket';
+export * from './IStreamWrapper';
+export * from './ITransport';
+export * from './ITransportReceiver';
+export * from './ITransportSender';

--- a/libraries/botframework-streaming/src/namedPipe/namedPipeClient.ts
+++ b/libraries/botframework-streaming/src/namedPipe/namedPipeClient.ts
@@ -34,7 +34,7 @@ export class NamedPipeClient implements IStreamingTransportClient {
      * @param requestHandler Optional [RequestHandler](xref:botframework-streaming.RequestHandler) to process incoming messages received by this client.
      * @param autoReconnect Optional setting to determine if the client sould attempt to reconnect automatically on disconnection events. Defaults to true.
      */
-    public constructor(baseName: string, requestHandler?: RequestHandler, autoReconnect = true) {
+    constructor(baseName: string, requestHandler?: RequestHandler, autoReconnect = true) {
         this._baseName = baseName;
         this._requestHandler = requestHandler;
         this._autoReconnect = autoReconnect;
@@ -54,7 +54,7 @@ export class NamedPipeClient implements IStreamingTransportClient {
     /**
      * Establish a connection with no custom headers.
      */
-    public async connect(): Promise<void> {
+    async connect(): Promise<void> {
         const outgoingPipeName: string =
             NamedPipeTransport.PipePath + this._baseName + NamedPipeTransport.ServerIncomingPath;
         const outgoing = connect(outgoingPipeName);
@@ -68,7 +68,7 @@ export class NamedPipeClient implements IStreamingTransportClient {
     /**
      * Disconnect the client.
      */
-    public disconnect(): void {
+    disconnect(): void {
         this._sender.disconnect();
         this._receiver.disconnect();
     }
@@ -79,14 +79,12 @@ export class NamedPipeClient implements IStreamingTransportClient {
      * @param request The [StreamingRequest](xref:botframework-streaming.StreamingRequest) to send.
      * @returns A promise for an instance of [IReceiveResponse](xref:botframework-streaming.IReceiveResponse) on completion of the send operation.
      */
-    public async send(request: StreamingRequest): Promise<IReceiveResponse> {
+    async send(request: StreamingRequest): Promise<IReceiveResponse> {
         return this._protocolAdapter.sendRequest(request);
     }
 
-    /**
-     * @private
-     */
-    private onConnectionDisconnected(sender: object, args: any): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private onConnectionDisconnected(sender: Record<string, unknown>, args: any): void {
         if (!this._isDisconnecting) {
             this._isDisconnecting = true;
             try {

--- a/libraries/botframework-streaming/src/namedPipe/namedPipeServer.ts
+++ b/libraries/botframework-streaming/src/namedPipe/namedPipeServer.ts
@@ -32,7 +32,7 @@ export class NamedPipeServer implements IStreamingTransportServer {
      * @param requestHandler Optional [RequestHandler](xref:botframework-streaming.RequestHandler) to process incoming messages received by this client.
      * @param autoReconnect Deprecated: Automatic reconnection is the default behavior.
      */
-    public constructor(private readonly baseName: string, requestHandler?: RequestHandler, autoReconnect?: boolean) {
+    constructor(private readonly baseName: string, requestHandler?: RequestHandler, autoReconnect?: boolean) {
         if (!baseName) {
             throw new TypeError('NamedPipeServer: Missing baseName parameter');
         }
@@ -51,7 +51,7 @@ export class NamedPipeServer implements IStreamingTransportServer {
      *
      * @returns true if currently connected.
      */
-    public get isConnected(): boolean {
+    get isConnected(): boolean {
         return this._receiver.isConnected && this._sender.isConnected;
     }
 
@@ -61,7 +61,7 @@ export class NamedPipeServer implements IStreamingTransportServer {
      * @param onListen Optional callback that fires once when server is listening on both incoming and outgoing pipe
      * @returns A promised string that will not resolve as long as the server is running.
      */
-    public async start(onListen?: () => void): Promise<string> {
+    async start(onListen?: () => void): Promise<string> {
         const { PipePath, ServerIncomingPath, ServerOutgoingPath } = NamedPipeTransport;
 
         // The first promise resolves as soon as the server is listening. The second resolves when the server
@@ -128,7 +128,7 @@ export class NamedPipeServer implements IStreamingTransportServer {
     /**
      * Allows for manually disconnecting the server.
      */
-    public disconnect(): void {
+    disconnect(): void {
         this._receiver.disconnect();
         this._incomingServer?.close();
         this._incomingServer = null;
@@ -144,7 +144,7 @@ export class NamedPipeServer implements IStreamingTransportServer {
      * @param request The [StreamingRequest](xref:botframework-streaming.StreamingRequest) to send.
      * @returns A promise for an instance of [IReceiveResponse](xref:botframework-streaming.IReceiveResponse) on completion of the send operation.
      */
-    public async send(request: StreamingRequest): Promise<IReceiveResponse> {
+    async send(request: StreamingRequest): Promise<IReceiveResponse> {
         return this._protocolAdapter.sendRequest(request);
     }
 }

--- a/libraries/botframework-streaming/src/payloadTransport/payloadReceiver.ts
+++ b/libraries/botframework-streaming/src/payloadTransport/payloadReceiver.ts
@@ -11,15 +11,13 @@ import { HeaderSerializer } from '../payloads/headerSerializer';
 import { SubscribableStream } from '../subscribableStream';
 import { PayloadConstants } from '../payloads/payloadConstants';
 import { TransportDisconnectedEvent } from './transportDisconnectedEvent';
-import { ITransportReceiver } from '../interfaces/ITransportReceiver';
-import { IHeader } from '../interfaces/IHeader';
-import { INodeBuffer } from '../interfaces/INodeBuffer';
+import { IHeader, INodeBuffer, ITransportReceiver } from '../interfaces';
 
 /**
  * Payload receiver for streaming.
  */
 export class PayloadReceiver {
-    public disconnected?: TransportDisconnectedEventHandler;
+    disconnected?: TransportDisconnectedEventHandler;
 
     private _receiver: ITransportReceiver;
     private _receiveHeaderBuffer: INodeBuffer;
@@ -33,7 +31,7 @@ export class PayloadReceiver {
      *
      * @returns true if connected to a transport sender.
      */
-    public get isConnected(): boolean {
+    get isConnected(): boolean {
         return this._receiver != null;
     }
 
@@ -43,7 +41,7 @@ export class PayloadReceiver {
      * @param receiver The [ITransportReceiver](xref:botframework-streaming.ITransportReceiver) object to pull incoming data from.
      * @returns a promise that resolves when the receiver is complete
      */
-    public connect(receiver: ITransportReceiver): Promise<void> {
+    connect(receiver: ITransportReceiver): Promise<void> {
         this._receiver = receiver;
         return this.receivePackets();
     }
@@ -54,7 +52,7 @@ export class PayloadReceiver {
      * @param getStream Callback when a new stream has been received.
      * @param receiveAction Callback when a new message has been received.
      */
-    public subscribe(
+    subscribe(
         getStream: (header: IHeader) => SubscribableStream,
         receiveAction: (header: IHeader, stream: SubscribableStream, count: number) => void
     ): void {
@@ -67,7 +65,7 @@ export class PayloadReceiver {
      *
      * @param event Event arguments to include when broadcasting disconnection event.
      */
-    public disconnect(event = TransportDisconnectedEvent.Empty): void {
+    disconnect(event = TransportDisconnectedEvent.Empty): void {
         if (!this.isConnected) {
             return;
         }

--- a/libraries/botframework-streaming/src/payloadTransport/payloadSender.ts
+++ b/libraries/botframework-streaming/src/payloadTransport/payloadSender.ts
@@ -7,9 +7,7 @@
  */
 
 import { HeaderSerializer } from '../payloads/headerSerializer';
-import { IHeader } from '../interfaces/IHeader';
-import { ISendPacket } from '../interfaces/ISendPacket';
-import { ITransportSender } from '../interfaces/ITransportSender';
+import { IHeader, ISendPacket, ITransportSender } from '../interfaces';
 import { PayloadConstants } from '../payloads/payloadConstants';
 import { SubscribableStream } from '../subscribableStream';
 import { TransportDisconnectedEvent } from './transportDisconnectedEvent';
@@ -19,7 +17,7 @@ import { TransportDisconnectedEventHandler } from './transportDisconnectedEventH
  * Streaming payload sender.
  */
 export class PayloadSender {
-    public disconnected?: TransportDisconnectedEventHandler;
+    disconnected?: TransportDisconnectedEventHandler;
 
     private _sender: ITransportSender;
 
@@ -28,7 +26,7 @@ export class PayloadSender {
      *
      * @returns true if connected to a transport sender.
      */
-    public get isConnected(): boolean {
+    get isConnected(): boolean {
         return this._sender != null;
     }
 
@@ -37,7 +35,7 @@ export class PayloadSender {
      *
      * @param sender The transport sender to connect this payload sender to.
      */
-    public connect(sender: ITransportSender): void {
+    connect(sender: ITransportSender): void {
         this._sender = sender;
     }
 
@@ -48,7 +46,7 @@ export class PayloadSender {
      * @param payload The stream of buffered data to send.
      * @param sentCallback The function to execute when the send has completed.
      */
-    public sendPayload(header: IHeader, payload?: SubscribableStream, sentCallback?: () => Promise<void>): void {
+    sendPayload(header: IHeader, payload?: SubscribableStream, sentCallback?: () => Promise<void>): void {
         const packet: ISendPacket = { header, payload, sentCallback };
         this.writePacket(packet);
     }
@@ -58,7 +56,7 @@ export class PayloadSender {
      *
      * @param event The disconnected event arguments to include in the disconnected event broadcast.
      */
-    public disconnect(event = TransportDisconnectedEvent.Empty): void {
+    disconnect(event = TransportDisconnectedEvent.Empty): void {
         if (!this.isConnected) {
             return;
         }

--- a/libraries/botframework-streaming/src/payloadTransport/transportDisconnectedEvent.ts
+++ b/libraries/botframework-streaming/src/payloadTransport/transportDisconnectedEvent.ts
@@ -13,20 +13,22 @@ export class TransportDisconnectedEvent {
     /**
      * A new and empty TransportDisconnectedEvent.
      */
-    public static Empty: TransportDisconnectedEvent = new TransportDisconnectedEvent();
+    static Empty: TransportDisconnectedEvent = new TransportDisconnectedEvent();
 
     /**
      * The reason the disconnection event fired, in plain text.
      */
-    public reason: string;
+    reason: string;
 
     /**
      * Indicates a transport disconnected with the reason provided via the constructor.
+     *
+     * @remarks
      * This class is used for communicating disconnection events between the
      * PayloadReceiver and PayloadSender.
      * @param reason The reason the disconnection event fired, in plain text.
      */
-    public constructor(reason?: string) {
+    constructor(reason?: string) {
         this.reason = reason;
     }
 }

--- a/libraries/botframework-streaming/src/payloadTransport/transportDisconnectedEventHandler.ts
+++ b/libraries/botframework-streaming/src/payloadTransport/transportDisconnectedEventHandler.ts
@@ -8,4 +8,5 @@
 
 import { TransportDisconnectedEvent } from './transportDisconnectedEvent';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type TransportDisconnectedEventHandler = (sender: any, e: TransportDisconnectedEvent) => void;

--- a/libraries/botframework-streaming/src/payloads/headerSerializer.ts
+++ b/libraries/botframework-streaming/src/payloads/headerSerializer.ts
@@ -5,29 +5,28 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IHeader } from '../interfaces/IHeader';
+import { IHeader, INodeBuffer } from '../interfaces';
 import { PayloadConstants } from './payloadConstants';
-import { INodeBuffer } from '../interfaces/INodeBuffer';
 
 /**
  * Streaming header serializer
  */
 export class HeaderSerializer {
-    public static readonly Delimiter = '.';
-    public static readonly Terminator = '\n';
-    public static readonly End = '1';
-    public static readonly NotEnd = '0';
-    public static readonly TypeOffset: number = 0;
-    public static readonly TypeDelimiterOffset = 1;
-    public static readonly LengthOffset = 2;
-    public static readonly LengthLength = 6;
-    public static readonly LengthDelimeterOffset = 8;
-    public static readonly IdOffset = 9;
-    public static readonly IdLength = 36;
-    public static readonly IdDelimeterOffset = 45;
-    public static readonly EndOffset = 46;
-    public static readonly TerminatorOffset = 47;
-    public static readonly Encoding = 'utf8';
+    static readonly Delimiter = '.';
+    static readonly Terminator = '\n';
+    static readonly End = '1';
+    static readonly NotEnd = '0';
+    static readonly TypeOffset: number = 0;
+    static readonly TypeDelimiterOffset = 1;
+    static readonly LengthOffset = 2;
+    static readonly LengthLength = 6;
+    static readonly LengthDelimeterOffset = 8;
+    static readonly IdOffset = 9;
+    static readonly IdLength = 36;
+    static readonly IdDelimeterOffset = 45;
+    static readonly EndOffset = 46;
+    static readonly TerminatorOffset = 47;
+    static readonly Encoding = 'utf8';
 
     /**
      * Serializes the header into a buffer
@@ -35,7 +34,7 @@ export class HeaderSerializer {
      * @param header The header to serialize.
      * @param buffer The buffer into which to serialize the header.
      */
-    public static serialize(header: IHeader, buffer: INodeBuffer): void {
+    static serialize(header: IHeader, buffer: INodeBuffer): void {
         buffer.write(header.payloadType, this.TypeOffset, 1, this.Encoding);
         buffer.write(this.Delimiter, this.TypeDelimiterOffset, 1, this.Encoding);
         buffer.write(
@@ -57,7 +56,7 @@ export class HeaderSerializer {
      * @param buffer The buffer from which to obtain the data to deserialize.
      * @returns The deserialized header from the buffer.
      */
-    public static deserialize(buffer: INodeBuffer): IHeader {
+    static deserialize(buffer: INodeBuffer): IHeader {
         const jsonBuffer = buffer.toString(this.Encoding);
         const headerArray = jsonBuffer.split(this.Delimiter);
 
@@ -102,11 +101,13 @@ export class HeaderSerializer {
 
     /**
      * Creates a padded string based on a length and character to be padded to.
+     *
      * @param lengthValue The value to be assingned on the result.
      * @param totalLength The length of the padded string result.
      * @param padChar The character value to use as filling.
+     * @returns The padded string.
      */
-    public static headerLengthPadder(lengthValue: number, totalLength: number, padChar: string): string {
+    static headerLengthPadder(lengthValue: number, totalLength: number, padChar: string): string {
         const result = Array(totalLength + 1).join(padChar);
 
         const lengthString = lengthValue.toString();

--- a/libraries/botframework-streaming/src/payloads/requestManager.ts
+++ b/libraries/botframework-streaming/src/payloads/requestManager.ts
@@ -5,15 +5,16 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IReceiveResponse } from '../interfaces/IReceiveResponse';
+import { IReceiveResponse } from '../interfaces';
 
 /**
  * A streaming pending request.
  */
 class PendingRequest {
-    public requestId: string;
-    public resolve: (response: IReceiveResponse) => void;
-    public reject: (reason?: any) => void;
+    requestId: string;
+    resolve: (response: IReceiveResponse) => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    reject: (reason?: any) => void;
 }
 
 /**
@@ -24,18 +25,21 @@ export class RequestManager {
 
     /**
      * Gets the count of the pending requests.
+     *
      * @returns Number with the pending requests count.
      */
-    public pendingRequestCount(): number {
+    pendingRequestCount(): number {
         return Object.keys(this._pendingRequests).length;
     }
 
     /**
      * Signal fired when all response tasks have completed.
+     *
      * @param requestId The ID of the StreamingRequest.
      * @param response The [IReceiveResponse](xref:botframework-streaming.IReceiveResponse) in response to the request.
+     * @returns A Promise that when completed returns `true` if the `requestId`'s pending response task was completed, otherwise `false`.
      */
-    public async signalResponse(requestId: string, response: IReceiveResponse): Promise<boolean> {
+    async signalResponse(requestId: string, response: IReceiveResponse): Promise<boolean> {
         const pendingRequest = this._pendingRequests[requestId];
 
         if (pendingRequest) {
@@ -50,10 +54,11 @@ export class RequestManager {
 
     /**
      * Constructs and returns a response for this request.
+     *
      * @param requestId The ID of the StreamingRequest being responded to.
      * @returns The response to the specified request.
      */
-    public getResponse(requestId: string): Promise<IReceiveResponse> {
+    getResponse(requestId: string): Promise<IReceiveResponse> {
         let pendingRequest = this._pendingRequests[requestId];
 
         if (pendingRequest) {

--- a/libraries/botframework-streaming/src/payloads/sendOperations.ts
+++ b/libraries/botframework-streaming/src/payloads/sendOperations.ts
@@ -22,18 +22,20 @@ export class SendOperations {
 
     /**
      * Initializes a new instance of the [SendOperations](xref:botframework-streaming.SendOperations) class.
+     *
      * @param payloadSender The [PayloadSender](xref:botframework-streaming.PayloadSender) that will send the disassembled data from all of this instance's send operations.
      */
-    public constructor(payloadSender: PayloadSender) {
+    constructor(payloadSender: PayloadSender) {
         this.payloadSender = payloadSender;
     }
 
     /**
      * The send operation used to send a [StreamingRequest](xref:botframework-streaming.StreamingRequest).
+     *
      * @param id The ID to assign to the [RequestDisassembler](xref:botframework-streaming.RequestDisassembler) used by this operation.
      * @param request The request to send.
      */
-    public async sendRequest(id: string, request: StreamingRequest): Promise<void> {
+    async sendRequest(id: string, request: StreamingRequest): Promise<void> {
         const disassembler = new RequestDisassembler(this.payloadSender, id, request);
 
         await disassembler.disassemble();
@@ -49,10 +51,11 @@ export class SendOperations {
 
     /**
      * The send operation used to send a [PayloadTypes.response](xref:botframework-streaming.PayloadTypes.response).
+     *
      * @param id The ID to assign to the [ResponseDisassembler](xref:botframework-streaming.ResponseDisassembler) used by this operation.
      * @param response The response to send.
      */
-    public async sendResponse(id: string, response: StreamingResponse): Promise<void> {
+    async sendResponse(id: string, response: StreamingResponse): Promise<void> {
         const disassembler = new ResponseDisassembler(this.payloadSender, id, response);
 
         await disassembler.disassemble();
@@ -68,9 +71,10 @@ export class SendOperations {
 
     /**
      * The send operation used to send a [PayloadTypes.cancelStream](xref:botframework-streaming.PayloadTypes.cancelStream).
+     *
      * @param id The ID to assign to the [CancelDisassembler](xref:botframework-streaming.CancelDisassembler) used by this operation.
      */
-    public async sendCancelStream(id: string): Promise<void> {
+    async sendCancelStream(id: string): Promise<void> {
         const disassembler = new CancelDisassembler(this.payloadSender, id, PayloadTypes.cancelStream);
         disassembler.disassemble();
     }

--- a/libraries/botframework-streaming/src/payloads/streamManager.ts
+++ b/libraries/botframework-streaming/src/payloads/streamManager.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IHeader } from '../interfaces/IHeader';
+import { IHeader } from '../interfaces';
 import { SubscribableStream } from '../subscribableStream';
 import { PayloadAssembler } from '../assemblers/payloadAssembler';
 
@@ -14,25 +14,24 @@ import { PayloadAssembler } from '../assemblers/payloadAssembler';
  */
 export class StreamManager {
     private readonly activeAssemblers = [];
-    private readonly onCancelStream: Function;
 
     /**
      * Initializes a new instance of the [StreamManager](xref:botframework-streaming.StreamManager) class.
+     *
      * @param onCancelStream Function to trigger if the managed stream is cancelled.
      */
-    public constructor(onCancelStream: Function) {
-        this.onCancelStream = onCancelStream;
-    }
+    constructor(private readonly onCancelStream: (contentStreamAssembler: PayloadAssembler) => void) {}
 
     /**
      * Retrieves a [PayloadAssembler](xref:botframework-streaming.PayloadAssembler) with the given ID if one exists, otherwise a new instance is created and assigned the given ID.
+     *
      * @param id The ID of the [PayloadAssembler](xref:botframework-streaming.PayloadAssembler) to retrieve or create.
      * @returns The [PayloadAssembler](xref:botframework-streaming.PayloadAssembler) with the given ID.
      */
-    public getPayloadAssembler(id: string): PayloadAssembler {
+    getPayloadAssembler(id: string): PayloadAssembler {
         if (!this.activeAssemblers[id]) {
             // A new id has come in, kick off the process of tracking it.
-            const assembler = new PayloadAssembler(this, { id: id });
+            const assembler = new PayloadAssembler(this, { id });
             this.activeAssemblers[id] = assembler;
 
             return assembler;
@@ -43,10 +42,11 @@ export class StreamManager {
 
     /**
      * Retrieves the [SubscribableStream](xref:botframework-streaming.SubscribableStream) from the [PayloadAssembler](xref:botframework-streaming.PayloadAssembler) this manager manages.
+     *
      * @param header The Header of the [SubscribableStream](xref:botframework-streaming.SubscribableStream) to retrieve.
      * @returns The [SubscribableStream](xref:botframework-streaming.SubscribableStream) with the given header.
      */
-    public getPayloadStream(header: IHeader): SubscribableStream {
+    getPayloadStream(header: IHeader): SubscribableStream {
         const assembler = this.getPayloadAssembler(header.id);
 
         return assembler.getPayloadStream();
@@ -54,11 +54,12 @@ export class StreamManager {
 
     /**
      * Used to set the behavior of the managed [PayloadAssembler](xref:botframework-streaming.PayloadAssembler) when data is received.
+     *
      * @param header The Header of the stream.
      * @param contentStream The [SubscribableStream](xref:botframework-streaming.SubscribableStream) to write incoming data to.
      * @param contentLength The amount of data to write to the contentStream.
      */
-    public onReceive(header: IHeader, contentStream: SubscribableStream, contentLength: number): void {
+    onReceive(header: IHeader, contentStream: SubscribableStream, contentLength: number): void {
         if (!this.activeAssemblers[header.id]) {
             return;
         }
@@ -67,9 +68,10 @@ export class StreamManager {
 
     /**
      * Closes the [PayloadAssembler](xref:botframework-streaming.PayloadAssembler) assigned to the [SubscribableStream](xref:botframework-streaming.SubscribableStream) with the given ID.
+     *
      * @param id The ID of the [SubscribableStream](xref:botframework-streaming.SubscribableStream) to close.
      */
-    public closeStream(id: string): void {
+    closeStream(id: string): void {
         if (!this.activeAssemblers[id]) {
             return;
         } else {

--- a/libraries/botframework-streaming/src/protocolAdapter.ts
+++ b/libraries/botframework-streaming/src/protocolAdapter.ts
@@ -31,14 +31,15 @@ export class ProtocolAdapter {
     private readonly streamManager: StreamManager;
     private readonly assemblerManager: PayloadAssemblerManager;
 
-    /// <summary>
-    /// Creates a new instance of the protocol adapter class.
-    /// </summary>
-    /// <param name="requestHandler">The handler that will process incoming requests.</param>
-    /// <param name="requestManager">The manager that will process outgoing requests.</param>
-    /// <param name="sender">The sender for use with outgoing requests.</param>
-    /// <param name="receiver">The receiver for use with incoming requests.</param>
-    public constructor(
+    /**
+     * Creates a new instance of the protocol adapter class.
+     *
+     * @param requestHandler The [RequestHandler](xref:botframework-streaming.RequestHandler) that will process incoming requests.
+     * @param requestManager The [RequestManager](xref:botframework-streaming.RequestManager) that will process outgoing requests.
+     * @param sender The [PayloadSender](xref:botframework-streaming.PayloadSender) for use with outgoing requests.
+     * @param receiver The [PayloadReceiver](xref:botframework-streaming.PayloadReceiver) for use with incoming requests.
+     */
+    constructor(
         requestHandler: RequestHandler,
         requestManager: RequestManager,
         sender: PayloadSender,
@@ -64,10 +65,11 @@ export class ProtocolAdapter {
 
     /**
      * Sends a request over the attached request manager.
+     *
      * @param request The outgoing request to send.
      * @returns The response to the specified request.
      */
-    public async sendRequest(request: StreamingRequest): Promise<IReceiveResponse> {
+    async sendRequest(request: StreamingRequest): Promise<IReceiveResponse> {
         const requestId: string = generateGuid();
         await this.sendOperations.sendRequest(requestId, request);
 
@@ -76,10 +78,11 @@ export class ProtocolAdapter {
 
     /**
      * Executes the receive pipeline when a request comes in.
+     *
      * @param id The id the resources created for the response will be assigned.
      * @param request The incoming request to process.
      */
-    public async onReceiveRequest(id: string, request: IReceiveRequest): Promise<void> {
+    async onReceiveRequest(id: string, request: IReceiveRequest): Promise<void> {
         if (this.requestHandler) {
             const response = await this.requestHandler.processRequest(request);
 
@@ -91,18 +94,20 @@ export class ProtocolAdapter {
 
     /**
      * Executes the receive pipeline when a response comes in.
+     *
      * @param id The id the resources created for the response will be assigned.
      * @param response The incoming response to process.
      */
-    public async onReceiveResponse(id: string, response: IReceiveResponse): Promise<void> {
+    async onReceiveResponse(id: string, response: IReceiveResponse): Promise<void> {
         await this.requestManager.signalResponse(id, response);
     }
 
     /**
      * Executes the receive pipeline when a cancellation comes in.
+     *
      * @param contentStreamAssembler The payload assembler processing the incoming data that this cancellation request targets.
      */
-    public onCancelStream(contentStreamAssembler: PayloadAssembler): void {
+    onCancelStream(contentStreamAssembler: PayloadAssembler): void {
         this.sendOperations.sendCancelStream(contentStreamAssembler.id).catch();
     }
 }

--- a/libraries/botframework-streaming/src/requestHandler.ts
+++ b/libraries/botframework-streaming/src/requestHandler.ts
@@ -5,8 +5,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IReceiveRequest } from './interfaces/IReceiveRequest';
-import { StreamingResponse } from './streamingResponse';
+import { IReceiveRequest } from './interfaces';
+import type { StreamingResponse } from './streamingResponse';
 
 /**
  * Implemented by classes used to process incoming streaming requests sent over an [IStreamingTransport](xref:botframework-streaming.IStreamingTransport).
@@ -18,5 +18,5 @@ export abstract class RequestHandler {
      * @param request A receipt request for this handler to process.
      * @returns A promise that will produce a streaming response on successful completion.
      */
-    public abstract processRequest(request: IReceiveRequest): Promise<StreamingResponse>;
+    abstract processRequest(request: IReceiveRequest): Promise<StreamingResponse>;
 }

--- a/libraries/botframework-streaming/src/streamingRequest.ts
+++ b/libraries/botframework-streaming/src/streamingRequest.ts
@@ -15,17 +15,17 @@ export class StreamingRequest {
     /**
      * Request verb, null on responses.
      */
-    public verb: string;
+    verb: string;
 
     /**
      * Request path; null on responses.
      */
-    public path: string;
+    path: string;
 
     /**
      * List of associated streams.
      */
-    public streams: HttpContentStream[] = [];
+    streams: HttpContentStream[] = [];
 
     /**
      * Creates a streaming request with the passed in method, path, and body.
@@ -35,7 +35,7 @@ export class StreamingRequest {
      * @param body Optional body to send to the remote server.
      * @returns On success returns a streaming request with appropriate status code and body.
      */
-    public static create(method: string, path?: string, body?: HttpContent): StreamingRequest {
+    static create(method: string, path?: string, body?: HttpContent): StreamingRequest {
         const request = new StreamingRequest();
         request.verb = method;
         request.path = path;
@@ -51,7 +51,7 @@ export class StreamingRequest {
      *
      * @param content The Http content to include in the new stream attachment.
      */
-    public addStream(content: HttpContent): void {
+    addStream(content: HttpContent): void {
         if (!content) {
             throw new Error('Argument Undefined Exception: content undefined.');
         }
@@ -64,7 +64,8 @@ export class StreamingRequest {
      *
      * @param body The JSON text to write to the body of the streamingRequest.
      */
-    public setBody(body: any): void {
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+    setBody(body: any): void {
         if (typeof body === 'string') {
             const stream = new SubscribableStream();
             stream.write(body, 'utf8');

--- a/libraries/botframework-streaming/src/streamingResponse.ts
+++ b/libraries/botframework-streaming/src/streamingResponse.ts
@@ -12,8 +12,8 @@ import { SubscribableStream } from './subscribableStream';
  * The basic response type sent over Bot Framework Protocol 3 with Streaming Extensions transports, equivalent to HTTP response messages.
  */
 export class StreamingResponse {
-    public statusCode: number;
-    public streams: HttpContentStream[] = [];
+    statusCode: number;
+    streams: HttpContentStream[] = [];
 
     /**
      * Creates a streaming response with the passed in method, path, and body.
@@ -22,7 +22,7 @@ export class StreamingResponse {
      * @param body Optional body containing additional information.
      * @returns A streaming response with the appropriate statuscode and passed in body.
      */
-    public static create(statusCode: number, body?: HttpContent): StreamingResponse {
+    static create(statusCode: number, body?: HttpContent): StreamingResponse {
         const response = new StreamingResponse();
         response.statusCode = statusCode;
         if (body) {
@@ -37,7 +37,7 @@ export class StreamingResponse {
      *
      * @param content The Http content to include in the new stream attachment.
      */
-    public addStream(content: HttpContent): void {
+    addStream(content: HttpContent): void {
         this.streams.push(new HttpContentStream(content));
     }
 
@@ -46,7 +46,8 @@ export class StreamingResponse {
      *
      * @param body The JSON text to write to the body of the streaming response.
      */
-    public setBody(body: any): void {
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+    setBody(body: any): void {
         const stream = new SubscribableStream();
         stream.write(JSON.stringify(body), 'utf8');
         this.addStream(

--- a/libraries/botframework-streaming/src/subscribableStream.ts
+++ b/libraries/botframework-streaming/src/subscribableStream.ts
@@ -11,27 +11,31 @@ import { Duplex, DuplexOptions } from 'stream';
  * An extension of `Duplex` that operates in conjunction with a `PayloadAssembler` to convert raw bytes into a consumable form.
  */
 export class SubscribableStream extends Duplex {
-    public length = 0;
+    length = 0;
 
     private readonly bufferList: Buffer[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private _onData: (chunk: any) => void;
 
     /**
      * Initializes a new instance of the [SubscribableStream](xref:botframework-streaming.SubscribableStream) class.
+     *
      * @param options The `DuplexOptions` to use when constructing this stream.
      */
-    public constructor(options?: DuplexOptions) {
+    constructor(options?: DuplexOptions) {
         super(options);
     }
 
     /**
      * Writes data to the buffered list.
      * All calls to writable.write() that occur between the time writable._write() is called and the callback is called will cause the written data to be buffered.
+     *
      * @param chunk The Buffer to be written.
-     * @param encoding The encoding.
+     * @param _encoding The encoding. Unused in the implementation of Duplex.
      * @param callback Callback for when this chunk of data is flushed.
      */
-    public _write(chunk: any, encoding: string, callback: (error?: Error | null) => void): void {
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+    _write(chunk: any, _encoding: string, callback: (error?: Error | null) => void): void {
         const buffer = Buffer.from(chunk);
         this.bufferList.push(buffer);
         this.length += chunk.length;
@@ -45,9 +49,10 @@ export class SubscribableStream extends Duplex {
      * Reads the buffered list.
      * Once the readable._read() method has been called, it will not be called again until more data is pushed through the readable.push() method.
      * Empty data such as empty buffers and strings will not cause readable._read() to be called.
+     *
      * @param size Number of bytes to read.
      */
-    public _read(size: number): void {
+    _read(size: number): void {
         if (this.bufferList.length === 0) {
             // null signals end of stream
             this.push(null);
@@ -64,9 +69,11 @@ export class SubscribableStream extends Duplex {
 
     /**
      * Subscribes to the stream when receives data.
+     *
      * @param onData Callback to be called when onData is executed.
      */
-    public subscribe(onData: (chunk: any) => void): void {
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+    subscribe(onData: (chunk: any) => void): void {
         this._onData = onData;
     }
 }

--- a/libraries/botframework-streaming/src/utilities/protocol-base.ts
+++ b/libraries/botframework-streaming/src/utilities/protocol-base.ts
@@ -9,6 +9,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 /**
  * Generates an uuid v4 string.
+ *
  * @returns An uuidv4 string.
  */
 export function generateGuid(): string {

--- a/libraries/botframework-streaming/src/webSocket/browserWebSocket.ts
+++ b/libraries/botframework-streaming/src/webSocket/browserWebSocket.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { IBrowserFileReader, IBrowserWebSocket, ISocket, INodeBuffer } from '../interfaces';
+import { IBrowserFileReader, IBrowserWebSocket, INodeBuffer, ISocket } from '../interfaces';
 
 /**
  * Represents a WebSocket that implements [ISocket](xref:botframework-streaming.ISocket).
@@ -18,7 +18,7 @@ export class BrowserWebSocket implements ISocket {
      *
      * @param socket The socket object to build this connection on.
      */
-    public constructor(socket?: IBrowserWebSocket) {
+    constructor(socket?: IBrowserWebSocket) {
         if (socket) {
             this.webSocket = socket;
         }
@@ -28,10 +28,12 @@ export class BrowserWebSocket implements ISocket {
      * Connects to the supporting socket using WebSocket protocol.
      *
      * @param serverAddress The address the server is listening on.
+     * @returns A Promise that resolves the websocket is open and rejects if an error is encountered.
      */
-    public async connect(serverAddress: string): Promise<void> {
-        let resolver;
-        let rejector;
+    async connect(serverAddress: string): Promise<void> {
+        let resolver: (value: void | PromiseLike<void>) => void;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let rejector: (reason?: any) => void;
 
         if (!this.webSocket) {
             this.webSocket = new WebSocket(serverAddress);
@@ -52,9 +54,11 @@ export class BrowserWebSocket implements ISocket {
     }
 
     /**
-     * True if the socket is currently connected.
+     * Indicates if the [BrowserWebSocket's](xref:botframework-streaming.BrowserWebSocket) underlying websocket is currently connected.
+     *
+     * @returns `true` if the underlying websocket is ready and availble to send messages, otherwise `false`.
      */
-    public get isConnected(): boolean {
+    get isConnected(): boolean {
         return this.webSocket.readyState === 1;
     }
 
@@ -63,21 +67,24 @@ export class BrowserWebSocket implements ISocket {
      *
      * @param buffer The buffer of data to send across the connection.
      */
-    public write(buffer: INodeBuffer): void {
+    write(buffer: INodeBuffer): void {
         this.webSocket.send(buffer);
     }
 
     /**
      * Close the socket.
      */
-    public close(): void {
+    close(): void {
         this.webSocket.close();
     }
 
     /**
      * Set the handler for text and binary messages received on the socket.
+     *
+     * @param handler The callback to handle the "message" event.
      */
-    public setOnMessageHandler(handler: (x: any) => void): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setOnMessageHandler(handler: (x: any) => void): void {
         const bufferKey = 'buffer';
         const packets = [];
         this.webSocket.onmessage = (evt): void => {
@@ -100,8 +107,11 @@ export class BrowserWebSocket implements ISocket {
 
     /**
      * Set the callback to call when encountering errors.
+     *
+     * @param handler The callback to handle the "error" event.
      */
-    public setOnErrorHandler(handler: (x: any) => void): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setOnErrorHandler(handler: (x: any) => void): void {
         this.webSocket.onerror = (error): void => {
             if (error) {
                 handler(error);
@@ -111,8 +121,11 @@ export class BrowserWebSocket implements ISocket {
 
     /**
      * Set the callback to call when encountering socket closures.
+     *
+     * @param handler The callback to handle the "close" event.
      */
-    public setOnCloseHandler(handler: (x: any) => void): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setOnCloseHandler(handler: (x: any) => void): void {
         this.webSocket.onclose = handler;
     }
 }

--- a/libraries/botframework-streaming/src/webSocket/browserWebSocketClient.ts
+++ b/libraries/botframework-streaming/src/webSocket/browserWebSocketClient.ts
@@ -6,14 +6,14 @@
  * Licensed under the MIT License.
  */
 
+import { BrowserWebSocket } from './browserWebSocket';
+import { IReceiveResponse, IStreamingTransportClient } from '../interfaces';
+import { PayloadReceiver, PayloadSender, TransportDisconnectedEvent } from '../payloadTransport';
 import { ProtocolAdapter } from '../protocolAdapter';
 import { RequestHandler } from '../requestHandler';
-import { StreamingRequest } from '../streamingRequest';
 import { RequestManager } from '../payloads';
-import { PayloadReceiver, PayloadSender, TransportDisconnectedEvent } from '../payloadTransport';
-import { BrowserWebSocket } from './browserWebSocket';
+import { StreamingRequest } from '../streamingRequest';
 import { WebSocketTransport } from './webSocketTransport';
-import { IStreamingTransportClient, IReceiveResponse } from '../interfaces';
 
 /**
  * Web socket based client to be used as streaming transport.
@@ -30,11 +30,20 @@ export class WebSocketClient implements IStreamingTransportClient {
     /**
      * Creates a new instance of the [WebSocketClient](xref:botframework-streaming.WebSocketClient) class.
      *
-     * @param url The URL of the remote server to connect to.
-     * @param requestHandler Optional [RequestHandler](xref:botframework-streaming.RequestHandler) to process incoming messages received by this server.
-     * @param disconnectionHandler Optional function to handle the disconnection message.
+     * @param config For configuring a [WebSocketClient](xref:botframework-streaming.WebSocketClient) instance to communicate with a WebSocket server.
+     * @param config.url The URL of the remote server to connect to.
+     * @param config.requestHandler The [RequestHandler](xref:botframework-streaming.RequestHandler) used to process incoming messages received by this client.
+     * @param config.disconnectionHandler Optional function to handle the disconnection message.
      */
-    public constructor({ url, requestHandler, disconnectionHandler = null }) {
+    constructor({
+        url,
+        requestHandler,
+        disconnectionHandler = null,
+    }: {
+        url: string;
+        requestHandler: RequestHandler;
+        disconnectionHandler: (message: string) => void;
+    }) {
         this._url = url;
         this._requestHandler = requestHandler;
         this._disconnectionHandler = disconnectionHandler;
@@ -59,7 +68,7 @@ export class WebSocketClient implements IStreamingTransportClient {
      *
      * @returns A promise that will not resolve until the client stops listening for incoming messages.
      */
-    public async connect(): Promise<void> {
+    async connect(): Promise<void> {
         const ws = new BrowserWebSocket();
         await ws.connect(this._url);
         const transport = new WebSocketTransport(ws);
@@ -70,7 +79,7 @@ export class WebSocketClient implements IStreamingTransportClient {
     /**
      * Stop this client from listening.
      */
-    public disconnect(): void {
+    disconnect(): void {
         this._sender.disconnect(new TransportDisconnectedEvent('Disconnect was called.'));
         this._receiver.disconnect(new TransportDisconnectedEvent('Disconnect was called.'));
     }
@@ -81,14 +90,12 @@ export class WebSocketClient implements IStreamingTransportClient {
      * @param request The streaming request to send.
      * @returns A promise that will produce an instance of receive response on completion of the send operation.
      */
-    public async send(request: StreamingRequest): Promise<IReceiveResponse> {
+    async send(request: StreamingRequest): Promise<IReceiveResponse> {
         return this._protocolAdapter.sendRequest(request);
     }
 
-    /**
-     * @private
-     */
-    private onConnectionDisconnected(sender: object, args: any): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private onConnectionDisconnected(sender: Record<string, unknown>, args: any): void {
         if (this._disconnectionHandler != null) {
             this._disconnectionHandler('Disconnected');
             return;

--- a/libraries/botframework-streaming/src/webSocket/factories/nodeWebSocketFactory.ts
+++ b/libraries/botframework-streaming/src/webSocket/factories/nodeWebSocketFactory.ts
@@ -14,7 +14,6 @@ import { NodeWebSocketFactoryBase } from './nodeWebSocketFactoryBase';
  * Represents a NodeWebSocketFactory to create a WebSocket server.
  */
 export class NodeWebSocketFactory extends NodeWebSocketFactoryBase {
-
     /**
      * Initializes a new instance of the [NodeWebSocketFactory](xref:botframework-streaming.NodeWebSocketFactory) class.
      */
@@ -24,17 +23,15 @@ export class NodeWebSocketFactory extends NodeWebSocketFactoryBase {
 
     /**
      * Creates a [NodeWebSocket](xref:botframework-streaming.NodeWebSocket) instance.
+     *
      * @remarks
      * The parameters for this method should be associated with an 'upgrade' event off of a Node.js HTTP Server.
      * @param req An IncomingMessage from the 'http' module in Node.js.
      * @param socket The Socket connecting the bot and the server, from the 'net' module in Node.js.
      * @param head The first packet of the upgraded stream which may be empty per https://nodejs.org/api/http.html#http_event_upgrade_1.
+     * @returns A [NodeWebSocket](xref:botframework-streaming.NodeWebSocket) instance ready for streaming.
      */
-    public async createWebSocket(
-        req: INodeIncomingMessage,
-        socket: INodeSocket,
-        head: INodeBuffer
-    ): Promise<NodeWebSocket> {
+    async createWebSocket(req: INodeIncomingMessage, socket: INodeSocket, head: INodeBuffer): Promise<NodeWebSocket> {
         const s = new NodeWebSocket();
         await s.create(req, socket, head);
 

--- a/libraries/botframework-streaming/src/webSocket/factories/nodeWebSocketFactoryBase.ts
+++ b/libraries/botframework-streaming/src/webSocket/factories/nodeWebSocketFactoryBase.ts
@@ -12,9 +12,5 @@ import { INodeIncomingMessage, INodeBuffer, INodeSocket, ISocket } from '../../i
  * Represents an abstract NodeWebSocketFactoryBase class to create a WebSocket.
  */
 export abstract class NodeWebSocketFactoryBase {
-    public abstract createWebSocket(
-        req: INodeIncomingMessage,
-        socket: INodeSocket,
-        head: INodeBuffer
-    ): Promise<ISocket>;
+    abstract createWebSocket(req: INodeIncomingMessage, socket: INodeSocket, head: INodeBuffer): Promise<ISocket>;
 }

--- a/libraries/botframework-streaming/src/webSocket/nodeWebSocketClient.ts
+++ b/libraries/botframework-streaming/src/webSocket/nodeWebSocketClient.ts
@@ -30,11 +30,20 @@ export class WebSocketClient implements IStreamingTransportClient {
     /**
      * Creates a new instance of the [WebSocketClient](xref:botframework-streaming.WebSocketClient) class.
      *
-     * @param url The URL of the remote server to connect to.
-     * @param requestHandler Optional [RequestHandler](xref:botframework-streaming.RequestHandler) to process incoming messages received by this server.
-     * @param disconnectionHandler Optional function to handle the disconnection message.
+     * @param config For configuring a [WebSocketClient](xref:botframework-streaming.WebSocketClient) instance to communicate with a WebSocket server.
+     * @param config.url The URL of the remote server to connect to.
+     * @param config.requestHandler The [RequestHandler](xref:botframework-streaming.RequestHandler) used to process incoming messages received by this client.
+     * @param config.disconnectionHandler Optional function to handle the disconnection message.
      */
-    public constructor({ url, requestHandler, disconnectionHandler = null }) {
+    constructor({
+        url,
+        requestHandler,
+        disconnectionHandler = null,
+    }: {
+        url: string;
+        requestHandler: RequestHandler;
+        disconnectionHandler: (message: string) => void;
+    }) {
         this._url = url;
         this._requestHandler = requestHandler;
         this._disconnectionHandler = disconnectionHandler;
@@ -59,14 +68,14 @@ export class WebSocketClient implements IStreamingTransportClient {
      *
      * @returns A promise that will not resolve until the client stops listening for incoming messages.
      */
-    public async connect(): Promise<void> {
+    async connect(): Promise<void> {
         const ws = new NodeWebSocket();
         try {
             await ws.connect(this._url);
             const transport = new WebSocketTransport(ws);
             this._sender.connect(transport);
             this._receiver.connect(transport);
-        } catch (error) {
+        } catch (_error) {
             throw new Error(`Unable to connect client to Node transport.`);
         }
     }
@@ -74,7 +83,7 @@ export class WebSocketClient implements IStreamingTransportClient {
     /**
      * Stop this client from listening.
      */
-    public disconnect(): void {
+    disconnect(): void {
         this._sender.disconnect(new TransportDisconnectedEvent('Disconnect was called.'));
         this._receiver.disconnect(new TransportDisconnectedEvent('Disconnect was called.'));
     }
@@ -82,17 +91,15 @@ export class WebSocketClient implements IStreamingTransportClient {
     /**
      * Task used to send data over this client connection.
      *
-     * @param request The streaming request to send.
+     * @param request The [StreamingRequest](xref:botframework-streaming.StreamingRequest) instance to send.
      * @returns A promise that will produce an instance of receive response on completion of the send operation.
      */
-    public async send(request: StreamingRequest): Promise<IReceiveResponse> {
+    async send(request: StreamingRequest): Promise<IReceiveResponse> {
         return this._protocolAdapter.sendRequest(request);
     }
 
-    /**
-     * @private
-     */
-    private onConnectionDisconnected(sender: object, args: any): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private onConnectionDisconnected(sender: Record<string, unknown>, args: any): void {
         if (this._disconnectionHandler != null) {
             this._disconnectionHandler('Disconnected');
             return;

--- a/libraries/botframework-streaming/src/webSocket/webSocketServer.ts
+++ b/libraries/botframework-streaming/src/webSocket/webSocketServer.ts
@@ -10,9 +10,8 @@ import { RequestHandler } from '../requestHandler';
 import { StreamingRequest } from '../streamingRequest';
 import { RequestManager } from '../payloads';
 import { PayloadReceiver, PayloadSender, TransportDisconnectedEvent } from '../payloadTransport';
-import { ISocket } from '../interfaces/ISocket';
 import { WebSocketTransport } from './webSocketTransport';
-import { IStreamingTransportServer, IReceiveResponse } from '../interfaces';
+import { ISocket, IStreamingTransportServer, IReceiveResponse } from '../interfaces';
 
 /**
  * Web socket based server to be used as streaming transport.
@@ -34,7 +33,7 @@ export class WebSocketServer implements IStreamingTransportServer {
      * @param socket The underlying web socket.
      * @param requestHandler Optional [RequestHandler](xref:botframework-streaming.RequestHandler) to process incoming messages received by this server.
      */
-    public constructor(socket: ISocket, requestHandler?: RequestHandler) {
+    constructor(socket: ISocket, requestHandler?: RequestHandler) {
         if (!socket) {
             throw new TypeError('WebSocketServer: Missing socket parameter');
         }
@@ -63,9 +62,11 @@ export class WebSocketServer implements IStreamingTransportServer {
     }
 
     /**
-     * Examines the stored ISocket and returns true if the socket connection is open.
+     * Examines the stored [ISocket](xref:botframework-streaming.ISocket) and returns `true` if the socket connection is open.
+     *
+     * @returns `true` if the underlying websocket is ready and availble to send messages, otherwise `false`.
      */
-    public get isConnected(): boolean {
+    get isConnected(): boolean {
         return this._socket.isConnected;
     }
 
@@ -74,7 +75,7 @@ export class WebSocketServer implements IStreamingTransportServer {
      *
      * @returns A promise to handle the server listen operation. This task will not resolve as long as the server is running.
      */
-    public async start(): Promise<string> {
+    async start(): Promise<string> {
         this._sender.connect(this._webSocketTransport);
         this._receiver.connect(this._webSocketTransport);
 
@@ -87,14 +88,14 @@ export class WebSocketServer implements IStreamingTransportServer {
      * @param request The streaming request to send.
      * @returns A promise that will produce an instance of receive response on completion of the send operation.
      */
-    public async send(request: StreamingRequest): Promise<IReceiveResponse> {
+    async send(request: StreamingRequest): Promise<IReceiveResponse> {
         return this._protocolAdapter.sendRequest(request);
     }
 
     /**
      * Stop this server.
      */
-    public disconnect(): void {
+    disconnect(): void {
         this._sender.disconnect(new TransportDisconnectedEvent('Disconnect was called.'));
         this._receiver.disconnect(new TransportDisconnectedEvent('Disconnect was called.'));
     }

--- a/libraries/botframework-streaming/src/webSocket/webSocketTransport.ts
+++ b/libraries/botframework-streaming/src/webSocket/webSocketTransport.ts
@@ -5,20 +5,18 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { INodeBuffer } from '../interfaces/INodeBuffer';
-import { ISocket } from '../interfaces/ISocket';
-import { ITransportSender } from '../interfaces/ITransportSender';
-import { ITransportReceiver } from '../interfaces/ITransportReceiver';
+
+import { INodeBuffer, ISocket, ITransportSender, ITransportReceiver } from '../interfaces';
 
 /**
  * Web socket based transport.
  */
 export class WebSocketTransport implements ITransportSender, ITransportReceiver {
-    private _socket: ISocket;
     private readonly _queue: INodeBuffer[];
     private _active: INodeBuffer;
     private _activeOffset: number;
     private _activeReceiveResolve: (resolve: INodeBuffer) => void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private _activeReceiveReject: (reason?: any) => void;
     private _activeReceiveCount: number;
 
@@ -27,18 +25,17 @@ export class WebSocketTransport implements ITransportSender, ITransportReceiver 
      *
      * @param ws The ISocket to build this transport on top of.
      */
-    public constructor(ws: ISocket) {
-        this._socket = ws;
+    constructor(private ws: ISocket) {
         this._queue = [];
         this._activeOffset = 0;
         this._activeReceiveCount = 0;
-        this._socket.setOnMessageHandler((data): void => {
+        this.ws.setOnMessageHandler((data): void => {
             this.onReceive(data);
         });
-        this._socket.setOnErrorHandler((err): void => {
+        this.ws.setOnErrorHandler((err): void => {
             this.onError(err);
         });
-        this._socket.setOnCloseHandler((): void => {
+        this.ws.setOnCloseHandler((): void => {
             this.onClose();
         });
     }
@@ -47,10 +44,11 @@ export class WebSocketTransport implements ITransportSender, ITransportReceiver 
      * Sends the given buffer out over the socket's connection.
      *
      * @param buffer The buffered data to send out over the connection.
+     * @returns A number indicating the length of the sent data if the data was successfully sent, otherwise 0.
      */
-    public send(buffer: INodeBuffer): number {
-        if (this._socket && this._socket.isConnected) {
-            this._socket.write(buffer);
+    send(buffer: INodeBuffer): number {
+        if (this.ws && this.ws.isConnected) {
+            this.ws.write(buffer);
 
             return buffer.length;
         }
@@ -60,17 +58,19 @@ export class WebSocketTransport implements ITransportSender, ITransportReceiver 
 
     /**
      * Returns true if the transport is connected to a socket.
+     *
+     * @returns `true` if the the transport is connected and ready to send data, `false` otherwise.
      */
-    public get isConnected(): boolean {
-        return this._socket.isConnected;
+    get isConnected(): boolean {
+        return this.ws.isConnected;
     }
 
     /**
      * Close the socket this transport is connected to.
      */
-    public close(): void {
-        if (this._socket && this._socket.isConnected) {
-            this._socket.close();
+    close(): void {
+        if (this.ws && this.ws.isConnected) {
+            this.ws.close();
         }
     }
 
@@ -80,7 +80,7 @@ export class WebSocketTransport implements ITransportSender, ITransportReceiver 
      * @param count The number of bytes to attempt to receive.
      * @returns A buffer populated with the received data.
      */
-    public async receive(count: number): Promise<INodeBuffer> {
+    async receive(count: number): Promise<INodeBuffer> {
         if (this._activeReceiveResolve) {
             throw new Error('Cannot call receive more than once before it has returned.');
         }
@@ -102,7 +102,7 @@ export class WebSocketTransport implements ITransportSender, ITransportReceiver 
      *
      * @param data A buffer to store incoming data in.
      */
-    public onReceive(data: INodeBuffer): void {
+    onReceive(data: INodeBuffer): void {
         if (this._queue && data && data.byteLength > 0) {
             this._queue.push(Buffer.from(data));
             this.trySignalData();
@@ -122,7 +122,7 @@ export class WebSocketTransport implements ITransportSender, ITransportReceiver 
         this._activeReceiveResolve = null;
         this._activeReceiveReject = null;
         this._activeReceiveCount = 0;
-        this._socket = null;
+        this.ws = null;
     }
 
     /**

--- a/libraries/botframework-streaming/tests/Assembler.test.js
+++ b/libraries/botframework-streaming/tests/Assembler.test.js
@@ -1,26 +1,32 @@
-const SubscribableStream = require('../lib/subscribableStream');
-const chai = require('chai');
-const StreamManager = require('../lib/payloads/streamManager');
-const PayloadTypes = require('../lib/payloads/payloadTypes');
-const PayloadAssembler = require('../lib/assemblers/payloadAssembler');
-const PayloadAssemblerManager = require('../lib/payloads/payloadAssemblerManager');
-const expect = chai.expect;
+const { SubscribableStream } = require('../lib/subscribableStream');
+const { PayloadAssemblerManager, PayloadTypes, StreamManager } = require('../lib/payloads');
+const { PayloadAssembler } = require('../lib/assemblers');
+const { expect } = require('chai');
 
-const streamManager = new StreamManager.StreamManager();
+const streamManager = new StreamManager();
 
 describe('PayloadAssembler', function () {
     it('constructs correctly.', function () {
-        const header = { payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '100', end: true };
-        const rra = new PayloadAssembler.PayloadAssembler(streamManager, { header: header });
+        const header = {
+            payloadType: PayloadTypes.request,
+            payloadLength: '42',
+            id: '100',
+            end: true,
+        };
+        const rra = new PayloadAssembler(streamManager, { header, onCompleted: () => {} });
 
         expect(rra.id).equals('100');
-        expect(rra._streamManager).equals(streamManager);
+        expect(rra.streamManager).equals(streamManager);
     });
 
     it('closes without throwing', function () {
-        const header = { payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '99', end: true };
-
-        const rra = new PayloadAssembler.PayloadAssembler(streamManager, { header: header });
+        const header = {
+            payloadType: PayloadTypes.request,
+            payloadLength: '42',
+            id: '99',
+            end: true,
+        };
+        const rra = new PayloadAssembler(streamManager, { header, onCompleted: () => {} });
 
         expect(() => {
             rra.close();
@@ -28,47 +34,65 @@ describe('PayloadAssembler', function () {
     });
 
     it('returns a new stream.', function () {
-        const header = { payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '42', id: '100', end: true };
+        const header = {
+            payloadType: PayloadTypes.response,
+            payloadLength: '42',
+            id: '100',
+            end: true,
+        };
+        const rra = new PayloadAssembler(streamManager, { header, onCompleted: () => {} });
 
-        const rra = new PayloadAssembler.PayloadAssembler(streamManager, { header: header });
-
-        expect(rra.createPayloadStream()).to.be.instanceOf(SubscribableStream.SubscribableStream);
+        expect(rra.createPayloadStream()).to.be.instanceOf(SubscribableStream);
     });
 
     it('processes a Request without throwing.', function (done) {
-        const header = { payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '5', id: '98', end: true };
-        const s = new SubscribableStream.SubscribableStream();
+        const header = {
+            payloadType: PayloadTypes.request,
+            payloadLength: '5',
+            id: '98',
+            end: true,
+        };
+        const s = new SubscribableStream();
+
         s.write('12345');
         const rp = { verb: 'POST', path: '/some/path' };
         rp.streams = s;
-        const rra = new PayloadAssembler.PayloadAssembler(streamManager, {
-            header: header,
-            onCompleted: function () {
-                done();
-            },
+        const rra = new PayloadAssembler(streamManager, {
+            header,
+            onCompleted: () => done(),
         });
         rra.onReceive(header, s, 5);
         rra.close();
     });
 
     it('processes a Response without throwing.', function (done) {
-        const header = { payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '5', id: '100', end: true };
-        const s = new SubscribableStream.SubscribableStream();
+        const header = {
+            payloadType: PayloadTypes.response,
+            payloadLength: '5',
+            id: '100',
+            end: true,
+        };
+        const s = new SubscribableStream();
+
         s.write('12345');
         const rp = { statusCode: 200 };
         rp.streams = s;
-        const rra = new PayloadAssembler.PayloadAssembler(streamManager, {
-            header: header,
-            onCompleted: function () {
-                done();
-            },
+        const rra = new PayloadAssembler(streamManager, {
+            header,
+            onCompleted: () => done(),
         });
         rra.onReceive(header, s, 5);
     });
 
     it('assigns values when constructed', function () {
-        const header = { payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 50, id: '1', end: undefined };
-        const csa = new PayloadAssembler.PayloadAssembler(streamManager, { header: header });
+        const header = {
+            payloadType: PayloadTypes.stream,
+            payloadLength: 50,
+            id: '1',
+            end: undefined,
+        };
+        const csa = new PayloadAssembler(streamManager, { header, onCompleted: () => {} });
+
         expect(csa.id).equals('1');
         expect(csa.contentLength).equals(50);
         expect(csa.payloadType).equals('S');
@@ -76,111 +100,165 @@ describe('PayloadAssembler', function () {
     });
 
     it('returns a Stream', function () {
-        const header = { payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 50, id: '1', end: true };
-        const csa = new PayloadAssembler.PayloadAssembler(streamManager, { header: header });
-        expect(csa.createPayloadStream()).instanceOf(SubscribableStream.SubscribableStream);
+        const header = {
+            payloadType: PayloadTypes.stream,
+            payloadLength: 50,
+            id: '1',
+            end: true,
+        };
+        const csa = new PayloadAssembler(streamManager, { header, onCompleted: () => {} });
+
+        expect(csa.createPayloadStream()).instanceOf(SubscribableStream);
     });
 
     it('closes a Stream', function () {
-        const header = { payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 50, id: '97', end: true };
-        const csa = new PayloadAssembler.PayloadAssembler(streamManager, { header: header });
-        expect(csa.createPayloadStream()).instanceOf(SubscribableStream.SubscribableStream);
+        const header = {
+            payloadType: PayloadTypes.stream,
+            payloadLength: 50,
+            id: '97',
+            end: true,
+        };
+        const csa = new PayloadAssembler(streamManager, { header, onCompleted: () => {} });
+
+        expect(csa.createPayloadStream()).instanceOf(SubscribableStream);
         expect(csa.close()).to.not.throw;
     });
 });
 
 describe('PayloadAssemblerManager', function () {
     it('creates a response stream', function (done) {
-        const p = new PayloadAssemblerManager.PayloadAssemblerManager(
+        const p = new PayloadAssemblerManager(
             streamManager,
             () => done(),
             () => done()
         );
-        const head = { payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '42', id: '100', end: true };
-        expect(p.getPayloadStream(head)).to.be.instanceOf(SubscribableStream.SubscribableStream);
+        const head = {
+            payloadType: PayloadTypes.response,
+            payloadLength: '42',
+            id: '100',
+            end: true,
+        };
+
+        expect(p.getPayloadStream(head)).to.be.instanceOf(SubscribableStream);
         done();
     });
 
     it('creates a request stream', function (done) {
-        const p = new PayloadAssemblerManager.PayloadAssemblerManager(
+        const p = new PayloadAssemblerManager(
             streamManager,
             () => done(),
             () => done()
         );
-        const head = { payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '100', end: true };
-        expect(p.getPayloadStream(head)).to.be.instanceOf(SubscribableStream.SubscribableStream);
+        const head = {
+            payloadType: PayloadTypes.request,
+            payloadLength: '42',
+            id: '100',
+            end: true,
+        };
+
+        expect(p.getPayloadStream(head)).to.be.instanceOf(SubscribableStream);
         done();
     });
 
     it('does not throw when receiving a request', function (done) {
-        const p = new PayloadAssemblerManager.PayloadAssemblerManager(
+        const p = new PayloadAssemblerManager(
             streamManager,
             () => done(),
             () => done()
         );
-        const head = { payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '100', end: true };
+
+        const head = {
+            payloadType: PayloadTypes.request,
+            payloadLength: '42',
+            id: '100',
+            end: true,
+        };
         const s = p.getPayloadStream(head);
-        expect(s).to.be.instanceOf(SubscribableStream.SubscribableStream);
+        expect(s).to.be.instanceOf(SubscribableStream);
         expect(p.onReceive(head, s, 0)).to.not.throw;
         done();
     });
 
     it('does not throw when receiving a stream', function (done) {
-        const p = new PayloadAssemblerManager.PayloadAssemblerManager(
+        const p = new PayloadAssemblerManager(
             streamManager,
             () => done(),
             () => done()
         );
-        const head = { payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: '42', id: '100', end: true };
+
+        const head = {
+            payloadType: PayloadTypes.stream,
+            payloadLength: '42',
+            id: '100',
+            end: true,
+        };
         const s = p.getPayloadStream(head);
-        expect(s).to.be.instanceOf(SubscribableStream.SubscribableStream);
+
+        expect(s).to.be.instanceOf(SubscribableStream);
         expect(p.onReceive(head, s, 0)).to.not.throw;
         done();
     });
 
     it('does not throw when receiving a response', function (done) {
-        const p = new PayloadAssemblerManager.PayloadAssemblerManager(
+        const p = new PayloadAssemblerManager(
             streamManager,
             () => done(),
             () => done()
         );
-        const head = { payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '42', id: '100', end: true };
+
+        const head = {
+            payloadType: PayloadTypes.response,
+            payloadLength: '42',
+            id: '100',
+            end: true,
+        };
         const s = p.getPayloadStream(head);
-        expect(s).to.be.instanceOf(SubscribableStream.SubscribableStream);
+
+        expect(s).to.be.instanceOf(SubscribableStream);
         expect(p.onReceive(head, s, 0)).to.not.throw;
         done();
     });
 
     it('returns undefined when asked to create an existing stream', function (done) {
-        const p = new PayloadAssemblerManager.PayloadAssemblerManager(
+        const p = new PayloadAssemblerManager(
             streamManager,
             () => done(),
             () => done()
         );
-        const head = { payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '42', id: '100', end: true };
+
+        const head = {
+            payloadType: PayloadTypes.request,
+            payloadLength: '42',
+            id: '100',
+            end: true,
+        };
         const s = p.getPayloadStream(head);
-        expect(s).to.be.instanceOf(SubscribableStream.SubscribableStream);
+
+        expect(s).to.be.instanceOf(SubscribableStream);
         expect(p.getPayloadStream(head)).to.be.undefined;
         done();
     });
 
     it('throws if not given an ID', function (done) {
-        const header = { payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '5', id: undefined, end: true };
+        const header = {
+            payloadType: PayloadTypes.request,
+            payloadLength: '5',
+            id: undefined,
+            end: true,
+        };
         expect(
             () =>
-                new PayloadAssembler.PayloadAssembler(streamManager, {
-                    header: header,
-                    onCompleted: function () {
-                        done();
-                    },
+                new PayloadAssembler(streamManager, {
+                    header,
+                    onCompleted: () => done(),
                 })
         ).to.throw('An ID must be supplied when creating an assembler.');
         done();
     });
 
     it('processes a response with streams without throwing.', function (done) {
-        const header = { payloadType: PayloadTypes.PayloadTypes.response, payloadLength: '5', id: '96', end: true };
-        const s = new SubscribableStream.SubscribableStream();
+        const header = { payloadType: PayloadTypes.response, payloadLength: '5', id: '96', end: true };
+        const s = new SubscribableStream();
         s.write(
             '{"statusCode": "12345","streams": [{"id": "1","contentType": "text","length": "2"},{"id": "2","contentType": "text","length": "2"},{"id": "3","contentType": "text","length": "2"}]}'
         );
@@ -188,11 +266,9 @@ describe('PayloadAssemblerManager', function () {
         rp.streams = [];
         rp.streams.push(s);
 
-        const rra = new PayloadAssembler.PayloadAssembler(streamManager, {
+        const rra = new PayloadAssembler(streamManager, {
             header: header,
-            onCompleted: function () {
-                done();
-            },
+            onCompleted: () => done(),
         });
         rra.onReceive(header, s, 5);
         rra.close();

--- a/libraries/botframework-streaming/tests/ContentStream.test.js
+++ b/libraries/botframework-streaming/tests/ContentStream.test.js
@@ -1,14 +1,13 @@
-const ContentStream = require('../lib/contentStream');
-const PayloadAssembler = require('../lib/assemblers/payloadAssembler');
-const chai = require('chai');
-const StreamManager = require('../lib/payloads/streamManager');
-const SubscribableStream = require('../lib/subscribableStream');
-const PayloadTypes = require('../lib/payloads/payloadTypes');
-var expect = chai.expect;
+const { ContentStream } = require('../lib/contentStream');
+const { PayloadAssembler } = require('../lib/assemblers');
+const { PayloadTypes } = require('../lib/payloads/payloadTypes');
+const { StreamManager } = require('../lib/payloads/streamManager');
+const { SubscribableStream } = require('../lib/subscribableStream');
+const { expect } = require('chai');
 
 class TestPayloadAssembler {
     constructor(content) {
-        this.stream1 = new SubscribableStream.SubscribableStream();
+        this.stream1 = new SubscribableStream();
         if (content) {
             this.stream1.write(content);
         } else {
@@ -23,120 +22,116 @@ class TestPayloadAssembler {
         return this.stream1;
     }
 
-    close() { }
+    close() {}
 }
 
-describe('Streaming Extensions ContentStream Tests ', () => {
-    const streamManager = new StreamManager.StreamManager();
+describe('Streaming Extensions ContentStream Tests ', function () {
+    const streamManager = new StreamManager();
 
-    const header = { payloadType: PayloadTypes.PayloadTypes.stream, payloadLength: 42, id: '68e999ca-a651-40f4-ad8f-3aaf781862b4', end: true };
+    const header = {
+        payloadType: PayloadTypes.stream,
+        payloadLength: 42,
+        id: '68e999ca-a651-40f4-ad8f-3aaf781862b4',
+        end: true,
+    };
 
-    it('assigns ID when constructed', () => {
-        let csa = new PayloadAssembler.PayloadAssembler(streamManager, { id: 'csa1' });
-        let cs = new ContentStream.ContentStream('1', csa);
+    it('assigns ID when constructed', function () {
+        const csa = new PayloadAssembler(streamManager, { id: 'csa1' });
+        const cs = new ContentStream('1', csa);
 
-        expect(cs.id)
-            .equal('1');
+        expect(cs.id).equal('1');
     });
 
-    it('throws if no assembler is passed in on construction', () => {
-        expect(() => new ContentStream.ContentStream('1', undefined))
-            .throws('Null Argument Exception');
+    it('throws if no assembler is passed in on construction', function () {
+        expect(() => new ContentStream('1', undefined)).throws('Null Argument Exception');
     });
 
-    it('can return payload type', () => {
-        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(streamManager, { id: 'csa1', header: header }));
+    it('can return payload type', function () {
+        const cs = new ContentStream('1', new PayloadAssembler(streamManager, { id: 'csa1', header: header }));
 
-        expect(cs.contentType)
-            .equal('S');
+        expect(cs.contentType).equal('S');
     });
 
-    it('can return length', () => {
-        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(streamManager, { id: 'csa1', header: header }));
+    it('can return length', function () {
+        const cs = new ContentStream('1', new PayloadAssembler(streamManager, { id: 'csa1', header: header }));
 
-        expect(cs.length)
-            .equal(42);
+        expect(cs.length).equal(42);
     });
 
-    it('can return ID', () => {
-        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(streamManager, { id: 'csa1', header: header }));
+    it('can return ID', function () {
+        const cs = new ContentStream('1', new PayloadAssembler(streamManager, { id: 'csa1', header: header }));
 
-        expect(cs.id)
-            .equal('1');
+        expect(cs.id).equal('1');
     });
 
-    it('does not return the stream when it is is undefined', () => {
-        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(streamManager, { id: 'csa1', header: header }));
+    it('does not return the stream when it is is undefined', function () {
+        const cs = new ContentStream('1', new PayloadAssembler(streamManager, { id: 'csa1', header: header }));
 
-        expect(cs.getStream())
-            .to
-            .not
-            .be
-            .undefined;
+        expect(cs.getStream()).to.not.be.undefined;
     });
 
-    it('reads a stream of length 0 and returns an empty string', () => {
-        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(streamManager, { id: 'csa1', header: { ...header, payloadLength: 0 } }));
+    it('reads a stream of length 0 and returns an empty string', function () {
+        const cs = new ContentStream(
+            '1',
+            new PayloadAssembler(streamManager, {
+                id: 'csa1',
+                header: { ...header, payloadLength: 0 },
+            })
+        );
 
-        return cs.readAsString()
-            .then(data => {
-                expect(data)
-                    .equal('');
-            });
+        return cs.readAsString().then((data) => {
+            expect(data).equal('');
+        });
     });
 
-    it('throws when reading an empty stream as JSON', () => {
+    it('throws when reading an empty stream as JSON', function () {
         const assemblerHeader = { ...header, PayloadLength: 0 };
         delete assemblerHeader.payloadLength;
 
-        let cs = new ContentStream.ContentStream('1', new PayloadAssembler.PayloadAssembler(streamManager, { id: 'csa1', header: assemblerHeader }));
-
-        return cs.readAsJson()
-            .then(data => {
-                expect(data)
-                    .to
-                    .not
-                    .be
-                    .undefined;
+        const cs = new ContentStream(
+            '1',
+            new PayloadAssembler(streamManager, {
+                id: 'csa1',
+                header: assemblerHeader,
             })
-            .catch(err => {
-                expect(err.toString())
-                    .to
-                    .equal('SyntaxError: Unexpected end of JSON input');
+        );
+
+        return cs
+            .readAsJson()
+            .then((data) => {
+                expect(data).to.not.be.undefined;
+            })
+            .catch((err) => {
+                expect(err.toString()).to.equal('SyntaxError: Unexpected end of JSON input');
             });
     });
 
-    it('reads a stream as a string', () => {
-        let cs = new ContentStream.ContentStream('cs1', new TestPayloadAssembler());
-        let result = cs.readAsString();
-
-        result.then(function(data) {
-            expect(data).to.equal('hello');
-        });
+    it('reads a stream as a string', async function () {
+        const cs = new ContentStream('cs1', new TestPayloadAssembler());
+        const data = await cs.readAsString();
+        expect(data).to.equal('hello');
     });
 
-    it('reads a stream as a json', () => {
-        let cs = new ContentStream.ContentStream('cs1', new TestPayloadAssembler('{"message":"hello"}'));
-        let result = cs.readAsJson();
-
-        result.then(function(data) {
-            expect(data.message).to.equal('hello');
-        });
+    it('reads a stream as a json', async function () {
+        const cs = new ContentStream('cs1', new TestPayloadAssembler('{"message":"hello"}'));
+        const data = await cs.readAsJson();
+        expect(data.message).to.equal('hello');
     });
 
-    it('reads a stream before receiving all the bits', () => {
-        let tcsa = new TestPayloadAssembler();
+    it('reads a stream before receiving all the bits', function () {
+        const tcsa = new TestPayloadAssembler();
         tcsa.contentLength = 10;
-        let cs = new ContentStream.ContentStream('cs1', tcsa);
-        let result = cs.readAsString();
+        const cs = new ContentStream('cs1', tcsa);
+        const result = cs.readAsString();
 
-        result.then(function(data) {
+        result.then(function (data) {
+            console.log('hello');
             expect(data).to.equal('hello');
         });
     });
 
-    it('can cancel', () => {
-        let cs = new ContentStream.ContentStream('cs1', new TestPayloadAssembler());
+    it('can cancel', function () {
+        const cs = new ContentStream('cs1', new TestPayloadAssembler());
         cs.readAsString();
 
         expect(cs.cancel()).to.not.throw;

--- a/libraries/botframework-streaming/tests/Disassembler.test.js
+++ b/libraries/botframework-streaming/tests/Disassembler.test.js
@@ -1,52 +1,44 @@
-const Disassemblers = require('../lib/disassemblers/requestDisassembler');
-const PayloadSender = require('../lib/payloadTransport/payloadSender');
-const Request = require('../lib/streamingRequest');
-const HttpContentStream = require('../lib/httpContentStream');
-const Stream = require('../lib/subscribableStream');
-const CancelDisassembler = require('../lib/disassemblers/cancelDisassembler');
-const PayloadTypes = require('../lib/payloads/payloadTypes');
-const  chai  = require('chai');
-var expect = chai.expect;
+const { CancelDisassembler, RequestDisassembler } = require('../lib/disassemblers');
+const { HttpContentStream } = require('../lib/httpContentStream');
+const { HttpContent, StreamingRequest, SubscribableStream } = require('..');
+const { PayloadSender } = require('../lib/payloadTransport');
+const { PayloadTypes } = require('../lib/payloads');
+const { expect } = require('chai');
 
-describe('RequestDisassembler', () => {
-
-    it('resolves calls to get stream.', (done) => {
-        let sender = new PayloadSender.PayloadSender();
-        let req = new Request.StreamingRequest();
-        let headers = {contentLength: 40, contentType: 'A'};
-        let stream = new Stream.SubscribableStream();
+describe('RequestDisassembler', function () {
+    it('resolves calls to get stream.', async function () {
+        const sender = new PayloadSender();
+        const req = new StreamingRequest();
+        const headers = { contentLength: 40, contentType: 'A' };
+        const stream = new SubscribableStream();
         stream.write('This is the data inside of the stream.', 'UTF-8');
-        let content = new HttpContentStream.HttpContent(headers, stream);
-        let contentStream = new HttpContentStream.HttpContentStream(content);
+        const content = new HttpContent(headers, stream);
+        const contentStream = new HttpContentStream(content);
         contentStream.content.headers = headers;
 
         req.addStream(contentStream);
-        let rd = new Disassemblers.RequestDisassembler(sender,'42', req);
+        const rd = new RequestDisassembler(sender, '42', req);
 
-        let result = rd.getStream()
-            .then(done());
+        await rd.getStream();
     });
 });
 
-describe('CancelDisassembler', () => {
-
-    it('constructs correctly.', () => {
-        let sender = new PayloadSender.PayloadSender();
-        let payloadType = PayloadTypes.PayloadTypes.cancelStream;
-        let cd = new CancelDisassembler.CancelDisassembler(sender, '42', payloadType);
+describe('CancelDisassembler', function () {
+    it('constructs correctly.', function () {
+        const sender = new PayloadSender();
+        const cd = new CancelDisassembler(sender, '42', PayloadTypes.cancelStream);
 
         expect(cd.id).to.equal('42');
-        expect(cd.payloadType).to.equal(payloadType);
+        expect(cd.payloadType).to.equal(PayloadTypes.cancelStream);
         expect(cd.sender).to.equal(sender);
     });
 
-    it('sends payload without throwing.', () => {
-        let sender = new PayloadSender.PayloadSender();
-        let payloadType = PayloadTypes.PayloadTypes.cancelStream;
-        let cd = new CancelDisassembler.CancelDisassembler(sender, '42', payloadType);
+    it('sends payload without throwing.', function () {
+        const sender = new PayloadSender();
+        const cd = new CancelDisassembler(sender, '42', PayloadTypes.cancelStream);
 
         expect(cd.id).to.equal('42');
-        expect(cd.payloadType).to.equal(payloadType);
+        expect(cd.payloadType).to.equal(PayloadTypes.cancelStream);
         expect(cd.sender).to.equal(sender);
 
         expect(cd.disassemble()).to.not.throw;

--- a/libraries/botframework-streaming/tests/HeaderSerializer.test.js
+++ b/libraries/botframework-streaming/tests/HeaderSerializer.test.js
@@ -1,133 +1,108 @@
-const chai = require( 'chai');
-const HeaderSerializer = require( '../lib/payloads/headerSerializer');
-const PayloadTypes = require( '../lib/payloads/payloadTypes');
-const PayloadConstants = require( '../lib/payloads/payloadConstants');
-var expect = chai.expect;
+const { HeaderSerializer, PayloadTypes } = require('../lib/payloads');
+const { PayloadConstants } = require('../lib/payloads/payloadConstants');
+const { expect } = require('chai');
 
-describe('HeaderSerializer', () => {
+describe('HeaderSerializer', function () {
+    it('serializes and deserializes correctly', function () {
+        const header = {
+            payloadType: PayloadTypes.request,
+            payloadLength: 168,
+            id: '68e999ca-a651-40f4-ad8f-3aaf781862b4',
+            end: true,
+        };
+        const buffer = Buffer.alloc(Number(PayloadConstants.MaxHeaderLength));
 
-    it('serializes and deserializes correctly', () => {
-        let header = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: 168, id: '68e999ca-a651-40f4-ad8f-3aaf781862b4', end: true};
-        let buffer = Buffer.alloc(Number(PayloadConstants.PayloadConstants.MaxHeaderLength));
+        HeaderSerializer.serialize(header, buffer);
 
-        HeaderSerializer.HeaderSerializer.serialize(header, buffer);
+        const result = HeaderSerializer.deserialize(buffer);
 
-        let result =  HeaderSerializer.HeaderSerializer.deserialize(buffer);
-
-        expect(result)
-            .to
-            .deep
-            .equal(header);
+        expect(result).to.deep.equal(header);
     });
 
-    it('can parse an ASCII header', () => {
-        let buffer = Buffer.alloc(Number(PayloadConstants.PayloadConstants.MaxHeaderLength));
+    it('can parse an ASCII header', function () {
+        const buffer = Buffer.alloc(Number(PayloadConstants.MaxHeaderLength));
         buffer.write('A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n');
 
-        let result =  HeaderSerializer.HeaderSerializer.deserialize(buffer);
-        expect(result.payloadType)
-            .equal('A');
-        expect(result.payloadLength)
-            .equal(168);
-        expect(result.id)
-            .equal('68e999ca-a651-40f4-ad8f-3aaf781862b4');
-        expect(result.end)
-            .equal(true);
+        const result = HeaderSerializer.deserialize(buffer);
+        expect(result.payloadType).equal('A');
+        expect(result.payloadLength).equal(168);
+        expect(result.id).equal('68e999ca-a651-40f4-ad8f-3aaf781862b4');
+        expect(result.end).equal(true);
     });
 
-    it('deserializes unknown types', () => {
-        let buffer = Buffer.alloc(Number(PayloadConstants.PayloadConstants.MaxHeaderLength));
+    it('deserializes unknown types', function () {
+        const buffer = Buffer.alloc(Number(PayloadConstants.MaxHeaderLength));
         buffer.write('Z.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n');
-        let result =  HeaderSerializer.HeaderSerializer.deserialize(buffer);
+        const result = HeaderSerializer.deserialize(buffer);
 
-        expect(result.payloadType)
-            .equal('Z');
+        expect(result.payloadType).equal('Z');
     });
 
-    it('throws if the header is missing a part', () => {
-        // expect.assertions(1);
-        let buffer = Buffer.alloc(Number(PayloadConstants.PayloadConstants.MaxHeaderLength));
+    it('throws if the header is missing a part', function () {
+        const buffer = Buffer.alloc(Number(PayloadConstants.MaxHeaderLength));
         buffer.write('A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4\n');
 
-        expect(() =>  HeaderSerializer.HeaderSerializer.deserialize(buffer))
-            .throws('Cannot parse header, header is malformed.');
+        expect(() => HeaderSerializer.deserialize(buffer)).throws('Cannot parse header, header is malformed.');
     });
 
-    it('throws if the header has too many parts', () => {
-        // expect.assertions(1);
-        let buffer = Buffer.alloc(Number(PayloadConstants.PayloadConstants.MaxHeaderLength));
+    it('throws if the header has too many parts', function () {
+        const buffer = Buffer.alloc(Number(PayloadConstants.MaxHeaderLength));
         buffer.write('A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1.2\n');
 
-        expect(() =>  HeaderSerializer.HeaderSerializer.deserialize(buffer))
-            .throws('Cannot parse header, header is malformed.');
+        expect(() => HeaderSerializer.deserialize(buffer)).throws('Cannot parse header, header is malformed.');
     });
 
-    it('throws if the header type is too long', () => {
-        // expect.assertions(1);
-        let buffer = Buffer.alloc(Number(PayloadConstants.PayloadConstants.MaxHeaderLength));
+    it('throws if the header type is too long', function () {
+        const buffer = Buffer.alloc(Number(PayloadConstants.MaxHeaderLength));
         buffer.write('ABCDE.000168.68e999ca-a651-40f4-ad8f-3aaf7b4.1\n');
 
-        expect(() =>  HeaderSerializer.HeaderSerializer.deserialize(buffer))
-            .throws('Header type \'5\' is missing or malformed.');
+        expect(() => HeaderSerializer.deserialize(buffer)).throws("Header type '5' is missing or malformed.");
     });
 
-    it('throws if the header length is malformed', () => {
-        // expect.assertions(1);
-        let buffer = Buffer.alloc(Number(PayloadConstants.PayloadConstants.MaxHeaderLength));
+    it('throws if the header length is malformed', function () {
+        const buffer = Buffer.alloc(Number(PayloadConstants.MaxHeaderLength));
         buffer.write('A.00b168.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n');
 
-        expect(() =>  HeaderSerializer.HeaderSerializer.deserialize(buffer))
-            .throws('Header length of NaN is missing or malformed');
+        expect(() => HeaderSerializer.deserialize(buffer)).throws('Header length of NaN is missing or malformed');
     });
 
-    it('throws if the header length is too small', () => {
-        // expect.assertions(1);
-        let buffer = Buffer.alloc(Number(PayloadConstants.PayloadConstants.MaxHeaderLength));
+    it('throws if the header length is too small', function () {
+        const buffer = Buffer.alloc(Number(PayloadConstants.MaxHeaderLength));
         buffer.write('A.-100000.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n');
 
-        expect(() =>  HeaderSerializer.HeaderSerializer.deserialize(buffer))
-            .throws('Header length of -100000 is missing or malformed');
+        expect(() => HeaderSerializer.deserialize(buffer)).throws('Header length of -100000 is missing or malformed');
     });
 
-    it('throws if the header length is too big', () => {
-        // expect.assertions(1);
-        let buffer = Buffer.alloc(Number(PayloadConstants.PayloadConstants.MaxHeaderLength));
+    it('throws if the header length is too big', function () {
+        const buffer = Buffer.alloc(Number(PayloadConstants.MaxHeaderLength));
         buffer.write('A.1111111.8e999ca-a651-40f4-ad8f-3aaf781862b4.1\n');
 
-        expect(() =>  HeaderSerializer.HeaderSerializer.deserialize(buffer))
-            .throws('Header length of 1111111 is missing or malformed');
+        expect(() => HeaderSerializer.deserialize(buffer)).throws('Header length of 1111111 is missing or malformed');
     });
 
-    it('throws if the header terminator is malformed', () => {
-        // expect.assertions(1);
-        let buffer = Buffer.alloc(Number(PayloadConstants.PayloadConstants.MaxHeaderLength));
+    it('throws if the header terminator is malformed', function () {
+        const buffer = Buffer.alloc(Number(PayloadConstants.MaxHeaderLength));
         buffer.write('A.000168.68e999ca-a651-40f4-ad8f-3aaf781862b4.2\n');
 
-        expect(() =>  HeaderSerializer.HeaderSerializer.deserialize(buffer))
-            .throws('Header End is missing or not a valid value.');
+        expect(() => HeaderSerializer.deserialize(buffer)).throws('Header End is missing or not a valid value.');
     });
 
-    it('throws if the header ID is malformed', () => {
-        //  expect.assertions(1);
+    it('throws if the header ID is malformed', function () {
         const headerId = '68e9p9ca-a651-40f4-ad8f-3aaf781862b4';
-        const header = `A.000168.${ headerId }.1\n`;
+        const header = `A.000168.${headerId}.1\n`;
 
-        let buffer = Buffer.alloc(Number(PayloadConstants.PayloadConstants.MaxHeaderLength));
+        const buffer = Buffer.alloc(Number(PayloadConstants.MaxHeaderLength));
         buffer.write(header);
 
-        expect(() =>  HeaderSerializer.HeaderSerializer.deserialize(buffer))
-            .throws(`Header ID \'${ headerId }\' is missing or malformed.`);
+        expect(() => HeaderSerializer.deserialize(buffer)).throws(`Header ID '${headerId}' is missing or malformed.`);
     });
 
-    it('accepts nil GUIDs as valid header IDs', () => {
-        let buffer = Buffer.alloc(Number(PayloadConstants.PayloadConstants.MaxHeaderLength));
+    it('accepts nil GUIDs as valid header IDs', function () {
+        const buffer = Buffer.alloc(Number(PayloadConstants.MaxHeaderLength));
         buffer.write('A.000168.00000000-0000-0000-0000-000000000000.1\n');
 
-        let result = HeaderSerializer.HeaderSerializer.deserialize(buffer);
-        
-        expect(result.id)
-            .to
-            .deep
-            .equal('00000000-0000-0000-0000-000000000000');
+        const result = HeaderSerializer.deserialize(buffer);
+
+        expect(result.id).to.deep.equal('00000000-0000-0000-0000-000000000000');
     });
 });

--- a/libraries/botframework-streaming/tests/NodeWebSocketFactory.test.js
+++ b/libraries/botframework-streaming/tests/NodeWebSocketFactory.test.js
@@ -1,14 +1,13 @@
-const { NodeWebSocket, NodeWebSocketFactory } = require('../');
+const { NodeWebSocket, NodeWebSocketFactory } = require('..');
 const { FauxSock, TestRequest } = require('./helpers');
 const { expect } = require('chai');
 const { randomBytes } = require('crypto');
 
-describe('NodeWebSocketFactory', () => {
-    it('createWebSocket() should create a new NodeWebSocket', async () => {
+describe('NodeWebSocketFactory', function () {
+    it('createWebSocket() should create a new NodeWebSocket', async function () {
         const factory = new NodeWebSocketFactory();
         const sock = new FauxSock();
         const request = new TestRequest();
-        request.method = 'GET' // TODO: Fix TestRequest class
         request.setIsUpgradeRequest(true);
         request.headers = [];
         request.headers['upgrade'] = 'websocket';

--- a/libraries/botframework-streaming/tests/PayloadSender.test.js
+++ b/libraries/botframework-streaming/tests/PayloadSender.test.js
@@ -1,81 +1,75 @@
-const SubscribableStream = require('../lib/subscribableStream');
-const StreamManager = require('../lib/payloads/streamManager');
-const PayloadSender = require('../lib/payloadTransport/payloadSender');
-const PayloadReceiver = require('../lib/payloadTransport/payloadReceiver');
-const PayloadTypes = require('../lib/payloads/payloadTypes');
-const PayloadAssemblerManager = require('../lib/payloads/payloadAssemblerManager');
-const  chai  = require('chai');
-var sinon = require('sinon');
-var expect = chai.expect;
+const { SubscribableStream } = require('..');
+const { PayloadReceiver, PayloadSender } = require('../lib/payloadTransport');
+const { PayloadAssemblerManager, PayloadTypes, StreamManager } = require('../lib/payloads');
+const { expect } = require('chai');
+const sinon = require('sinon');
 
-class FauxSock{
-    constructor(contentString){
-        if(contentString){
+class FauxSock {
+    constructor(contentString) {
+        if (contentString) {
             this.contentString = contentString;
             this.position = 0;
         }
     }
-    send(buffer){
+    send(buffer) {
         return buffer.length;
-    };
+    }
 
-    receive(readLength){
-        if(this.contentString[this.position])
-        {
+    receive(readLength) {
+        if (this.contentString[this.position]) {
             this.buff = Buffer.from(this.contentString[this.position]);
             this.position++;
 
             return this.buff.slice(0, readLength);
         }
 
-        if(this.receiver.isConnected)
-            this.receiver.disconnect();
+        if (this.receiver.isConnected) this.receiver.disconnect();
     }
-    close(){};
+    close() {}
 
-    setReceiver(receiver){
+    setReceiver(receiver) {
         this.receiver = receiver;
     }
 }
-describe('PayloadTransport', () => {
-    describe('PayloadSender', () => {
-        it('starts out disconnected.', () => {
-            let ps = new PayloadSender.PayloadSender();
+describe('PayloadTransport', function () {
+    describe('PayloadSender', function () {
+        it('starts out disconnected.', function () {
+            const ps = new PayloadSender();
             expect(ps.isConnected).to.equal(false);
         });
 
-        it('connects to its sender.', () => {
-            let ps = new PayloadSender.PayloadSender();
-            ps.connect(new FauxSock);
+        it('connects to its sender.', function () {
+            const ps = new PayloadSender();
+            ps.connect(new FauxSock());
             expect(ps.isConnected).to.equal(true);
         });
 
-        it('writes to its sender.', (done) => {
-            let ps = new PayloadSender.PayloadSender();
-            ps.connect(new FauxSock);
+        it('writes to its sender.', function (done) {
+            const ps = new PayloadSender();
+            ps.connect(new FauxSock());
             expect(ps.isConnected).to.equal(true);
 
-            let stream = new SubscribableStream.SubscribableStream();
+            const stream = new SubscribableStream();
             stream.write('This is a test stream.');
-            let header = {
-                payloadType: PayloadTypes.PayloadTypes.request,
+            const header = {
+                payloadType: PayloadTypes.request,
                 payloadLength: stream.length,
                 id: '100',
-                end: true
+                end: true,
             };
 
             const psSenderSpy = sinon.spy(ps._sender, 'send');
-            expect(ps.sendPayload(header, stream, ()=>done()));
+            expect(ps.sendPayload(header, stream, () => done()));
             expect(psSenderSpy.calledTwice).to.be.true;
         });
 
-        it('writes a large stream to its sender.', (done) => {
-            const ps = new PayloadSender.PayloadSender();
-            ps.connect(new FauxSock);
+        it('writes a large stream to its sender.', function (done) {
+            const ps = new PayloadSender();
+            ps.connect(new FauxSock());
             expect(ps.isConnected).to.equal(true);
 
-            const stream = new SubscribableStream.SubscribableStream();
-            let testString;
+            const stream = new SubscribableStream();
+            let testString = '';
             let count = 250;
             while (count >= 0) {
                 testString += 'This is a LARGE test stream.';
@@ -85,103 +79,117 @@ describe('PayloadTransport', () => {
             stream.write(testString);
             // Max PayloadLength is 4096
             const header = {
-                payloadType: PayloadTypes.PayloadTypes.request,
+                payloadType: PayloadTypes.request,
                 payloadLength: stream.length,
                 id: '100',
-                end: true
+                end: true,
             };
             const psSenderSpy = sinon.spy(ps._sender, 'send');
 
-            expect(ps.sendPayload(header, stream, () => {
-                // This try-catch is required as chai failures need to be caught and bubbled up via done().
-                try {
-                    expect(psSenderSpy.callCount).to.equal(4);
-                    done();
-                } catch (e) {
-                    done(e);
-                }
-            }));
+            expect(
+                ps.sendPayload(header, stream, () => {
+                    // This try-catch is required as chai failures need to be caught and bubbled up via done().
+                    try {
+                        expect(psSenderSpy.callCount).to.equal(4);
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                })
+            );
         });
 
-        it('calls the packet sent callback.', (done) => {
-            let ps = new PayloadSender.PayloadSender();
-            ps.connect(new FauxSock);
+        it('calls the packet sent callback.', function (done) {
+            const ps = new PayloadSender();
+            ps.connect(new FauxSock());
             expect(ps.isConnected).to.equal(true);
 
-            let stream = new SubscribableStream.SubscribableStream();
+            const stream = new SubscribableStream();
             stream.write('This is a test stream.');
-            let header = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: 22, id: '100', end: true};
+            const header = {
+                payloadType: PayloadTypes.request,
+                payloadLength: 22,
+                id: '100',
+                end: true,
+            };
 
-            ps.sendPayload(header, stream, ()=>done());
+            ps.sendPayload(header, stream, () => done());
         });
 
-        it('disconnects when header length is longer than packet length.', () => {
-            let ps = new PayloadSender.PayloadSender();
-            ps.connect(new FauxSock);
+        it('disconnects when header length is longer than packet length.', function () {
+            const ps = new PayloadSender();
+            ps.connect(new FauxSock());
             expect(ps.isConnected).to.equal(true);
 
-            let stream = new SubscribableStream.SubscribableStream();
+            const stream = new SubscribableStream();
             stream.write('This is a test stream.');
-            let header = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: 42, id: '100', end: true};
-            let packet = {header: header, payload: stream, sendCallBack: undefined};
+            const header = {
+                payloadType: PayloadTypes.request,
+                payloadLength: 42,
+                id: '100',
+                end: true,
+            };
 
-            ps.sendPayload(header, stream, ()=>done());
+            ps.sendPayload(header, stream);
 
             expect(ps.isConnected).to.equal(false);
         });
 
-        it('gracefully fails when trying to write before connecting.', (done) => {
-            let ps = new PayloadSender.PayloadSender();
+        it('gracefully fails when trying to write before connecting.', function (done) {
+            const ps = new PayloadSender();
             ps.disconnected = () => done();
             expect(ps.isConnected).to.equal(false);
-            ps.connect(new FauxSock);
+            ps.connect(new FauxSock());
             expect(ps.isConnected).to.equal(true);
             expect(ps.disconnected).to.not.be.undefined;
 
-            let stream = new SubscribableStream.SubscribableStream();
+            const stream = new SubscribableStream();
             stream.write('This is a test stream.');
-            let header = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: 22, id: '100', end: true};
-            let packet = {header: header, payload: stream, sendCallBack: ()=>done()};
+            const header = {
+                payloadType: PayloadTypes.request,
+                payloadLength: 22,
+                id: '100',
+                end: true,
+            };
 
-            ps.sendPayload(header, stream, ()=>done());
+            ps.sendPayload(header, stream, () => done());
         });
-
     });
 
-    describe('PayloadReceiver', () => {
-
-        it('begins disconnected.', () => {
-            let pr = new PayloadReceiver.PayloadReceiver();
+    describe('PayloadReceiver', function () {
+        it('begins disconnected.', function () {
+            const pr = new PayloadReceiver();
             expect(pr.isConnected).to.be.false;
         });
 
-        it('connects to and reads a header with no payload from the transport.', () => {
-            let pr = new PayloadReceiver.PayloadReceiver();
-            expect(pr.isConnected).to.be.false;
+        it('connects to and reads a header with no payload from the transport.', function () {
+            const pr = new PayloadReceiver();
 
-            let sock = new FauxSock(['A.000000.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n']);
+            const sock = new FauxSock(['A.000000.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n']);
             sock.setReceiver(pr);
 
             pr.connect(sock);
             expect(pr.isConnected).to.be.true;
         });
 
-        it('connects to and reads a header with a stream the transport.', (done) => {
-            let pr = new PayloadReceiver.PayloadReceiver();
-            expect(pr.isConnected).to.be.false;
+        it('connects to and reads a header with a stream the transport.', function (done) {
+            const pr = new PayloadReceiver();
 
-            let sock = new FauxSock(['S.000005.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n', '12345']);
+            const sock = new FauxSock(['S.000005.68e999ca-a651-40f4-ad8f-3aaf781862b4.1\n', '12345']);
             sock.setReceiver(pr);
 
-            this.streamManager = new StreamManager.StreamManager(undefined);
-            const assemblerManager = new PayloadAssemblerManager.PayloadAssemblerManager(
+            this.streamManager = new StreamManager(undefined);
+            const assemblerManager = new PayloadAssemblerManager(
                 this.streamManager,
-                (id, response) => onReceiveResponse(id, response),
-                (id, request) => onReceiveRequest(id, request)
+                () => done(),
+                () => done()
             );
 
-            pr.subscribe((header) =>  assemblerManager.getPayloadStream(header),
-                (header, contentStream, contentLength) => assemblerManager.onReceive(header, contentStream, contentLength));
+            pr.subscribe(
+                (header) => assemblerManager.getPayloadStream(header),
+                (header, contentStream, contentLength) =>
+                    assemblerManager.onReceive(header, contentStream, contentLength)
+            );
 
             expect(pr.connect(sock)).to.not.throw;
 

--- a/libraries/botframework-streaming/tests/ProtocolAdapter.test.js
+++ b/libraries/botframework-streaming/tests/ProtocolAdapter.test.js
@@ -1,4 +1,4 @@
-const PayloadAssembler = require('../lib/assemblers/payloadAssembler');
+const PayloadAssembler = require('../lib/assemblers');
 const ProtocolAdapter = require('../lib/protocolAdapter');
 const RequestManager = require('../lib/payloads/requestManager');
 const PayloadSender = require('../lib/payloadTransport/payloadSender');
@@ -9,9 +9,8 @@ const RequestHandler = require('../lib/requestHandler');
 const Response = require('../lib/streamingResponse');
 const Request = require('../lib/streamingRequest');
 const StreamManager = require('../lib/payloads/streamManager');
-const chai = require('chai');
+const { expect } = require('chai');
 const sinon = require('sinon');
-const expect = chai.expect;
 
 class TestRequestHandler extends RequestHandler.RequestHandler {
     constructor() {

--- a/libraries/botframework-streaming/tests/RequestManager.test.js
+++ b/libraries/botframework-streaming/tests/RequestManager.test.js
@@ -1,61 +1,44 @@
-const RequestManager = require( '../lib/payloads/requestManager');
-const chai = require( 'chai');
-var expect = chai.expect;
+const { RequestManager } = require('../lib/payloads');
+const { expect } = require('chai');
+const REQUEST_ID = '123';
 
-describe('RequestManager', () => {
+describe('RequestManager', function () {
+    it('RequestManager starts empty', function () {
+        const rm = new RequestManager();
 
-    it('RequestManager starts empty', () => {
-        let rm = new RequestManager.RequestManager();
-
-        let count = rm.pendingRequestCount();
-        expect(count)
-            .to
-            .equal(0);
+        const count = rm.pendingRequestCount();
+        expect(count).to.equal(0);
     });
 
-    it('RequestManager.getResponse called twice throws', async () => {
-        let rm = new RequestManager.RequestManager();
-        let requestId = '123';
-        rm.getResponse(requestId, undefined);
+    it('getResponse() called twice throws', async function () {
+        const rm = new RequestManager();
+        rm.getResponse(REQUEST_ID);
 
-        rm.getResponse(requestId, undefined)
-            .catch((reason) => expect(reason)
-                .to
-                .equal(`requestId \'${ requestId }\' already exists in RequestManager`));
-
+        rm.getResponse(REQUEST_ID).catch((reason) =>
+            expect(reason).to.equal(`requestId '${REQUEST_ID}' already exists in RequestManager`)
+        );
     });
 
-    it('RequestManager.signalResponse with no requestId returns false', async () => {
-        let rm = new RequestManager.RequestManager();
-        let requestId = '123';
-        let response;
-        let result = await rm.signalResponse(requestId, response);
+    it('signalResponse() with no requestId returns false', async function () {
+        const rm = new RequestManager();
+        const requestId = '123';
+        const result = await rm.signalResponse(requestId, undefined);
 
-        expect(result)
-            .to
-            .equal(false);
+        expect(result).to.equal(false);
     });
 
-    it('RequestManager end to end success', async () => {
-        let rm = new RequestManager.RequestManager();
-        let requestId = '123';
-        let response;
+    it('RequestManager end to end success', async function () {
+        const rm = new RequestManager();
+        const requestId = '123';
 
-        let promise = rm.getResponse(requestId, undefined);
+        const promise = rm.getResponse(requestId, undefined);
 
-        let result = await rm.signalResponse(requestId, response);
-        expect(result)
-            .to
-            .equal(true);
+        const result = await rm.signalResponse(requestId, undefined);
+        expect(result).to.equal(true);
 
-        let receiveResponse = await promise;
+        const receiveResponse = await promise;
 
-        expect(receiveResponse)
-            .to
-            .equal(response);
-        expect(rm.pendingRequestCount())
-            .to
-            .equal(0);
+        expect(receiveResponse).to.equal(undefined);
+        expect(rm.pendingRequestCount()).to.equal(0);
     });
-
 });

--- a/libraries/botframework-streaming/tests/SendOperations.test.js
+++ b/libraries/botframework-streaming/tests/SendOperations.test.js
@@ -1,66 +1,59 @@
-const HttpContent = require('../lib/httpContentStream');
-const PayloadSender = require('../lib/payloadTransport/payloadSender');
-const SubscribableStream = require('../lib/subscribableStream');
-const SendOperations = require('../lib/payloads/sendOperations');
-const StreamingRequest = require('../lib/streamingRequest');
-const StreamingResponse = require('../lib/streamingResponse');
-const  chai  = require('chai');
-var expect = chai.expect;
+const { HttpContent, StreamingRequest, StreamingResponse, SubscribableStream } = require('..');
+const { PayloadSender } = require('../lib/payloadTransport');
+const { SendOperations } = require('../lib/payloads');
+const { expect } = require('chai');
 
-describe('Streaming Extension SendOperations Tests', () => {
-    it('constructs a new instance', () => {
-        let ps = new PayloadSender.PayloadSender();
-        let so = new SendOperations.SendOperations(ps);
+describe('SendOperations', function () {
+    it('constructs a new instance', function () {
+        const ps = new PayloadSender();
+        const so = new SendOperations(ps);
 
-        expect(so).to.be.instanceOf(SendOperations.SendOperations);
+        expect(so).to.be.instanceOf(SendOperations);
     });
 
-    it('processes a send request operation', async (done) => {
-        let ps = new PayloadSender.PayloadSender();
-        let so = new SendOperations.SendOperations(ps);
-        let r = new StreamingRequest.StreamingRequest();
-        let stream1 = new SubscribableStream.SubscribableStream();
-        stream1.write('hello');
-        let headers = {contentLength: '5', contentType: 'text/plain'};
-        let hc = new HttpContent.HttpContent(headers, stream1);
-        r.addStream(hc);
-        expect(so).to.be.instanceOf(SendOperations.SendOperations);
-        so.sendRequest('test1', r).then(done());
+    let ps = new PayloadSender();
+    let so = new SendOperations(ps);
+    let headers = { contentLength: '5', contentType: 'text/plain' };
+    let subscribableStream = new SubscribableStream();
+
+    this.beforeEach(function () {
+        ps = new PayloadSender();
+        so = new SendOperations(ps);
+        headers = { contentLength: '5', contentType: 'text/plain' };
+        subscribableStream = new SubscribableStream();
     });
 
-    it('processes a send response with streams operation', (done) => {
-        let ps = new PayloadSender.PayloadSender();
-        let so = new SendOperations.SendOperations(ps);
-        let stream1 = new SubscribableStream.SubscribableStream();
-        stream1.write('hello');
-        let headers = {contentLength: '5', contentType: 'text/plain'};
-        let hc = new HttpContent.HttpContent(headers, stream1);
-        let r = StreamingResponse.StreamingResponse.create(200, hc);
+    this.afterEach(function () {
+        ps = null;
+        so = null;
+        headers = null;
+        subscribableStream = null;
+    });
+
+    it('processes a send request operation', async function () {
+        const r = new StreamingRequest();
+        subscribableStream.write('hello');
+        r.addStream(new HttpContent(headers, subscribableStream));
+        await so.sendRequest('test1', r);
+    });
+
+    it('processes a send response with streams operation', async function () {
+        subscribableStream.write('hello');
+        const r = StreamingResponse.create(200, new HttpContent(headers, subscribableStream));
         r.setBody('This is a new body.');
-
-        expect(r).to.be.instanceOf(StreamingResponse.StreamingResponse);
         expect(r.streams[1].content.stream.bufferList[0].toString()).to.contain('This is a new body.');
-        expect(r.statusCode).to.equal(200);
 
-        so.sendResponse('test1', r).then(done());
+        await so.sendResponse('test1', r);
     });
 
-    it('processes a send response with no streams operation', (done) => {
-        let ps = new PayloadSender.PayloadSender();
-        let so = new SendOperations.SendOperations(ps);
-        let stream1 = new SubscribableStream.SubscribableStream();
-        stream1.write('hello');
-        let headers = {contentLength: '5', contentType: 'text/plain'};
-        let hc = new HttpContent.HttpContent(headers, stream1);
-        let r = StreamingResponse.StreamingResponse.create(200, hc);
+    it('processes a send response with no streams operation', async function () {
+        subscribableStream.write('hello');
+        const r = StreamingResponse.create(200, new HttpContent(headers, subscribableStream));
 
-        so.sendResponse('test1', r).then(done());
+        await so.sendResponse('test1', r);
     });
 
-    it('processes a cancel stream operation', async (done) => {
-        let ps = new PayloadSender.PayloadSender();
-        let so = new SendOperations.SendOperations(ps);
-
-        so.sendCancelStream('test1').then(done());
+    it('processes a cancel stream operation', async function () {
+        await so.sendCancelStream('test1');
     });
 });

--- a/libraries/botframework-streaming/tests/StreamManager.test.js
+++ b/libraries/botframework-streaming/tests/StreamManager.test.js
@@ -1,95 +1,96 @@
-const StreamManager = require('../lib/payloads/streamManager');
-const PayloadTypes = require('../lib/payloads/payloadTypes');
-const SubscribableStream = require('../lib/subscribableStream');
-const PayloadAssembler = require('../lib/assemblers/payloadAssembler');
-const  chai  = require('chai');
-var expect = chai.expect;
+const { PayloadAssembler } = require('../lib/assemblers');
+const { PayloadTypes, StreamManager } = require('../lib/payloads');
+const { SubscribableStream } = require('..');
+const { expect } = require('chai');
 
-describe('Streaming Protocol StreamManager Tests', () => {
-
-    it('properly constructs a new instance', () => {
-        let sm = new StreamManager.StreamManager(undefined);
-        expect(sm).to.be.instanceOf(StreamManager.StreamManager);
+describe('StreamManager', function () {
+    it('properly constructs a new instance', function () {
+        const sm = new StreamManager();
+        expect(sm).to.be.instanceOf(StreamManager);
     });
 
-    it('creates and returns a new assembler when none currently exist', () => {
-        let sm = new StreamManager.StreamManager(undefined);
-        expect(sm).to.be.instanceOf(StreamManager.StreamManager);
+    it('creates and returns a new assembler when none currently exist', function () {
+        const sm = new StreamManager();
+        const pa = sm.getPayloadAssembler('bob');
 
-        let pa = sm.getPayloadAssembler('bob');
-
-        expect(pa).to.be.instanceOf(PayloadAssembler.PayloadAssembler);
+        expect(pa).to.be.instanceOf(PayloadAssembler);
         expect(pa.id).to.equal('bob');
     });
 
-    it('creates and returns a new assembler when others already exist', () => {
-        let sm = new StreamManager.StreamManager(undefined);
-        expect(sm).to.be.instanceOf(StreamManager.StreamManager);
-
-        let pa = sm.getPayloadAssembler('Huey');
-
-        expect(pa).to.be.instanceOf(PayloadAssembler.PayloadAssembler);
+    it('creates and returns a new assembler when others already exist', function () {
+        const sm = new StreamManager();
+        const pa = sm.getPayloadAssembler('Huey');
         expect(pa.id).to.equal('Huey');
 
-        let pa2 = sm.getPayloadAssembler('Dewey');
-        expect(pa2).to.be.instanceOf(PayloadAssembler.PayloadAssembler);
+        const pa2 = sm.getPayloadAssembler('Dewey');
         expect(pa2.id).to.equal('Dewey');
 
-        let pa3 = sm.getPayloadAssembler('Louie');
-        expect(pa3).to.be.instanceOf(PayloadAssembler.PayloadAssembler);
+        const pa3 = sm.getPayloadAssembler('Louie');
         expect(pa3.id).to.equal('Louie');
     });
 
-    it('looks up the correct assembler and returns the stream', () => {
-        let sm = new StreamManager.StreamManager(undefined);
-        expect(sm).to.be.instanceOf(StreamManager.StreamManager);
-        let head = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '0', id: 'bob', end: true};
-        let ps = sm.getPayloadStream(head);
+    it('looks up the correct assembler and returns the stream', function () {
+        const sm = new StreamManager();
+        const head = {
+            payloadType: PayloadTypes.request,
+            payloadLength: '0',
+            id: 'bob',
+            end: true,
+        };
+        const ps = sm.getPayloadStream(head);
 
-        expect(ps).to.be.instanceOf(SubscribableStream.SubscribableStream);
+        expect(ps).to.be.instanceOf(SubscribableStream);
 
-        let pa = sm.getPayloadAssembler('bob');
-        expect(pa).to.be.instanceOf(PayloadAssembler.PayloadAssembler);
+        const pa = sm.getPayloadAssembler('bob');
         expect(pa.id).to.equal('bob');
     });
 
-    it('does not throw when asked to receive on a non-existant stream', () => {
-        let sm = new StreamManager.StreamManager(undefined);
-        expect(sm).to.be.instanceOf(StreamManager.StreamManager);
-        let head = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '0', id: 'bob', end: true};
-        let stream1 = new SubscribableStream.SubscribableStream();
-        stream1.write('hello');
-        expect(sm.onReceive(head, stream1, 5)).to.not.throw;
+    it('does not throw when asked to receive on a non-existant stream', function () {
+        const sm = new StreamManager();
+        const head = {
+            payloadType: PayloadTypes.request,
+            payloadLength: '0',
+            id: 'bob',
+            end: true,
+        };
+        const stream = new SubscribableStream();
+        stream.write('hello');
+        expect(sm.onReceive(head, stream, 5)).to.not.throw;
     });
 
-    it('attempts to receive from an existing stream', () => {
-        let sm = new StreamManager.StreamManager(undefined);
-        expect(sm).to.be.instanceOf(StreamManager.StreamManager);
-        let head = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '0', id: 'bob', end: true};
-        let pa = sm.getPayloadAssembler('bob');
-        expect(pa).to.be.instanceOf(PayloadAssembler.PayloadAssembler);
+    it('attempts to receive from an existing stream', function () {
+        const sm = new StreamManager();
+        const head = {
+            payloadType: PayloadTypes.request,
+            payloadLength: '0',
+            id: 'bob',
+            end: true,
+        };
+        const pa = sm.getPayloadAssembler('bob');
         expect(pa.id).to.equal('bob');
-        let stream1 = new SubscribableStream.SubscribableStream();
-        stream1.write('hello');
-        expect(sm.onReceive(head, stream1, 5)).to.not.throw;
+        const stream = new SubscribableStream();
+        stream.write('hello');
+        expect(sm.onReceive(head, stream, 5)).to.not.throw;
     });
 
-    it('can close a stream', (done) => {
-        let sm = new StreamManager.StreamManager(done());
-        expect(sm).to.be.instanceOf(StreamManager.StreamManager);
-        let head = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '0', id: 'bob', end: true};
-        let pa = sm.getPayloadAssembler('bob');
-        expect(pa).to.be.instanceOf(PayloadAssembler.PayloadAssembler);
+    it('can close a stream', function (done) {
+        const sm = new StreamManager(done());
+        const pa = sm.getPayloadAssembler('bob');
+
         expect(pa.id).to.equal('bob');
-        let stream1 = new SubscribableStream.SubscribableStream();
-        stream1.write('hello');
+        const stream = new SubscribableStream();
+        stream.write('hello');
         expect(sm.closeStream(pa.id)).to.not.throw;
     });
 
-    it('does not throw when asked to close a stream that does not exist', (done) => {
-        let sm = new StreamManager.StreamManager(done());
-        expect(sm).to.be.instanceOf(StreamManager.StreamManager);
-        let head = {payloadType: PayloadTypes.PayloadTypes.request, payloadLength: '0', id: 'bob', end: true};
+    it('does not throw when asked to close a stream that does not exist', function (done) {
+        const sm = new StreamManager(done());
+        const head = {
+            payloadType: PayloadTypes.request,
+            payloadLength: '0',
+            id: 'bob',
+            end: true,
+        };
         expect(sm.closeStream(head.id)).to.not.throw;
     });
 });

--- a/libraries/botframework-streaming/tests/StreamingResponse.test.js
+++ b/libraries/botframework-streaming/tests/StreamingResponse.test.js
@@ -1,20 +1,16 @@
-const SubscribableStream = require('../lib/subscribableStream');
-const HttpContentStream = require('../lib/httpContentStream');
-const StreamingResponse = require('../lib/streamingResponse');
-const chai = require('chai');
-var expect = chai.expect;
+const { HttpContent, StreamingResponse, SubscribableStream } = require('..');
+const { expect } = require('chai');
 
-describe('Streaming Extensions Response Tests', () => {
-
-    it('can set the response body', () => {
-        let stream1 = new SubscribableStream.SubscribableStream();
-        stream1.write('hello');
-        let headers = { contentLength: '5', contentType: 'text/plain' };
-        let hc = new HttpContentStream.HttpContent(headers, stream1);
-        let r = StreamingResponse.StreamingResponse.create(200, hc);
+describe('Streaming Extensions Response Tests', function () {
+    it('can set the response body', function () {
+        const stream = new SubscribableStream();
+        stream.write('hello');
+        const headers = { contentLength: '5', contentType: 'text/plain' };
+        const hc = new HttpContent(headers, stream);
+        const r = StreamingResponse.create(200, hc);
         r.setBody('This is a new body.');
 
-        expect(r).to.be.instanceOf(StreamingResponse.StreamingResponse);
+        expect(r).to.be.instanceOf(StreamingResponse);
         expect(r.streams[1].content.stream.bufferList[0].toString()).to.contain('This is a new body.');
         expect(r.statusCode).to.equal(200);
     });

--- a/libraries/botframework-streaming/tests/SubscribableStream.test.js
+++ b/libraries/botframework-streaming/tests/SubscribableStream.test.js
@@ -1,32 +1,22 @@
-const Stream = require( '../lib/subscribableStream');
-const chai = require( 'chai');
-var expect = chai.expect;
+const { SubscribableStream } = require('../lib/subscribableStream');
+const { expect } = require('chai');
 
-describe('Streaming Extensions Stream Tests', () => {
-    it('throws on invalid encoding types', () => {
-        //  expect.assertions(1);
-        let s = new Stream.SubscribableStream();
+describe('Streaming Extensions Stream Tests', function () {
+    it('throws on invalid encoding types', function () {
+        const s = new SubscribableStream();
 
-        expect(() => s.write('data', 'supercoolencoding'))
-            .to
-            .throw();
-
+        expect(() => s.write('data', 'supercoolencoding')).to.throw();
     });
 
-    it('does not throw on valid on valid encoding types', () => {
-        //  expect.assertions(1);
-        let s = new Stream.SubscribableStream();
+    it('does not throw on valid on valid encoding types', function () {
+        const s = new SubscribableStream();
 
-        expect(() => s.write('data', 'utf8'))
-            .not
-            .to
-            .throw();
-
+        expect(() => s.write('data', 'utf8')).not.to.throw();
     });
 
-    it('subscribes to data events', (done) => {
-        let s = new Stream.SubscribableStream();
-        s.subscribe((data) => done());
+    it('subscribes to data events', function (done) {
+        const s = new SubscribableStream();
+        s.subscribe((_data) => done());
 
         s._write('hello', 'utf8', () => {});
     });

--- a/libraries/botframework-streaming/tests/TransportConstants.test.js
+++ b/libraries/botframework-streaming/tests/TransportConstants.test.js
@@ -1,29 +1,24 @@
-const Constants = require( '../lib/payloads/payloadConstants');
-const chai = require( 'chai');
-var expect = chai.expect;
-describe('TransportConstants', () => {
+const { PayloadConstants } = require('../lib/payloads/payloadConstants');
+const { expect } = require('chai');
 
-    it('has the proper value for MaxPayloadLength', () => {
-        expect(Constants.PayloadConstants.MaxPayloadLength)
-            .equal(4096);
+describe('PayloadConstants', function () {
+    it('has the proper value for MaxPayloadLength', function () {
+        expect(PayloadConstants.MaxPayloadLength).equal(4096);
     });
 
-    it('has the proper value for MaxHeaderLength', () => {
-        expect(Constants.PayloadConstants.MaxHeaderLength)
-            .equal(48);
-    });
-    it('has the proper value for MaxLength', () => {
-        expect(Constants.PayloadConstants.MaxLength)
-            .equal(999999);
-    });
-    it('has the proper value for MinLength', () => {
-        expect(Constants.PayloadConstants.MinLength)
-            .equal(0);
+    it('has the proper value for MaxHeaderLength', function () {
+        expect(PayloadConstants.MaxHeaderLength).equal(48);
     });
 
-    it('throws when attempting to change value for MaxPayloadLength', () => {
-        expect(Constants.PayloadConstants.MaxPayloadLength)
-            .equal(4096);
+    it('has the proper value for MaxLength', function () {
+        expect(PayloadConstants.MaxLength).equal(999999);
     });
 
+    it('has the proper value for MinLength', function () {
+        expect(PayloadConstants.MinLength).equal(0);
+    });
+
+    it('throws when attempting to change value for MaxPayloadLength', function () {
+        expect(PayloadConstants.MaxPayloadLength).equal(4096);
+    });
 });

--- a/libraries/botframework-streaming/tests/WebSocket.test.js
+++ b/libraries/botframework-streaming/tests/WebSocket.test.js
@@ -110,7 +110,7 @@ describe('Streaming Extensions WebSocket Library Tests', function () {
             expect(transport._active).to.be.null;
             expect(transport._activeReceiveResolve).to.be.null;
             expect(transport._activeReceiveReject).to.be.null;
-            expect(transport._socket).to.be.null;
+            expect(transport.ws).to.be.null;
             expect(transport._activeOffset).to.equal(0);
             expect(transport._activeReceiveCount).to.equal(0);
         });
@@ -126,7 +126,7 @@ describe('Streaming Extensions WebSocket Library Tests', function () {
             expect(transport._active).to.be.null;
             expect(transport._activeReceiveResolve).to.be.null;
             expect(transport._activeReceiveReject).to.be.null;
-            expect(transport._socket).to.be.null;
+            expect(transport.ws).to.be.null;
             expect(transport._activeOffset).to.equal(0);
             expect(transport._activeReceiveCount).to.equal(0);
         });

--- a/libraries/botframework-streaming/tests/helpers/fauxSock.js
+++ b/libraries/botframework-streaming/tests/helpers/fauxSock.js
@@ -25,7 +25,7 @@ class FauxSock {
     }
 
     /* Start of `ws` specific methods. */
-    removeListener(event, handler) {
+    removeListener(event, _handler) {
         switch (event) {
             case 'error':
                 return;
@@ -36,11 +36,9 @@ class FauxSock {
 
     setTimeout(value) {
         this.timeoutValue = value;
-        return;
     }
 
-    setNoDelay() {
-    }
+    setNoDelay() {}
     /* End of `ws` specific methods. */
 
     get isConnected() {
@@ -53,7 +51,7 @@ class FauxSock {
 
     send(buffer) {
         return buffer.length;
-    };
+    }
 
     receive(readLength) {
         if (this.contentString[this.position]) {
@@ -63,25 +61,23 @@ class FauxSock {
             return this.buff.slice(0, readLength);
         }
 
-        if (this.receiver.isConnected)
-            this.receiver.disconnect();
+        if (this.receiver.isConnected) this.receiver.disconnect();
     }
-    close() { };
     close() {
         this.connected = false;
-    };
+    }
     end() {
         this.exists = false;
         return true;
-    };
+    }
     destroyed() {
         return this.exists;
-    };
+    }
 
     /** WaterShed Socket Specific? */
     destroy() {
         return true;
-    };
+    }
 
     /** WaterShed Socket Specific? */
     removeAllListeners() {
@@ -89,35 +85,33 @@ class FauxSock {
     }
 
     on(action, handler) {
-        if (action === 'error') {
-            this.errorHandler = handler;
+        switch (action) {
+            case 'error':
+                this.errorHandler = handler;
+                break;
+            case 'data':
+                this.messageHandler = handler;
+                this.dataHandler = handler; // Required for `ws` WebSockets
+                break;
+            case 'close':
+                this.closeHandler = handler;
+                break;
+            case 'end':
+                this.endHandler = handler;
+                break;
+            case 'text':
+                this.textHandler = handler; // Required for `watershed` WebSockets
+                break;
+            case 'binary':
+                this.binaryHandler = handler; // Required for `watershed` WebSockets
+                break;
+            case 'message':
+                this._messageHandler = handler; // Required for `ws` WebSockets
+                break;
+            default:
+                throw new Error(`TestError: Unknown action ("${action}") passed to FauxSock.on()`);
         }
-        if (action === 'data') {
-            this.messageHandler = handler;
-        }
-        if (action === 'close') {
-            this.closeHandler = handler;
-        }
-        if (action === 'end') {
-            this.endHandler = handler;
-        }
-        // Required for `watershed` WebSockets
-        if (action === 'text') {
-            this.textHandler = handler;
-        }
-        // Required for `watershed` WebSockets
-        if (action === 'binary') {
-            this.binaryHandler = handler;
-        }
-        // Required for `ws` WebSockets
-        if (action === 'data') {
-            this.dataHandler = handler;
-        }
-        // Required for `ws` WebSockets
-        if (action === 'message') {
-            this._messageHandler = handler;
-        }
-    };
+    }
 
     setReceiver(receiver) {
         this.receiver = receiver;
@@ -125,13 +119,13 @@ class FauxSock {
 
     setOnMessageHandler(handler) {
         this.messageHandler = handler;
-    };
+    }
     setOnErrorHandler(handler) {
         this.errorHandler = handler;
-    };
+    }
     setOnCloseHandler(handler) {
         this.closeHandler = handler;
-    };
+    }
 }
 
 module.exports.FauxSock = FauxSock;

--- a/libraries/botframework-streaming/tests/helpers/testRequest.js
+++ b/libraries/botframework-streaming/tests/helpers/testRequest.js
@@ -5,10 +5,6 @@
 
 class TestRequest {
     constructor() {
-        let headers = [];
-    }
-
-    setMethod(verb) {
         this.method = 'GET';
     }
 
@@ -22,46 +18,45 @@ class TestRequest {
         this.upgradeRequestVal = value;
     }
 
-    status() {
+    get status() {
         return this.statusVal;
     }
 
-    status(value) {
+    set status(value) {
         this.statusVal = value;
     }
 
-    path(value) {
+    set path(value) {
         this.pathVal = value;
     }
 
-    path() {
+    get path() {
         return this.pathVal;
     }
 
-    verb(value) {
+    set verb(value) {
         this.verbVal = value;
     }
 
-    verb() {
+    get verb() {
         return this.verbVal;
     }
 
-    streams(value) {
+    set streams(value) {
         this.streamsVal = value;
     }
 
-    streams() {
+    get streams() {
         return this.streamsVal;
     }
 
-    setHeaders() {
+    get setHeaders() {
         return this.headersVal;
     }
 
-    setHeaders(value) {
+    set setHeaders(value) {
         this.headers = value;
     }
-
 }
 
 module.exports.TestRequest = TestRequest;


### PR DESCRIPTION
Part 2 of #3518
#minor


Description:
Removed public access modifier from botframework-streaming. botframework-streaming is now eslint compliant.
