### PR TITLE
fix: handle reactions added/removed separately

### DIFF
--- a/libraries/botbuilder-core/src/activityHandlerBase.ts
+++ b/libraries/botbuilder-core/src/activityHandlerBase.ts
@@ -155,9 +155,11 @@ export class ActivityHandlerBase {
      *   call [onReactionsRemovedActivity](xref:botbuilder-core.ActivityHandlerBase.onReactionsRemovedActivity).
      */
     protected async onMessageReactionActivity(context: TurnContext): Promise<void> {
-        if (context.activity.reactionsAdded && context.activity.reactionsAdded.length > 0) {
+        if (context.activity.reactionsAdded?.length) {
             await this.onReactionsAddedActivity(context.activity.reactionsAdded, context);
-        } else if (context.activity.reactionsRemoved && context.activity.reactionsRemoved.length > 0) {
+        }
+
+        if (context.activity.reactionsRemoved?.length) {
             await this.onReactionsRemovedActivity(context.activity.reactionsRemoved, context);
         }
     }

--- a/libraries/botbuilder-core/tests/activityHandlerBase.test.js
+++ b/libraries/botbuilder-core/tests/activityHandlerBase.test.js
@@ -317,5 +317,20 @@ describe('ActivityHandlerBase', function () {
             assert(onMessageReactionActivityCalled, 'onMessageReactionActivity was not called');
             assert(onReactionsRemovedActivityCalled, 'onReactionsRemovedActivity was not called');
         });
+
+        it(`should call onReactionsAddedActivity if reactionsAdded and onReactionsRemovedActivity if reactionsRemoved if they both exist and have items`, async function () {
+            const bot = new MessageReactionActivityHandler();
+            const activity = createMsgReactActivity('bot', {
+                reactionsAdded: [{ type: 'laugh' }],
+                reactionsRemoved: [{ type: 'like' }],
+            });
+
+            await processActivity(activity, bot);
+
+            assert(onTurnActivityCalled, 'onTurnActivity was not called');
+            assert(onMessageReactionActivityCalled, 'onMessageReactionActivity was not called');
+            assert(onReactionsAddedActivityCalled, 'onReactionsAddedActivity was not called');
+            assert(onReactionsRemovedActivityCalled, 'onReactionsRemovedActivity was not called');
+        });
     });
 });


### PR DESCRIPTION
Fixes #3795 

## Description
Simple change for .NET parity. We just needed to allow reactions `added` and `removed` to _both_ be handled.

## Testing
![image](https://user-images.githubusercontent.com/40401643/123178309-c8aef400-d43b-11eb-93dd-63e2ff513812.png)