### PR TITLE
fix: OAuth prompt should store in turn.token, not dialog.token

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.OAuthInput.schema
+++ b/libraries/botbuilder-dialogs-adaptive/schemas/Dialogs/Microsoft.OAuthInput.schema
@@ -51,7 +51,7 @@
             "description": "Property to store the OAuth token result. WARNING: Changing this location is not recommended as you should call OAuthInput immediately before each use of the token.",
             "default": "turn.token",
             "examples": [
-                "dialog.token"
+                "turn.token"
             ]
         },
         "invalidPrompt": {

--- a/libraries/tests.schema
+++ b/libraries/tests.schema
@@ -5280,7 +5280,7 @@
           "description": "Property to store the OAuth token result. WARNING: Changing this location is not recommended as you should call OAuthInput immediately before each use of the token.",
           "default": "turn.token",
           "examples": [
-            "dialog.token"
+            "turn.token"
           ]
         },
         "invalidPrompt": {


### PR DESCRIPTION
Fixes #3797 

Note: The .NET PR also replaces this for TestBot, but we don't have that or anything like it (particularly, the testbot.schema file), so the JS port gets 2 of the 3 changes.

![image](https://user-images.githubusercontent.com/40401643/123305318-d2386a80-d4d4-11eb-8d21-239a20fb7125.png)

![image](https://user-images.githubusercontent.com/40401643/123305277-c8af0280-d4d4-11eb-91c7-9fe6005ad80c.png)
![image](https://user-images.githubusercontent.com/40401643/123305446-f72cdd80-d4d4-11eb-9066-65523aa7c54b.png)
![image](https://user-images.githubusercontent.com/40401643/123305484-01e77280-d4d5-11eb-97dc-9e20bc113348.png)
