### PR TITLE
chore: use BFAuthentication for BFClient in runtime, fix comparison bug

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBot.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/coreBot.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { BotFrameworkAuthentication } from 'botframework-connector';
 import { DialogManager, MemoryScope, PathResolver } from 'botbuilder-dialogs';
 import { ResourceExplorer } from 'botbuilder-dialogs-declarative';
 
@@ -9,7 +10,6 @@ import {
     BotTelemetryClient,
     ConversationState,
     SkillConversationIdFactoryBase,
-    SkillHttpClient,
     UserState,
 } from 'botbuilder';
 
@@ -27,7 +27,7 @@ export class CoreBot extends ActivityHandler {
         resourceExplorer: ResourceExplorer,
         userState: UserState,
         conversationState: ConversationState,
-        skillClient: SkillHttpClient,
+        botFrameworkAuthentication: BotFrameworkAuthentication,
         skillConversationIdFactory: SkillConversationIdFactoryBase,
         botTelemetryClient: BotTelemetryClient,
         defaultLocale: string,
@@ -39,6 +39,7 @@ export class CoreBot extends ActivityHandler {
 
         const rootResource = resourceExplorer.getResource(defaultRootDialog);
         const rootDialog = resourceExplorer.loadType<AdaptiveDialog>(rootResource);
+        const skillClient = botFrameworkAuthentication.createBotFrameworkClient();
 
         const dialogManager = new DialogManager(rootDialog).configure({
             conversationState,

--- a/libraries/botframework-connector/src/auth/passwordServiceClientCredentialFactory.ts
+++ b/libraries/botframework-connector/src/auth/passwordServiceClientCredentialFactory.ts
@@ -58,7 +58,7 @@ export class PasswordServiceClientCredentialFactory implements ServiceClientCred
                 appId == null
                     ? MicrosoftAppCredentials.Empty
                     : new MicrosoftAppCredentials(appId, this.password, undefined, audience);
-        } else if (normalizedEndpoint == GovernmentConstants.ToChannelFromBotLoginUrl.toLowerCase()) {
+        } else if (normalizedEndpoint === GovernmentConstants.ToChannelFromBotLoginUrl.toLowerCase()) {
             credentials =
                 appId == null
                     ? new MicrosoftAppCredentials(

--- a/libraries/botframework-connector/src/auth/passwordServiceClientCredentialFactory.ts
+++ b/libraries/botframework-connector/src/auth/passwordServiceClientCredentialFactory.ts
@@ -58,7 +58,7 @@ export class PasswordServiceClientCredentialFactory implements ServiceClientCred
                 appId == null
                     ? MicrosoftAppCredentials.Empty
                     : new MicrosoftAppCredentials(appId, this.password, undefined, audience);
-        } else if (normalizedEndpoint == GovernmentConstants.ToChannelFromBotLoginUrl) {
+        } else if (normalizedEndpoint == GovernmentConstants.ToChannelFromBotLoginUrl.toLowerCase()) {
             credentials =
                 appId == null
                     ? new MicrosoftAppCredentials(

--- a/libraries/botframework-connector/tests/passwordServiceClientCredentialFactory.test.js
+++ b/libraries/botframework-connector/tests/passwordServiceClientCredentialFactory.test.js
@@ -53,7 +53,7 @@ describe('PasswordServiceClientCredentialFactory', function () {
             // The PasswordServiceClientCredentialFactory generates subclasses of the AppCredentials class.
             assert.strictEqual(cred.appId, APP_ID);
             assert.strictEqual(cred.oAuthScope, testArgs[idx][1]);
-            assert.strictEqual(cred.oAuthEndpoint, testArgs[idx][2].toLowerCase());
+            assert.strictEqual(cred.oAuthEndpoint, testArgs[idx][2]);
         });
     });
 


### PR DESCRIPTION
#minor

## Description
- Removes `SkillHttpClient` node from Adaptive runtime in favor of `BotFrameworkAuthentication.createBotFrameworkClient()` ([`AdaptiveDialogBot`](https://github.com/microsoft/botbuilder-dotnet/blob/e5b4e812171015d3b7bf5fb077ef7fbdb6dc226c/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/AdaptiveDialogBot.cs#L98) in .NET)
  - The `addSkills()` method is now more aligned with .NET's implementation ([`AddBotRuntimeSkills()`](https://github.com/microsoft/botbuilder-dotnet/blob/e5b4e812171015d3b7bf5fb077ef7fbdb6dc226c/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime/Extensions/ServiceCollectionExtensions.cs#L115))
  - Also removes `SkillHttpCllient` dependency `ICredentialProvider` from Adaptive runtime
  - Ran code formatter in `botbuilder-dialogs-adaptive-runtime/src/index.ts`
- Fixes comparison issue in `PasswordServiceClientCredentialFactory.create()`


## Testing
Tested with Skills on US Gov Cloud.