### PR TITLE
fix: build label before state label

### DIFF
--- a/libraries/botbuilder-repo-utils/src/updateVersions.ts
+++ b/libraries/botbuilder-repo-utils/src/updateVersions.ts
@@ -44,16 +44,16 @@ export const getPackageVersion = (
 ): PackageVersion => {
     const prerelease = [];
 
+    if (options.buildLabel) {
+        prerelease.push(options.buildLabel);
+    }
+
     if (pkg.deprecated) {
         prerelease.push(options.deprecated);
     } else if (pkg.internal) {
         prerelease.push(options.internal);
     } else if (pkg.preview) {
         prerelease.push(options.preview);
-    }
-
-    if (options.buildLabel) {
-        prerelease.push(options.buildLabel);
     }
 
     if (options.commitSha) {

--- a/libraries/botbuilder-repo-utils/tests/updateVersions.test.ts
+++ b/libraries/botbuilder-repo-utils/tests/updateVersions.test.ts
@@ -80,7 +80,7 @@ describe('updateVersions', function () {
                 label: 'preview package with date, commitSha, and build label',
                 pkg: previewPackage,
                 options: { ...defaultOptions, buildLabel: 'BUILD', commitSha: 'COMMIT', date: 'DATE' },
-                expected: `${newVersion}-PREVIEW.BUILD.COMMIT+date-DATE`,
+                expected: `${newVersion}-BUILD.PREVIEW.COMMIT+date-DATE`,
             },
             {
                 label: 'deprecated package with defaults',
@@ -110,7 +110,7 @@ describe('updateVersions', function () {
                 label: 'deprecated package with date, commitSha, and buildLabel',
                 pkg: deprecatedPackage,
                 options: { ...defaultOptions, buildLabel: 'BUILD', commitSha: 'COMMIT', date: 'DATE' },
-                expected: `${newVersion}-DEPRECATED.BUILD.COMMIT+date-DATE`,
+                expected: `${newVersion}-BUILD.DEPRECATED.COMMIT+date-DATE`,
             },
         ];
 
@@ -288,12 +288,12 @@ describe('updateVersions', function () {
             const expectedVersion = new PackageVersion(`${packageVersion}-dev.COMMIT`, `date-${formattedDate}`);
 
             const expectedPreviewVersion = new PackageVersion(
-                `${packageVersion}-preview.dev.COMMIT`,
+                `${packageVersion}-dev.preview.COMMIT`,
                 `date-${formattedDate}`
             );
 
             const expectedDeprecatedVersion = new PackageVersion(
-                `${packageVersion}-deprecated.dev.COMMIT`,
+                `${packageVersion}-dev.deprecated.COMMIT`,
                 `date-${formattedDate}`
             );
 


### PR DESCRIPTION
.NET does versions like 4.14.0-rc0.preview, i.e. the "build label" comes before "preview".

#minor