### PR TITLE
fix: enable TeamsInfo methods to work with CloudAdapter

### DIFF
--- a/libraries/botbuilder/src/teamsInfo.ts
+++ b/libraries/botbuilder/src/teamsInfo.ts
@@ -414,7 +414,10 @@ export class TeamsInfo {
      * @private
      */
     private static getConnectorClient(context: TurnContext): ConnectorClient {
-        const client = context.turnState?.get<ConnectorClient>(context.adapter.ConnectorClientKey);
+        const client =
+            context.adapter && 'createConnectorClient' in context.adapter
+                ? (context.adapter as BotFrameworkAdapter).createConnectorClient(context.activity.serviceUrl)
+                : context.turnState?.get<ConnectorClient>(context.adapter.ConnectorClientKey);
         if (!client) {
             throw new Error('This method requires a connector client.');
         }

--- a/libraries/botbuilder/src/teamsInfo.ts
+++ b/libraries/botbuilder/src/teamsInfo.ts
@@ -414,11 +414,12 @@ export class TeamsInfo {
      * @private
      */
     private static getConnectorClient(context: TurnContext): ConnectorClient {
-        if (!context.adapter || !('createConnectorClient' in context.adapter)) {
+        const client = context.turnState?.get<ConnectorClient>(context.adapter.ConnectorClientKey);
+        if (!client) {
             throw new Error('This method requires a connector client.');
         }
 
-        return (context.adapter as BotFrameworkAdapter).createConnectorClient(context.activity.serviceUrl);
+        return client;
     }
 
     /**

--- a/libraries/botbuilder/tests/teamsInfo.test.js
+++ b/libraries/botbuilder/tests/teamsInfo.test.js
@@ -182,7 +182,9 @@ const teamActivity = {
 };
 
 describe('TeamsInfo', function () {
-    const connectorClient = new ConnectorClient(new MicrosoftAppCredentials('abc', '123'), { baseUri: 'https://smba.trafficmanager.net/amer' });
+    const connectorClient = new ConnectorClient(new MicrosoftAppCredentials('abc', '123'), {
+        baseUri: 'https://smba.trafficmanager.net/amer/',
+    });
 
     beforeEach(function () {
         nock.cleanAll();
@@ -955,12 +957,11 @@ describe('TeamsInfo', function () {
                 );
             });
 
-            it(`should error if the turnState doesn't have a ConnectorClient`, function () {
-                const context = new TestContext(teamActivity);
-                assert.throws(
-                    () => TeamsInfo.getConnectorClient(context),
-                    new Error('This method requires a connector client.')
-                );
+            it(`should fallback to the connectorClient on turnState if adapter doesn't exist in context.adapter`, function () {
+                const context = new TurnContext({});
+                context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
+                const result = TeamsInfo.getConnectorClient(context);
+                assert.deepStrictEqual(result, connectorClient);
             });
         });
 

--- a/libraries/botbuilder/tests/teamsInfo.test.js
+++ b/libraries/botbuilder/tests/teamsInfo.test.js
@@ -3,7 +3,7 @@ const nock = require('nock');
 const sinon = require('sinon');
 const { BotFrameworkAdapter, TeamsInfo, CloudAdapter } = require('../');
 const { Conversations } = require('botframework-connector/lib/connectorApi/operations');
-const { MicrosoftAppCredentials, ConnectorClient } = require('botframework-connector');
+const { MicrosoftAppCredentials, ConnectorClient, ServiceClientCredentialsFactory, PasswordServiceClientCredentialFactory } = require('botframework-connector');
 const { TurnContext, MessageFactory, ActionTypes, BotAdapter, Channels } = require('botbuilder-core');
 
 class TeamsInfoAdapter extends BotFrameworkAdapter {
@@ -182,6 +182,8 @@ const teamActivity = {
 };
 
 describe('TeamsInfo', function () {
+    const connectorClient = new ConnectorClient(new MicrosoftAppCredentials('abc', '123'), { baseUri: 'https://smba.trafficmanager.net/amer' });
+
     beforeEach(function () {
         nock.cleanAll();
     });
@@ -342,6 +344,7 @@ describe('TeamsInfo', function () {
                 .reply(200, { conversations });
 
             const context = new TestContext(teamActivity);
+            context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
             const channels = await TeamsInfo.getTeamChannels(context);
 
             assert(fetchOauthToken.isDone());
@@ -381,6 +384,7 @@ describe('TeamsInfo', function () {
                 .reply(200, { conversations });
 
             const context = new TestContext(teamActivity);
+            context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
             const channels = await TeamsInfo.getTeamChannels(context, '19:ChannelIdgeneralChannelId@thread.skype');
 
             assert(fetchOauthToken.isDone());
@@ -431,6 +435,7 @@ describe('TeamsInfo', function () {
                 .reply(200, teamDetails);
 
             const context = new TestContext(teamActivity);
+            context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
             const fetchedTeamDetails = await TeamsInfo.getTeamDetails(context);
 
             assert(fetchOauthToken.isDone());
@@ -457,6 +462,7 @@ describe('TeamsInfo', function () {
                 .reply(200, teamDetails);
 
             const context = new TestContext(teamActivity);
+            context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
             const fetchedTeamDetails = await TeamsInfo.getTeamDetails(
                 context,
                 '19:ChannelIdgeneralChannelId@thread.skype'
@@ -495,6 +501,7 @@ describe('TeamsInfo', function () {
                 .reply(200, members);
 
             const context = new TestContext(oneOnOneActivity);
+            context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
             const fetchedMembers = await TeamsInfo.getMembers(context);
 
             assert(fetchOauthToken.isDone());
@@ -548,6 +555,7 @@ describe('TeamsInfo', function () {
                 .reply(200, members);
 
             const context = new TestContext(groupChatActivity);
+            context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
             const fetchedMembers = await TeamsInfo.getMembers(context);
 
             assert(fetchOauthToken.isDone());
@@ -591,6 +599,7 @@ describe('TeamsInfo', function () {
                 .reply(200, members);
 
             const context = new TestContext(teamActivity);
+            context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
             const fetchedMembers = await TeamsInfo.getMembers(context);
 
             assert(fetchOauthToken.isDone());
@@ -604,6 +613,7 @@ describe('TeamsInfo', function () {
 
         it('should not work if conversationId is falsey', async function () {
             const context = new TestContext(oneOnOneActivity);
+            context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
             context.activity.conversation.id = undefined;
 
             await assert.rejects(TeamsInfo.getMembers(context), (err) => {
@@ -635,6 +645,7 @@ describe('TeamsInfo', function () {
                 .reply(200, member);
 
             const context = new TestContext(oneOnOneActivity);
+            context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
             const fetchedMember = await TeamsInfo.getMember(context, oneOnOneActivity.from.id);
 
             assert(fetchOauthToken.isDone());
@@ -663,6 +674,7 @@ describe('TeamsInfo', function () {
                 .reply(200, member);
 
             const context = new TestContext(teamActivity);
+            context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
             const fetchedMember = await TeamsInfo.getMember(context, teamActivity.from.id);
 
             assert(fetchOauthToken.isDone());
@@ -685,6 +697,7 @@ describe('TeamsInfo', function () {
 
     describe('getMeetingParticipant', function () {
         const context = new TestContext(teamActivity);
+        context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
 
         it('should work with correct arguments', async function () {
             const participant = {
@@ -729,6 +742,7 @@ describe('TeamsInfo', function () {
 
     describe('getMeetingInfo', function () {
         const context = new TestContext(teamActivity);
+        context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
 
         it('should work with correct arguments-meetingId in context', async function () {
             const details = {
@@ -772,6 +786,9 @@ describe('TeamsInfo', function () {
         });
 
         it('should work with correct arguments-meetingId passed in', async function () {
+            const context = new TestContext(teamActivity);
+            context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
+
             const details = {
                 organizer: {
                     id: teamActivity.from.id,
@@ -872,6 +889,7 @@ describe('TeamsInfo', function () {
                 .reply(200, members);
 
             const context = new TestContext(teamActivity);
+            context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
             const fetchedMembers = await TeamsInfo.getTeamMembers(context);
 
             assert(fetchOauthToken.isDone());
@@ -915,6 +933,7 @@ describe('TeamsInfo', function () {
                 .reply(200, members);
 
             const context = new TestContext(teamActivity);
+            context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
             const fetchedMembers = await TeamsInfo.getTeamMembers(context, '19:ChannelIdgeneralChannelId@thread.skype');
 
             assert(fetchOauthToken.isDone());
@@ -932,13 +951,6 @@ describe('TeamsInfo', function () {
             it(`should error if the context doesn't have an adapter`, function () {
                 assert.throws(
                     () => TeamsInfo.getConnectorClient({}),
-                    new Error('This method requires a connector client.')
-                );
-            });
-
-            it(`should error if the adapter doesn't have a createConnectorClient method`, function () {
-                assert.throws(
-                    () => TeamsInfo.getConnectorClient({ adapter: {} }),
                     new Error('This method requires a connector client.')
                 );
             });

--- a/libraries/botbuilder/tests/teamsInfo.test.js
+++ b/libraries/botbuilder/tests/teamsInfo.test.js
@@ -961,7 +961,7 @@ describe('TeamsInfo', function () {
                 const context = new TurnContext({});
                 context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
                 const result = TeamsInfo.getConnectorClient(context);
-                assert.deepStrictEqual(result, connectorClient);
+                assert.strictEqual(result, connectorClient);
             });
         });
 

--- a/libraries/botbuilder/tests/teamsInfo.test.js
+++ b/libraries/botbuilder/tests/teamsInfo.test.js
@@ -954,6 +954,14 @@ describe('TeamsInfo', function () {
                     new Error('This method requires a connector client.')
                 );
             });
+
+            it(`should error if the turnState doesn't have a ConnectorClient`, function () {
+                const context = new TestContext(teamActivity);
+                assert.throws(
+                    () => TeamsInfo.getConnectorClient(context),
+                    new Error('This method requires a connector client.')
+                );
+            });
         });
 
         describe('getMembersInternal()', function () {


### PR DESCRIPTION
#minor

## Description

Many of the TeamsInfo methods fail with ["This method requires a connector client."](https://github.com/microsoft/botbuilder-js/blob/main/libraries/botbuilder/src/teamsInfo.ts#L418) when using `CloudAdapter`. This is because most of them have a check for `adapter.createConnectorClient()`, which doesn't exist in CloudAdapter.

## Specific Changes

Align JS TeamsInfo with [.NET](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder/Teams/TeamsInfo.cs#L330) by having the adapter get pulled from the `TurnState`.

## Testing

This also required a lot of testing changes since the adapter didn't exist on the `TurnState` in the tests. The JS tests now manually add the adapter to the `TurnState`, [as also done in .NET](https://github.com/microsoft/botbuilder-dotnet/blob/main/tests/Microsoft.Bot.Builder.Tests/Teams/TeamsInfoTests.cs#L49).