### PR TITLE
feat: msal for opt-in authentication

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-runtime-core/src/serviceCollection.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime-core/src/serviceCollection.ts
@@ -69,6 +69,10 @@ export class ServiceCollection {
      * @returns this for chaining
      */
     addInstance<InstanceType>(key: string, instance: InstanceType): this {
+        if (this.graph.hasNode(key)) {
+            this.graph.removeNode(key);
+        }
+
         this.graph.addNode(key, [() => instance]);
         return this;
     }

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -28,11 +28,13 @@
   },
   "dependencies": {
     "@azure/ms-rest-js": "1.9.1",
+    "@azure/msal-node": "^1.2.0",
     "@types/jsonwebtoken": "7.2.8",
     "@types/node": "^10.17.27",
     "adal-node": "0.2.2",
     "axios": "^0.21.1",
     "base64url": "^3.0.0",
+    "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
     "botbuilder-stdlib": "4.1.6",
     "botframework-schema": "4.1.6",
     "cross-fetch": "^3.0.5",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -34,7 +34,6 @@
     "adal-node": "0.2.2",
     "axios": "^0.21.1",
     "base64url": "^3.0.0",
-    "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
     "botbuilder-stdlib": "4.1.6",
     "botframework-schema": "4.1.6",
     "cross-fetch": "^3.0.5",

--- a/libraries/botframework-connector/src/auth/index.ts
+++ b/libraries/botframework-connector/src/auth/index.ts
@@ -30,3 +30,6 @@ export * from './passwordServiceClientCredentialFactory';
 export * from './skillValidation';
 export * from './serviceClientCredentialsFactory';
 export * from './userTokenClient';
+
+export { MsalAppCredentials } from './msalAppCredentials';
+export { MsalServiceClientCredentialsFactory } from './msalServiceClientCredentialsFactory';

--- a/libraries/botframework-connector/src/auth/msalAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/msalAppCredentials.ts
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AppCredentials } from './appCredentials';
+import { ConfidentialClientApplication, NodeAuthOptions } from '@azure/msal-node';
+import { TokenResponse } from 'adal-node';
+
+export interface Certificate {
+    thumbprint: string;
+    privateKey: string;
+}
+
+/**
+ * An implementation of AppCredentials that uses @azure/msal-node to fetch tokens.
+ */
+export class MsalAppCredentials extends AppCredentials {
+    /**
+     * A reference used for Empty auth scenarios
+     */
+    static Empty = new MsalAppCredentials();
+
+    private readonly clientApplication?: ConfidentialClientApplication;
+
+    /**
+     * Create an MsalAppCredentials instance using a confidential client application.
+     *
+     * @param clientApplication An @azure/msal-node ConfidentialClientApplication instance.
+     * @param appId The application ID.
+     * @param authority The authority to use for fetching tokens
+     * @param scope The oauth scope to use when fetching tokens.
+     */
+    constructor(clientApplication: ConfidentialClientApplication, appId: string, authority: string, scope: string);
+
+    /**
+     * Create an MsalAppCredentials instance using a confidential client application.
+     *
+     * @param appId The application ID.
+     * @param appPassword The application password.
+     * @param authority The authority to use for fetching tokens
+     * @param scope The oauth scope to use when fetching tokens.
+     */
+    constructor(appId: string, appPassword: string, authority: string, scope: string);
+
+    /**
+     * Create an MsalAppCredentials instance using a confidential client application.
+     *
+     * @param appId The application ID.
+     * @param certificate The client certificate details.
+     * @param authority The authority to use for fetching tokens
+     * @param scope The oauth scope to use when fetching tokens.
+     */
+    constructor(appId: string, certificate: Certificate, authority: string, scope: string);
+
+    /**
+     * @internal
+     */
+    constructor();
+
+    /**
+     * @internal
+     */
+    constructor(
+        maybeClientApplicationOrAppId?: ConfidentialClientApplication | string,
+        maybeAppIdOrAppPasswordOrCertificate?: string | Certificate,
+        maybeAuthority?: string,
+        maybeScope?: string
+    ) {
+        const appId =
+            typeof maybeClientApplicationOrAppId === 'string'
+                ? maybeClientApplicationOrAppId
+                : typeof maybeAppIdOrAppPasswordOrCertificate === 'string'
+                ? maybeAppIdOrAppPasswordOrCertificate
+                : undefined;
+
+        super(appId, undefined, maybeScope);
+
+        if (typeof maybeClientApplicationOrAppId !== 'string') {
+            this.clientApplication = maybeClientApplicationOrAppId;
+        } else {
+            const auth: NodeAuthOptions = {
+                authority: maybeAuthority,
+                clientId: appId,
+            };
+
+            auth.clientCertificate =
+                typeof maybeAppIdOrAppPasswordOrCertificate !== 'string'
+                    ? maybeAppIdOrAppPasswordOrCertificate
+                    : undefined;
+
+            auth.clientSecret =
+                typeof maybeAppIdOrAppPasswordOrCertificate === 'string'
+                    ? maybeAppIdOrAppPasswordOrCertificate
+                    : undefined;
+
+            this.clientApplication = new ConfidentialClientApplication({ auth });
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    async getToken(forceRefresh: boolean): Promise<string> {
+        if (!this.clientApplication) {
+            throw new Error('getToken should not be called for empty credentials.');
+        }
+
+        const scopePostfix = '/.default';
+        let scope = this.oAuthScope;
+        if (!scope.endsWith(scopePostfix)) {
+            scope = `${scope}${scopePostfix}`;
+        }
+
+        const token = await this.clientApplication.acquireTokenByClientCredential({
+            scopes: [scope],
+            skipCache: forceRefresh,
+        });
+
+        const { accessToken } = token ?? {};
+        if (typeof accessToken !== 'string') {
+            throw new Error('Authentication: No access token received from MSAL.');
+        }
+
+        return accessToken;
+    }
+
+    protected async refreshToken(): Promise<TokenResponse> {
+        throw new Error('NotImplemented');
+    }
+}

--- a/libraries/botframework-connector/src/auth/msalServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/msalServiceClientCredentialsFactory.ts
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ConfidentialClientApplication } from '@azure/msal-node';
+import { Configuration } from 'botbuilder-dialogs-adaptive-runtime-core';
+import { MsalAppCredentials } from './msalAppCredentials';
+import { ServiceClientCredentials } from '@azure/ms-rest-js';
+import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
+import { AuthenticationConstants } from './authenticationConstants';
+import { GovernmentConstants } from './governmentConstants';
+
+/**
+ * An implementation of ServiceClientCredentialsFactory that generates MsalAppCredentials
+ */
+export class MsalServiceClientCredentialsFactory implements ServiceClientCredentialsFactory {
+    private readonly appId: string;
+
+    /**
+     * Create an MsalServiceClientCredentialsFactory instance using runtime configuration and an
+     * `@azure/msal-node` `ConfidentialClientApplication`.
+     *
+     * @param configuration Runtime configuration.
+     * @param clientApplication An `@azure/msal-node` `ConfidentialClientApplication` instance.
+     */
+    constructor(configuration: Configuration, private readonly clientApplication: ConfidentialClientApplication) {
+        const appId = configuration.get(['MicrosoftAppId']) ?? '';
+        if (typeof appId !== 'string') {
+            throw new Error('Invalid appId');
+        }
+
+        this.appId = appId;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    async isValidAppId(appId: string): Promise<boolean> {
+        return appId === this.appId;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    async isAuthenticationDisabled(): Promise<boolean> {
+        return !this.appId;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    async createCredentials(
+        appId: string,
+        audience: string,
+        loginEndpoint: string,
+        _validateAuthority: boolean
+    ): Promise<ServiceClientCredentials> {
+        if (await this.isAuthenticationDisabled()) {
+            return MsalAppCredentials.Empty;
+        }
+
+        if (!(await this.isValidAppId(appId))) {
+            throw new Error('Invalid appId.');
+        }
+
+        const normalizedEndpoint = loginEndpoint.toLowerCase();
+
+        if (normalizedEndpoint.startsWith(AuthenticationConstants.ToChannelFromBotLoginUrlPrefix)) {
+            return new MsalAppCredentials(
+                this.clientApplication,
+                appId,
+                undefined,
+                audience || AuthenticationConstants.ToBotFromChannelTokenIssuer
+            );
+        }
+
+        if (normalizedEndpoint === GovernmentConstants.ToChannelFromBotLoginUrl.toLowerCase()) {
+            return new MsalAppCredentials(
+                this.clientApplication,
+                appId,
+                GovernmentConstants.ToChannelFromBotLoginUrl,
+                audience || GovernmentConstants.ToChannelFromBotOAuthScope
+            );
+        }
+
+        return new MsalAppCredentials(this.clientApplication, appId, loginEndpoint, audience);
+    }
+}

--- a/libraries/botframework-connector/src/auth/msalServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/msalServiceClientCredentialsFactory.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { ConfidentialClientApplication } from '@azure/msal-node';
-import { Configuration } from 'botbuilder-dialogs-adaptive-runtime-core';
 import { MsalAppCredentials } from './msalAppCredentials';
 import { ServiceClientCredentials } from '@azure/ms-rest-js';
 import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
@@ -19,15 +18,10 @@ export class MsalServiceClientCredentialsFactory implements ServiceClientCredent
      * Create an MsalServiceClientCredentialsFactory instance using runtime configuration and an
      * `@azure/msal-node` `ConfidentialClientApplication`.
      *
-     * @param configuration Runtime configuration.
+     * @param appId App ID for validation.
      * @param clientApplication An `@azure/msal-node` `ConfidentialClientApplication` instance.
      */
-    constructor(configuration: Configuration, private readonly clientApplication: ConfidentialClientApplication) {
-        const appId = configuration.get(['MicrosoftAppId']) ?? '';
-        if (typeof appId !== 'string') {
-            throw new Error('Invalid appId');
-        }
-
+    constructor(appId: string, private readonly clientApplication: ConfidentialClientApplication) {
         this.appId = appId;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -166,6 +166,23 @@
     uuid "^3.2.1"
     xml2js "^0.4.19"
 
+"@azure/msal-common@^4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-4.4.0.tgz#818526042f78838ebc332fb735e7de64d8bccb45"
+  integrity sha512-Qrs33Ctt2KM7NxArFPIUKc8UbIcm7zYxJFdJeQ9k7HKBhVk3e88CUz1Mw33cS/Jr+YA1H02OAzHg++bJ+4SFyQ==
+  dependencies:
+    debug "^4.1.1"
+
+"@azure/msal-node@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-1.2.0.tgz#d08a5fb3391436715cb37c6eb44816013bdfa11e"
+  integrity sha512-79o5n483vslc7Qegh9+0BsxODRmlk6YYjVdl9jvwmAuF+i+oylq57e7RVhTVocKCbLCIMOKARI14JyKdDbW0WA==
+  dependencies:
+    "@azure/msal-common" "^4.4.0"
+    axios "^0.21.1"
+    jsonwebtoken "^8.5.1"
+    uuid "^8.3.0"
+
 "@azure/storage-blob@^12.2.1":
   version "12.2.1"
   resolved "https://registry.yarnpkg.com/@azure/storage-blob/-/storage-blob-12.2.1.tgz#8397a492b44f0771d671880a841a8c8c0cd45b60"
@@ -8005,6 +8022,22 @@ jsonwebtoken@8.0.1:
     ms "^2.0.0"
     xtend "^4.0.1"
 
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jspath@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/jspath/-/jspath-0.4.0.tgz#2f5fd1808ff2249a88a3c45e642288a226f85e1d"
@@ -8034,7 +8067,7 @@ jwa@^1.4.1:
     ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
-jws@3.x.x, jws@^3.1.4:
+jws@3.x.x, jws@^3.1.4, jws@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
   integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==


### PR DESCRIPTION
Fixes #2782

This PR is the JS analog of https://github.com/microsoft/botbuilder-dotnet/pull/5736. With this change, users can make a small runtime bot change to opt into MSAL authentication:

```javascript
const { ConfidentialClientApplication } = require("@azure/msal-node");
const { getRuntimeServices } = require("botbuilder-dialogs-adaptive-runtime");

const {
  makeApp,
} = require("botbuilder-dialogs-adaptive-runtime-integration-express");

const {
  MsalServiceClientCredentialsFactory,
} = require("botframework-connector");

(async function () {
  try {
    const [services, configuration] = await getRuntimeServices(
      process.cwd(),
      "settings"
    );

    const serviceClientCredentialsFactory = new MsalServiceClientCredentialsFactory(
      configuration,
      new ConfidentialClientApplication({
        auth: {
          clientId: configuration.get(["MicrosoftAppId"]),
          clientSecret: configuration.get(["MicrosoftAppPassword"]),
        },
      })
    );

    services.addInstance(
      "serviceClientCredentialsFactory",
      serviceClientCredentialsFactory
    );

    const [, listen] = await makeApp(services, configuration, process.cwd());
    listen();
  } catch (err) {
    console.error(err);
    process.exit(1);
  }
})();
```