### PR TITLE
fix: configuration key handling

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/configuration.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/configuration.ts
@@ -54,8 +54,8 @@ export class Configuration implements CoreConfiguration {
      * @returns the value, or undefined
      */
     get<T = unknown>(path: string[] = []): T | undefined {
-        // Note: `|| undefined` ensures that empty string yields "undefined" as
-        // this ensures nconf returns the entire merged configuration.
+        // Note: `|| undefined` ensures that empty string is coerced to undefined
+        // which ensures nconf returns the entire merged configuration.
         return this.provider.get(this.key(path) || undefined);
     }
 

--- a/libraries/botbuilder-dialogs-adaptive-runtime/test/configuration.test.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/test/configuration.test.ts
@@ -96,7 +96,10 @@ describe('Configuration', function () {
             });
 
             it('yields all values for no key', function () {
-                assert.deepStrictEqual(configuration.bind(['one']).get(), { key: 'value-one', two: { key: 'value-two' } });
+                assert.deepStrictEqual(configuration.bind(['one']).get(), {
+                    key: 'value-one',
+                    two: { key: 'value-two' },
+                });
             });
         });
     });

--- a/libraries/botbuilder-dialogs-adaptive-runtime/test/configuration.test.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/test/configuration.test.ts
@@ -59,9 +59,9 @@ describe('Configuration', function () {
         const configuration = new Configuration({
             key: 'value',
             one: {
-                key: 'value',
+                key: 'value-one',
                 two: {
-                    key: 'value',
+                    key: 'value-two',
                 },
             },
         });
@@ -69,34 +69,34 @@ describe('Configuration', function () {
         describe('non-prefixed', function () {
             it('yields a value for a key', function () {
                 assert.strictEqual(configuration.get(['key']), 'value');
-                assert.strictEqual(configuration.get(['one', 'key']), 'value');
+                assert.strictEqual(configuration.get(['one', 'key']), 'value-one');
             });
 
             it('yields all values for a key', function () {
-                assert.deepStrictEqual(configuration.get(['one']), { key: 'value', two: { key: 'value' } });
+                assert.deepStrictEqual(configuration.get(['one']), { key: 'value-one', two: { key: 'value-two' } });
             });
 
             it('yields all values for no key', function () {
                 assert.deepStrictEqual(configuration.get(), {
                     key: 'value',
-                    one: { key: 'value', two: { key: 'value' } },
+                    one: { key: 'value-one', two: { key: 'value-two' } },
                 });
             });
         });
 
         describe('prefixed', function () {
             it('yields a value for a key', function () {
-                assert.strictEqual(configuration.bind(['one']).get(['key']), 'value');
+                assert.strictEqual(configuration.bind(['one']).get(['key']), 'value-one');
             });
 
             it('yields all values for a key', function () {
                 assert.deepStrictEqual(configuration.bind(['one']).get(['two']), {
-                    key: 'value',
+                    key: 'value-two',
                 });
             });
 
             it('yields all values for no key', function () {
-                assert.deepStrictEqual(configuration.bind(['one']).get(), { key: 'value', two: { key: 'value' } });
+                assert.deepStrictEqual(configuration.bind(['one']).get(), { key: 'value-one', two: { key: 'value-two' } });
             });
         });
     });

--- a/libraries/botbuilder-dialogs-adaptive-runtime/test/configuration.test.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/test/configuration.test.ts
@@ -54,4 +54,50 @@ describe('Configuration', function () {
             assert.strictEqual(layered.get(['root', 'key']), 'layer');
         });
     });
+
+    describe('keys', function () {
+        const configuration = new Configuration({
+            key: 'value',
+            one: {
+                key: 'value',
+                two: {
+                    key: 'value',
+                },
+            },
+        });
+
+        describe('non-prefixed', function () {
+            it('yields a value for a key', function () {
+                assert.strictEqual(configuration.get(['key']), 'value');
+                assert.strictEqual(configuration.get(['one', 'key']), 'value');
+            });
+
+            it('yields all values for a key', function () {
+                assert.deepStrictEqual(configuration.get(['one']), { key: 'value', two: { key: 'value' } });
+            });
+
+            it('yields all values for no key', function () {
+                assert.deepStrictEqual(configuration.get(), {
+                    key: 'value',
+                    one: { key: 'value', two: { key: 'value' } },
+                });
+            });
+        });
+
+        describe('prefixed', function () {
+            it('yields a value for a key', function () {
+                assert.strictEqual(configuration.bind(['one']).get(['key']), 'value');
+            });
+
+            it('yields all values for a key', function () {
+                assert.deepStrictEqual(configuration.bind(['one']).get(['two']), {
+                    key: 'value',
+                });
+            });
+
+            it('yields all values for no key', function () {
+                assert.deepStrictEqual(configuration.bind(['one']).get(), { key: 'value', two: { key: 'value' } });
+            });
+        });
+    });
 });


### PR DESCRIPTION
https://github.com/microsoft/botbuilder-js/pull/3840 introduced an issue with configuration key handling that broke the behavior of `.get()`. This PR fixes that handling and adds tests to ensure the behavior remains consistent going forward. The code was not released as part of 4.14 so it doesn't need patching.

#minor