### PR TITLE
feat: allow custom webSocketFactory for CloudAdapter

### DIFF
--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -226,10 +226,12 @@ export class ChannelServiceRoutes {
 
 // @public (undocumented)
 export class CloudAdapter extends CloudAdapterBase implements BotFrameworkHttpAdapter {
-    constructor(botFrameworkAuthentication?: BotFrameworkAuthentication);
+    constructor(botFrameworkAuthentication?: BotFrameworkAuthentication, webSocketFactory?: NodeWebSocketFactoryBase);
     connectNamedPipe(pipeName: string, logic: (context: TurnContext) => Promise<void>, appId: string, audience: string, callerId?: string, retryCount?: number): Promise<void>;
     process(req: Request_2, res: Response_2, logic: (context: TurnContext) => Promise<void>): Promise<void>;
     process(req: Request_2, socket: INodeSocket, head: INodeBuffer, logic: (context: TurnContext) => Promise<void>): Promise<void>;
+    // (undocumented)
+    protected readonly webSocketFactory: NodeWebSocketFactoryBase;
 }
 
 // Warning: (ae-forgotten-export) The symbol "CloudChannelServiceHandler" needs to be exported by the entry point index.d.ts

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -33,6 +33,11 @@ describe('CloudAdapter', function () {
                 name: 'TypeError',
                 message: '`botFrameworkAuthentication` parameter required',
             });
+
+            assert.throws(() => new CloudAdapter(BotFrameworkAuthenticationFactory.create(), null), {
+                name: 'TypeError',
+                message: '`webSocketFactory` parameter required',
+            });
         });
 
         it('succeeds', function () {


### PR DESCRIPTION
Fixes #3866 

## Description
This allows for setting the `webSocketFactory` as an optional parameter in the `CloudAdapter` class.

## Specific Changes

  - Optional `webSocketFactory` parameter for `CloudAdapter` constructor, which defaults to previously used `NodeWebSocketFactory`
  - Use `webSocketFactory` when creating the `WebSocketServer` in `connect`

## Testing

- Added optional argument check to tests