### PR TITLE
feat: allow sending trace activities to clients

### DIFF
--- a/libraries/botbuilder-core/etc/botbuilder-core.api.md
+++ b/libraries/botbuilder-core/etc/botbuilder-core.api.md
@@ -292,7 +292,9 @@ export class CardFactory {
 
 // @public (undocumented)
 export abstract class CloudAdapterBase extends BotAdapter {
-    constructor(botFrameworkAuthentication: BotFrameworkAuthentication);
+    constructor(botFrameworkAuthentication: BotFrameworkAuthentication, allowTraceActivities?: boolean);
+    // (undocumented)
+    protected readonly allowTraceActivities: boolean;
     // (undocumented)
     protected readonly botFrameworkAuthentication: BotFrameworkAuthentication;
     // (undocumented)

--- a/libraries/botbuilder-core/src/cloudAdapterBase.ts
+++ b/libraries/botbuilder-core/src/cloudAdapterBase.ts
@@ -39,8 +39,12 @@ export abstract class CloudAdapterBase extends BotAdapter {
      * Create a new [CloudAdapterBase](xref:botbuilder.CloudAdapterBase) instance.
      *
      * @param botFrameworkAuthentication A [BotFrameworkAuthentication](xref:botframework-connector.BotFrameworkAuthentication) used for validating and creating tokens.
+     * @param allowTraceActivities A flag to turn on sending trace activities to clients.
      */
-    constructor(protected readonly botFrameworkAuthentication: BotFrameworkAuthentication) {
+    constructor(
+        protected readonly botFrameworkAuthentication: BotFrameworkAuthentication,
+        protected readonly allowTraceActivities: boolean = false
+    ) {
         super();
 
         if (!botFrameworkAuthentication) {
@@ -72,7 +76,11 @@ export abstract class CloudAdapterBase extends BotAdapter {
                     await delay(typeof activity.value === 'number' ? activity.value : 1000);
                 } else if (activity.type === ActivityTypes.InvokeResponse) {
                     context.turnState.set(INVOKE_RESPONSE_KEY, activity);
-                } else if (activity.type === ActivityTypes.Trace && activity.channelId !== Channels.Emulator) {
+                } else if (
+                    !this.allowTraceActivities &&
+                    activity.type === ActivityTypes.Trace &&
+                    activity.channelId !== Channels.Emulator
+                ) {
                     // no-op
                 } else {
                     const connectorClient = context.turnState.get<ConnectorClient>(this.ConnectorClientKey);

--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -226,7 +226,7 @@ export class ChannelServiceRoutes {
 
 // @public (undocumented)
 export class CloudAdapter extends CloudAdapterBase implements BotFrameworkHttpAdapter {
-    constructor(botFrameworkAuthentication?: BotFrameworkAuthentication);
+    constructor(botFrameworkAuthentication?: BotFrameworkAuthentication, allowTraceActivities?: boolean);
     connectNamedPipe(pipeName: string, logic: (context: TurnContext) => Promise<void>, appId: string, audience: string, callerId?: string, retryCount?: number): Promise<void>;
     process(req: Request_2, res: Response_2, logic: (context: TurnContext) => Promise<void>): Promise<void>;
     process(req: Request_2, socket: INodeSocket, head: INodeBuffer, logic: (context: TurnContext) => Promise<void>): Promise<void>;

--- a/libraries/botbuilder/src/cloudAdapter.ts
+++ b/libraries/botbuilder/src/cloudAdapter.ts
@@ -45,9 +45,13 @@ export class CloudAdapter extends CloudAdapterBase implements BotFrameworkHttpAd
      * Initializes a new instance of the [CloudAdapter](xref:botbuilder:CloudAdapter) class.
      *
      * @param botFrameworkAuthentication Optional [BotFrameworkAuthentication](xref:botframework-connector.BotFrameworkAuthentication) instance
+     * @param allowTraceActivities A flag to turn on sending trace activities to clients.
      */
-    constructor(botFrameworkAuthentication: BotFrameworkAuthentication = BotFrameworkAuthenticationFactory.create()) {
-        super(botFrameworkAuthentication);
+    constructor(
+        botFrameworkAuthentication: BotFrameworkAuthentication = BotFrameworkAuthenticationFactory.create(),
+        allowTraceActivities: boolean = false
+    ) {
+        super(botFrameworkAuthentication, allowTraceActivities);
     }
 
     /**

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -36,6 +36,7 @@ describe('CloudAdapter', function () {
         });
 
         it('succeeds', function () {
+            new CloudAdapter(BotFrameworkAuthenticationFactory.create(), true);
             new CloudAdapter(BotFrameworkAuthenticationFactory.create());
             new CloudAdapter();
         });


### PR DESCRIPTION
Fixes #3865

## Description
Allows sending trace activities to the client even if it is not the official botframework emulator.

## Specific Changes
  - CloudAdapter(Base) has a new flag that allows enabling trace activities being sent to the client all the time.

## Testing
Added tests to check the flag actually being used.