### PR TITLE
fix: Make getTopScoringIntent return '' instead of undefined

### DIFF
--- a/libraries/botbuilder-core/src/recognizerResult.ts
+++ b/libraries/botbuilder-core/src/recognizerResult.ts
@@ -46,7 +46,7 @@ export const getTopScoringIntent = (result: RecognizerResult): { intent: string;
         throw new Error('result is empty');
     }
 
-    let topIntent: string;
+    let topIntent: string = '';
     let topScore = -1;
     for (const [intentName, intent] of Object.entries(result.intents)) {
         const score = intent.score ?? -1;

--- a/libraries/botbuilder-core/tests/getTopScoringIntent.test.js
+++ b/libraries/botbuilder-core/tests/getTopScoringIntent.test.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+const { getTopScoringIntent} = require('../lib');
+
+describe('getTopScoringIntent', function () {
+    it(' should never return undefined', function () {
+        let result = getTopScoringIntent({
+            text: '',
+            intents: {},
+            entities: {}
+        });
+
+        assert.notStrictEqual(result.intent, undefined);
+        assert.strictEqual(result.intent, '');
+    });
+
+});

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts
@@ -186,7 +186,7 @@ export class CrossTrainedRecognizerSet extends AdaptiveRecognizer implements Cro
      * @returns {boolean} Boolean result of whether or not an intent begins with the `DeferToRecognizer_` prefix.
      */
     private isRedirect(intent: string): boolean {
-        return intent.startsWith(deferPrefix);
+        return intent?.startsWith(deferPrefix) ?? false;
     }
 
     /**


### PR DESCRIPTION
Fixes [Composer#8368](https://github.com/microsoft/BotFramework-Composer/issues/8368). fixes #minor.

## Description

There is a minor drift between the dotnet and nodeJs implementation of `getTopScoringIntent`.  

1. In the NodeJS implementation, `topIntent` is declared but not initialized. In the case of empty `intents` bag, can return `undefined`.  

    [NodeJS Implementation](https://github.com/microsoft/botbuilder-js/blob/4ba6d97ec3a80446184c8ad4136b1808dee6158f/libraries/botbuilder-core/src/recognizerResult.ts#L49)
    ``` javascript
         let topIntent: string;
    ```

     In the dotnet implementation, the topIntent is initialized.
    [Dotnet Implementation](https://github.com/microsoft/botbuilder-dotnet/blob/1220aed51d97a300a73b46c230dc49867483a97c/libraries/Microsoft.Bot.Builder/RecognizerResultExtensions.cs#L30)
    ``` c#
          var topIntent = (string.Empty, 0.0d);
   ```

1. This later causes an issue in [`crossTrainedRecognizerSet` line 110](https://github.com/microsoft/botbuilder-js/blob/4ba6d97ec3a80446184c8ad4136b1808dee6158f/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts#L110), where an `undefined` intent can be set. 
The [`isRedirect` function](https://github.com/microsoft/botbuilder-js/blob/4ba6d97ec3a80446184c8ad4136b1808dee6158f/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts#L189)  will eventually be called on the undefined intent and cause the 500 error in the bot.

Note: this entire chain of events is started at the end of a text input, when the recognizers are fired with an empty utterance (not sure why). Orchestrator recognizer will return a `RecognizerResult` with this shape in the case of [empty utterance](https://github.com/microsoft/botbuilder-js/blob/4ba6d97ec3a80446184c8ad4136b1808dee6158f/libraries/botbuilder-ai-orchestrator/src/orchestratorRecognizer.ts#L183): 

```
        let recognizerResult: RecognizerResult = {
            text,
            intents: {},
            entities: {},
        };
```

Both LUIS and QnA fill the intents bag.  

The dotnet Orchestrator implementation also returns an empty `intents` dictionary in the case of an empty utterance so we follow that behavior.


## Testing
UT added, manual testing to test for correct behavior.