### PR TITLE
fix: prerelease for date instead of metadata

### DIFF
--- a/libraries/botbuilder-repo-utils/package.json
+++ b/libraries/botbuilder-repo-utils/package.json
@@ -14,10 +14,10 @@
     "dayjs": "^1.10.3",
     "get-stream": "^6.0.0",
     "globby": "^11.0.1",
+    "lodash": "^4.17.20",
     "minimatch": "^3.0.4",
     "minimist": "^1.2.5",
-    "p-map": "^4.0.0",
-    "remeda": "^0.0.26"
+    "p-map": "^4.0.0"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",

--- a/libraries/botbuilder-repo-utils/src/updateVersions.ts
+++ b/libraries/botbuilder-repo-utils/src/updateVersions.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import * as R from 'remeda';
-import minimist from 'minimist';
+import compact from 'lodash/compact';
 import dayjs from 'dayjs';
+import minimist from 'minimist';
 import path from 'path';
 import { Package } from './package';
 import { collectWorkspacePackages } from './workspace';
@@ -21,14 +21,6 @@ export interface PackageVersionOptions {
     preview?: string;
 }
 
-export class PackageVersion {
-    constructor(readonly version: string, readonly metadata: string) {}
-
-    toString(): string {
-        return R.compact([this.version, this.metadata]).join('+');
-    }
-}
-
 /**
  * Computes the final version identifier components for a package.
  *
@@ -41,7 +33,7 @@ export const getPackageVersion = (
     pkg: Partial<Package>,
     newVersion: string,
     options: PackageVersionOptions
-): PackageVersion => {
+): string => {
     const prerelease = [];
 
     if (options.buildLabel) {
@@ -60,16 +52,11 @@ export const getPackageVersion = (
         prerelease.push(options.commitSha);
     }
 
-    const metadata = [];
-
     if (options.date) {
-        metadata.push(`date-${options.date}`);
+        prerelease.push(options.date);
     }
 
-    return new PackageVersion(
-        R.compact([newVersion, R.compact(prerelease).join('.')]).join('-'),
-        R.compact(metadata).join('.')
-    );
+    return compact([newVersion, compact(prerelease).join('.')]).join('-');
 };
 
 export const command = (argv: string[], quiet = false) => async (): Promise<Result> => {
@@ -111,7 +98,7 @@ export const command = (argv: string[], quiet = false) => async (): Promise<Resu
     const workspaces = await collectWorkspacePackages(repoRoot, packageFile.workspaces, { noPrivate: true });
 
     // Build an object mapping a package name to its new, updated version
-    const workspaceVersions = workspaces.reduce<Record<string, PackageVersion>>(
+    const workspaceVersions = workspaces.reduce<Record<string, string>>(
         (acc, { pkg }) => ({
             ...acc,
             [pkg.name]: getPackageVersion(pkg, newVersion, {
@@ -128,7 +115,12 @@ export const command = (argv: string[], quiet = false) => async (): Promise<Resu
 
     // Rewrites the version for any dependencies found in `workspaceVersions`
     const rewriteWithNewVersions = (dependencies: Record<string, string>) =>
-        R.mapValues(dependencies, (value, key) => workspaceVersions[key]?.version ?? value);
+        Object.entries(dependencies)
+            .map(([dependency, version]) => [dependency, workspaceVersions[dependency] ?? version])
+            .reduce<Record<string, string>>((acc, [dependency, version]) => {
+                acc[dependency] = version;
+                return acc;
+            }, {});
 
     // Rewrite package.json files by updating version as well as dependencies and devDependencies.
     const results = await Promise.all<Result>(

--- a/libraries/botbuilder-repo-utils/src/workspace.ts
+++ b/libraries/botbuilder-repo-utils/src/workspace.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import * as R from 'remeda';
+import compact from 'lodash/compact';
 import globby from 'globby';
 import minimatch from 'minimatch';
 import path from 'path';
@@ -94,5 +94,5 @@ export async function collectWorkspacePackages(
         )
     );
 
-    return R.compact(maybeWorkspaces);
+    return compact(maybeWorkspaces);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11026,11 +11026,6 @@ release-zalgo@^1.0.0:
   dependencies:
     es6-error "^4.0.1"
 
-remeda@^0.0.26:
-  version "0.0.26"
-  resolved "https://registry.yarnpkg.com/remeda/-/remeda-0.0.26.tgz#a254c76dc5ec6c36a6d16947dec90848d0830d44"
-  integrity sha512-Nw22Ux3F7u4vA0TviUkuTDgt9wyMp7yH4e0iHcTjW/v8An30xv0fZCJWYlnuT8woNzLIUF3CcUPVOrQK44C9Uw==
-
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"


### PR DESCRIPTION
MyGet and npm have inconsistent handling for semver metadata which causes several nightly tests to fail. Let's revert to
prerelease for dates.

#minor