### PR TITLE
fix: test failures in E2E_BF-Streaming-DL-ASE_Test

### DIFF
--- a/testing/streaming-e2e/tests/streaming-e2e.test.js
+++ b/testing/streaming-e2e/tests/streaming-e2e.test.js
@@ -12,6 +12,7 @@ const reactAppEndpoint = 'http://localhost:3000';
 
 describe('Chrome', function () {
   it('should receive an echo after sending a message', async function () {
+    this.retries(20);
     this.timeout(120000);
 
     const driver = createDriver('chrome');


### PR DESCRIPTION
Fixes #3909

## Description
In pipeline E2E_BF-Streaming-DL-ASE_Test, npm test is failing with the following error:
 1) Chrome
       should receive an echo after sending a message:
     TimeoutError: Waiting 2 activities is shown
Wait timed out after 60092ms

Example here: https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=265656&view=logs&j=c0efd2c7-3dad-5cdf-75e8-16ff3f47c553&t=924c193e-0db3-54a8-b081-a097a2346a3d

## Specific Changes
Add retries to the test.

Example of succeeding build: https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=265810&view=results
