### PR TITLE
Switch to new xmldom and xml-js

### DIFF
--- a/libraries/adaptive-expressions/package.json
+++ b/libraries/adaptive-expressions/package.json
@@ -36,9 +36,9 @@
     "lodash.isequal": "^4.5.0",
     "lru-cache": "^5.1.1",
     "uuid": "^8.3.2",
-    "x2js": "^3.4.0",
+    "xml-js": "^1.6.11",
     "xml2js": "^0.4.23",
-    "xmldom": "^0.5.0",
+    "@xmldom/xmldom": "^0.7.4",
     "xpath": "^0.0.32"
   },
   "devDependencies": {

--- a/libraries/adaptive-expressions/src/builtinFunctions/xml.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/xml.ts
@@ -30,9 +30,9 @@ export class XML extends ExpressionEvaluator {
     private static platformSpecificXML(args: unknown[]): { value: unknown; error: string } {
         if (typeof window !== 'undefined' || typeof self !== 'undefined') {
             // this is for evaluating in browser environment, however it is not covered by any test currently
-            // x2js package can run on browser environment, see ref: https://www.npmjs.com/package/x2js
+            // xml-js package can run on browser environment, see ref: https://www.npmjs.com/package/x2js
             // eslint-disable-next-line @typescript-eslint/no-var-requires
-            const X2JS = require('x2js');
+            const XMLJS = require('xml-js');
             let result: unknown;
             let error: string;
             let obj: unknown;
@@ -43,7 +43,7 @@ export class XML extends ExpressionEvaluator {
                     obj = args[0];
                 }
 
-                result = new X2JS.json2xml_str(obj);
+                result = new XMLJS.json2xml(obj);
             } catch (err) {
                 error = `${args[0]} is not a valid json`;
             }

--- a/libraries/adaptive-expressions/src/builtinFunctions/xml.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/xml.ts
@@ -30,7 +30,7 @@ export class XML extends ExpressionEvaluator {
     private static platformSpecificXML(args: unknown[]): { value: unknown; error: string } {
         if (typeof window !== 'undefined' || typeof self !== 'undefined') {
             // this is for evaluating in browser environment, however it is not covered by any test currently
-            // xml-js package can run on browser environment, see ref: https://www.npmjs.com/package/x2js
+            // xml-js package can run on browser environment, see ref: https://www.npmjs.com/package/xml-js
             // eslint-disable-next-line @typescript-eslint/no-var-requires
             const XMLJS = require('xml-js');
             let result: unknown;

--- a/libraries/adaptive-expressions/src/builtinFunctions/xpath.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/xpath.ts
@@ -67,7 +67,7 @@ export class XPath extends ExpressionEvaluator {
             // eslint-disable-next-line @typescript-eslint/no-var-requires
             const xpath = require('xpath');
             // eslint-disable-next-line @typescript-eslint/no-var-requires
-            const { DOMParser } = require('xmldom');
+            const { DOMParser } = require('@xmldom/xmldom');
             let doc: XMLDocument;
             try {
                 doc = new DOMParser().parseFromString(args[0], 'text/xml');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2235,6 +2235,11 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@xmldom/xmldom@^0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.4.tgz#93b2f9486c88b6464e97f76c9ab49b0a548fbe57"
+  integrity sha512-wdxC79cvO7PjSM34jATd/RYZuYWQ8y/R7MidZl1NYYlbpFn1+spfjkiR3ZsJfcaTs2IyslBN7VwBBJwrYKM+zw==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -11392,7 +11397,7 @@ sax@0.5.x:
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
   integrity sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=
 
-sax@>=0.6.0:
+sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -13603,12 +13608,12 @@ wsrun@^5.2.4:
     throat "^4.1.0"
     yargs "^13.0.0"
 
-x2js@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/x2js/-/x2js-3.4.0.tgz#1414ad99062705086a4838e8dde4ecd06e8bd3a9"
-  integrity sha512-1tozn7D51ghz2DAiy5U6R55qn9x2F3lHUxusOD0QtYlLSDGxyXjHfn0c508eXG1D7s8qqj54SiU5HsPEfhDIpg==
+xml-js@^1.6.11:
+  version "1.6.11"
+  resolved "https://registry.yarnpkg.com/xml-js/-/xml-js-1.6.11.tgz#927d2f6947f7f1c19a316dd8eea3614e8b18f8e9"
+  integrity sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==
   dependencies:
-    xmldom "^0.1.19"
+    sax "^1.2.4"
 
 xml2js@0.2.8:
   version "0.2.8"
@@ -13649,16 +13654,6 @@ xmlbuilder@~11.0.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.4.0.tgz#8771e482a333af44587e30ce026f0998c23f3830"
   integrity sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA==
-
-xmldom@^0.1.19:
-  version "0.1.31"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
-  integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
-
-xmldom@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
-  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
 
 xpath.js@~1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Fixes #3916

## Description

Since x2js did not respond to PR I have changed the library to **xml-js** which is far more maintained and then I have updated xmldom to latest @xmldom/xmldom

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - In package.json I have changed xmldom to latest @xmldom/xmldom which has newer versions
  - In package.json I have changed **x2js** with **xml-js** which is more maintained project for conversion. 
  - In xml.ts i have changed x2js to xml-js
  - In xpath.ts i have changed xmldom to @xmldom/xmldom

## Testing
All existing tests are passing as no functionality is changed