### PR TITLE
fix: [#3969] useLanguagePolicy setting turn state, instead of languagePolicy

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
@@ -390,6 +390,10 @@ describe('ActionTests', function () {
         await TestUtils.runTestScript(resourceExplorer, 'Action_SetProperties');
     });
 
+    it('MissingProperty', async () => {
+        await TestUtils.runTestScript(resourceExplorer, 'Action_MissingProperty');
+    });
+
     it('SetProperty', async () => {
         await TestUtils.runTestScript(resourceExplorer, 'Action_SetProperty');
     });

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_MissingProperty.test.dialog
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/Action_MissingProperty.test.dialog
@@ -1,0 +1,167 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "generator": "main.lg",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnBeginDialog",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "user.missingProperties",
+                        "value": "=missingProperties('${dialog.first} and ${dialog.second}')"
+                    },
+                    {
+                        "$kind": "Microsoft.Foreach",
+                        "itemsProperty": "user.missingProperties",
+                        "actions": [
+                            {
+                                "$kind": "Microsoft.IfCondition",
+                                "condition": "empty(getProperty(dialog.foreach.value))",
+                                "actions": [
+                                    {
+                                        "$kind": "Microsoft.TextInput",
+                                        "property": "=dialog.foreach.value",
+                                        "prompt": "Hello, please input ${dialog.foreach.value}"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "You finish all slot filling. And get result: ${dialog.first} and ${dialog.second}"
+                    },
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "user.missingProperties",
+                        "value": "=missingProperties('${nameAndAge()}')"
+                    },
+                    {
+                        "$kind": "Microsoft.Foreach",
+                        "itemsProperty": "user.missingProperties",
+                        "actions": [
+                            {
+                                "$kind": "Microsoft.IfCondition",
+                                "condition": "empty(getProperty(dialog.foreach.value))",
+                                "actions": [
+                                    {
+                                        "$kind": "Microsoft.TextInput",
+                                        "property": "=dialog.foreach.value",
+                                        "prompt": "Hello, please input ${dialog.foreach.value}"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "You finish all slot filling. And get result: ${nameAndAge()}"
+                    },
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "user.missingProperties",
+                        "value": "=missingProperties('${nameAndAge()}')"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${count(user.missingProperties)}"
+                    },
+                    {
+                        "$kind": "Microsoft.BeginDialog",
+                        "options": {},
+                        "dialog": {
+                            "$kind": "Microsoft.AdaptiveDialog",
+                            "generator": "sub.lg",
+                            "triggers": [
+                                {
+                                    "$kind": "Microsoft.OnBeginDialog",
+                                    "actions": [
+                                        {
+                                            "$kind": "Microsoft.SetProperty",
+                                            "property": "user.missingProperties",
+                                            "value": "=missingProperties('${showPetName()}')"
+                                        },
+                                        {
+                                            "$kind": "Microsoft.SendActivity",
+                                            "activity": "${count(user.missingProperties)}"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "$kind": "Microsoft.SetProperty",
+                        "property": "user.missingProperties",
+                        "value": "=missingProperties('${nameAndAge()}')"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${count(user.missingProperties)}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserConversationUpdate"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Hello, please input dialog.first"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "1"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Hello, please input dialog.second"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "2"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "You finish all slot filling. And get result: 1 and 2"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Hello, please input user.name"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "Jack"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Hello, please input user.age"
+        },
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "20"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "You finish all slot filling. And get result: my name is Jack and my age is 20"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "2"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "1"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "2"
+        }
+    ]
+}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/main.lg
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/main.lg
@@ -18,3 +18,6 @@
 
 # length
 - length in main
+
+# nameAndAge
+- my name is ${user.name} and my age is ${user.age}

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/sub.lg
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/resources/ActionTests/sub.lg
@@ -1,0 +1,2 @@
+# showPetName
+- the pet's name is ${petName}

--- a/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
+++ b/libraries/botbuilder-dialogs-adaptive/etc/botbuilder-dialogs-adaptive.api.md
@@ -43,9 +43,11 @@ import { Headers as Headers_2 } from 'node-fetch';
 import { ImportResolverDelegate } from 'botbuilder-lg';
 import { IntExpression } from 'adaptive-expressions';
 import { ListStyle } from 'botbuilder-dialogs';
+import { MemoryInterface } from 'adaptive-expressions';
 import { ModelResult } from 'botbuilder-dialogs';
 import { NumberExpression } from 'adaptive-expressions';
 import { ObjectExpression } from 'adaptive-expressions';
+import { Options } from 'adaptive-expressions';
 import { PromptOptions } from 'botbuilder-dialogs';
 import { Recognizer } from 'botbuilder-dialogs';
 import { RecognizerConfiguration } from 'botbuilder-dialogs';
@@ -1364,6 +1366,7 @@ export class LanguageGenerationBotComponent extends BotComponent {
 // @public
 export interface LanguageGenerator<T = unknown, D = Record<string, unknown>> {
     generate(dialogContext: DialogContext, template: string, data: D): Promise<T>;
+    missingProperties(dialogContext: DialogContext, template: string, state?: MemoryInterface, options?: Options): string[];
 }
 
 // @public
@@ -1445,6 +1448,12 @@ export class MentionEntityRecognizer extends TextEntityRecognizer {
     protected _recognize(text: string, culture: string): ModelResult[];
 }
 
+// @public
+export class MissingPropertiesFunction extends ExpressionEvaluator {
+    constructor(context: DialogContext);
+    static readonly functionName = "missingProperties";
+    }
+
 // @public (undocumented)
 export class MostSpecificSelector extends TriggerSelector implements MostSpecificSelectorConfiguration {
     // (undocumented)
@@ -1480,6 +1489,8 @@ export abstract class MultiLanguageGeneratorBase<T = unknown, D extends Record<s
     // (undocumented)
     getConverter(property: keyof MultiLanguageGeneratorBaseConfiguration): Converter | ConverterFactory;
     languagePolicy: LanguagePolicy;
+    // (undocumented)
+    missingProperties(dialogContext: DialogContext, template: string, state?: MemoryInterface, options?: Options): string[];
     abstract tryGetGenerator(dialogContext: DialogContext, locale: string): {
         exist: boolean;
         result: LanguageGenerator<T, D>;
@@ -2328,7 +2339,8 @@ export class TemplateEngineLanguageGenerator<T = unknown, D extends Record<strin
     generate(dialogContext: DialogContext, template: string, data: D): Promise<T>;
     // (undocumented)
     id: string;
-    }
+    missingProperties(dialogContext: DialogContext, template: string, _state?: MemoryInterface, _options?: Options): string[];
+}
 
 // @public (undocumented)
 export interface TemplateEngineLanguageGeneratorConfiguration {

--- a/libraries/botbuilder-dialogs-adaptive/package.json
+++ b/libraries/botbuilder-dialogs-adaptive/package.json
@@ -36,7 +36,8 @@
     "botbuilder-dialogs-declarative": "4.1.6",
     "botbuilder-lg": "4.1.6",
     "lodash": "^4.17.21",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@microsoft/recognizers-text": "~1.1.4",

--- a/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/adaptiveDialog.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { BoolExpression, BoolExpressionConverter, IntExpression } from 'adaptive-expressions';
+import { BoolExpression, BoolExpressionConverter, Expression, IntExpression } from 'adaptive-expressions';
 import {
     Activity,
     ActivityTypes,
@@ -48,6 +48,7 @@ import { EntityAssignment } from './entityAssignment';
 import { EntityAssignmentComparer } from './entityAssignmentComparer';
 import { EntityAssignments } from './entityAssignments';
 import { EntityInfo, NormalizedEntityInfos } from './entityInfo';
+import { MissingPropertiesFunction } from './functions';
 import { LanguageGenerator } from './languageGenerator';
 import { languageGeneratorKey } from './languageGeneratorExtensions';
 import { BoolProperty } from './properties';
@@ -775,6 +776,10 @@ export class AdaptiveDialog<O extends object = {}> extends DialogContainer<O> im
     protected onSetScopedServices(dialogContext: DialogContext): void {
         if (this.generator) {
             dialogContext.services.set(languageGeneratorKey, this.generator);
+            Expression.functions.set(
+                MissingPropertiesFunction.functionName,
+                new MissingPropertiesFunction(dialogContext)
+            );
         }
     }
 

--- a/libraries/botbuilder-dialogs-adaptive/src/functions/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/functions/index.ts
@@ -8,3 +8,4 @@
 
 export * from './hasPendingActionsFunction';
 export * from './isDialogActiveFunction';
+export * from './missingPropertiesFunction';

--- a/libraries/botbuilder-dialogs-adaptive/src/functions/missingPropertiesFunction.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/functions/missingPropertiesFunction.ts
@@ -1,0 +1,75 @@
+/**
+ * @module botbuilder-dialogs-adaptive
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    Expression,
+    ExpressionEvaluator,
+    FunctionUtils,
+    MemoryInterface,
+    Options,
+    ReturnType,
+    ValueWithError,
+} from 'adaptive-expressions';
+import { LanguageGenerator } from '../languageGenerator';
+
+import { DialogContext, DialogStateManager } from 'botbuilder-dialogs';
+/**
+ * Defines missingProperties(template) expression function.
+ * This expression will get all variables the template contains.
+ *
+ * @example missingProperties('${a} ${b}')
+ */
+export class MissingPropertiesFunction extends ExpressionEvaluator {
+    /**
+     * Function identifier name.
+     */
+    public static readonly functionName = 'missingProperties'; // `name` is reserved in JavaScript.
+
+    private static readonly generatorPath = 'dialogclass.generator';
+
+    private static dialogContext: DialogContext;
+
+    /**
+     * Intializes a new instance of the [MissingProperties](xref:botbuilder-dialogs-adaptive.MissingProperties) class.
+     *
+     * @param context dialog context.
+     */
+    public constructor(context: DialogContext) {
+        super(
+            MissingPropertiesFunction.functionName,
+            MissingPropertiesFunction.function,
+            ReturnType.Array,
+            FunctionUtils.validateUnaryString
+        );
+
+        MissingPropertiesFunction.dialogContext = context;
+    }
+
+    private static function(expression: Expression, state: MemoryInterface, options: Options): ValueWithError {
+        const { args, error } = FunctionUtils.evaluateChildren(expression, state, options);
+        if (error != null) {
+            return { value: undefined, error };
+        }
+
+        const templateBody = args[0].toString();
+
+        const generator = (state as DialogStateManager).getValue<LanguageGenerator>(MissingPropertiesFunction.generatorPath);
+        if (generator) {
+            return {
+                value: generator.missingProperties(
+                    MissingPropertiesFunction.dialogContext,
+                    templateBody,
+                    state,
+                    options
+                ),
+                error: undefined,
+            };
+        }
+        return { value: undefined, error: undefined };
+    }
+}

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/multiLanguageGeneratorBase.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/multiLanguageGeneratorBase.ts
@@ -6,10 +6,12 @@
  * Licensed under the MIT License.
  */
 
-import { Configurable, Converter, ConverterFactory, DialogContext } from 'botbuilder-dialogs';
+import { Configurable, Converter, ConverterFactory, DialogContext, TurnPath } from 'botbuilder-dialogs';
 import { LanguageGenerator } from '../languageGenerator';
 import { LanguagePolicy, LanguagePolicyConverter } from '../languagePolicy';
 import { languagePolicyKey } from '../languageGeneratorExtensions';
+import { MemoryInterface, Options } from 'adaptive-expressions';
+import { TemplateEngineLanguageGenerator } from './templateEngineLanguageGenerator';
 
 export interface MultiLanguageGeneratorBaseConfiguration {
     languagePolicy?: Record<string, string[]> | LanguagePolicy;
@@ -55,40 +57,10 @@ export abstract class MultiLanguageGeneratorBase<
      * @param data Data to bind to.
      */
     public async generate(dialogContext: DialogContext, template: string, data: D): Promise<T> {
-        // priority
-        // 1. local policy
-        // 2. shared policy in turnContext
-        // 3. default policy
-        if (!this.languagePolicy) {
-            this.languagePolicy = dialogContext.services.get(languagePolicyKey);
-            if (!this.languagePolicy) {
-                this.languagePolicy = new LanguagePolicy();
-            }
-        }
-
-        // see if we have any locales that match
-        const fallbackLocales = [];
-        const targetLocale = dialogContext.getLocale().toLowerCase();
-        if (this.languagePolicy.has(targetLocale)) {
-            this.languagePolicy.get(targetLocale).forEach((u: string): number => fallbackLocales.push(u));
-        }
-
-        // append empty as fallback to end
-        if (targetLocale !== '' && this.languagePolicy.has('')) {
-            this.languagePolicy.get('').forEach((u: string): number => fallbackLocales.push(u));
-        }
-
-        if (fallbackLocales.length === 0) {
-            throw Error(`No supported language found for ${targetLocale}`);
-        }
-
-        const generators: LanguageGenerator<T, D>[] = [];
-        for (const locale of fallbackLocales) {
-            const result = this.tryGetGenerator(dialogContext, locale);
-            if (result.exist) {
-                generators.push(result.result);
-            }
-        }
+        const languagePolicy = this.getLanguagePolicy(dialogContext);
+        const targetLocale = this.getCurrentLocale(dialogContext);
+        const fallbackLocales = this.getFallbackLocales(languagePolicy, targetLocale);
+        const generators = this.getGenerators(dialogContext, fallbackLocales);
 
         if (generators.length === 0) {
             throw Error(`No generator found for language ${targetLocale}`);
@@ -104,5 +76,97 @@ export abstract class MultiLanguageGeneratorBase<
         }
 
         throw Error(errors.join(',\n'));
+    }
+
+    public missingProperties(
+        dialogContext: DialogContext,
+        template: string,
+        state?: MemoryInterface,
+        options?: Options
+    ): string[] {
+        const currentLocale = this.getCurrentLocale(dialogContext, state, options);
+        const languagePolicy = this.getLanguagePolicy(dialogContext, state);
+        const fallbackLocales = this.getFallbackLocales(languagePolicy, currentLocale);
+        const generators = this.getGenerators(dialogContext, fallbackLocales);
+
+        if (generators.length === 0) {
+            generators.push(new TemplateEngineLanguageGenerator());
+        }
+
+        for (const generator of generators) {
+            try {
+                return generator.missingProperties(dialogContext, template, state, options);
+            } catch {
+                // retry the next generator
+            }
+        }
+
+        return [];
+    }
+
+    private getLanguagePolicy(dialogContext: DialogContext, memory?: MemoryInterface): LanguagePolicy {
+        // priority
+        // 1. local policy
+        // 2. turn.languagePolicy
+        // 2. shared policy in turnContext
+        // 3. default policy
+        if (this.languagePolicy) {
+            return this.languagePolicy;
+        }
+
+        if (memory) {
+            const lpInTurn = memory.getValue(TurnPath.languagePolicy);
+            if (lpInTurn != null) {
+                return lpInTurn;
+            }
+        }
+
+        const lpInDc = dialogContext.services.get(languagePolicyKey);
+        if (lpInDc) {
+            return lpInDc;
+        }
+
+        return new LanguagePolicy();
+    }
+
+    private getCurrentLocale(dialogContext: DialogContext, memory?: MemoryInterface, options?: Options): string {
+        // order
+        // 1. turn.locale
+        // 2. options.locale
+        // 3. Context.Activity.Locale
+        // 4. Thread.CurrentThread.CurrentCulture.Name
+        if (memory) {
+            const localeInTurn = memory.getValue(TurnPath.locale);
+            if (localeInTurn) {
+                return localeInTurn.toString();
+            }
+        }
+
+        return options?.locale ?? dialogContext.getLocale();
+    }
+
+    private getFallbackLocales(languagePolicy: LanguagePolicy, targetLocale: string): string[] {
+        const fallbackLocales = [];
+        targetLocale = targetLocale.toLowerCase();
+        if (languagePolicy.has(targetLocale)) {
+            fallbackLocales.push(...languagePolicy.get(targetLocale));
+        }
+
+        // append empty as fallback to end
+        if (targetLocale !== '' && languagePolicy.has('')) {
+            fallbackLocales.push(...languagePolicy.get(''));
+        }
+        return fallbackLocales;
+    }
+
+    private getGenerators(dialogContext: DialogContext, fallbackLocales: string[]): LanguageGenerator<T, D>[] {
+        const generators: LanguageGenerator<T, D>[] = [];
+        for (const locale of fallbackLocales) {
+            const result = this.tryGetGenerator(dialogContext, locale);
+            if (result.exist) {
+                generators.push(result.result);
+            }
+        }
+        return generators;
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/languageGenerator.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languageGenerator.ts
@@ -7,6 +7,7 @@
  */
 
 import { DialogContext } from 'botbuilder-dialogs';
+import { MemoryInterface, Options } from 'adaptive-expressions';
 
 /**
  * Defines interface for a Language Generator system to bind to text.
@@ -20,4 +21,15 @@ export interface LanguageGenerator<T = unknown, D = Record<string, unknown>> {
      * @returns Result of rendering template using data.
      */
     generate(dialogContext: DialogContext, template: string, data: D): Promise<T>;
+
+    /**
+     * Method to get missing properties.
+     *
+     * @param dialogContext DialogContext.
+     * @param template Template.
+     * @param state Memory state.
+     * @param options Options.
+     * @returns Property list.
+     */
+    missingProperties(dialogContext: DialogContext, template: string, state?: MemoryInterface, options?: Options): string[];
 }

--- a/libraries/botbuilder-dialogs-adaptive/src/languageGeneratorExtensions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languageGeneratorExtensions.ts
@@ -79,12 +79,8 @@ export class LanguageGeneratorExtensions {
     public static useLanguagePolicy(dialogManager: DialogManager, policy: LanguagePolicy): DialogManager {
         dialogManager.initialTurnState.set(languagePolicyKey, policy);
 
-        const turnScope = dialogManager.initialTurnState.get('turn');
-        if (turnScope) {
-            turnScope.languagePolicy = policy;
-        } else {
-            dialogManager.initialTurnState.set('turn', { languagePolicy: policy });
-        }
+        // put global language policy into turn scope for lg functions fallback
+        dialogManager.initialTurnState.set(TurnPath.languagePolicy, policy);
 
         return dialogManager;
     }

--- a/libraries/botbuilder-dialogs-adaptive/src/languageGeneratorExtensions.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/languageGeneratorExtensions.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { DialogManager } from 'botbuilder-dialogs';
+import { DialogManager, TurnPath } from 'botbuilder-dialogs';
 import { ResourceExplorer } from 'botbuilder-dialogs-declarative';
 import {
     LanguageGeneratorManager,
@@ -78,6 +78,14 @@ export class LanguageGeneratorExtensions {
      */
     public static useLanguagePolicy(dialogManager: DialogManager, policy: LanguagePolicy): DialogManager {
         dialogManager.initialTurnState.set(languagePolicyKey, policy);
+
+        const turnScope = dialogManager.initialTurnState.get('turn');
+        if (turnScope) {
+            turnScope.languagePolicy = policy;
+        } else {
+            dialogManager.initialTurnState.set('turn', { languagePolicy: policy });
+        }
+
         return dialogManager;
     }
 }

--- a/libraries/botbuilder-dialogs-adaptive/tests/LGGenerator.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/LGGenerator.test.js
@@ -43,22 +43,22 @@ describe('LGLanguageGenerator', function() {
             it('assert empty locale', async () => {
                 assert(lgResourceGroup.has(''));
                 var resourceNames = lgResourceGroup.get('').map(u => u.id);
-                assert.equal(resourceNames.length, 7);
-                assert.deepStrictEqual(new Set(resourceNames), new Set(['a.lg', 'b.lg', 'c.lg', 'NormalStructuredLG.lg','root.lg', 'subDialog.lg', 'test.lg']));
+                assert.equal(resourceNames.length, 8);
+                assert.deepStrictEqual(new Set(resourceNames), new Set(['properties.lg', 'a.lg', 'b.lg', 'c.lg', 'NormalStructuredLG.lg','root.lg', 'subDialog.lg', 'test.lg']));
             });
 
             it('assert en-us locale', async () => {
                 assert(lgResourceGroup.has('en-us'));
                 var resourceNames = lgResourceGroup.get('en-us').map(u => u.id);
-                assert.equal(resourceNames.length, 7);
-                assert.deepStrictEqual(new Set(resourceNames), new Set(['a.en-US.lg', 'b.en-us.lg', 'test.en-US.lg', 'c.en.lg', 'NormalStructuredLG.lg','root.lg', 'subDialog.lg']));
+                assert.equal(resourceNames.length, 8);
+                assert.deepStrictEqual(new Set(resourceNames), new Set(['properties.lg', 'a.en-US.lg', 'b.en-us.lg', 'test.en-US.lg', 'c.en.lg', 'NormalStructuredLG.lg','root.lg', 'subDialog.lg']));
             });
 
             it('assert en locale', async () => {
                 assert(lgResourceGroup.has('en'));
                 var resourceNames = lgResourceGroup.get('en').map(u => u.id);
-                assert.equal(resourceNames.length, 7);
-                assert.deepStrictEqual(new Set(resourceNames), new Set(['c.en.lg', 'test.en.lg', 'a.lg', 'b.lg', 'NormalStructuredLG.lg','root.lg', 'subDialog.lg']));
+                assert.equal(resourceNames.length, 8);
+                assert.deepStrictEqual(new Set(resourceNames), new Set(['properties.lg', 'c.en.lg', 'test.en.lg', 'a.lg', 'b.lg', 'NormalStructuredLG.lg','root.lg', 'subDialog.lg']));
             });
         });
 
@@ -86,11 +86,11 @@ describe('LGLanguageGenerator', function() {
 
             it('should throw for missing template: "${greeting()}", no data', async () => {
                 assert.throws(() => {generator.generate(getDialogContext(), '${greeting()}', undefined);});
-            });       
+            });
         });
-        
-        describe('Test Multi-Language Import with no locale', function() {   
-            let generator; 
+
+        describe('Test Multi-Language Import with no locale', function() {
+            let generator;
             this.beforeAll(async function() {
                 const resource = resourceExplorer.getResource('a.lg');
                 generator = new TemplateEngineLanguageGenerator(resource, lgResourceGroup);
@@ -114,7 +114,7 @@ describe('LGLanguageGenerator', function() {
             it('"${greeting()}", no data', async () => {
                 const result = await generator.generate(getDialogContext(), '${greeting()}', undefined);
                 assert.strictEqual(result, 'hi');
-            });    
+            });
         });
     });
 
@@ -125,22 +125,22 @@ describe('LGLanguageGenerator', function() {
             const multiLanguageResources = await LanguageResourceLoader.groupByLocale(resourceExplorer);
 
             //Should have a setup for the threadLocale here.
-        
+
             let resource = resourceExplorer.getResource('test.lg');
             lg.languageGenerators.set('', new TemplateEngineLanguageGenerator(resource, multiLanguageResources));
-        
+
             resource = resourceExplorer.getResource('test.de.lg');
             lg.languageGenerators.set('de', new TemplateEngineLanguageGenerator(resource, multiLanguageResources));
-        
+
             resource = resourceExplorer.getResource('test.en.lg');
             lg.languageGenerators.set('en', new TemplateEngineLanguageGenerator(resource, multiLanguageResources));
-        
+
             resource = resourceExplorer.getResource('test.en-US.lg');
             lg.languageGenerators.set('en-us', new TemplateEngineLanguageGenerator(resource, multiLanguageResources));
-        
+
             resource = resourceExplorer.getResource('test.en-GB.lg');
             lg.languageGenerators.set('en-gb', new TemplateEngineLanguageGenerator(resource, multiLanguageResources));
-        
+
             resource = resourceExplorer.getResource('test.fr.lg');
             lg.languageGenerators.set('fr', new TemplateEngineLanguageGenerator(resource, multiLanguageResources));
         });
@@ -254,5 +254,32 @@ describe('LGLanguageGenerator', function() {
             assert.equal(result11, 'english-US');
         });
 */
+    });
+
+    describe('TestMissingPropertiesInGenerator', () => {
+        let lgResourceGroup;
+        this.beforeAll(async function() {
+            lgResourceGroup = await LanguageResourceLoader.groupByLocale(resourceExplorer);
+        });
+
+        it('empty TemplateEngineLanguageGenerator', () => {
+            const generator = new TemplateEngineLanguageGenerator();
+            const properties = generator.missingProperties(getDialogContext(''), '${user.name} and ${user.age}');
+            assert.deepStrictEqual(properties, ['user.name', 'user.age']);
+        });
+
+        it('TemplateEngineLanguageGenerator', () => {
+            const resource = resourceExplorer.getResource('properties.lg');
+            const generator = new TemplateEngineLanguageGenerator(resource, lgResourceGroup);
+
+            const properties = generator.missingProperties(getDialogContext(''), '${nameAndAge()}');
+            assert.deepStrictEqual(properties, ['user.name', 'user.age']);
+        });
+
+        it('ResourceMultiLanguageGenerator', () => {
+            const generator = new ResourceMultiLanguageGenerator('properties.lg');
+            const properties = generator.missingProperties(getDialogContext(''), '${nameAndAge()}');
+            assert.deepStrictEqual(properties, ['user.name', 'user.age']);
+        });
     });
 });

--- a/libraries/botbuilder-dialogs-adaptive/tests/lg/properties.lg
+++ b/libraries/botbuilder-dialogs-adaptive/tests/lg/properties.lg
@@ -1,0 +1,2 @@
+# nameAndAge
+- my name is ${user.name} and my age is ${user.age}

--- a/libraries/botbuilder-dialogs/etc/botbuilder-dialogs.api.md
+++ b/libraries/botbuilder-dialogs/etc/botbuilder-dialogs.api.md
@@ -820,7 +820,11 @@ export class TurnPath {
     // (undocumented)
     static readonly interrupted = "turn.interrupted";
     // (undocumented)
+    static readonly languagePolicy = "turn.languagePolicy";
+    // (undocumented)
     static readonly lastResult = "turn.lastresult";
+    // (undocumented)
+    static readonly locale = "turn.locale";
     // (undocumented)
     static readonly recognized = "turn.recognized";
     // (undocumented)

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -194,9 +194,7 @@ export class DialogContext {
      * @returns a locale string.
      */
     public getLocale(): string {
-        const _turnLocaleProperty = 'turn.locale';
-
-        const turnLocaleValue = this.state.getValue(_turnLocaleProperty);
+        const turnLocaleValue = this.state.getValue(TurnPath.locale);
         if (turnLocaleValue) {
             return turnLocaleValue;
         }

--- a/libraries/botbuilder-dialogs/src/memory/turnPath.ts
+++ b/libraries/botbuilder-dialogs/src/memory/turnPath.ts
@@ -45,4 +45,10 @@ export class TurnPath {
 
     /// This is a bool which if set means that the turncontext.activity has been consumed by some component in the system.
     public static readonly activityProcessed = 'turn.activityProcessed';
+
+    // Language Policy.
+    static readonly languagePolicy = "turn.languagePolicy";
+    
+    /// Locale.
+    static readonly locale = "turn.locale";
 }


### PR DESCRIPTION
Reverts #3970

Fixes #3969

Fix: [commit](https://github.com/microsoft/botbuilder-js/commit/52d282246ff903f81fcf551c6a2082f0652c6a3d)

## Description
This PR fixes an issue where the bot wasn't able to respond to messages after the Welcome message is sent.
When the `AdaptiveDialog.beginDialog` method is executed, the `context.turnState` for the second message (`e.g.: help`) was the same as the first message (`WelcomeMessage`), thus, having the `activityProcessed` property set to `true`, the bot didn't process the new Activity and ended the Dialog right away.

## Specific Changes
- Revert PR #3970
- Updates the `LanguageGeneratorExtensions.useLanguagePolicy` method to set the correct LanguagePolicy like in DotNet ([link](https://github.com/microsoft/botbuilder-dotnet/blob/406d58042e49737b8738416d35bc7fbb47deccc9/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/LanguageGeneratorExtensions.cs#L83-L84)) instead of setting the `turnState` object with the `languagePolicy`.
  - Change: `dialogManager.initialTurnState.set(TurnPath.languagePolicy, policy);`

## Testing
The following images show what was causing the issue, the DialogContext using the same turnState as the message sent before, and the bot working after the fix.
![image](https://user-images.githubusercontent.com/62260472/140406591-cbe7c20b-f032-4545-abe2-d73b4c5ac3ba.png)