### PR TITLE
Suggestion for on-responded on prompts

### DIFF
--- a/libraries/botbuilder-dialogs/tests/textPrompt.test.js
+++ b/libraries/botbuilder-dialogs/tests/textPrompt.test.js
@@ -1,5 +1,5 @@
 const { ActivityTypes, ConversationState, MemoryStorage, TestAdapter } = require('botbuilder-core');
-const { DialogSet, TextPrompt, DialogTurnStatus } = require('../');
+const { DialogSet, TextPrompt, DialogTurnStatus, Prompt } = require('../');
 const assert = require('assert');
 const lineReader = require('line-reader');
 const path = require('path');
@@ -188,6 +188,157 @@ describe('TextPrompt', function() {
 
         await adapter.send('Hello')
             .send(invalidMessage)
+            .send('test')
+            .assertReply('test')
+            .startTest();
+    });    
+    
+    it('should send retryPrompt when a message is sent before validation.', async function() {
+
+        const alwaysSentMessage = 'Working on your answer, hold on a second.'
+        const adapter = new TestAdapter(async (turnContext) => {
+            await turnContext.sendActivity(alwaysSentMessage);
+            const dc = await dialogs.createContext(turnContext);
+
+            const results = await dc.continueDialog();
+            if (results.status === DialogTurnStatus.empty) {
+                await dc.prompt('prompt', { prompt: 'Please say something.', retryPrompt: 'Text is required.' });
+            } else if (results.status === DialogTurnStatus.complete) {
+                const reply = results.result;
+                await turnContext.sendActivity(reply);
+            }
+            await convoState.saveChanges(turnContext);
+        });
+
+        const convoState = new ConversationState(new MemoryStorage());
+
+        const dialogState = convoState.createProperty('dialogState');
+        const dialogs = new DialogSet(dialogState);
+        dialogs.add(new TextPrompt('prompt'));
+
+        await adapter.send('Hello')
+            .assertReply(alwaysSentMessage)
+            .assertReply('Please say something.')
+            .send(invalidMessage)
+            .assertReply(alwaysSentMessage)
+            .assertReply('Text is required.')
+            .send('test')
+            .assertReply(alwaysSentMessage)
+            .assertReply('test')
+            .startTest();
+
+    });   
+
+    it('should not send retryPrompt if the validator replies, even when a message is sent before.', async function() {
+
+        const alwaysSentMessage = 'Working on your answer, hold on a second.'
+        const adapter = new TestAdapter(async (turnContext) => {
+            await turnContext.sendActivity(alwaysSentMessage);
+            const dc = await dialogs.createContext(turnContext);
+
+            const results = await dc.continueDialog();
+            if (results.status === DialogTurnStatus.empty) {
+                await dc.prompt('prompt', { prompt: 'Please say something.', retryPrompt: 'Text is required.' });
+            } else if (results.status === DialogTurnStatus.complete) {
+                const reply = results.result;
+                await turnContext.sendActivity(reply);
+            }
+            await convoState.saveChanges(turnContext);
+        });
+
+        const convoState = new ConversationState(new MemoryStorage());
+
+        const dialogState = convoState.createProperty('dialogState');
+        const dialogs = new DialogSet(dialogState);
+        dialogs.add(new TextPrompt('prompt', async (prompt) => {
+            if (!prompt.recognized.succeeded) {
+                await prompt.context.sendActivity('dont send an empty text.')
+            }
+            return prompt.recognized.succeeded;
+        }));
+
+        await adapter.send('Hello')
+            .assertReply(alwaysSentMessage)
+            .assertReply('Please say something.')
+            .send(invalidMessage)
+            .assertReply(alwaysSentMessage)
+            .assertReply('dont send an empty text.')
+            .send('test')
+            .assertReply(alwaysSentMessage)
+            .assertReply('test')
+            .startTest();
+
+    });    
+    
+    it('should not send retryPrompt if  repromptRetry status is false.', async function() {
+
+        const alwaysSentMessage = 'Working on your answer, hold on a second.'
+        const adapter = new TestAdapter(async (turnContext) => {
+            await turnContext.sendActivity(alwaysSentMessage);
+            Prompt.setRepromptRetry(turnContext, false);
+            const dc = await dialogs.createContext(turnContext);
+
+            const results = await dc.continueDialog();
+            if (results.status === DialogTurnStatus.empty) {
+                await dc.prompt('prompt', { prompt: 'Please say something.', retryPrompt: 'Text is required.' });
+            } else if (results.status === DialogTurnStatus.complete) {
+                const reply = results.result;
+                await turnContext.sendActivity(reply);
+            }
+            await convoState.saveChanges(turnContext);
+        });
+
+        const convoState = new ConversationState(new MemoryStorage());
+
+        const dialogState = convoState.createProperty('dialogState');
+        const dialogs = new DialogSet(dialogState);
+        dialogs.add(new TextPrompt('prompt'));
+
+        await adapter.send('Hello')
+            .assertReply(alwaysSentMessage)
+            .assertReply('Please say something.')
+            .send(invalidMessage)
+            .assertReply(alwaysSentMessage)
+            .send('test')
+            .assertReply(alwaysSentMessage)
+            .assertReply('test')
+            .startTest();
+
+    });
+
+    it('should send retryPrompt even if validator replies when repromptRetry status is true', async function() {
+        const adapter = new TestAdapter(async (turnContext) => {
+            const dc = await dialogs.createContext(turnContext);
+
+            const results = await dc.continueDialog();
+            if (results.status === DialogTurnStatus.empty) {
+                await dc.prompt('prompt', { prompt: 'Please say something.', retryPrompt: 'Text is required.' });
+            } else if (results.status === DialogTurnStatus.complete) {
+                const reply = results.result;
+                await turnContext.sendActivity(reply);
+            }
+            await convoState.saveChanges(turnContext);
+        });
+
+        const convoState = new ConversationState(new MemoryStorage());
+
+        const dialogState = convoState.createProperty('dialogState');
+        const dialogs = new DialogSet(dialogState);
+        dialogs.add(new TextPrompt('prompt', async (prompt) => {
+            assert(prompt);
+            Prompt.setRepromptRetry(prompt.context, true)
+            const valid = prompt.recognized.value.length >= 3;
+            if (!valid) {
+                await prompt.context.sendActivity('too short');
+            }
+            return valid;
+        }));
+
+        await adapter.send('Hello')
+            .assertReply('Please say something.')
+            .send('i')
+            .assertReply('too short')
+            .assertReply('Text is required.')
             .send('test')
             .assertReply('test')
             .startTest();


### PR DESCRIPTION
Fixes #3947

## Description
On issue #3947, relying on the responded flag todecide whether to show the prompt interferes with logic that could be happening either

a. Concurrently
b. On some middleware
c. As part of how we reached the prompt

I believe the *intention* is to *not* send a prompt if the validator has already sent a message. This is in fact not explained anywhere and it leads to confusion, and restricts the ability to write concise explanations to users along side a retry.

## Specific Changes

  - The default behavior is kept, *except* if a message was sent *before* the validator (Those are not considered as part of the prompt logic). This still runs into concurrency issues. For that,
  - A static method in Prompt has been added, setRepromptStatus. This allows the user to choose explicitly if the prompt should re-prompt or not.


## Testing

- Added extra tests for the new functionality *only* for the text prompt, since all other prompts reuse that same logic.