### PR TITLE
fix: Update chromedriver to v 96

### DIFF
--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -3,7 +3,7 @@
 #
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'windows-latest'
 
 trigger:
 - main

--- a/testing/browser-functional/nightwatch.conf.js
+++ b/testing/browser-functional/nightwatch.conf.js
@@ -16,6 +16,7 @@ module.exports = {
         selenium: {
             selenium: {
                 start_process: true,
+                check_process_delay: 5000,
                 port: 9515,
                 server_path: seleniumServer.path,
                 cli_args: {

--- a/testing/browser-functional/package.json
+++ b/testing/browser-functional/package.json
@@ -5,7 +5,7 @@
   "description": "Test to check browser compatibility",
   "main": "",
   "devDependencies": {
-    "chromedriver": "^94.0.0",
+    "chromedriver": "^96.0.0",
     "dotenv": "^8.2.0",
     "geckodriver": "^1.19.1",
     "nightwatch": "^1.6.3",

--- a/testing/browser-functional/package.json
+++ b/testing/browser-functional/package.json
@@ -8,7 +8,7 @@
     "chromedriver": "^96.0.0",
     "dotenv": "^8.2.0",
     "geckodriver": "^1.19.1",
-    "nightwatch": "^1.6.3",
+    "nightwatch": "^1.7.12",
     "selenium-server": "^3.141.59"
   },
   "directories": {


### PR DESCRIPTION
Fixes #minor

## Description
Fixes pipeline error "Current browser version is 96.0.4664.45 This version of ChromeDriver only supports Chrome version 94"
This also required a 5 second delay put into nightwatch config to fix error "Timeout while trying to connect to Selenium Server".

Also updates vmImage.

Affected pipelines:
Run-JS-Functional-Tests-BrowserBot-yaml
Run-JS-Functional-Tests-Linux