### PR TITLE
fix: [botbuilder-core] TestAdapter throws unhandled promise rejection on error

### DIFF
--- a/libraries/botbuilder-core/etc/botbuilder-core.api.md
+++ b/libraries/botbuilder-core/etc/botbuilder-core.api.md
@@ -810,13 +810,14 @@ export class TestFlow {
     assertReplyOneOf(candidates: string[], description?: string, timeout?: number): TestFlow;
     catch(onRejected?: (reason: any) => void): TestFlow;
     delay(ms: number): TestFlow;
+    finally(onFinally: () => void): Promise<void>;
     // (undocumented)
     previous: Promise<void>;
     send(userSays: string | Partial<Activity>): TestFlow;
     sendConversationUpdate(): TestFlow;
     startTest(): Promise<void>;
     test(userSays: string | Partial<Activity>, expected: string | Partial<Activity> | ((activity: Partial<Activity>, description?: string) => void), description?: string, timeout?: number): TestFlow;
-    then(onFulfilled?: () => void): TestFlow;
+    then(onFulfilled?: () => void, onRejected?: (err: any) => void): TestFlow;
 }
 
 // @public (undocumented)

--- a/libraries/botbuilder-core/src/testAdapter.ts
+++ b/libraries/botbuilder-core/src/testAdapter.ts
@@ -978,8 +978,17 @@ export class TestFlow {
      * Adds a `then()` step to the tests promise chain.
      * @param onFulfilled Code to run if the test is currently passing.
      */
-    public then(onFulfilled?: () => void): TestFlow {
-        return new TestFlow(this.previous.then(onFulfilled), this.adapter, this.callback);
+    public then(onFulfilled?: () => void, onRejected?: (err) => void): TestFlow {
+        return new TestFlow(this.previous.then(onFulfilled, onRejected), this.adapter, this.callback);
+    }
+
+    /**
+     * Adds a finally clause. Note that you can't keep chaining afterwards.
+     * @param onFinally 
+     * @returns 
+     */
+    public finally(onFinally: () => void): Promise<void> {
+        return Promise.resolve(this.previous.finally(onFinally));
     }
 
     /**

--- a/libraries/botbuilder-core/tests/testAdapter.test.js
+++ b/libraries/botbuilder-core/tests/testAdapter.test.js
@@ -25,6 +25,41 @@ describe(`TestAdapter`, function () {
         await adapter.receiveActivity('test');
     });
 
+    it(`should reject on unhandled error.`, async function () {
+        const err = new Error('Intentional');
+        const adapter = new TestAdapter(() => {
+            throw err;
+        });
+        await assert.rejects(async () => {
+            await adapter.send('Message');
+        }, err);
+    });
+
+    it(`should call finally when no error happens`, async function () {
+        const adapter = new TestAdapter(async () => undefined);
+        let runFinally = false;
+
+        await adapter.send('Message').finally(() => {
+            runFinally = true;
+        });
+        assert(runFinally, 'Finally was not called');
+    });
+
+    it(`should call finally when an error happens`, async function () {
+        const err = new Error('Intentional');
+        const adapter = new TestAdapter(() => {
+            throw err;
+        });
+        let runFinally = false;
+
+        await assert.rejects(async () => {
+            await adapter.send('Message').finally(() => {
+                runFinally = true;
+            });
+        }, err);
+        assert(runFinally, 'Finally was not called');
+    });
+
     it(`should support receiveActivity() called with an Activity.`, async function () {
         const adapter = new TestAdapter((context) => {
             assert(context.activity.type === ActivityTypes.Message, `wrong type.`);


### PR DESCRIPTION
## Description
TestAdapter throws unhalded promise rejections on errors

- The testadapter should handle errors
- For that, TestFlow must implement the thenable implementation correctly

## Specific Changes

  - Implemented further the tenable on TestFlow to allow handling catch clauses correctly

## Testing

A test is added to verify the behavior change (If you run that test on main before this PR is merged, it fails)

#minor 