### PR TITLE
fix: Incorrect check against Content-Type instead of content-type in httpRequest #3992

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/src/actions/httpRequest.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/httpRequest.ts
@@ -268,7 +268,7 @@ export class HttpRequest<O extends object = {}> extends Dialog<O> implements Htt
 
         const instanceHeaders = {};
         for (let key in this.headers) {
-            if (key.toLowerCase() === 'Content-Type') {
+            if (key.toLowerCase() === 'content-type') {
                 key = 'Content-Type';
             }
             instanceHeaders[key] = this.headers[key].getValue(dc.state);


### PR DESCRIPTION
Fixes Issue [Incorrect check against Content-Type instead of content-type in httpRequest #3992](https://github.com/microsoft/botbuilder-js/issues/3992)
Fixes #3992 