### PR TITLE
chore: adding component governance to build

### DIFF
--- a/build/yaml/botbuilder-js-daily.yml
+++ b/build/yaml/botbuilder-js-daily.yml
@@ -105,3 +105,17 @@ steps:
   continueOnError: true
 
 - template: templates/list-files.yml
+
+- task: DeleteFiles@1
+  displayName: 'Delete files from '
+  inputs:
+    Contents: |
+     ./testing/*
+     ./tools/*
+     ./package.json
+
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: 'Component Detection'
+  inputs:
+    failOnAlert: true
+


### PR DESCRIPTION
#minor
## Description
Adding Component governance to the build to enable failure on error and deleting all package manager files before it is run.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - 
  -
  -
