### PR TITLE
chore: Delete node modules after build

### DIFF
--- a/build/yaml/botbuilder-js-daily.yml
+++ b/build/yaml/botbuilder-js-daily.yml
@@ -113,8 +113,7 @@ steps:
      ./testing/*
      ./tools/*
      ./package.json
-     
-#./node_modules/*
+     ./node_modules/*
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'

--- a/build/yaml/botbuilder-js-daily.yml
+++ b/build/yaml/botbuilder-js-daily.yml
@@ -113,6 +113,7 @@ steps:
      ./testing/*
      ./tools/*
      ./package.json
+     ./node_modules/*
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'

--- a/build/yaml/botbuilder-js-daily.yml
+++ b/build/yaml/botbuilder-js-daily.yml
@@ -113,7 +113,8 @@ steps:
      ./testing/*
      ./tools/*
      ./package.json
-     ./node_modules/*
+     
+#./node_modules/*
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'


### PR DESCRIPTION
#minor
Deleting node_modules after build to remove overhead of package manager dependencies and prevent Component Governance to report unused packages

  - 
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->