### PR TITLE
fix: Change component detection scan path to root

### DIFF
--- a/build/yaml/botbuilder-js-daily.yml
+++ b/build/yaml/botbuilder-js-daily.yml
@@ -115,5 +115,5 @@ steps:
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'
   inputs:
-    ignoreDirectories: './testing,./tools,./generators/generator-botbuilder'
+    ignoreDirectories: './testing,./tools,./generators'
     failOnAlert: false

--- a/build/yaml/botbuilder-js-daily.yml
+++ b/build/yaml/botbuilder-js-daily.yml
@@ -115,7 +115,5 @@ steps:
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'
   inputs:
-    sourceScanPath: './libraries'
-    ignoreDirectories: './testing,./tools'
+    ignoreDirectories: './testing,./tools,./generators/generator-botbuilder'
     failOnAlert: false
-


### PR DESCRIPTION
Fixes #minor

## Description
This changes the Component Detection scan area to include the yarn.lock file at the root. I believe those dependencies should be included in the Component Detection scanning process. 

## Specific Changes
Delete the sourceScanPath input line so scanning includes the yarn.lock file at the root.
Add ./generators to the ignoreDirectories list because that is currently scanned in the pipeline BotBuilder-Generators-JS-daily.