### PR TITLE
fix: follow-redirects Component Governance vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@azure/logger": "^1.0.2",
-    "@azure/ms-rest-js": "1.9.1",
+    "@azure/ms-rest-js": "2.6.0",
     "@microsoft/api-extractor": "^7.15.1",
     "@standardlabs/downlevel-dts": "^0.7.5",
     "@standardlabs/is-private": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,7 +32,7 @@
     "@opentelemetry/api" "^0.6.1"
     tslib "^2.0.0"
 
-"@azure/core-auth@^1.3.0":
+"@azure/core-auth@^1.1.4", "@azure/core-auth@^1.3.0":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.3.2.tgz#6a2c248576c26df365f6c7881ca04b7f6d08e3d0"
   integrity sha512-7CU6DmCHIZp5ZPiZ9r3J17lTKMmYsm/zGvNkjArQwPkrLlZ1TZ+EUYfGgh2X31OLMVAQCTJZW4cXHJi02EbJnA==
@@ -230,6 +230,21 @@
     tslib "^1.9.2"
     tunnel "0.0.6"
     uuid "^3.2.1"
+    xml2js "^0.4.19"
+
+"@azure/ms-rest-js@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@azure/ms-rest-js/-/ms-rest-js-2.6.0.tgz#ec06e6a0b704567ea9b2c8044821cf47148c586b"
+  integrity sha512-4C5FCtvEzWudblB+h92/TYYPiq7tuElX8icVYToxOdggnYqeec4Se14mjse5miInKtZahiFHdl8lZA/jziEc5g==
+  dependencies:
+    "@azure/core-auth" "^1.1.4"
+    abort-controller "^3.0.0"
+    form-data "^2.5.0"
+    node-fetch "^2.6.0"
+    tough-cookie "^3.0.1"
+    tslib "^1.10.0"
+    tunnel "0.0.6"
+    uuid "^8.3.2"
     xml2js "^0.4.19"
 
 "@azure/ms-rest-js@^1.6.0":
@@ -2390,6 +2405,13 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
 
 accepts@^1.3.7, accepts@~1.3.7:
   version "1.3.7"
@@ -5581,6 +5603,11 @@ event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
 events@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
@@ -7363,6 +7390,11 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
+
+ip-regex@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
 ip-regex@^4.1.0:
   version "4.3.0"
@@ -12960,6 +12992,15 @@ tough-cookie@^2.3.3, tough-cookie@^2.4.3, tough-cookie@~2.5.0:
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
   dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
+tough-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-3.0.1.tgz#9df4f57e739c26930a018184887f4adb7dca73b2"
+  integrity sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
+  dependencies:
+    ip-regex "^2.1.0"
     psl "^1.1.28"
     punycode "^2.1.1"
 


### PR DESCRIPTION
Fixes #minor

## Description
Fixes the high severity follow-redirects vulnerability listed in these 2 CG alerts:
https://fuselabs.visualstudio.com/SDK_v4/_componentGovernance/112352/alert/6373557?typeId=10422422
https://fuselabs.visualstudio.com/SDK_v4/_componentGovernance/112352/alert/6373574?typeId=10422422

Vulnerability: follow-redirects 1.5.10
-- Recommendation: Upgrade follow-redirects from 1.5.10 to 1.14.7
Vulnerability: follow-redirects 1.14.4
--  Recommendation: Upgrade follow-redirects from 1.14.4 to 1.14.7

The initial follow-redirects dependency tree looked like this:

```
C:\src\botbuilder-js>npm ls follow-redirects
botbuilder-js@4.13.0 C:\src\botbuilder-js
`-- @azure/ms-rest-js@1.9.1
  `-- axios@0.21.4
    `-- follow-redirects@1.14.4
```
I fixed it with the command:
`yarn upgrade @azure/ms-rest-js@2.6.0
`
...resulting in the dependency being eliminated:
```
C:\src\botbuilder-js>npm ls follow-redirects
botbuilder-js@4.13.0 C:\src\botbuilder-js
`-- (empty)
```
## Testing
I tested the fix in these 4 Sample-Js E2E test runs:
[Sample-Js-CoreBot-Linux-Test-yaml](https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=287747&view=results)
[Sample-Js-CoreBot-Win-Test-yaml](https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=287748&view=results)
[Sample-Js-EchoBot-Linux-Test-yaml](https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=287749&view=results)
[Sample-Js-EchoBot-Win-Test-yaml](https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=287754&view=results)
