### PR TITLE
fix: mixme Component Governance vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "test:schemas": "mocha libraries/botbuilder-dialogs-declarative/tests/schemaMergeTest.js --exit --bail",
     "update-versions": "yarn workspace botbuilder-repo-utils update-versions"
   },
+  "resolutions": {
+    "mixme": "0.5.2"
+  },
   "devDependencies": {
     "@azure/logger": "^1.0.2",
     "@azure/ms-rest-js": "1.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9210,10 +9210,10 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mixme@^0.3.1:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/mixme/-/mixme-0.3.5.tgz#304652cdaf24a3df0487205e61ac6162c6906ddd"
-  integrity sha512-SyV9uPETRig5ZmYev0ANfiGeB+g6N2EnqqEfBbCGmmJ6MgZ3E4qv5aPbnHVdZ60KAHHXV+T3sXopdrnIXQdmjQ==
+mixme@0.5.2, mixme@^0.3.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/mixme/-/mixme-0.5.2.tgz#33c7e21d8e9b73abc2711c5197ae6c93f65fe0e4"
+  integrity sha512-fzzuzXSqp14Mk2eZK15yqcJHwNlLtg+EliQBO/ihYfZed9WUuDHR9ZuEUqQDD8FcW/742y0JGq8xBfL9fNsWZw==
 
 mkdirp-classic@^0.5.2:
   version "0.5.3"


### PR DESCRIPTION
Fixes #minor

## Description
Fixes the high severity mixme vulnerability listed in these CG alerts:
https://fuselabs.visualstudio.com/SDK_v4/_componentGovernance/112352/alert/5657655?typeId=10422422
https://fuselabs.visualstudio.com/SDK_v4/_componentGovernance/112352/alert/5657656?typeId=10422422

Vulnerability: mixme 0.3.5. Recommended to upgrade to v 0.5.2.

Force dependency mixme to version 0.5.2.

## Specific Changes
Add a resolutions section to the root package.json.