### PR TITLE
fix: Failing pipeline E2E_BF-Streaming-DL-ASE_Test

### DIFF
--- a/testing/streaming-e2e/build/create-react-app.yml
+++ b/testing/streaming-e2e/build/create-react-app.yml
@@ -14,8 +14,8 @@ steps:
     condition: ne(variables.CacheRestored, 'true')
     workingDirectory: $(ReactProjectDir)
 
-  - powershell: npm install react-scripts@latest
-    displayName: npm install react-scripts@latest
+  - powershell: npm install react-scripts@4.0.3
+    displayName: npm install react-scripts@4.0.3
     workingDirectory: $(ReactProjectDir)
 
   - template: customize-dljs.yml


### PR DESCRIPTION
Fixes #minor

## Description
> react-app@0.1.0 build
> react-scripts build
Creating an optimized production build...
Failed to compile.
Module not found: Error: Can't resolve 'stream' in 'D:\a\1\s\testing\streaming-e2e\react-app\node_modules\jws\lib'
BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
- add a fallback 'resolve.fallback: { "stream": require.resolve("stream-browserify") }'
- install 'stream-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
resolve.fallback: { "stream": false }
## Specific Changes
Switch from npm install react-scripts@latest to npm install react-scripts@4.0.3
