### PR TITLE
fix: failing pipeline Run-JS-Functional-Tests-BrowserBot-yaml

### DIFF
--- a/testing/browser-functional/nightwatch.conf.js
+++ b/testing/browser-functional/nightwatch.conf.js
@@ -16,7 +16,7 @@ module.exports = {
         selenium: {
             selenium: {
                 start_process: true,
-                check_process_delay: 5000,
+                check_process_delay: 10000,
                 port: 9515,
                 server_path: seleniumServer.path,
                 cli_args: {

--- a/testing/browser-functional/package.json
+++ b/testing/browser-functional/package.json
@@ -6,9 +6,9 @@
   "main": "",
   "devDependencies": {
     "chromedriver": "^98.0.0",
-    "dotenv": "^8.2.0",
+    "dotenv": "^8.6.0",
     "geckodriver": "^1.19.1",
-    "nightwatch": "^2.0.7",
+    "nightwatch": "^1.7.13",
     "selenium-server": "^3.141.59"
   },
   "directories": {

--- a/testing/browser-functional/package.json
+++ b/testing/browser-functional/package.json
@@ -8,7 +8,7 @@
     "chromedriver": "^98.0.0",
     "dotenv": "^8.2.0",
     "geckodriver": "^1.19.1",
-    "nightwatch": "^1.7.12",
+    "nightwatch": "^2.0.7",
     "selenium-server": "^3.141.59"
   },
   "directories": {

--- a/testing/browser-functional/package.json
+++ b/testing/browser-functional/package.json
@@ -5,7 +5,7 @@
   "description": "Test to check browser compatibility",
   "main": "",
   "devDependencies": {
-    "chromedriver": "^96.0.0",
+    "chromedriver": "^98.0.0",
     "dotenv": "^8.2.0",
     "geckodriver": "^1.19.1",
     "nightwatch": "^1.7.12",


### PR DESCRIPTION
Fixes #minor

error: [
         'Current browser version is 98.0.4758.102 ... This version of ChromeDriver only supports Chrome version 96'

Failing run: https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=293897&view=logs&j=6b902995-b73d-5f5c-66fd-a7f66c857d2c&t=a1c457be-0fbe-5525-b6b0-ac3cf58f8d6c

The following changes address frequent timeout errors when nightwatch runs selenium tests:

Increase check_process_delay to 10 seconds.

Update nightwatch.