### PR TITLE
chore: Deprecate getTeamMembers and getMembers.

### DIFF
--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -431,12 +431,14 @@ export class TeamsInfo {
     static getMeetingInfo(context: TurnContext, meetingId?: string): Promise<TeamsMeetingInfo>;
     static getMeetingParticipant(context: TurnContext, meetingId?: string, participantId?: string, tenantId?: string): Promise<TeamsMeetingParticipant>;
     static getMember(context: TurnContext, userId: string): Promise<TeamsChannelAccount>;
+    // @deprecated
     static getMembers(context: TurnContext): Promise<TeamsChannelAccount[]>;
     static getPagedMembers(context: TurnContext, pageSize?: number, continuationToken?: string): Promise<TeamsPagedMembersResult>;
     static getPagedTeamMembers(context: TurnContext, teamId?: string, pageSize?: number, continuationToken?: string): Promise<TeamsPagedMembersResult>;
     static getTeamChannels(context: TurnContext, teamId?: string): Promise<ChannelInfo[]>;
     static getTeamDetails(context: TurnContext, teamId?: string): Promise<TeamDetails>;
     static getTeamMember(context: TurnContext, teamId?: string, userId?: string): Promise<TeamsChannelAccount>;
+    // @deprecated
     static getTeamMembers(context: TurnContext, teamId?: string): Promise<TeamsChannelAccount[]>;
     static sendMessageToTeamsChannel(context: TurnContext, activity: Activity, teamsChannelId: string, botAppId?: string): Promise<[ConversationReference, string]>;
 }

--- a/libraries/botbuilder/src/teamsInfo.ts
+++ b/libraries/botbuilder/src/teamsInfo.ts
@@ -214,6 +214,8 @@ export class TeamsInfo {
      *
      * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * @returns The list of [TeamsChannelAccount](xref:botframework-schema.TeamsChannelAccount).
+     *
+     * @deprecated Use `getPagedTeamMembers` instead.
      */
     public static async getMembers(context: TurnContext): Promise<TeamsChannelAccount[]> {
         const teamId = this.getTeamId(context);
@@ -277,6 +279,8 @@ export class TeamsInfo {
      * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
      * @param teamId ID of the Teams team.
      * @returns The list of [TeamsChannelAccount](xref:botframework-schema.TeamsChannelAccount) of the members.
+     *
+     * @deprecated Use `getPagedTeamMembers` instead.
      */
     public static async getTeamMembers(context: TurnContext, teamId?: string): Promise<TeamsChannelAccount[]> {
         const t = teamId || this.getTeamId(context);


### PR DESCRIPTION
chore: Marked getMembers and getTeamMembers as deprecated.

Fixes #4140

## Description
Marked getMembers and getTeamMembers as deprecated.
