### PR TITLE
port: Obsolete classes for future deprecation

### DIFF
--- a/libraries/botbuilder-core/src/extendedUserTokenProvider.ts
+++ b/libraries/botbuilder-core/src/extendedUserTokenProvider.ts
@@ -13,6 +13,8 @@ import { SignInUrlResponse, TokenResponse, TokenExchangeRequest } from 'botframe
 
 /**
  * Interface for User Token OAuth Single Sign On and Token Exchange APIs for BotAdapters
+ *
+ * @obsolete Use `UserTokenClient` instead.
  */
 export interface ExtendedUserTokenProvider extends IUserTokenProvider {
     /**

--- a/libraries/botbuilder-core/src/userTokenProvider.ts
+++ b/libraries/botbuilder-core/src/userTokenProvider.ts
@@ -11,6 +11,8 @@ import { TokenResponse } from 'botframework-schema';
 
 /**
  * Interface for User Token OAuth APIs for BotAdapters
+ *
+ * @obsolete Use `UserTokenClient` instead.
  */
 export interface IUserTokenProvider {
     /**

--- a/libraries/botbuilder-dialogs/src/dialogManager.ts
+++ b/libraries/botbuilder-dialogs/src/dialogManager.ts
@@ -61,6 +61,8 @@ export interface DialogManagerConfiguration {
 
 /**
  * Class which runs the dialog system.
+ *
+ * @obsolete This class will be deprecated.
  */
 export class DialogManager extends Configurable {
     private _rootDialogId: string;

--- a/libraries/botbuilder/src/inspectionMiddleware.ts
+++ b/libraries/botbuilder/src/inspectionMiddleware.ts
@@ -169,6 +169,7 @@ abstract class InterceptionMiddleware implements Middleware {
  * @remarks
  * InspectionMiddleware for emulator inspection of runtime Activities and BotState.
  *
+ * @obsolete This class will be removed in a future version of the framework.
  */
 export class InspectionMiddleware extends InterceptionMiddleware {
     private static readonly command = '/INSPECT';
@@ -444,6 +445,7 @@ class InspectionSessionsByStatus {
  * @remarks
  * InspectionState for use by the InspectionMiddleware for emulator inspection of runtime Activities and BotState.
  *
+ * @obsolete This class will be removed in a future version of the framework.
  */
 export class InspectionState extends BotState {
     /**


### PR DESCRIPTION
Fixes #4060, #4061, #4108 

### In this change:

- Obsolete sidecar debugging classes
- Add Obsolete attribute to IExtendedUserTokenProvider and IUserTokenProvider
- Add Obsolete attribute to DialogManager