### PR TITLE
port: [#4062] Log BadRequest in adapter (#6135)

### DIFF
--- a/libraries/botbuilder/src/cloudAdapter.ts
+++ b/libraries/botbuilder/src/cloudAdapter.ts
@@ -128,6 +128,7 @@ export class CloudAdapter extends CloudAdapterBase implements BotFrameworkHttpAd
         const activity = validateAndFixActivity(ActivityT.parse(req.body));
 
         if (!activity.type) {
+            console.warn('BadRequest: Missing activity or activity type.');
             return end(StatusCodes.BAD_REQUEST);
         }
 


### PR DESCRIPTION
Fixes #4062

## Description
This PR ports the changes in [BotBuilder-DotNet's PR#6135](https://github.com/microsoft/botbuilder-dotnet/pull/6135) adding a warn logger in CloudAdapter's process method when the activity hasn't a type.

## Specific Changes
- Updated CloudAdapter class adding a `console.warn` when a BadRequest error is thrown for a missing activity type.

## Testing
This image shows the tests passing after the change.
![image](https://user-images.githubusercontent.com/97895605/157874062-bd1981c9-1ec9-44c5-b7ee-c3b4b4718e10.png)