### PR TITLE
port: [#4039] Teams now supports <= 50 Card Actions (#6085)

### DIFF
--- a/libraries/botbuilder-dialogs/src/choices/channel.ts
+++ b/libraries/botbuilder-dialogs/src/choices/channel.ts
@@ -42,7 +42,7 @@ export function supportsCardActions(channelId: string, buttonCnt = 100): boolean
         case Channels.Facebook:
         case Channels.Skype:
         case Channels.Msteams:
-            return buttonCnt <= 3;
+            return buttonCnt <= 50;
         case Channels.Line:
             return buttonCnt <= 99;
         case Channels.Slack:

--- a/libraries/botbuilder-dialogs/src/choices/channel.ts
+++ b/libraries/botbuilder-dialogs/src/choices/channel.ts
@@ -41,6 +41,7 @@ export function supportsCardActions(channelId: string, buttonCnt = 100): boolean
     switch (channelId) {
         case Channels.Facebook:
         case Channels.Skype:
+            return buttonCnt <= 3;
         case Channels.Msteams:
             return buttonCnt <= 50;
         case Channels.Line:

--- a/libraries/botbuilder-dialogs/tests/choices_channel.test.js
+++ b/libraries/botbuilder-dialogs/tests/choices_channel.test.js
@@ -57,6 +57,14 @@ describe('channel methods', function () {
         assert.strictEqual(supportsCardActions(Channels.Skype, 5), false);
     });
 
+    it('should return true for supportsCardActions() with teams and 50', function (){
+        assert.strictEqual(supportsCardActions(Channels.Msteams, 50), true);
+    })
+
+    it('should return false for supportsCardActions() with teams and 51', function (){
+        assert.strictEqual(supportsCardActions(Channels.Msteams, 51), false);
+    })
+
     it('should return the channelId from context.activity.', function () {
         assert.strictEqual(getChannelId({ activity: { channelId: Channels.Facebook } }), Channels.Facebook);
     });


### PR DESCRIPTION
Fixes #4039

### Description
This PR ports the changes in [BotBuilder-DotNet's PR#6085](https://github.com/microsoft/botbuilder-dotnet/pull/6085) to add support for <= 50 Card Actions on teams.

### Specific Changes
- Updated `channel.ts` to support <= 50 Card Actions on teams.
- Added unit tests in `choices_channel.test.js` to cover the different test cases.

### Testing
This image shows the new unit tests passing.
![2022-03-11 16_04_15-PowerShell 7 (x64)](https://user-images.githubusercontent.com/64086728/157935914-e6b02d6c-b9b2-478a-9d9b-2af2c1704807.png)

