### PR TITLE
port: [#4073] Set TeamsNotifyUser Alert to opposite of AlertInMeeting

### DIFF
--- a/libraries/botbuilder/src/teamsActivityHelpers.ts
+++ b/libraries/botbuilder/src/teamsActivityHelpers.ts
@@ -104,7 +104,7 @@ export function teamsGetChannelId(activity: Activity): string | null {
  * @param alertInMeeting Sent to a meeting chat, this will cause the Teams client to render it in a notification popup as well as in the chat thread.
  * @param externalResourceUrl Url to external resource. Must be included in manifest's valid domains.
  */
-export function teamsNotifyUser(activity: Activity, alertInMeeting?: boolean, externalResourceUrl?: string): void {
+export function teamsNotifyUser(activity: Activity, alertInMeeting = false, externalResourceUrl?: string): void {
     validateActivity(activity);
 
     if (!isTeamsChannelData(activity.channelData)) {
@@ -112,6 +112,6 @@ export function teamsNotifyUser(activity: Activity, alertInMeeting?: boolean, ex
     }
 
     if (isTeamsChannelData(activity.channelData)) {
-        activity.channelData.notification = { alert: true, alertInMeeting, externalResourceUrl };
+        activity.channelData.notification = { alert: !alertInMeeting, alertInMeeting, externalResourceUrl };
     }
 }

--- a/libraries/botbuilder/tests/teamsHelpers.test.js
+++ b/libraries/botbuilder/tests/teamsHelpers.test.js
@@ -111,33 +111,37 @@ describe('TeamsActivityHelpers method', function () {
             const activity = createActivityTeamId();
             teamsNotifyUser(activity);
             assert(activity.channelData.notification.alert === true);
+            assert(activity.channelData.notification.alertInMeeting === false);
         });
 
         it('should add notify with no channelData', async function () {
             const activity = createActivityNoChannelData();
             teamsNotifyUser(activity);
             assert(activity.channelData.notification.alert === true);
+            assert(activity.channelData.notification.alertInMeeting === false);
         });
 
         it('should throw an error if no activity is passed in', function () {
             assert.throws(() => teamsNotifyUser(undefined), Error('Missing activity parameter'));
         });
 
-        it('should add notify with no notification in channelData', async function () {
+        it('should add notify with no notification in channelData, and externalUrl', async function () {
             const activity = createActivityTeamId();
             teamsNotifyUser(activity, true, 'externalUrl');
+            assert(activity.channelData.notification.alert === false);
             assert(activity.channelData.notification.alertInMeeting === true);
             assert(activity.channelData.notification.externalResourceUrl === 'externalUrl');
         });
 
-        it('should add notify with no channelData', async function () {
+        it('should add notify with no channelData, and externalUrl', async function () {
             const activity = createActivityNoChannelData();
             teamsNotifyUser(activity, true, 'externalUrl');
+            assert(activity.channelData.notification.alert === false);
             assert(activity.channelData.notification.alertInMeeting === true);
             assert(activity.channelData.notification.externalResourceUrl === 'externalUrl');
         });
 
-        it('should throw an error if no activity is passed in', function () {
+        it('should throw an error if no activity is passed in, and externalUrl', function () {
             assert.throws(() => teamsNotifyUser(undefined, true, 'externalUrl'), Error('Missing activity parameter'));
         });
     });


### PR DESCRIPTION
Fixes #4073

## Description
This PR updates the `alert` property for the `teamsNotifyUser` method notification, to depend on the `alertInMeeting` property. Additionally, it updates the unit tests to support these changes.

## Specific Changes
- Updates `alertInMeeting` property default value to be false instead of undefined, when the parameter is not passed in.
- Updates the `alert` property notification to be the opposite value of the `alertInMeeting` property.
- Updates the unit tests to include the conditions of `alertInMeeting` and `alert` properties. Additionally, it updates the naming for some unit tests, to differ from the rest.

## Testing
The following image shows the tests passing successfully.
![image](https://user-images.githubusercontent.com/62260472/158621393-3ac52e7c-f9a8-41ea-9fda-42432e5ac1be.png)