### PR TITLE
fix: [#4154] teamsNotifyUser does not accept messages returned from MessageFactory

### DIFF
--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -444,7 +444,7 @@ export class TeamsInfo {
 }
 
 // @public
-export function teamsNotifyUser(activity: Activity, alertInMeeting?: boolean, externalResourceUrl?: string): void;
+export function teamsNotifyUser(activity: Partial<Activity>, alertInMeeting?: boolean, externalResourceUrl?: string): void;
 
 // @public
 export class TeamsSSOTokenExchangeMiddleware implements Middleware {

--- a/libraries/botbuilder/src/teamsActivityHelpers.ts
+++ b/libraries/botbuilder/src/teamsActivityHelpers.ts
@@ -12,7 +12,7 @@ function isTeamsChannelData(channelData: unknown): channelData is TeamsChannelDa
     return typeof channelData === 'object';
 }
 
-function validateActivity(activity: Activity): void {
+function validateActivity(activity: Partial<Activity>): void {
     if (!activity) {
         throw new Error('Missing activity parameter');
     }
@@ -104,7 +104,11 @@ export function teamsGetChannelId(activity: Activity): string | null {
  * @param alertInMeeting Sent to a meeting chat, this will cause the Teams client to render it in a notification popup as well as in the chat thread.
  * @param externalResourceUrl Url to external resource. Must be included in manifest's valid domains.
  */
-export function teamsNotifyUser(activity: Activity, alertInMeeting?: boolean, externalResourceUrl?: string): void {
+export function teamsNotifyUser(
+    activity: Partial<Activity>,
+    alertInMeeting?: boolean,
+    externalResourceUrl?: string
+): void {
     validateActivity(activity);
 
     if (!isTeamsChannelData(activity.channelData)) {


### PR DESCRIPTION
Fixes #4154

## Description
This PR updates the `teamsNotifyUser` method in teamsActivityHelper class to receive a Partial<Activity> instead of an Activity enabling to call it using a MessageFactory.
This method only uses the Activity's ChannelData which is not a required property.

## Specific Changes
- Updated `teamsNotifyUser` method to receive a Partial<Activity> as parameter.
- Updated the method signature in `botbuilder.api.md` documentation.

## Testing
These images show a Teams bot sending a notification to the user.
![image](https://user-images.githubusercontent.com/44245136/158872149-3112b9e7-1109-469f-98f5-e4c65eaf5bf4.png)
