### PR TITLE
fix: [#3192] Missing LICENSE files and invalid package.json - Part 1

### DIFF
--- a/libraries/botbuilder-repo-utils/src/package.ts
+++ b/libraries/botbuilder-repo-utils/src/package.ts
@@ -15,6 +15,7 @@ export interface Package {
 
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
 
     scripts?: Record<string, string>;
 }


### PR DESCRIPTION
Addresses #3192
#minor

## Description
This PR modifies the `update-versions` script, to take the private packages into account when updating all the libraries versions and references and also the `peerDependencies`.

## Specific Changes
- Updated `update-versions` script to gather all the repo packages and update the version for the ones that aren't private.
- Updated `update-versions` script to take the `peerDependencies` into consideration.