### PR TITLE
fix: failing Samples E2E JS CoreBot tests

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@azure/cognitiveservices-luis-runtime": "2.0.0",
     "@azure/ms-rest-js": "1.9.1",
+    "adaptive-expressions": "4.1.6",
     "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
     "botbuilder-dialogs-declarative": "4.1.6",
     "lodash": "^4.17.21",
@@ -41,7 +42,6 @@
   },
   "devDependencies": {
     "@types/node-fetch": "^2.5.7",
-    "adaptive-expressions": "4.1.6",
     "botbuilder-core": "4.1.6",
     "botbuilder-dialogs": "4.1.6",
     "fs-extra": "^7.0.1",


### PR DESCRIPTION
Fixes #4179

## Description
4 E2E test pipelines are failing. A sample error:
```
npm ERR! path D:\a\1\s\samples\typescript_nodejs\13.core-bot
node_modules/botbuilder-ai/lib/luisAdaptivePredictionOptions.d.ts(8,79): error TS2307: Cannot find module 'adaptive-expressions' or its corresponding type declarations.
```
This was a regression from this PR: https://github.com/microsoft/botbuilder-js/pull/4152
## The fix
Move the "adaptive-expressions" reference in libraries/botbuilder-ai/package.json from devDependencies to dependencies.

## Tests
Running against the packages with the fix, the 4 failing test pipelines passed:
- https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=298474&view=results
- https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=298472&view=results
- https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=298471&view=results
- https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=298473&view=results
