### PR TITLE
fix: Azure Blob transcript key 

### DIFF
--- a/libraries/botbuilder-azure-blobs/etc/botbuilder-azure-blobs.api.md
+++ b/libraries/botbuilder-azure-blobs/etc/botbuilder-azure-blobs.api.md
@@ -31,11 +31,12 @@ export class BlobsTranscriptStore implements TranscriptStore {
     deleteTranscript(channelId: string, conversationId: string): Promise<void>;
     getTranscriptActivities(channelId: string, conversationId: string, continuationToken?: string, startDate?: Date): Promise<PagedResult<Activity>>;
     listTranscripts(channelId: string, continuationToken?: string): Promise<PagedResult<TranscriptInfo>>;
-    logActivity(activity: Activity): Promise<void>;
+    logActivity(activity: Activity, options?: BlobsTranscriptStoreOptions): Promise<void>;
     }
 
 // @public
 export interface BlobsTranscriptStoreOptions {
+    decodeTranscriptKey?: boolean;
     storagePipelineOptions?: StoragePipelineOptions;
 }
 

--- a/libraries/botbuilder-azure-blobs/src/sanitizeBlobKey.ts
+++ b/libraries/botbuilder-azure-blobs/src/sanitizeBlobKey.ts
@@ -14,5 +14,5 @@ export function sanitizeBlobKey(key: string): string {
     }
 
     const sanitized = key.split('/').reduce((acc, part, idx) => (part ? [acc, part].join(idx < 255 ? '/' : '') : acc));
-    return encodeURIComponent(sanitized).substr(0, 1024);
+    return decodeURIComponent(sanitized).substr(0, 1024);
 }

--- a/libraries/botbuilder-azure-blobs/src/sanitizeBlobKey.ts
+++ b/libraries/botbuilder-azure-blobs/src/sanitizeBlobKey.ts
@@ -1,18 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { BlobsTranscriptStoreOptions } from './blobsTranscriptStore';
+
 /**
  * Ensures that `key` is a properly sanitized Azure Blob Storage key. It should be URI encoded,
  * no longer than 1024 characters, and contain no more than 254 slash ("/") chars.
  *
  * @param {string} key string blob key to sanitize
+ * @param {BlobsTranscriptStoreOptions} options Optional settings for BlobsTranscriptStore
  * @returns {string} sanitized blob key
  */
-export function sanitizeBlobKey(key: string): string {
+export function sanitizeBlobKey(key: string, options?: BlobsTranscriptStoreOptions): string {
     if (!key || !key.length) {
         throw new Error('Please provide a non-empty key');
     }
 
     const sanitized = key.split('/').reduce((acc, part, idx) => (part ? [acc, part].join(idx < 255 ? '/' : '') : acc));
-    return decodeURIComponent(sanitized).substr(0, 1024);
+
+    // Options settings to decode key in order to support previous Blob
+    if (options?.decodeTranscriptKey) {
+        return decodeURIComponent(sanitized).substr(0, 1024);
+    }
+    return encodeURIComponent(sanitized).substr(0, 1024);
 }

--- a/libraries/botbuilder-azure-blobs/tests/blobsTranscriptStore.test.js
+++ b/libraries/botbuilder-azure-blobs/tests/blobsTranscriptStore.test.js
@@ -24,6 +24,11 @@ describe('BlobsStorage', function () {
         timestamp: new Date(),
     };
 
+    // Options for BlobsTranscriptStore.
+    const blobTranscriptOptions = {
+        decodeTranscriptKey: false,
+    };
+
     // Constructs a random channel ID and set of activities, and then handles preloading
     // and clearing them with beforeEach/afterEach IFF client is defined
     const maybePreload = () => {
@@ -77,7 +82,7 @@ describe('BlobsStorage', function () {
         });
 
         maybeIt('should log an activity', async () => {
-            await client.logActivity(activity);
+            await client.logActivity(activity, blobTranscriptOptions);
         });
     });
 

--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/index.ts
@@ -96,6 +96,7 @@ function addFeatures(services: ServiceCollection, configuration: Configuration):
                         .object({
                             connectionString: z.string(),
                             containerName: z.string(),
+                            decodeTranscriptKey: z.boolean().optional(),
                         })
                         .nonstrict()
                 );


### PR DESCRIPTION
Fixes #4176 <!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Expecting Azure blob to creat transcript activity and follow the pattern of `container/{channelId]/{conversationId}/{Timestamp.ticks}-{activity.id}.json`

instead it was creating directory `container%2F{channelId}%2F{conversationId}%2F{Timestamp.ticks}-{activid.id}.json` due to [sanitizeBlobKey ](https://github.com/microsoft/botbuilder-js/blob/c5de4422f37793e6080949974368e3a41846a7a6/libraries/botbuilder-azure-blobs/src/sanitizeBlobKey.ts#L11)method using the [encodeURIComponent ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)function.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Created optional `decodeTranscriptKey` boolean property in [`BlobsTranscriptStoreOptions`](https://github.com/microsoft/botbuilder-js/blob/ramfattah/blobTranscript/libraries/botbuilder-azure-blobs/src/blobsTranscriptStore.ts#:~:text=export%20interface%20BlobsTranscriptStoreOptions%20%7B) interface to return a new string representing the decoded version of the given encoded blob transcript key. This remains the default behavior to false but can be overridden by setting decodeTranscriptKey to true.

## Steps to reproduce

> Prerequisite: Azure Blob

1) Run `git clone --branch ramfattah/blobTranscript https://github.com/microsoft/botbuilder-js.git`

2) Run `yarn` and `yarn build` in the root folder of SDK

3) Open `libraries/botbuilder-azure-blobs/tests/blobsTranscriptStore.test.js` file
     * Add your blob `connectionString` and `containerName`. Note, it will create the container automatically if the name doesn't already exist. 
     * ![image](https://user-images.githubusercontent.com/38049078/163324478-a7df1ea9-87ca-44aa-9a79-e783474c0fd7.png)
     * Flip `decodeTranscriptKey` flag to true
     * ![image](https://user-images.githubusercontent.com/38049078/163324930-e9bf4415-cbc9-4cff-beb5-8c9d8b600ba9.png)

4) In terminal, run `mocha <path-to-blobsTranscriptStore.test.js`
     * Ex: `mocha /Users/ram/Documents/bot/botbuilder-js/libraries/botbuilder-azure-blobs/tests/blobsTranscriptStore.test.js`

5) This will create blob transcript key in the container as the following pattern  `container/{channelId]/{conversationId}/{Timestamp.ticks}-{activity.id}.json`


## Before
![image](https://user-images.githubusercontent.com/38049078/162111343-9ad4741e-e24f-4ac4-b58d-005dc82f225a.png)

## After

[![Image from Gyazo](https://i.gyazo.com/ebd603d7ed9ab57f8471de489901332e.gif)](https://gyazo.com/ebd603d7ed9ab57f8471de489901332e)

