### PR TITLE
fix: Move "adaptive-expressions" to dependencies (#4178)

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@azure/cognitiveservices-luis-runtime": "2.0.0",
     "@azure/ms-rest-js": "1.9.1",
+    "adaptive-expressions": "4.1.6",
     "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
     "botbuilder-dialogs-declarative": "4.1.6",
     "lodash": "^4.17.21",
@@ -41,7 +42,6 @@
   },
   "devDependencies": {
     "@types/node-fetch": "^2.5.7",
-    "adaptive-expressions": "4.1.6",
     "botbuilder-core": "4.1.6",
     "botbuilder-dialogs": "4.1.6",
     "fs-extra": "^7.0.1",


### PR DESCRIPTION
#minor

Cherry pick to 4.16 for AE dependency for AI package