### PR TITLE
fix: Force dependencies on async to v 3.2.3 - branch releases/4.16

### DIFF
--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@azure/cognitiveservices-luis-runtime": "2.0.0",
     "@azure/ms-rest-js": "1.9.1",
+    "adaptive-expressions": "4.1.6",
     "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
     "botbuilder-dialogs-declarative": "4.1.6",
     "lodash": "^4.17.21",
@@ -41,7 +42,6 @@
   },
   "devDependencies": {
     "@types/node-fetch": "^2.5.7",
-    "adaptive-expressions": "4.1.6",
     "botbuilder-core": "4.1.6",
     "botbuilder-dialogs": "4.1.6",
     "fs-extra": "^7.0.1",

--- a/libraries/botbuilder-azure-blobs/etc/botbuilder-azure-blobs.api.md
+++ b/libraries/botbuilder-azure-blobs/etc/botbuilder-azure-blobs.api.md
@@ -31,11 +31,12 @@ export class BlobsTranscriptStore implements TranscriptStore {
     deleteTranscript(channelId: string, conversationId: string): Promise<void>;
     getTranscriptActivities(channelId: string, conversationId: string, continuationToken?: string, startDate?: Date): Promise<PagedResult<Activity>>;
     listTranscripts(channelId: string, continuationToken?: string): Promise<PagedResult<TranscriptInfo>>;
-    logActivity(activity: Activity): Promise<void>;
+    logActivity(activity: Activity, options?: BlobsTranscriptStoreOptions): Promise<void>;
     }
 
 // @public
 export interface BlobsTranscriptStoreOptions {
+    decodeTranscriptKey?: boolean;
     storagePipelineOptions?: StoragePipelineOptions;
 }
 

--- a/libraries/botbuilder-azure-blobs/src/sanitizeBlobKey.ts
+++ b/libraries/botbuilder-azure-blobs/src/sanitizeBlobKey.ts
@@ -1,18 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { BlobsTranscriptStoreOptions } from './blobsTranscriptStore';
+
 /**
  * Ensures that `key` is a properly sanitized Azure Blob Storage key. It should be URI encoded,
  * no longer than 1024 characters, and contain no more than 254 slash ("/") chars.
  *
  * @param {string} key string blob key to sanitize
+ * @param {BlobsTranscriptStoreOptions} options Optional settings for BlobsTranscriptStore
  * @returns {string} sanitized blob key
  */
-export function sanitizeBlobKey(key: string): string {
+export function sanitizeBlobKey(key: string, options?: BlobsTranscriptStoreOptions): string {
     if (!key || !key.length) {
         throw new Error('Please provide a non-empty key');
     }
 
     const sanitized = key.split('/').reduce((acc, part, idx) => (part ? [acc, part].join(idx < 255 ? '/' : '') : acc));
+
+    // Options settings to decode key in order to support previous Blob
+    if (options?.decodeTranscriptKey) {
+        return decodeURIComponent(sanitized).substr(0, 1024);
+    }
     return encodeURIComponent(sanitized).substr(0, 1024);
 }

--- a/libraries/botbuilder-azure-blobs/tests/blobsTranscriptStore.test.js
+++ b/libraries/botbuilder-azure-blobs/tests/blobsTranscriptStore.test.js
@@ -24,6 +24,11 @@ describe('BlobsStorage', function () {
         timestamp: new Date(),
     };
 
+    // Options for BlobsTranscriptStore.
+    const blobTranscriptOptions = {
+        decodeTranscriptKey: false,
+    };
+
     // Constructs a random channel ID and set of activities, and then handles preloading
     // and clearing them with beforeEach/afterEach IFF client is defined
     const maybePreload = () => {
@@ -77,7 +82,7 @@ describe('BlobsStorage', function () {
         });
 
         maybeIt('should log an activity', async () => {
-            await client.logActivity(activity);
+            await client.logActivity(activity, blobTranscriptOptions);
         });
     });
 

--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/index.ts
@@ -96,6 +96,7 @@ function addFeatures(services: ServiceCollection, configuration: Configuration):
                         .object({
                             connectionString: z.string(),
                             containerName: z.string(),
+                            decodeTranscriptKey: z.boolean().optional(),
                         })
                         .nonstrict()
                 );

--- a/libraries/botbuilder-repo-utils/package.json
+++ b/libraries/botbuilder-repo-utils/package.json
@@ -16,7 +16,7 @@
     "globby": "^11.0.1",
     "lodash": "^4.17.20",
     "minimatch": "^3.0.4",
-    "minimist": "^1.2.5",
+    "minimist": "^1.2.6",
     "p-map": "^4.0.0"
   },
   "devDependencies": {

--- a/libraries/botbuilder-repo-utils/src/package.ts
+++ b/libraries/botbuilder-repo-utils/src/package.ts
@@ -15,6 +15,7 @@ export interface Package {
 
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
 
     scripts?: Record<string, string>;
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "update-versions": "yarn workspace botbuilder-repo-utils update-versions"
   },
   "resolutions": {
+    "async": "3.2.3",
     "mixme": "0.5.2",
     "node-fetch": "2.6.7",
     "underscore": "1.13.1"

--- a/testing/browser-functional/browser-echo-bot/yarn.lock
+++ b/testing/browser-functional/browser-echo-bot/yarn.lock
@@ -4395,9 +4395,9 @@ minimatch@^3.0.4:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mississippi@^3.0.0:
   version "3.0.0"

--- a/testing/consumer-test/package.json
+++ b/testing/consumer-test/package.json
@@ -35,7 +35,7 @@
     "botframework-connector": "4.1.6",
     "botframework-schema": "4.1.6",
     "botframework-streaming": "4.1.6",
-    "minimist": "^1.2.5",
+    "minimist": "^1.2.6",
     "p-map": "^4.0.0"
   },
   "devDependencies": {

--- a/testing/streaming-e2e/react-app/package-lock.json
+++ b/testing/streaming-e2e/react-app/package-lock.json
@@ -9012,9 +9012,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minipass": {
       "version": "3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9183,10 +9183,10 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9425,9 +9425,9 @@ mold-source-map@~0.4.0:
     through "~2.2.7"
 
 moment@^2.19.3, moment@^2.21.0, moment@^2.22.2:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
+  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2917,34 +2917,10 @@ async-listener@^0.6.0:
     semver "^5.3.0"
     shimmer "^1.1.0"
 
-async@0.9.x:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
-  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
-
-async@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
-  integrity sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==
-  dependencies:
-    lodash "^4.14.0"
-
-async@>=0.6.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
-  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
-
-async@^1.4.0, async@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
-
-async@^2.6.1, async@^2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
-  dependencies:
-    lodash "^4.17.14"
+async@0.9.x, async@2.6.0, async@3.2.3, async@>=0.6.0, async@^1.4.0, async@^1.5.2, async@^2.6.1, async@^2.6.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -8745,7 +8721,7 @@ lodash.trimend@^4.5.1:
   resolved "https://registry.yarnpkg.com/lodash.trimend/-/lodash.trimend-4.5.1.tgz#12804437286b98cad8996b79414e11300114082f"
   integrity sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8=
 
-lodash@^4.1.2, lodash@^4.14.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@~4.17.15, lodash@~4.17.19:
+lodash@^4.1.2, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@~4.17.15, lodash@~4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
Fixes #4188

## Description
Component Governance alerts like [this one](https://fuselabs.visualstudio.com/SDK_v4/_componentGovernance/112352/alert/6862405?typeId=11638130) recommend:
"Upgrade async...to 3.2.2 to fix the vulnerability." V 3.2.3 is now the latest.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - 
  -
  -

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->