### PR TITLE
fix: sku for Microsoft.BotService/botServices in 2 ARM templates

### DIFF
--- a/testing/functional/functionaltestbot/template/linux/template.json
+++ b/testing/functional/functionaltestbot/template/linux/template.json
@@ -3,8 +3,15 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "botName": {
-            "type": "string",            
+            "type": "string",
             "minLength": 2
+        },
+        "botSku": {
+        "defaultValue": "F0",
+        "type": "string",
+        "metadata": {
+            "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+        }
         },
         "sku": {
             "defaultValue": {
@@ -51,7 +58,7 @@
             "properties": {
                 "name": "[parameters('botName')]",
                 "reserved": true,
-                "perSiteScaling": false,                
+                "perSiteScaling": false,
                 "targetWorkerCount": 0,
                 "targetWorkerSizeId": 0
             }
@@ -105,7 +112,7 @@
                 "containerSize": 0,
                 "dailyMemoryTimeQuota": 0,
                 "httpsOnly": false
-            }        
+            }
         },
         {
             "type": "Microsoft.Web/sites/config",
@@ -204,7 +211,7 @@
 			"location": "global",
 			"kind": "bot",
 			"sku": {
-				"name": "[parameters('botName')]"
+				"name": "[parameters('botSku')]"
 			},
 			"properties": {
 				"name": "[parameters('botName')]",

--- a/testing/testbot/template/linux/template.json
+++ b/testing/testbot/template/linux/template.json
@@ -3,8 +3,15 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "botName": {
-            "type": "string",            
+            "type": "string",
             "minLength": 2
+        },
+        "botSku": {
+        "defaultValue": "F0",
+        "type": "string",
+        "metadata": {
+            "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+        }
         },
         "sku": {
             "defaultValue": {
@@ -51,7 +58,7 @@
             "properties": {
                 "name": "[parameters('botName')]",
                 "reserved": true,
-                "perSiteScaling": false,                
+                "perSiteScaling": false,
                 "targetWorkerCount": 0,
                 "targetWorkerSizeId": 0
             }
@@ -105,7 +112,7 @@
                 "containerSize": 0,
                 "dailyMemoryTimeQuota": 0,
                 "httpsOnly": false
-            }        
+            }
         },
         {
             "type": "Microsoft.Web/sites/config",
@@ -204,7 +211,7 @@
 			"location": "global",
 			"kind": "bot",
 			"sku": {
-				"name": "[parameters('botName')]"
+				"name": "[parameters('botSku')]"
 			},
 			"properties": {
 				"name": "[parameters('botName')]",


### PR DESCRIPTION
Fixes #minor

## Description
This fixes the bot SKU format as was done for Samples in this PR: https://github.com/microsoft/BotBuilder-Samples/pull/3732

Pipeline Run-JS-Functional-Tests-Linux is failling.