### PR TITLE
fix: Critical alert for es5-ext 0.10.60

### DIFF
--- a/testing/streaming-e2e/build/create-react-app.yml
+++ b/testing/streaming-e2e/build/create-react-app.yml
@@ -14,27 +14,27 @@ steps:
     condition: ne(variables.CacheRestored, 'true')
     workingDirectory: $(ReactProjectDir)
 
-  - powershell: npm install react-scripts@4.0.3
-    displayName: npm install react-scripts@4.0.3
+  - powershell: npm install react-scripts@5.0.1
+    displayName: npm install react-scripts@5.0.1
     workingDirectory: $(ReactProjectDir)
 
   - template: customize-dljs.yml
-  
+
   - powershell: npm install $(DLJSDir)/botframework-directlinejs.tgz
     displayName: 'npm install botframework-directlinejs.tgz'
     workingDirectory: $(ReactProjectDir)
-  
+
   - powershell: |
       Rename-Item ./botframework-directlinejs botframework-directlinejs.old
       Rename-Item ./botframework-streaming botframework-streaming.old
       ls
     displayName: Rename DLJS node modules
     workingDirectory: $(ReactProjectDir)/node_modules/botframework-webchat/node_modules
-  
+
   - powershell: npm run build
     displayName: Build React App
     workingDirectory: $(ReactProjectDir)
-  
+
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Artifact: ReactApp'
     inputs:


### PR DESCRIPTION
Fixes #minor

## Description
Pipeline [E2E_BF-Streaming-DL-ASE_Test](https://dev.azure.com/FuseLabs/SDK_v4/_build?definitionId=1018&_a=summary) is failing in task Component Detection with 1 Malware alert(s) rated at 'Critical’ severity. Malicious component found: es5-ext 0.10.60
```
npm ls es5-ext
react-app@0.1.0 C:\src\botbuilder-js\testing\streaming-e2e\react-app
`-- react-scripts@4.0.3
  `-- resolve-url-loader@3.1.4
    `-- es6-iterator@2.0.3
      +-- d@1.0.1
      | `-- es5-ext@0.10.60  deduped
      `-- es5-ext@0.10.60
```
## Specific Changes
Update react-scripts to v 5.0.1
```
npm ls es5-ext
react-app@0.1.0 C:\src\botbuilder-js\testing\streaming-e2e\react-app
`-- (empty)
```
