### PR TITLE
fix: Critical alert for es5-ext 0.10.60

### DIFF
--- a/testing/streaming-e2e/build/create-react-app.yml
+++ b/testing/streaming-e2e/build/create-react-app.yml
@@ -19,24 +19,27 @@ steps:
     workingDirectory: $(ReactProjectDir)
 
   - template: customize-dljs.yml
-  
+
   - powershell: npm install $(DLJSDir)/botframework-directlinejs.tgz
     displayName: 'npm install botframework-directlinejs.tgz'
     workingDirectory: $(ReactProjectDir)
-  
+
   - powershell: |
       Rename-Item ./botframework-directlinejs botframework-directlinejs.old
       Rename-Item ./botframework-streaming botframework-streaming.old
       ls
     displayName: Rename DLJS node modules
     workingDirectory: $(ReactProjectDir)/node_modules/botframework-webchat/node_modules
-  
+
   - powershell: npm run build
     displayName: Build React App
     workingDirectory: $(ReactProjectDir)
-  
+
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Artifact: ReactApp'
     inputs:
       targetPath: $(ReactProjectDir)/build
       artifactName: 'ReactApp'
+
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'

--- a/testing/streaming-e2e/react-app/package.json
+++ b/testing/streaming-e2e/react-app/package.json
@@ -9,7 +9,10 @@
     "botframework-webchat": "4.10.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-scripts": "3.4.3"
+    "react-scripts": "^4.0.3"
+  },
+  "overrides": {
+    "es5-ext": "0.10.53"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Fixes #minor

## Description
Pipeline [E2E_BF-Streaming-DL-ASE_Test](https://dev.azure.com/FuseLabs/SDK_v4/_build?definitionId=1018&_a=summary) is failing in task Component Detection with 1 Malware alert(s) rated at 'Critical’ severity. Malicious component found: es5-ext 0.10.60
```
npm ls es5-ext
react-app@0.1.0 C:\src\botbuilder-js\testing\streaming-e2e\react-app
`-- react-scripts@4.0.3
  `-- resolve-url-loader@3.1.4
    `-- es6-iterator@2.0.3
      +-- d@1.0.1
      | `-- es5-ext@0.10.60  deduped
      `-- es5-ext@0.10.60
```
I tried updating react-scripts to v 5.0.1, but that broke the build at step Build React App with "Can't resolve 'stream'".

## Specific Changes
Override "es5-ext" downgrading it to "0.10.53". (0.10.60 is the latest version.)

This fix resolves the es5-ext 0.10.60 critical alert and stops the build from failing.

Add Component Governance task. This replaces the injected CG task, which only runs against the main branch. It makes testing CG fixes easier.