### PR TITLE
fix: Botbuilder-ai bugs

### DIFF
--- a/libraries/botbuilder-ai/src/qnaMaker.ts
+++ b/libraries/botbuilder-ai/src/qnaMaker.ts
@@ -270,12 +270,6 @@ export class QnAMaker implements QnAMakerClient, QnAMakerTelemetryClient {
 
         if (question.length > 0) {
             result = await this.generateAnswerUtils.queryQnaServiceRaw(this.endpoint, question, queryOptions);
-
-            const sortedQnaAnswers: QnAMakerResult[] = GenerateAnswerUtils.sortAnswersWithinThreshold(
-                result.answers,
-                queryOptions
-            );
-            queryResult.push(...sortedQnaAnswers);
         }
 
         if (!result) {
@@ -284,13 +278,13 @@ export class QnAMaker implements QnAMakerClient, QnAMakerTelemetryClient {
 
         await Promise.all([
             // Log telemetry
-            this.onQnaResults(queryResult, context, telemetryProperties, telemetryMetrics),
-            this.generateAnswerUtils.emitTraceInfo(context, queryResult, queryOptions),
+            this.onQnaResults(result?.answers, context, telemetryProperties, telemetryMetrics),
+            this.generateAnswerUtils.emitTraceInfo(context, result?.answers, queryOptions),
         ]);
 
         const qnaResponse: QnAMakerResults = {
             activeLearningEnabled: result.activeLearningEnabled,
-            answers: queryResult,
+            answers: result?.answers,
         };
 
         return qnaResponse;

--- a/libraries/botbuilder-ai/src/qnaMaker.ts
+++ b/libraries/botbuilder-ai/src/qnaMaker.ts
@@ -260,7 +260,6 @@ export class QnAMaker implements QnAMakerClient, QnAMakerTelemetryClient {
         telemetryProperties?: { [key: string]: string },
         telemetryMetrics?: { [key: string]: number }
     ): Promise<QnAMakerResults> {
-        const queryResult: QnAMakerResult[] = [] as QnAMakerResult[];
         const question: string = this.getTrimmedMessageText(context);
         const queryOptions: QnAMakerOptions = { ...this._options, ...options } as QnAMakerOptions;
 

--- a/libraries/botbuilder-ai/src/qnaMakerDialog.ts
+++ b/libraries/botbuilder-ai/src/qnaMakerDialog.ts
@@ -731,12 +731,14 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
         if (response?.length > 0) {
             const activity = dialogOptions.qnaDialogResponseOptions.noAnswer;
             if (response[0].id !== -1) {
-                await step.context.sendActivity(response[0].answer);
+                const message = QnACardBuilder.getQnAAnswerCard(response[0], this.displayPreciseAnswerOnly);
+                await step.context.sendActivity(message);
             } else {
                 if (activity && activity.text) {
                     await step.context.sendActivity(activity);
                 } else {
-                    await step.context.sendActivity(response[0].answer);
+                    const message = QnACardBuilder.getQnAAnswerCard(response[0], this.displayPreciseAnswerOnly);
+                    await step.context.sendActivity(message);
                 }
             }
         } else {
@@ -906,25 +908,19 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
 
         if (response?.length > 0 && response[0].id != -1) {
             const answer = response[0];
-            if (answer.answerSpan?.text || answer?.context?.prompts?.length > 0) {
-                if (answer?.context?.prompts?.length > 0) {
-                    const previousContextData: { [key: string]: number } = {};
+            if (answer?.context?.prompts?.length > 0) {
+                const previousContextData: { [key: string]: number } = {};
 
-                    answer.context.prompts.forEach((prompt) => {
-                        previousContextData[prompt.displayText] = prompt.qnaId;
-                    });
+                answer.context.prompts.forEach((prompt) => {
+                    previousContextData[prompt.displayText] = prompt.qnaId;
+                });
 
-                    step.activeDialog.state[this.qnAContextData] = previousContextData;
-                    step.activeDialog.state[this.previousQnAId] = answer.id;
-                    step.activeDialog.state[this.options] = dialogOptions;
-                    const message = QnACardBuilder.getQnAAnswerCard(answer, this.displayPreciseAnswerOnly);
-                    await step.context.sendActivity(message);
-                    return Dialog.EndOfTurn;
-                } else {
-                    const message = QnACardBuilder.getQnAAnswerCard(answer, this.displayPreciseAnswerOnly);
-                    await step.context.sendActivity(message);
-                    return step.endDialog();
-                }
+                step.activeDialog.state[this.qnAContextData] = previousContextData;
+                step.activeDialog.state[this.previousQnAId] = answer.id;
+                step.activeDialog.state[this.options] = dialogOptions;
+                const message = QnACardBuilder.getQnAAnswerCard(answer, this.displayPreciseAnswerOnly);
+                await step.context.sendActivity(message);
+                return Dialog.EndOfTurn;
             }
         }
 

--- a/libraries/botbuilder-ai/src/qnaMakerDialog.ts
+++ b/libraries/botbuilder-ai/src/qnaMakerDialog.ts
@@ -917,12 +917,16 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
                     step.activeDialog.state[this.qnAContextData] = previousContextData;
                     step.activeDialog.state[this.previousQnAId] = answer.id;
                     step.activeDialog.state[this.options] = dialogOptions;
+                    const message = QnACardBuilder.getQnAAnswerCard(answer, this.displayPreciseAnswerOnly);
+                    await step.context.sendActivity(message);
+                    return Dialog.EndOfTurn;
+                }
+                else {
+                    const message = QnACardBuilder.getQnAAnswerCard(answer, this.displayPreciseAnswerOnly);
+                    await step.context.sendActivity(message);
+                    return step.endDialog();
                 }
 
-                const message = QnACardBuilder.getQnAAnswerCard(answer, this.displayPreciseAnswerOnly);
-                await step.context.sendActivity(message);
-
-                return Dialog.EndOfTurn;
             }
         }
 

--- a/libraries/botbuilder-ai/src/qnaMakerDialog.ts
+++ b/libraries/botbuilder-ai/src/qnaMakerDialog.ts
@@ -920,13 +920,11 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
                     const message = QnACardBuilder.getQnAAnswerCard(answer, this.displayPreciseAnswerOnly);
                     await step.context.sendActivity(message);
                     return Dialog.EndOfTurn;
-                }
-                else {
+                } else {
                     const message = QnACardBuilder.getQnAAnswerCard(answer, this.displayPreciseAnswerOnly);
                     await step.context.sendActivity(message);
                     return step.endDialog();
                 }
-
             }
         }
 

--- a/libraries/botbuilder-ai/src/qnamaker-utils/generateAnswerUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/generateAnswerUtils.ts
@@ -159,25 +159,6 @@ export class GenerateAnswerUtils {
         }
     }
 
-    /**
-     * Sorts all QnAMakerResult from highest-to-lowest scoring.
-     * Filters QnAMakerResults within threshold specified (default threshold: .001).
-     *
-     * @param {QnAMakerResult[]} answers Answers returned by QnA Maker.
-     * @param {QnAMakerOptions} queryOptions (Optional) The options for the QnA Maker knowledge base. If null, constructor option is used for this instance.
-     * @returns {QnAMakerResult[]} the sorted and filtered results
-     */
-    static sortAnswersWithinThreshold(
-        answers: QnAMakerResult[] = [] as QnAMakerResult[],
-        queryOptions: QnAMakerOptions
-    ): QnAMakerResult[] {
-        const minScore: number = typeof queryOptions.scoreThreshold === 'number' ? queryOptions.scoreThreshold : 0.001;
-
-        return answers
-            .filter((ans: QnAMakerResult) => ans.score >= minScore)
-            .sort((a: QnAMakerResult, b: QnAMakerResult) => b.score - a.score);
-    }
-
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private formatQnaResult(qnaResult: QnAMakerResults | any): QnAMakerResults {
         qnaResult.answers = qnaResult.answers.map((answer: QnAMakerResult & { qnaId?: number }) => {

--- a/libraries/botbuilder-ai/tests/qnaMaker.test.js
+++ b/libraries/botbuilder-ai/tests/qnaMaker.test.js
@@ -302,7 +302,7 @@ describe('QnAMaker', function () {
 
             const results = await qna.getAnswers(context, options);
 
-            assert.strictEqual(results.length, 0);
+            assert.strictEqual(results.length, 1);
         });
 
         it('calls qnamaker with rankerType questionOnly', async function () {
@@ -312,7 +312,7 @@ describe('QnAMaker', function () {
 
             const results = await qna.getAnswers(context, options);
 
-            assert.strictEqual(results.length, 0);
+            assert.strictEqual(results.length, 1);
         });
 
         it('returns answer with timeout option specified', async function () {
@@ -456,14 +456,14 @@ describe('QnAMaker', function () {
                     sinon.match({
                         name: 'QnaMessage',
                         properties: sinon.match({
-                            answer: sinon.match.string,
-                            articleFound: 'false',
                             knowledgeBaseId,
-                            matchedQuestion: 'No Qna Question matched',
                             question: 'where are the unicorns?',
-                            questionId: 'No Qna Question Id matched',
                             username: sinon.match.string,
+                            questionId: '-1',
+                            answer: sinon.match.string,
+                            articleFound: 'true',
                         }),
+                        metrics: { score: 0 },
                     })
                 )
                 .once();
@@ -475,7 +475,8 @@ describe('QnAMaker', function () {
 
             sandbox.verify();
             assert(qna.logPersonalInformation);
-            assert.deepStrictEqual(results, []);
+            assert.strictEqual(results.length, 1);
+            assert.strictEqual(results[0].answer, 'No good match found in KB.');
         });
 
         it('does not log telemetry pii', async function () {


### PR DESCRIPTION
Fixes #4207
Fixes #4205

## Description
1) Card is formed for every response and check for answerSpan is removed from checkForMultiTurnPrompt in qnamakerDialog to maintain parity with C#.
2) Sorting and filtering of the answers is removed from generateAnswerUtils

## Testing
Updated QnAMaker tests.