### PR TITLE
fix: [#4204] Fix remaining eslint warnings - botbuilder-core (2/2)

### DIFF
--- a/libraries/botbuilder-core/package.json
+++ b/libraries/botbuilder-core/package.json
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "chatdown": "^1.2.4",
-    "lodash": "^4.17.20",
     "request": "^2.88.2",
     "unzipper": "^0.10.9"
   },

--- a/libraries/botbuilder-core/tests/ActivityHandler.test.js
+++ b/libraries/botbuilder-core/tests/ActivityHandler.test.js
@@ -1,5 +1,12 @@
 const assert = require('assert');
-const { ActivityHandler, ActivityTypes, Channels, TestAdapter, tokenResponseEventName, TurnContext } = require('../lib');
+const {
+    ActivityHandler,
+    ActivityTypes,
+    Channels,
+    TestAdapter,
+    tokenResponseEventName,
+    TurnContext,
+} = require('../lib');
 
 describe('ActivityHandler', function () {
     const adapter = new TestAdapter();
@@ -17,7 +24,7 @@ describe('ActivityHandler', function () {
         await bot.run(context);
     }
 
-    it(`should fire onTurn for any inbound activity`, async function () {
+    it('should fire onTurn for any inbound activity', async function () {
         const bot = new ActivityHandler();
 
         let onTurnCalled = false;
@@ -30,7 +37,7 @@ describe('ActivityHandler', function () {
         assert(onTurnCalled);
     });
 
-    it(`should fire onMessage for any message activities`, async function () {
+    it('should fire onMessage for any message activities', async function () {
         const bot = new ActivityHandler();
 
         let onMessageCalled = false;
@@ -43,7 +50,7 @@ describe('ActivityHandler', function () {
         assert(onMessageCalled);
     });
 
-    it(`calling  next allows following events to firing`, async function () {
+    it('calling  next allows following events to firing', async function () {
         const bot = new ActivityHandler();
 
         let onTurnCalled = false;
@@ -63,11 +70,11 @@ describe('ActivityHandler', function () {
         assert(onMessageCalled);
     });
 
-    it(`omitting call to next prevents following events from firing`, async function () {
+    it('omitting call to next prevents following events from firing', async function () {
         const bot = new ActivityHandler();
 
         let onTurnCalled = false;
-        bot.onTurn(async (context, next) => {
+        bot.onTurn(async (_context, _next) => {
             onTurnCalled = true;
         });
 
@@ -82,19 +89,19 @@ describe('ActivityHandler', function () {
         assert(!onMessageCalled);
     });
 
-    it(`binding 2 methods to the same event both fire`, async function () {
+    it('binding 2 methods to the same event both fire', async function () {
         const bot = new ActivityHandler();
         let count = 0;
 
         let onMessageCalled = false;
-        bot.onMessage(async (context, next) => {
+        bot.onMessage(async (_context, next) => {
             onMessageCalled = true;
             count++;
             await next();
         });
 
         let onMessageCalledAgain = false;
-        bot.onMessage(async (context, next) => {
+        bot.onMessage(async (_context, next) => {
             onMessageCalledAgain = true;
             count++;
             await next();
@@ -106,7 +113,7 @@ describe('ActivityHandler', function () {
         assert(count === 2, 'all events did fire');
     });
 
-    it(`should fire onConversationUpdate`, async function () {
+    it('should fire onConversationUpdate', async function () {
         const bot = new ActivityHandler();
 
         let onConversationUpdateCalled = false;
@@ -119,7 +126,7 @@ describe('ActivityHandler', function () {
         assert(onConversationUpdateCalled);
     });
 
-    it(`should fire onMembersAdded`, async function () {
+    it('should fire onMembersAdded', async function () {
         const bot = new ActivityHandler();
 
         let onMembersAddedCalled = false;
@@ -132,7 +139,7 @@ describe('ActivityHandler', function () {
         assert(onMembersAddedCalled);
     });
 
-    it(`should fire onMembersRemoved`, async function () {
+    it('should fire onMembersRemoved', async function () {
         const bot = new ActivityHandler();
 
         let onMembersRemovedCalled = false;
@@ -145,7 +152,7 @@ describe('ActivityHandler', function () {
         assert(onMembersRemovedCalled);
     });
 
-    it(`should fire onMessageReaction`, async function () {
+    it('should fire onMessageReaction', async function () {
         const bot = new ActivityHandler();
 
         let onMessageReactionCalled = false;
@@ -158,7 +165,7 @@ describe('ActivityHandler', function () {
         assert(onMessageReactionCalled);
     });
 
-    it(`should fire onReactionsAdded`, async function () {
+    it('should fire onReactionsAdded', async function () {
         const bot = new ActivityHandler();
 
         let onReactionsAddedCalled = false;
@@ -171,7 +178,7 @@ describe('ActivityHandler', function () {
         assert(onReactionsAddedCalled);
     });
 
-    it(`should fire onReactionsRemoved`, async function () {
+    it('should fire onReactionsRemoved', async function () {
         const bot = new ActivityHandler();
 
         let onReactionsRemovedCalled = false;
@@ -184,7 +191,7 @@ describe('ActivityHandler', function () {
         assert(onReactionsRemovedCalled);
     });
 
-    it(`should fire onEvent`, async function () {
+    it('should fire onEvent', async function () {
         const bot = new ActivityHandler();
 
         let onEventCalled = false;
@@ -197,7 +204,7 @@ describe('ActivityHandler', function () {
         assert(onEventCalled);
     });
 
-    it(`should fire onEndOfConversation`, async function () {
+    it('should fire onEndOfConversation', async function () {
         const bot = new ActivityHandler();
 
         let onEndConversationCalled = false;
@@ -210,7 +217,7 @@ describe('ActivityHandler', function () {
         assert(onEndConversationCalled);
     });
 
-    it(`should fire onTyping`, async function () {
+    it('should fire onTyping', async function () {
         const bot = new ActivityHandler();
 
         let onTypingCalled = false;
@@ -223,7 +230,7 @@ describe('ActivityHandler', function () {
         assert(onTypingCalled);
     });
 
-    it(`should fire onInstallationUpdate`, async function () {
+    it('should fire onInstallationUpdate', async function () {
         const bot = new ActivityHandler();
 
         let onInstallationUpdateCalled = false;
@@ -236,7 +243,7 @@ describe('ActivityHandler', function () {
         assert(onInstallationUpdateCalled);
     });
 
-    it(`should fire onInstallationUpdateAdd`, async function () {
+    it('should fire onInstallationUpdateAdd', async function () {
         const bot = new ActivityHandler();
 
         let onInstallationUpdateAddCalled = false;
@@ -249,7 +256,7 @@ describe('ActivityHandler', function () {
         assert(onInstallationUpdateAddCalled);
     });
 
-    it(`should fire onInstallationUpdateAddUpgrade`, async function () {
+    it('should fire onInstallationUpdateAddUpgrade', async function () {
         const bot = new ActivityHandler();
 
         let onInstallationUpdateAddCalled = false;
@@ -262,7 +269,7 @@ describe('ActivityHandler', function () {
         assert(onInstallationUpdateAddCalled);
     });
 
-    it(`should fire onInstallationUpdateRemove`, async function () {
+    it('should fire onInstallationUpdateRemove', async function () {
         const bot = new ActivityHandler();
 
         let onInstallationUpdateRemoveCalled = false;
@@ -275,7 +282,7 @@ describe('ActivityHandler', function () {
         assert(onInstallationUpdateRemoveCalled);
     });
 
-    it(`should fire onInstallationUpdateRemoveUpgrade`, async function () {
+    it('should fire onInstallationUpdateRemoveUpgrade', async function () {
         const bot = new ActivityHandler();
 
         let onInstallationUpdateRemoveCalled = false;
@@ -288,7 +295,7 @@ describe('ActivityHandler', function () {
         assert(onInstallationUpdateRemoveCalled);
     });
 
-    it(`should fire onAdaptiveCardInvoke`, async function () {
+    it('should fire onAdaptiveCardInvoke', async function () {
         const bot = new ActivityHandler();
 
         let onAdpativeCardInvokeCalled = false;
@@ -312,7 +319,7 @@ describe('ActivityHandler', function () {
         assert(onAdpativeCardInvokeCalled);
     });
 
-    it(`should fire onUnrecognizedActivityType`, async function () {
+    it('should fire onUnrecognizedActivityType', async function () {
         const bot = new ActivityHandler();
 
         let onUnrecognizedActivityTypeCalled = false;
@@ -325,7 +332,7 @@ describe('ActivityHandler', function () {
         assert(onUnrecognizedActivityTypeCalled);
     });
 
-    it(`should fire onDialog`, async function () {
+    it('should fire onDialog', async function () {
         const bot = new ActivityHandler();
 
         let onDialogCalled = false;
@@ -339,7 +346,7 @@ describe('ActivityHandler', function () {
     });
 
     describe('ActivityHandler.onSearchInvoke', function () {
-        it(`should fire onSearchInvoke`, async function () {
+        it('should fire onSearchInvoke', async function () {
             const activity = {
                 type: ActivityTypes.Invoke,
                 name: 'application/search',
@@ -348,37 +355,37 @@ describe('ActivityHandler', function () {
                     queryText: 'test bot',
                     queryOptions: {
                         skip: 5,
-                        top: 10
+                        top: 10,
                     },
-                    context: "bot framework"
+                    context: 'bot framework',
                 },
             };
 
             await assertonSearchInvoke(activity, activity.value.kind);
         });
 
-        it(`should throw on onSearchInvoke activity missing value`, async function () {
+        it('should throw on onSearchInvoke activity missing value', async function () {
             const activity = {
                 type: ActivityTypes.Invoke,
-                name: 'application/search'
+                name: 'application/search',
             };
 
             await assertSearchResultError(activity, 'Missing value property for search');
         });
 
-        it(`should throw on onSearchInvoke activity missing kind`, async function () {
+        it('should throw on onSearchInvoke activity missing kind', async function () {
             const activity = {
                 type: ActivityTypes.Invoke,
                 name: 'application/search',
                 value: {
-                    queryText: 'test bot'
-                }
+                    queryText: 'test bot',
+                },
             };
 
             await assertSearchResultError(activity, 'Missing kind property for search.');
         });
 
-        it(`should not throw on onSearchInvoke activity missing kind when channel is msTeams`, async function () {
+        it('should not throw on onSearchInvoke activity missing kind when channel is msTeams', async function () {
             const activity = {
                 type: ActivityTypes.Invoke,
                 name: 'application/search',
@@ -387,21 +394,21 @@ describe('ActivityHandler', function () {
                     queryText: 'test bot',
                     queryOptions: {
                         skip: 5,
-                        top: 10
-                    }
-                }
+                        top: 10,
+                    },
+                },
             };
 
             await assertonSearchInvoke(activity, 'search');
         });
 
-        it(`should throw on onSearchInvoke activity missing queryText`, async function () {
+        it('should throw on onSearchInvoke activity missing queryText', async function () {
             const activity = {
                 type: ActivityTypes.Invoke,
                 name: 'application/search',
                 value: {
-                    kind: 'search'
-                }
+                    kind: 'search',
+                },
             };
 
             await assertSearchResultError(activity, 'Missing queryText for search.');
@@ -435,7 +442,7 @@ describe('ActivityHandler', function () {
             const testAdapter = new TestAdapter();
 
             let onSearchInvokeCalled = false;
-            bot.onSearchInvoke = async (context, invokeValue) => {
+            bot.onSearchInvoke = async (_context, _invokeValue) => {
                 onSearchInvokeCalled = true;
                 return { statusCode: 200, value: 'called' };
             };

--- a/libraries/botbuilder-core/tests/activityHandlerBase.test.js
+++ b/libraries/botbuilder-core/tests/activityHandlerBase.test.js
@@ -203,7 +203,7 @@ describe('ActivityHandlerBase', function () {
             return activity;
         }
 
-        it(`should call onMembersAddedActivity if the id of the member added does not match the recipient's id`, async function () {
+        it("should call onMembersAddedActivity if the id of the member added does not match the recipient's id", async function () {
             const bot = new ConversationUpdateActivityHandler();
             const activity = createConvUpdateActivity('bot', { membersAdded: [{ id: 'user' }] });
 
@@ -214,7 +214,7 @@ describe('ActivityHandlerBase', function () {
             assert(onMembersAddedActivityCalled, 'onMembersAddedActivity was not called');
         });
 
-        it(`should call onMembersRemovedActivity if the id of the member removed does not match the recipient's id`, async function () {
+        it("should call onMembersRemovedActivity if the id of the member removed does not match the recipient's id", async function () {
             const bot = new ConversationUpdateActivityHandler();
             const activity = createConvUpdateActivity('bot', { membersRemoved: [{ id: 'user' }] });
 
@@ -225,7 +225,7 @@ describe('ActivityHandlerBase', function () {
             assert(onMembersRemovedActivityCalled, 'onMembersRemovedActivity was not called');
         });
 
-        it(`should not call onMembersAddedActivity if the id of the member added matches the recipient's id`, async function () {
+        it("should not call onMembersAddedActivity if the id of the member added matches the recipient's id", async function () {
             const bot = new ConversationUpdateActivityHandler();
             const activity = createConvUpdateActivity('bot', { membersAdded: [{ id: 'bot' }] }, true);
 
@@ -235,7 +235,7 @@ describe('ActivityHandlerBase', function () {
             assert(onConversationUpdateActivityCalled, 'onConversationUpdateActivity was not called');
         });
 
-        it(`should not call onMembersRemovedActivity if the id of the member removed matches the recipient's id`, async function () {
+        it("should not call onMembersRemovedActivity if the id of the member removed matches the recipient's id", async function () {
             const bot = new ConversationUpdateActivityHandler();
             const activity = createConvUpdateActivity('bot', { membersRemoved: [{ id: 'bot' }] }, true);
 
@@ -296,7 +296,7 @@ describe('ActivityHandlerBase', function () {
             return activity;
         }
 
-        it(`should call onReactionsAddedActivity if reactionsAdded exists and reactionsAdded.length > 0`, async function () {
+        it('should call onReactionsAddedActivity if reactionsAdded exists and reactionsAdded.length > 0', async function () {
             const bot = new MessageReactionActivityHandler();
             const activity = createMsgReactActivity('bot', { reactionsAdded: [{ type: 'like' }] });
 
@@ -307,7 +307,7 @@ describe('ActivityHandlerBase', function () {
             assert(onReactionsAddedActivityCalled, 'onReactionsAddedActivity was not called');
         });
 
-        it(`should call onReactionsRemovedActivity if reactionsRemoved exists and reactionsRemoved.length > 0`, async function () {
+        it('should call onReactionsRemovedActivity if reactionsRemoved exists and reactionsRemoved.length > 0', async function () {
             const bot = new MessageReactionActivityHandler();
             const activity = createMsgReactActivity('bot', { reactionsRemoved: [{ type: 'like' }] });
 
@@ -318,7 +318,7 @@ describe('ActivityHandlerBase', function () {
             assert(onReactionsRemovedActivityCalled, 'onReactionsRemovedActivity was not called');
         });
 
-        it(`should call onReactionsAddedActivity if reactionsAdded and onReactionsRemovedActivity if reactionsRemoved if they both exist and have items`, async function () {
+        it('should call onReactionsAddedActivity if reactionsAdded and onReactionsRemovedActivity if reactionsRemoved if they both exist and have items', async function () {
             const bot = new MessageReactionActivityHandler();
             const activity = createMsgReactActivity('bot', {
                 reactionsAdded: [{ type: 'laugh' }],

--- a/libraries/botbuilder-core/tests/autoSaveStateMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/autoSaveStateMiddleware.test.js
@@ -11,8 +11,8 @@ class BotStateMock {
         this.writeCalled = false;
     }
     load(context, force) {
-        assert(context, `BotStateMock.load() not passed context.`);
-        if (this.assertForce) assert(force, `BotStateMock.load(): force not set.`);
+        assert(context, 'BotStateMock.load() not passed context.');
+        if (this.assertForce) assert(force, 'BotStateMock.load(): force not set.');
         this.readCalled = true;
         return new Promise((resolve, _reject) => {
             setTimeout(() => resolve(this.state), Math.random() * 50);
@@ -20,8 +20,8 @@ class BotStateMock {
     }
 
     saveChanges(context, force) {
-        assert(context, `BotStateMock.saveChanges() not passed context.`);
-        if (this.assertForce) assert(force, `BotStateMock.saveChanges(): force not set.`);
+        assert(context, 'BotStateMock.saveChanges() not passed context.');
+        if (this.assertForce) assert(force, 'BotStateMock.saveChanges(): force not set.');
         this.writeCalled = true;
         return new Promise((resolve, _reject) => {
             setTimeout(() => resolve(), Math.random() * 50);
@@ -29,7 +29,7 @@ class BotStateMock {
     }
 }
 
-describe(`AutoSaveStateMiddleware`, function () {
+describe('AutoSaveStateMiddleware', function () {
     this.timeout(5000);
 
     const adapter = new TestAdapter();
@@ -37,65 +37,65 @@ describe(`AutoSaveStateMiddleware`, function () {
     const fooState = new BotStateMock({ foo: 'bar' });
     const barState = new BotStateMock({ bar: 'foo' });
 
-    it(`should add() and call loadAll() on a single BotState plugin.`, async function () {
+    it('should add() and call loadAll() on a single BotState plugin.', async function () {
         const set = new AutoSaveStateMiddleware().add(fooState);
         await set.botStateSet.loadAll(context);
     });
 
-    it(`should add() and call loadAll() on multiple BotState plugins.`, async function () {
+    it('should add() and call loadAll() on multiple BotState plugins.', async function () {
         const set = new AutoSaveStateMiddleware().add(fooState, barState);
         await set.botStateSet.loadAll(context);
     });
 
-    it(`should add() and call saveAllChanges() on a single BotState plugin.`, async function () {
+    it('should add() and call saveAllChanges() on a single BotState plugin.', async function () {
         const set = new AutoSaveStateMiddleware().add(fooState);
         await set.botStateSet.saveAllChanges(context);
-        assert(fooState.writeCalled, `write not called for plugin.`);
+        assert(fooState.writeCalled, 'write not called for plugin.');
     });
 
-    it(`should add() and call saveAllChanges() on multiple BotState plugins.`, async function () {
+    it('should add() and call saveAllChanges() on multiple BotState plugins.', async function () {
         const set = new AutoSaveStateMiddleware().add(fooState, barState);
         await set.botStateSet.saveAllChanges(context);
-        assert(fooState.writeCalled || barState.writeCalled, `write not called for either plugin.`);
-        assert(fooState.writeCalled, `write not called for 'fooState' plugin.`);
-        assert(barState.writeCalled, `write not called for 'barState' plugin.`);
+        assert(fooState.writeCalled || barState.writeCalled, 'write not called for either plugin.');
+        assert(fooState.writeCalled, "write not called for 'fooState' plugin.");
+        assert(barState.writeCalled, "write not called for 'barState' plugin.");
     });
 
-    it(`should pass 'force' flag through in loadAll() call.`, async function () {
+    it("should pass 'force' flag through in loadAll() call.", async function () {
         const fooState = new BotStateMock({ foo: 'bar' });
         fooState.assertForce = true;
         const set = new AutoSaveStateMiddleware().add(fooState);
         await set.botStateSet.loadAll(context, true);
     });
 
-    it(`should pass 'force' flag through in saveAllChanges() call.`, async function () {
+    it("should pass 'force' flag through in saveAllChanges() call.", async function () {
         const fooState = new BotStateMock({ foo: 'bar' });
         fooState.assertForce = true;
         const set = new AutoSaveStateMiddleware().add(fooState);
         await set.botStateSet.saveAllChanges(context, true);
     });
 
-    it(`should work as a middleware plugin.`, async function () {
+    it('should work as a middleware plugin.', async function () {
         const set = new AutoSaveStateMiddleware().add(fooState);
         await set.onTurn(context, () => Promise.resolve());
-        assert(fooState.writeCalled, `saveAllChanges() not called.`);
+        assert(fooState.writeCalled, 'saveAllChanges() not called.');
     });
 
-    it(`should support plugins passed to constructor.`, async function () {
+    it('should support plugins passed to constructor.', async function () {
         const set = new AutoSaveStateMiddleware(fooState);
         await set.onTurn(context, () => Promise.resolve());
-        assert(fooState.writeCalled, `saveAllChanges() not called.`);
+        assert(fooState.writeCalled, 'saveAllChanges() not called.');
     });
 
-    it(`should throw exception if invalid plugin passed in.`, function () {
+    it('should throw exception if invalid plugin passed in.', function () {
         assert.throws(
             () => new AutoSaveStateMiddleware(fooState, { read: () => {} }),
             new Error("BotStateSet: a object was added that isn't an instance of BotState.")
         );
     });
 
-    it(`should not add any BotState on construction if none are passed in.`, async function () {
+    it('should not add any BotState on construction if none are passed in.', async function () {
         const middleware = new AutoSaveStateMiddleware();
-        assert(middleware.botStateSet.botStates.length === 0, `should not have added any BotState.`);
+        assert(middleware.botStateSet.botStates.length === 0, 'should not have added any BotState.');
     });
 });

--- a/libraries/botbuilder-core/tests/botAdapter.test.js
+++ b/libraries/botbuilder-core/tests/botAdapter.test.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const { uniqueId } = require('lodash');
 const sinon = require('sinon');
 const { BotAdapter, TurnContext } = require('../');
 
@@ -12,13 +11,13 @@ class SimpleAdapter extends BotAdapter {
     }
 }
 
-describe('BotAdapter', () => {
+describe('BotAdapter', function () {
     let sandbox;
-    beforeEach(() => {
+    beforeEach(function () {
         sandbox = sinon.createSandbox();
     });
 
-    afterEach(() => {
+    afterEach(function () {
         sandbox.restore();
     });
 
@@ -26,18 +25,18 @@ describe('BotAdapter', () => {
 
     const getAdapter = () => new SimpleAdapter();
 
-    describe('middleware handling', () => {
-        it('should use() middleware individually', () => {
+    describe('middleware handling', function () {
+        it('should use() middleware individually', function () {
             const adapter = getAdapter();
             adapter.use(getNextFake()).use(getNextFake());
         });
 
-        it('should use() a list of middleware', () => {
+        it('should use() a list of middleware', function () {
             const adapter = getAdapter();
             adapter.use(getNextFake(), getNextFake(), getNextFake());
         });
 
-        it('should run all middleware', async () => {
+        it('should run all middleware', async function () {
             const adapter = getAdapter();
 
             const middlewares = [getNextFake(), getNextFake()];
@@ -57,8 +56,8 @@ describe('BotAdapter', () => {
         });
     });
 
-    describe('Get locale from activity', () => {
-        it('should have locale', async () => {
+    describe('Get locale from activity', function () {
+        it('should have locale', async function () {
             const adapter = getAdapter();
             const activity = testMessage;
             activity.locale = 'de-DE';
@@ -71,7 +70,7 @@ describe('BotAdapter', () => {
         });
     });
 
-    describe('onTurnError', () => {
+    describe('onTurnError', function () {
         const testCases = [
             { label: 'promise is rejected', logic: () => Promise.reject('error') },
             {
@@ -83,7 +82,7 @@ describe('BotAdapter', () => {
         ];
 
         testCases.forEach(({ label, logic }) => {
-            it(`should reach onTurnError when a ${label}`, async () => {
+            it(`should reach onTurnError when a ${label}`, async function () {
                 const adapter = getAdapter();
 
                 adapter.onTurnError = sandbox.fake((context, error) => {
@@ -99,7 +98,7 @@ describe('BotAdapter', () => {
                 assert(handler.called, 'handler was called');
             });
 
-            it(`should propagate error when onTurnError is not defined and a ${label}`, async () => {
+            it(`should propagate error when onTurnError is not defined and a ${label}`, async function () {
                 const adapter = getAdapter();
 
                 const handler = sandbox.fake(logic);
@@ -112,7 +111,7 @@ describe('BotAdapter', () => {
                 assert(handler.called, 'handler was called');
             });
 
-            it(`should propagate error if a ${label} in onTurnError when a ${label} in handler`, async () => {
+            it(`should propagate error if a ${label} in onTurnError when a ${label} in handler`, async function () {
                 const adapter = getAdapter();
 
                 adapter.onTurnError = sandbox.fake((context, error) => {
@@ -134,8 +133,8 @@ describe('BotAdapter', () => {
         });
     });
 
-    describe('proxy context revocation', () => {
-        it('should revoke after execution', async () => {
+    describe('proxy context revocation', function () {
+        it('should revoke after execution', async function () {
             const adapter = getAdapter();
 
             const handler = sandbox.fake((context) => {
@@ -149,7 +148,7 @@ describe('BotAdapter', () => {
             assert.throws(() => context.activity, 'accessing context property should throw since it has been revoked');
         });
 
-        it('should revoke after onTurnError', async () => {
+        it('should revoke after onTurnError', async function () {
             const adapter = getAdapter();
 
             adapter.onTurnError = sandbox.fake((context) => {
@@ -165,7 +164,7 @@ describe('BotAdapter', () => {
             assert.throws(() => context.activity, 'accessing context property should throw since it has been revoked');
         });
 
-        it('should revoke after unhandled error', async () => {
+        it('should revoke after unhandled error', async function () {
             const adapter = getAdapter();
 
             const handler = sandbox.fake(() => Promise.reject('error'));

--- a/libraries/botbuilder-core/tests/botState.test.js
+++ b/libraries/botbuilder-core/tests/botState.test.js
@@ -9,98 +9,101 @@ function cachedState(context, stateKey) {
     return cached ? cached.state : undefined;
 }
 
-describe(`BotState`, function () {
+describe('BotState', function () {
     this.timeout(5000);
 
     const storage = new MemoryStorage();
     const adapter = new TestAdapter();
     const context = new TurnContext(adapter, receivedMessage);
     const botState = new BotState(storage, (context) => {
-        assert(context, `context not passed into storage stateKey factory.`);
+        assert(context, 'context not passed into storage stateKey factory.');
         return storageKey;
     });
-    it(`should return undefined from get() if nothing cached.`, async function () {
+    it('should return undefined from get() if nothing cached.', async function () {
         const state = botState.get(context);
-        assert(state === undefined, `state returned.`);
+        assert(state === undefined, 'state returned.');
     });
 
-    it(`should load and save state from storage.`, async function () {
+    it('should load and save state from storage.', async function () {
         await botState.load(context);
-        let state = cachedState(context, botState.stateKey);
-        assert(state, `State not loaded`);
+        const state = cachedState(context, botState.stateKey);
+        assert(state, 'State not loaded');
         state.test = 'foo';
         await botState.saveChanges(context);
 
         const items = await storage.read([storageKey]);
-        assert(items.hasOwnProperty(storageKey), `Saved state not found in storage.`);
-        assert(items[storageKey].test === 'foo', `Missing test value in stored state.`);
+        assert(Object.prototype.hasOwnProperty.call(items, storageKey), 'Saved state not found in storage.');
+        assert(items[storageKey].test === 'foo', 'Missing test value in stored state.');
     });
 
-    it(`should force load() of state from storage.`, async function () {
+    it('should force load() of state from storage.', async function () {
         await botState.load(context);
         const state = cachedState(context, botState.stateKey);
-        assert(state.test === 'foo', `invalid initial state`);
+        assert(state.test === 'foo', 'invalid initial state');
         delete state.test === 'foo';
         await botState.load(context, true);
-        assert(cachedState(context, botState.stateKey).test === 'foo', `state not reloaded`);
+        assert(cachedState(context, botState.stateKey).test === 'foo', 'state not reloaded');
     });
 
-    it(`should clear() state storage.`, async function () {
+    it('should clear() state storage.', async function () {
         await botState.load(context);
-        assert(cachedState(context, botState.stateKey).test === 'foo', `invalid initial state`);
+        assert(cachedState(context, botState.stateKey).test === 'foo', 'invalid initial state');
         await botState.clear(context);
-        assert(!cachedState(context, botState.stateKey).hasOwnProperty('test'), `state not cleared on context.`);
+        assert(
+            !Object.prototype.hasOwnProperty.call(cachedState(context, botState.stateKey), 'test'),
+            'state not cleared on context.'
+        );
         await botState.saveChanges(context);
 
         const items = await storage.read([storageKey]);
-        assert(items[storageKey], `state removed from storage.`);
-        assert(!items[storageKey].hasOwnProperty('test'), `state not cleared from storage.`);
+        assert(items[storageKey], 'state removed from storage.');
+        assert(!Object.prototype.hasOwnProperty.call(items[storageKey], 'test'), 'state not cleared from storage.');
     });
 
-    it(`should delete() state storage.`, async function () {
+    it('should delete() state storage.', async function () {
         await botState.load(context);
-        assert(cachedState(context, botState.stateKey), `invalid initial state`);
+        assert(cachedState(context, botState.stateKey), 'invalid initial state');
         await botState.delete(context);
-        assert(!cachedState(context, botState.stateKey), `state not cleared on context.`);
+        assert(!cachedState(context, botState.stateKey), 'state not cleared on context.');
 
         const items = await storage.read([storageKey]);
-        assert(!items.hasOwnProperty(storageKey), `state not removed from storage.`);
+        assert(!Object.prototype.hasOwnProperty.call(items, storageKey), 'state not removed from storage.');
     });
 
-    it(`should force immediate saveChanges() of state to storage.`, async function () {
+    it('should force immediate saveChanges() of state to storage.', async function () {
         await botState.load(context);
         const state = cachedState(context, botState.stateKey);
-        assert(!state.hasOwnProperty('foo'), `invalid initial state`);
+        assert(!Object.prototype.hasOwnProperty.call(state, 'foo'), 'invalid initial state');
         state.test = 'foo';
         await botState.saveChanges(context, true);
         const items = await storage.read([storageKey]);
-        assert(items[storageKey].test === 'foo', `state not immediately flushed.`);
+        assert(items[storageKey].test === 'foo', 'state not immediately flushed.');
     });
 
-    it(`should load() from storage if cached state missing.`, async function () {
+    it('should load() from storage if cached state missing.', async function () {
         context.turnState.set(botState.stateKey, undefined);
         const state = await botState.load(context);
-        assert(state.test === 'foo', `state not loaded.`);
+        assert(state.test === 'foo', 'state not loaded.');
     });
 
-    it(`should load() from storage if cached.state missing.`, async function () {
+    it('should load() from storage if cached.state missing.', async function () {
         context.turnState.set(botState.stateKey, {});
         const state = await botState.load(context);
-        assert(state.test === 'foo', `state not loaded.`);
+        assert(state.test === 'foo', 'state not loaded.');
     });
 
-    it(`should force saveChanges() to storage of an empty state object.`, async function () {
+    it('should force saveChanges() to storage of an empty state object.', async function () {
         context.turnState.set(botState.stateKey, undefined);
         await botState.saveChanges(context, true);
     });
 
-    it(`should no-op calls to clear() when nothing cached.`, async function () {
+    it('should no-op calls to clear() when nothing cached.', async function () {
         context.turnState.set(botState.stateKey, undefined);
         await botState.clear(context);
     });
 
-    it(`should create new PropertyAccessors`, async function () {
-        let count = botState.createProperty('count', 1);
-        assert(count !== undefined, `did not successfully create PropertyAccessor.`);
+    it('should create new PropertyAccessors', async function () {
+        const count = botState.createProperty('count', 1);
+        assert(count !== undefined, 'did not successfully create PropertyAccessor.');
     });
 });

--- a/libraries/botbuilder-core/tests/botStatePropertyAccessor.test.js
+++ b/libraries/botbuilder-core/tests/botStatePropertyAccessor.test.js
@@ -3,45 +3,45 @@ const { BotState, MemoryStorage, TestAdapter, TurnContext } = require('../');
 
 const storageKey = 'stateKey';
 
-describe(`BotStatePropertyAccessor`, function () {
+describe('BotStatePropertyAccessor', function () {
     this.timeout(5000);
 
     const receivedActivity = { text: 'received', type: 'message' };
     const storage = new MemoryStorage();
     const adapter = new TestAdapter();
     const botState = new BotState(storage, (context) => {
-        assert(context, `context not passed into storage stateKey factory.`);
+        assert(context, 'context not passed into storage stateKey factory.');
         return storageKey;
     });
     const staticContext = new TurnContext(adapter, receivedActivity);
 
-    it(`should use default value when a default value is assigned.`, async function () {
+    it('should use default value when a default value is assigned.', async function () {
         const USER_COUNT = 'userCount';
         const userProperty = botState.createProperty(USER_COUNT);
 
         const tAdapter = new TestAdapter(async (context) => {
-            let userCount = await userProperty.get(context, 100);
-            assert(userCount === 100, `default value for PropertyAccessor was not used.`);
+            const userCount = await userProperty.get(context, 100);
+            assert(userCount === 100, 'default value for PropertyAccessor was not used.');
             await botState.saveChanges(context);
         });
 
-        await tAdapter.receiveActivity(`Hello world!`);
+        await tAdapter.receiveActivity('Hello world!');
     });
 
-    it(`should return undefined when default value is not assigned.`, async function () {
+    it('should return undefined when default value is not assigned.', async function () {
         const NO_DEFAULT_VALUE = 'noValue';
         const testProperty = botState.createProperty(NO_DEFAULT_VALUE);
 
         const tAdapter = new TestAdapter(async (context) => {
-            let testValue = await testProperty.get(context);
-            assert(testValue === undefined, `PropertyAccessor's value was not undefined.`);
+            const testValue = await testProperty.get(context);
+            assert(testValue === undefined, "PropertyAccessor's value was not undefined.");
             await botState.saveChanges(context);
         });
 
-        await tAdapter.receiveActivity(`Hello world!`);
+        await tAdapter.receiveActivity('Hello world!');
     });
 
-    it(`should save changes to registered Property multiple times.`, async function () {
+    it('should save changes to registered Property multiple times.', async function () {
         const MESSAGE_COUNT = 'messageCount';
         const messageProperty = botState.createProperty(MESSAGE_COUNT);
 
@@ -54,11 +54,11 @@ describe(`BotStatePropertyAccessor`, function () {
         });
 
         await tAdapter
-            .test(`Hello world!`, `1`, `messageCount was not incremented.`)
-            .test(`Hello world!`, `2`, `messageCount was not properly saved.`);
+            .test('Hello world!', '1', 'messageCount was not incremented.')
+            .test('Hello world!', '2', 'messageCount was not properly saved.');
     });
 
-    it(`should delete property value on state.`, async function () {
+    it('should delete property value on state.', async function () {
         const BOOLEAN_PROPERTY = 'booleanProperty';
         const booleanProperty = botState.createProperty(BOOLEAN_PROPERTY);
 
@@ -69,20 +69,20 @@ describe(`BotStatePropertyAccessor`, function () {
             await booleanProperty.set(context, booleanValue);
 
             // Retrieve the property value which should be true.
-            let retrievedValue = await booleanProperty.get(context);
-            assert(booleanValue, `value for PropertyAccessor was not properly saved.`);
+            const retrievedValue = await booleanProperty.get(context);
+            assert(retrievedValue, 'value for PropertyAccessor was not properly saved.');
 
             // Delete the value from state, and verify that the value is now undefined.
             await booleanProperty.delete(context);
-            let noPropertyValue = await booleanProperty.get(context);
-            assert(noPropertyValue === undefined, `value for PropertyAccessor was not properly deleted.`);
+            const noPropertyValue = await booleanProperty.get(context);
+            assert(noPropertyValue === undefined, 'value for PropertyAccessor was not properly deleted.');
             await botState.saveChanges(context);
         });
 
-        await tAdapter.receiveActivity(`Hello world!`);
+        await tAdapter.receiveActivity('Hello world!');
     });
 
-    it(`should not delete anything if property not found in current state.`, async function () {
+    it('should not delete anything if property not found in current state.', async function () {
         const DOES_NOT_EXIST = 'doesNotExist';
         const doesNotExistProperty = botState.createProperty(DOES_NOT_EXIST);
 
@@ -93,50 +93,50 @@ describe(`BotStatePropertyAccessor`, function () {
             await botState.saveChanges(context);
         });
 
-        await tAdapter.receiveActivity(`Hello world!`);
+        await tAdapter.receiveActivity('Hello world!');
     });
 
-    it(`should successfully set default value if default value is an Array.`, async function () {
+    it('should successfully set default value if default value is an Array.', async function () {
         const NUMBERS_PROPERTY = 'numbersProperty';
         const numbersProperty = botState.createProperty(NUMBERS_PROPERTY);
 
         const tAdapter = new TestAdapter(async (context) => {
-            let numbersValue = await numbersProperty.get(context, [1]);
-            assert(Array.isArray(numbersValue), `default value for PropertyAccessor was not properly set.`);
+            const numbersValue = await numbersProperty.get(context, [1]);
+            assert(Array.isArray(numbersValue), 'default value for PropertyAccessor was not properly set.');
             assert(numbersValue.length === 1, `numbersValue.length should be 1, not ${numbersValue.length}.`);
             assert(numbersValue[0] === 1, `numbersValue[0] should be 1, not ${numbersValue[0]}.`);
             await botState.saveChanges(context);
         });
 
-        await tAdapter.receiveActivity(`Hello world!`);
+        await tAdapter.receiveActivity('Hello world!');
     });
 
-    it(`should successfully set default value if default value is an Object.`, async function () {
+    it('should successfully set default value if default value is an Object.', async function () {
         const ADDRESS_PROPERTY = 'addressProperty';
         const addressProperty = botState.createProperty(ADDRESS_PROPERTY);
 
         const tAdapter = new TestAdapter(async (context) => {
-            let addressValue = await addressProperty.get(context, {
+            const addressValue = await addressProperty.get(context, {
                 street: '1 Microsoft Way',
                 zipCode: 98052,
                 state: 'WA',
             });
-            assert(typeof addressValue === 'object', `default value for PropertyAccessor was not properly set.`);
+            assert(typeof addressValue === 'object', 'default value for PropertyAccessor was not properly set.');
             assert(
                 addressValue.street === '1 Microsoft Way',
-                `default value for PropertyAccessor was not properly set.`
+                'default value for PropertyAccessor was not properly set.'
             );
-            assert(addressValue.zipCode === 98052, `default value for PropertyAccessor was not properly set.`);
-            assert(addressValue.state === 'WA', `default value for PropertyAccessor was not properly set.`);
+            assert(addressValue.zipCode === 98052, 'default value for PropertyAccessor was not properly set.');
+            assert(addressValue.state === 'WA', 'default value for PropertyAccessor was not properly set.');
             await botState.saveChanges(context);
         });
 
-        await tAdapter.receiveActivity(`Hello world!`);
+        await tAdapter.receiveActivity('Hello world!');
     });
 
-    it(`should get() initial default value when a second get() with a second default value is called.`, async function () {
+    it('should get() initial default value when a second get() with a second default value is called.', async function () {
         const testState = new BotState(storage, (context) => {
-            assert(context, `context was not passed into storage stateKey factory.`);
+            assert(context, 'context was not passed into storage stateKey factory.');
             return 'testState';
         });
         const WORD_PROPERTY = 'word';
@@ -144,12 +144,12 @@ describe(`BotStatePropertyAccessor`, function () {
 
         const tAdapter = new TestAdapter(async (turnContext) => {
             let word = await wordProperty.get(turnContext, 'word');
-            assert(word === 'word', `default value for "wordProperty" was not properly set.`);
+            assert(word === 'word', 'default value for "wordProperty" was not properly set.');
 
             word = await wordProperty.get(turnContext, 'second');
             assert(word === 'word', `expected value of "word" for word, received "${word}".`);
         });
 
-        await tAdapter.receiveActivity(`Hello world!`);
+        await tAdapter.receiveActivity('Hello world!');
     });
 });

--- a/libraries/botbuilder-core/tests/botStateSet.test.js
+++ b/libraries/botbuilder-core/tests/botStateSet.test.js
@@ -1,67 +1,46 @@
 const assert = require('assert');
 
-const { TurnContext, BotStateSet, BotState, MemoryStorage, UserState, ConversationState, TestAdapter } = require('../lib');
+const { TurnContext, BotStateSet, MemoryStorage, UserState, ConversationState, TestAdapter } = require('../lib');
 
-const receivedMessage = { text: 'received', type: 'message', channelId: 'test', from: { id: 'testuser' }, conversation: { id: 'conv' } };
+const receivedMessage = {
+    text: 'received',
+    type: 'message',
+    channelId: 'test',
+    from: { id: 'testuser' },
+    conversation: { id: 'conv' },
+};
 
-class BotStateMock {
-    constructor(state) {
-        this.state = state || {};
-        this.assertForce = false;
-        this.readCalled = false;
-        this.writeCalled = false;
-    }
-    load(context, force) {
-        assert(context, `BotStateMock.load() not passed context.`);
-        if (this.assertForce) assert(force, `BotStateMock.load(): force not set.`);
-        this.readCalled = true;
-        return new Promise((resolve, reject) => {
-            setTimeout(() => resolve(this.state), Math.random() * 50);
-        });
-    }
-
-    saveChanges(context, force) {
-        assert(context, `BotStateMock.saveChanges() not passed context.`);
-        if (this.assertForce) assert(force, `BotStateMock.saveChanges(): force not set.`);
-        this.writeCalled = true;
-        return new Promise((resolve, reject) => {
-            setTimeout(() => resolve(), Math.random() * 50);
-        });
-    }
-}
-
-describe(`BotStateSet`, function () {
+describe('BotStateSet', function () {
     this.timeout(5000);
 
     const adapter = new TestAdapter();
     const turnContext = new TurnContext(adapter, receivedMessage);
 
-    it(`should use() and call readAll() on a single BotState plugin.`, async function () {
+    it('should use() and call readAll() on a single BotState plugin.', async function () {
         const memoryStorage = new MemoryStorage();
         const userState = new UserState(memoryStorage);
         const convState = new ConversationState(memoryStorage);
 
-        let botStateSet = new BotStateSet(userState)
-            .add(convState);
+        const botStateSet = new BotStateSet(userState).add(convState);
         assert.equal(botStateSet.botStates.length, 2);
     });
 
-    it(`BotStateSet_LoadSave`, async function () {
+    it('BotStateSet_LoadSave', async function () {
         const memoryStorage = new MemoryStorage();
 
         {
             const userState = new UserState(memoryStorage);
             const convState = new ConversationState(memoryStorage);
-            let botStateSet = new BotStateSet(userState, convState);
+            const botStateSet = new BotStateSet(userState, convState);
 
-            let userProperty = userState.createProperty("userCount");
-            let convProperty = convState.createProperty("convCount");
+            const userProperty = userState.createProperty('userCount');
+            const convProperty = convState.createProperty('convCount');
 
             assert.equal(botStateSet.botStates.length, 2);
 
-            let userCount = await userProperty.get(turnContext, 0);
+            const userCount = await userProperty.get(turnContext, 0);
             assert.equal(userCount, 0);
-            let convCount = await convProperty.get(turnContext, 0);
+            const convCount = await convProperty.get(turnContext, 0);
             assert.equal(convCount, 0);
 
             await userProperty.set(turnContext, 10);
@@ -73,20 +52,19 @@ describe(`BotStateSet`, function () {
         {
             const userState = new UserState(memoryStorage);
             const convState = new ConversationState(memoryStorage);
-            let botStateSet = new BotStateSet(userState, convState);
+            const botStateSet = new BotStateSet(userState, convState);
 
-            let userProperty = userState.createProperty("userCount");
-            let convProperty = convState.createProperty("convCount");
+            const userProperty = userState.createProperty('userCount');
+            const convProperty = convState.createProperty('convCount');
 
             assert.equal(botStateSet.botStates.length, 2);
 
             await botStateSet.loadAll(turnContext);
 
-            let userCount = await userProperty.get(turnContext, 0);
+            const userCount = await userProperty.get(turnContext, 0);
             assert.equal(userCount, 10);
-            let convCount = await convProperty.get(turnContext, 0);
+            const convCount = await convProperty.get(turnContext, 0);
             assert.equal(convCount, 20);
         }
-
     });
 });

--- a/libraries/botbuilder-core/tests/cardFactory.test.js
+++ b/libraries/botbuilder-core/tests/cardFactory.test.js
@@ -2,368 +2,372 @@ const assert = require('assert');
 const { CardFactory } = require('../');
 
 function assertAttachment(attachment, contentType) {
-    assert(attachment, `attachment not created.`);
-    assert(attachment.contentType === contentType, `attachment has wrong contentType.`);
-    assert(attachment.content, `attachment missing content.`);
+    assert(attachment, 'attachment not created.');
+    assert(attachment.contentType === contentType, 'attachment has wrong contentType.');
+    assert(attachment.content, 'attachment missing content.');
 }
 
 function assertActions(actions, count, titles) {
-    assert(Array.isArray(actions), `actions not array.`);
-    assert(actions.length === count, `wrong number of actions returned.`);
+    assert(Array.isArray(actions), 'actions not array.');
+    assert(actions.length === count, 'wrong number of actions returned.');
     for (let i = 0; i < count; i++) {
-        assert(actions[i].title, `title[${ i }] missing`);
+        assert(actions[i].title, `title[${i}] missing`);
         if (titles) {
-            assert(actions[i].title === titles[i], `title[${ i }] invalid`);
+            assert(actions[i].title === titles[i], `title[${i}] invalid`);
         }
-        assert(actions[i].type, `type[${ i }] missing`);
-        assert(actions[i].value, `value[${ i }] missing`);
+        assert(actions[i].type, `type[${i}] missing`);
+        assert(actions[i].value, `value[${i}] missing`);
     }
 }
 
 function assertImages(images, count, links) {
-    assert(Array.isArray(images), `images not array.`);
-    assert(images.length === count, `wrong number of images returned.`);
+    assert(Array.isArray(images), 'images not array.');
+    assert(images.length === count, 'wrong number of images returned.');
     for (let i = 0; i < count; i++) {
-        assert(images[i].url, `image url[${ i }] missing`);
+        assert(images[i].url, `image url[${i}] missing`);
         if (links) {
-            assert(images[i].url === links[i], `image url[${ i }] invalid`);
+            assert(images[i].url === links[i], `image url[${i}] invalid`);
         }
     }
 }
 
 function assertMedia(media, count, links) {
-    assert(Array.isArray(media), `media not array.`);
-    assert(media.length === count, `wrong number of media returned.`);
+    assert(Array.isArray(media), 'media not array.');
+    assert(media.length === count, 'wrong number of media returned.');
     for (let i = 0; i < count; i++) {
-        assert(media[i].url, `media url[${ i }] missing`);
+        assert(media[i].url, `media url[${i}] missing`);
         if (links) {
-            assert(media[i].url === links[i], `media url[${ i }] invalid`);
+            assert(media[i].url === links[i], `media url[${i}] invalid`);
         }
     }
 }
 
 function assertOAuthActions(actions, title) {
-    assert(Array.isArray(actions), `received actions is not an array.`);
-    assert(actions.length === 1, `should have received only one action.`);
+    assert(Array.isArray(actions), 'received actions is not an array.');
+    assert(actions.length === 1, 'should have received only one action.');
     const button = actions[0];
-    assert(button.value === undefined, `OAuthCard actions' value should be undefined.`);
-    assert(button.title === title, `action's title [${ button.title }] is not expected "${ title }".`);
+    assert(button.value === undefined, "OAuthCard actions' value should be undefined.");
+    assert(button.title === title, `action's title [${button.title}] is not expected "${title}".`);
     assert(button.type === 'signin', `action's type [${button.type}] is not expected "signin".`);
 }
 
-describe(`CardFactory`, function () {
+describe('CardFactory', function () {
     this.timeout(5000);
 
-    it(`should map array of strings passed to actions() to CardAction objects.`, function () {
+    it('should map array of strings passed to actions() to CardAction objects.', function () {
         const actions = CardFactory.actions(['a', 'b', 'c']);
         assertActions(actions, 3, ['a', 'b', 'c']);
     });
 
-    it(`should support an array of CardAction options passed to actions().`, function () {
-        const actions = CardFactory.actions([{
-            title: 'foo',
-            type: 'postBack',
-            value: 'bar'
-        }]);
+    it('should support an array of CardAction options passed to actions().', function () {
+        const actions = CardFactory.actions([
+            {
+                title: 'foo',
+                type: 'postBack',
+                value: 'bar',
+            },
+        ]);
         assertActions(actions, 1, ['foo']);
-        assert(actions[0].type === 'postBack', `invalid action type`);
-        assert(actions[0].value === 'bar', `invalid action value.`);
+        assert(actions[0].type === 'postBack', 'invalid action type');
+        assert(actions[0].value === 'bar', 'invalid action value.');
     });
 
-    it(`should support a 'undefined' actions array passed to actions().`, function () {
+    it("should support a 'undefined' actions array passed to actions().", function () {
         const actions = CardFactory.actions(undefined);
         assertActions(actions, 0);
     });
 
-    it(`should map array of strings passed to images() to CardImage objects.`, function () {
+    it('should map array of strings passed to images() to CardImage objects.', function () {
         const images = CardFactory.images(['a', 'b', 'c']);
         assertImages(images, 3, ['a', 'b', 'c']);
     });
 
-    it(`should support an array of CardImage options passed to images().`, function () {
-        const images = CardFactory.images([{
-            url: 'foo',
-            alt: 'bar',
-            tap: {}
-        }]);
+    it('should support an array of CardImage options passed to images().', function () {
+        const images = CardFactory.images([
+            {
+                url: 'foo',
+                alt: 'bar',
+                tap: {},
+            },
+        ]);
         assertImages(images, 1, ['foo']);
-        assert(images[0].alt === 'bar', `invalid image.alt property.`);
-        assert(typeof images[0].tap === 'object', `invalid image.type property.`);
+        assert(images[0].alt === 'bar', 'invalid image.alt property.');
+        assert(typeof images[0].tap === 'object', 'invalid image.type property.');
     });
 
-    it(`should support a 'undefined' images array passed to images().`, function () {
+    it("should support a 'undefined' images array passed to images().", function () {
         const images = CardFactory.images(undefined);
         assertImages(images, 0);
     });
 
-    it(`should map array of strings passed to media() to CardMedia objects.`, function () {
+    it('should map array of strings passed to media() to CardMedia objects.', function () {
         const media = CardFactory.media(['a', 'b', 'c']);
         assertMedia(media, 3, ['a', 'b', 'c']);
     });
 
-    it(`should support an array of CardMedia options passed to media().`, function () {
-        const media = CardFactory.media([{
-            url: 'foo',
-            profile: 'bar'
-        }]);
+    it('should support an array of CardMedia options passed to media().', function () {
+        const media = CardFactory.media([
+            {
+                url: 'foo',
+                profile: 'bar',
+            },
+        ]);
         assertMedia(media, 1, ['foo']);
-        assert(media[0].profile === 'bar', `invalid media.profile property.`);
+        assert(media[0].profile === 'bar', 'invalid media.profile property.');
     });
 
-    it(`should support a 'undefined' media array passed to media().`, function () {
+    it("should support a 'undefined' media array passed to media().", function () {
         const media = CardFactory.media(undefined);
         assertMedia(media, 0);
     });
 
-    it(`should create an adaptiveCard().`, function () {
+    it('should create an adaptiveCard().', function () {
         const attachment = CardFactory.adaptiveCard({ type: 'AdaptiveCard' });
         assertAttachment(attachment, CardFactory.contentTypes.adaptiveCard);
-        assert(attachment.content.type, `wrong content.`);
+        assert(attachment.content.type, 'wrong content.');
     });
 
-    it(`should create an animationCard().`, function () {
+    it('should create an animationCard().', function () {
         const links = ['https://example.org/media'];
         const attachment = CardFactory.animationCard('foo', links);
         assertAttachment(attachment, CardFactory.contentTypes.animationCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
+        assert(content.title === 'foo', 'wrong title.');
         assertMedia(content.media, 1, links);
     });
 
-    it(`should create an animationCard() with buttons.`, function () {
+    it('should create an animationCard() with buttons.', function () {
         const links = ['https://example.org/media'];
         const attachment = CardFactory.animationCard('foo', links, ['a', 'b', 'c']);
         assertAttachment(attachment, CardFactory.contentTypes.animationCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
+        assert(content.title === 'foo', 'wrong title.');
         assertMedia(content.media, 1, links);
         assertActions(content.buttons, 3, ['a', 'b', 'c']);
     });
 
-    it(`should create an animationCard() with other fields.`, function () {
+    it('should create an animationCard() with other fields.', function () {
         const links = ['https://example.org/media'];
         const attachment = CardFactory.animationCard('foo', links, undefined, { text: 'bar' });
         assertAttachment(attachment, CardFactory.contentTypes.animationCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
-        assert(content.text === 'bar', `missing or invalid other fields.`);
+        assert(content.title === 'foo', 'wrong title.');
+        assert(content.text === 'bar', 'missing or invalid other fields.');
         assertMedia(content.media, 1, links);
     });
 
-    it(`should create an animationCard() with no title.`, function () {
+    it('should create an animationCard() with no title.', function () {
         const links = ['https://example.org/media'];
         const attachment = CardFactory.animationCard(undefined, links);
         assertAttachment(attachment, CardFactory.contentTypes.animationCard);
         const content = attachment.content;
-        assert(content.title === undefined, `wrong title.`);
+        assert(content.title === undefined, 'wrong title.');
         assertMedia(content.media, 1, links);
     });
 
-    it(`should create an audioCard().`, function () {
+    it('should create an audioCard().', function () {
         const links = ['https://example.org/media'];
         const attachment = CardFactory.audioCard('foo', links);
         assertAttachment(attachment, CardFactory.contentTypes.audioCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
+        assert(content.title === 'foo', 'wrong title.');
         assertMedia(content.media, 1, links);
     });
 
-    it(`should create an audioCard() with buttons.`, function () {
+    it('should create an audioCard() with buttons.', function () {
         const links = ['https://example.org/media'];
         const attachment = CardFactory.audioCard('foo', links, ['a', 'b', 'c']);
         assertAttachment(attachment, CardFactory.contentTypes.audioCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
+        assert(content.title === 'foo', 'wrong title.');
         assertMedia(content.media, 1, links);
         assertActions(content.buttons, 3, ['a', 'b', 'c']);
     });
 
-    it(`should create an audioCard() with other fields.`, function () {
+    it('should create an audioCard() with other fields.', function () {
         const links = ['https://example.org/media'];
         const attachment = CardFactory.audioCard('foo', links, undefined, { text: 'bar' });
         assertAttachment(attachment, CardFactory.contentTypes.audioCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
-        assert(content.text === 'bar', `missing or invalid other fields.`);
+        assert(content.title === 'foo', 'wrong title.');
+        assert(content.text === 'bar', 'missing or invalid other fields.');
         assertMedia(content.media, 1, links);
     });
 
-    it(`should create an videoCard().`, function () {
+    it('should create an videoCard().', function () {
         const links = ['https://example.org/media'];
         const attachment = CardFactory.videoCard('foo', links);
         assertAttachment(attachment, CardFactory.contentTypes.videoCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
+        assert(content.title === 'foo', 'wrong title.');
         assertMedia(content.media, 1, links);
     });
 
-    it(`should create an videoCard() with buttons.`, function () {
+    it('should create an videoCard() with buttons.', function () {
         const links = ['https://example.org/media'];
         const attachment = CardFactory.videoCard('foo', links, ['a', 'b', 'c']);
         assertAttachment(attachment, CardFactory.contentTypes.videoCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
+        assert(content.title === 'foo', 'wrong title.');
         assertMedia(content.media, 1, links);
         assertActions(content.buttons, 3, ['a', 'b', 'c']);
     });
 
-    it(`should create an videoCard() with other fields.`, function () {
+    it('should create an videoCard() with other fields.', function () {
         const links = ['https://example.org/media'];
         const attachment = CardFactory.videoCard('foo', links, undefined, { text: 'bar' });
         assertAttachment(attachment, CardFactory.contentTypes.videoCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
-        assert(content.text === 'bar', `missing or invalid other fields.`);
+        assert(content.title === 'foo', 'wrong title.');
+        assert(content.text === 'bar', 'missing or invalid other fields.');
         assertMedia(content.media, 1, links);
     });
 
-    it(`should create a heroCard().`, function () {
+    it('should create a heroCard().', function () {
         const attachment = CardFactory.heroCard('foo');
         assertAttachment(attachment, CardFactory.contentTypes.heroCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
+        assert(content.title === 'foo', 'wrong title.');
     });
 
-    it(`should create a thumbnailCard().`, function () {
+    it('should create a thumbnailCard().', function () {
         const attachment = CardFactory.thumbnailCard('foo');
         assertAttachment(attachment, CardFactory.contentTypes.thumbnailCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
+        assert(content.title === 'foo', 'wrong title.');
     });
 
-    it(`should create a thumbnailCard() with images.`, function () {
+    it('should create a thumbnailCard() with images.', function () {
         const links = ['https://example.org/image'];
         const attachment = CardFactory.thumbnailCard('foo', links);
         assertAttachment(attachment, CardFactory.contentTypes.thumbnailCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
+        assert(content.title === 'foo', 'wrong title.');
         assertImages(content.images, 1, links);
     });
 
-    it(`should create a thumbnailCard() with text.`, function () {
+    it('should create a thumbnailCard() with text.', function () {
         const attachment = CardFactory.thumbnailCard('foo', 'bar');
         assertAttachment(attachment, CardFactory.contentTypes.thumbnailCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
-        assert(content.text === 'bar', `wrong text.`);
+        assert(content.title === 'foo', 'wrong title.');
+        assert(content.text === 'bar', 'wrong text.');
     });
 
-    it(`should create a thumbnailCard() with text and images.`, function () {
+    it('should create a thumbnailCard() with text and images.', function () {
         const links = ['https://example.org/image'];
         const attachment = CardFactory.thumbnailCard('foo', 'bar', links);
         assertAttachment(attachment, CardFactory.contentTypes.thumbnailCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
-        assert(content.text === 'bar', `wrong text.`);
+        assert(content.title === 'foo', 'wrong title.');
+        assert(content.text === 'bar', 'wrong text.');
         assertImages(content.images, 1, links);
     });
 
-    it(`should create a thumbnailCard() with buttons.`, function () {
+    it('should create a thumbnailCard() with buttons.', function () {
         const attachment = CardFactory.thumbnailCard('foo', undefined, ['a', 'b', 'c']);
         assertAttachment(attachment, CardFactory.contentTypes.thumbnailCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
+        assert(content.title === 'foo', 'wrong title.');
         assertActions(content.buttons, 3, ['a', 'b', 'c']);
     });
 
-    it(`should create a thumbnailCard() with buttons and no title.`, function () {
+    it('should create a thumbnailCard() with buttons and no title.', function () {
         const attachment = CardFactory.thumbnailCard(undefined, undefined, ['a', 'b', 'c']);
         assertAttachment(attachment, CardFactory.contentTypes.thumbnailCard);
         const content = attachment.content;
-        assert(content.title === undefined, `wrong title.`);
+        assert(content.title === undefined, 'wrong title.');
         assertActions(content.buttons, 3, ['a', 'b', 'c']);
     });
 
-    it(`should create a thumbnailCard() with text and buttons.`, function () {
+    it('should create a thumbnailCard() with text and buttons.', function () {
         const attachment = CardFactory.thumbnailCard('foo', 'bar', undefined, ['a', 'b', 'c']);
         assertAttachment(attachment, CardFactory.contentTypes.thumbnailCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
-        assert(content.text === 'bar', `wrong text.`);
+        assert(content.title === 'foo', 'wrong title.');
+        assert(content.text === 'bar', 'wrong text.');
         assertActions(content.buttons, 3, ['a', 'b', 'c']);
     });
 
-    it(`should create a thumbnailCard() with other.`, function () {
+    it('should create a thumbnailCard() with other.', function () {
         const attachment = CardFactory.thumbnailCard('foo', undefined, undefined, { subtitle: 'sub' });
         assertAttachment(attachment, CardFactory.contentTypes.thumbnailCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
-        assert(content.subtitle === 'sub', `wrong subtitle.`);
+        assert(content.title === 'foo', 'wrong title.');
+        assert(content.subtitle === 'sub', 'wrong subtitle.');
     });
 
-    it(`should create a thumbnailCard() with text and other.`, function () {
+    it('should create a thumbnailCard() with text and other.', function () {
         const attachment = CardFactory.thumbnailCard('foo', 'bar', undefined, undefined, { subtitle: 'sub' });
         assertAttachment(attachment, CardFactory.contentTypes.thumbnailCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong title.`);
-        assert(content.text === 'bar', `wrong text.`);
-        assert(content.subtitle === 'sub', `wrong subtitle.`);
+        assert(content.title === 'foo', 'wrong title.');
+        assert(content.text === 'bar', 'wrong text.');
+        assert(content.subtitle === 'sub', 'wrong subtitle.');
     });
 
-    it(`should create a receiptCard().`, function () {
+    it('should create a receiptCard().', function () {
         const attachment = CardFactory.receiptCard({ title: 'foo' });
         assertAttachment(attachment, CardFactory.contentTypes.receiptCard);
         const content = attachment.content;
-        assert(content.title === 'foo', `wrong content.`);
+        assert(content.title === 'foo', 'wrong content.');
     });
 
-    it(`should create a signinCard().`, function () {
+    it('should create a signinCard().', function () {
         const attachment = CardFactory.signinCard('foo', 'https://example.org/signin');
         assertAttachment(attachment, CardFactory.contentTypes.signinCard);
         const content = attachment.content;
         assertActions(content.buttons, 1, ['foo']);
-        assert(content.buttons[0].type === 'signin', `wrong action type.`);
-        assert(content.buttons[0].value === 'https://example.org/signin', `wrong action value.`);
+        assert(content.buttons[0].type === 'signin', 'wrong action type.');
+        assert(content.buttons[0].value === 'https://example.org/signin', 'wrong action value.');
     });
 
-    it(`should create a signinCard() with text.`, function () {
+    it('should create a signinCard() with text.', function () {
         const attachment = CardFactory.signinCard('foo', 'https://example.org/signin', 'bar');
         assertAttachment(attachment, CardFactory.contentTypes.signinCard);
         const content = attachment.content;
         assertActions(content.buttons, 1, ['foo']);
-        assert(content.buttons[0].type === 'signin', `wrong action type.`);
-        assert(content.buttons[0].value === 'https://example.org/signin', `wrong action value.`);
-        assert(content.text === 'bar', `wrong text.`);
+        assert(content.buttons[0].type === 'signin', 'wrong action type.');
+        assert(content.buttons[0].value === 'https://example.org/signin', 'wrong action value.');
+        assert(content.text === 'bar', 'wrong text.');
     });
 
-    it(`should create an OAuthCard with text.`, function () {
+    it('should create an OAuthCard with text.', function () {
         const attachment = CardFactory.oauthCard('ConnectionName', 'Test', 'Test-text');
         assertAttachment(attachment, CardFactory.contentTypes.oauthCard);
         const content = attachment.content;
         assertOAuthActions(content.buttons, 'Test');
-        assert(content.text === 'Test-text', `wrong text.`);
-        assert(content.connectionName === 'ConnectionName', `wrong connectionName.`);
+        assert(content.text === 'Test-text', 'wrong text.');
+        assert(content.connectionName === 'ConnectionName', 'wrong connectionName.');
     });
 
-    it(`should create an OAuthCard without text.`, function () {
+    it('should create an OAuthCard without text.', function () {
         const attachment = CardFactory.oauthCard('ConnectionName', 'Test');
         assertAttachment(attachment, CardFactory.contentTypes.oauthCard);
         const content = attachment.content;
         assertOAuthActions(content.buttons, 'Test');
-        assert(content.text === undefined, `text should not exist.`);
-        assert(content.connectionName === 'ConnectionName', `wrong connectionName.`);
+        assert(content.text === undefined, 'text should not exist.');
+        assert(content.connectionName === 'ConnectionName', 'wrong connectionName.');
     });
 
-    it(`should create an o365ConnectorCard.`, function () {
-        const attachment = CardFactory.o365ConnectorCard(
-            {
-                "title": "card title",
-                "text": "card text",
-                "summary": "O365 card summary",
-                "themeColor": "#E67A9E",
-                "sections": [
-                    {
-                        "title": "**section title**",
-                        "text": "section text",
-                        "activityTitle": "activity title",
-                     }
-                ]
-            }
-        );
+    it('should create an o365ConnectorCard.', function () {
+        const attachment = CardFactory.o365ConnectorCard({
+            title: 'card title',
+            text: 'card text',
+            summary: 'O365 card summary',
+            themeColor: '#E67A9E',
+            sections: [
+                {
+                    title: '**section title**',
+                    text: 'section text',
+                    activityTitle: 'activity title',
+                },
+            ],
+        });
         assertAttachment(attachment, CardFactory.contentTypes.o365ConnectorCard);
         const content = attachment.content;
-        assert(content.title === 'card title', `wrong title.`);
-        assert(content.sections.length === 1, `wrong sections count.`);
-        assert(content.potentialAction === undefined, `potentialAction should not exist.`);
+        assert(content.title === 'card title', 'wrong title.');
+        assert(content.sections.length === 1, 'wrong sections count.');
+        assert(content.potentialAction === undefined, 'potentialAction should not exist.');
     });
 });

--- a/libraries/botbuilder-core/tests/conversationState.test.js
+++ b/libraries/botbuilder-core/tests/conversationState.test.js
@@ -5,51 +5,51 @@ const receivedMessage = { text: 'received', type: 'message', channelId: 'test', 
 const missingChannelId = { text: 'received', type: 'message', conversation: { id: 'convo' } };
 const missingConversation = { text: 'received', type: 'message', channelId: 'test' };
 
-describe(`ConversationState`, function () {
+describe('ConversationState', function () {
     this.timeout(5000);
 
     const storage = new MemoryStorage();
     const adapter = new TestAdapter();
     const context = new TurnContext(adapter, receivedMessage);
     const conversationState = new ConversationState(storage);
-    it(`should load and save state from storage.`, async function () {
+    it('should load and save state from storage.', async function () {
         // Simulate a "Turn" in a conversation by loading the state,
         // changing it and then saving the changes to state.
         await conversationState.load(context);
         const key = conversationState.getStorageKey(context);
         const state = conversationState.get(context);
-        assert(state, `State not loaded`);
-        assert(key, `Key not found`);
+        assert(state, 'State not loaded');
+        assert(key, 'Key not found');
         state.test = 'foo';
         await conversationState.saveChanges(context);
 
         // Check the storage to see if the changes to state were saved.
         const items = await storage.read([key]);
-        assert(items[key], `Saved state not found in storage.`);
-        assert(items[key].test === 'foo', `Missing test value in stored state.`);
+        assert(items[key], 'Saved state not found in storage.');
+        assert(items[key].test === 'foo', 'Missing test value in stored state.');
     });
 
-    it(`should ignore any activities that aren't "endOfConversation".`, async function () {
+    it('should ignore any activities that aren\'t "endOfConversation".', async function () {
         await conversationState.load(context);
         const key = conversationState.getStorageKey(context);
-        assert(conversationState.get(context).test === 'foo', `invalid initial state`);
+        assert(conversationState.get(context).test === 'foo', 'invalid initial state');
         await context.sendActivity({ type: ActivityTypes.Message, text: 'foo' });
 
         const items = await storage.read([key]);
-        assert(items[key].test != null, `state cleared and shouldn't have been.`);
+        assert(items[key].test != null, "state cleared and shouldn't have been.");
     });
 
-    it(`should reject with error if channelId missing.`, function () {
+    it('should reject with error if channelId missing.', function () {
         const ctx = new TurnContext(adapter, missingChannelId);
         assert.throws(() => conversationState.load(ctx), Error('missing activity.channelId'));
     });
 
-    it(`should reject with error if conversation missing.`, function () {
+    it('should reject with error if conversation missing.', function () {
         const ctx = new TurnContext(adapter, missingConversation);
         assert.throws(() => conversationState.load(ctx), Error('missing activity.conversation.id'));
     });
 
-    it(`should throw NO_KEY error if getStorageKey() returns falsey value.`, async function () {
+    it('should throw NO_KEY error if getStorageKey() returns falsey value.', async function () {
         conversationState.getStorageKey = (_turnContext) => undefined;
         await assert.rejects(
             conversationState.load(context, true),

--- a/libraries/botbuilder-core/tests/getTopScoringIntent.test.js
+++ b/libraries/botbuilder-core/tests/getTopScoringIntent.test.js
@@ -1,16 +1,15 @@
 const assert = require('assert');
-const { getTopScoringIntent} = require('../lib');
+const { getTopScoringIntent } = require('../lib');
 
 describe('getTopScoringIntent', function () {
     it(' should never return undefined', function () {
-        let result = getTopScoringIntent({
+        const result = getTopScoringIntent({
             text: '',
             intents: {},
-            entities: {}
+            entities: {},
         });
 
         assert.notStrictEqual(result.intent, undefined);
         assert.strictEqual(result.intent, '');
     });
-
 });

--- a/libraries/botbuilder-core/tests/memoryStorage.test.js
+++ b/libraries/botbuilder-core/tests/memoryStorage.test.js
@@ -3,83 +3,83 @@ const { MemoryStorage } = require('../');
 const { StorageBaseTests } = require('../../botbuilder-core/tests/storageBaseTests');
 
 function testStorage(storage) {
-    it('return empty object when reading unknown key', async function() {
+    it('return empty object when reading unknown key', async function () {
         const testRan = await StorageBaseTests.returnEmptyObjectWhenReadingUnknownKey(storage);
-        
+
         assert.strictEqual(testRan, true);
     });
 
-    it('throws when reading null keys', async function() {
+    it('throws when reading null keys', async function () {
         const testRan = await StorageBaseTests.handleNullKeysWhenReading(storage);
 
         assert.strictEqual(testRan, true);
     });
 
-    it('throws when writing null keys', async function() {
+    it('throws when writing null keys', async function () {
         const testRan = await StorageBaseTests.handleNullKeysWhenWriting(storage);
-        
+
         assert.strictEqual(testRan, true);
     });
 
-    it('does not throw when writing no items', async function() {
+    it('does not throw when writing no items', async function () {
         const testRan = await StorageBaseTests.doesNotThrowWhenWritingNoItems(storage);
-        
+
         assert.strictEqual(testRan, true);
     });
 
-    it('create an object', async function() {
+    it('create an object', async function () {
         const testRan = await StorageBaseTests.createObject(storage);
 
         assert.strictEqual(testRan, true);
     });
 
-    it('handle crazy keys', async function() {
+    it('handle crazy keys', async function () {
         const testRan = await StorageBaseTests.handleCrazyKeys(storage);
 
         assert.strictEqual(testRan, true);
     });
 
-    it('update an object', async function() {
+    it('update an object', async function () {
         const testRan = await StorageBaseTests.updateObject(storage);
 
         assert.strictEqual(testRan, true);
     });
 
-    it('delete an object', async function() {
+    it('delete an object', async function () {
         const testRan = await StorageBaseTests.deleteObject(storage);
 
         assert.strictEqual(testRan, true);
     });
 
-    it('does not throw when deleting an unknown object', async function() {
+    it('does not throw when deleting an unknown object', async function () {
         const testRan = await StorageBaseTests.deleteUnknownObject(storage);
 
         assert.strictEqual(testRan, true);
     });
 
-    it('performs batch operations', async function() {
+    it('performs batch operations', async function () {
         const testRan = await StorageBaseTests.performBatchOperations(storage);
 
         assert.strictEqual(testRan, true);
     });
 
-    it('proceeds through a waterfall dialog', async function() {
+    it('proceeds through a waterfall dialog', async function () {
         const testRan = await StorageBaseTests.proceedsThroughWaterfall(storage);
 
         assert.strictEqual(testRan, true);
     });
 }
 
-describe('MemoryStorage - Empty', function() {
+describe('MemoryStorage - Empty', function () {
     testStorage(new MemoryStorage());
 });
 
-describe('MemoryStorage - PreExisting', function() {
-    const dictionary = { 'test': JSON.stringify({counter:12})};
+describe('MemoryStorage - PreExisting', function () {
+    const dictionary = { test: JSON.stringify({ counter: 12 }) };
     const storage = new MemoryStorage(dictionary);
     testStorage(storage);
 
-    it('should still have test', function() {
+    it('should still have test', function () {
         return storage.read(['test']).then((result) => {
             assert(result.test.counter == 12, 'read()  test.counter should be 12');
         });

--- a/libraries/botbuilder-core/tests/mention.test.js
+++ b/libraries/botbuilder-core/tests/mention.test.js
@@ -1,11 +1,12 @@
 const assert = require('assert');
 const { MessageFactory, SkypeMentionNormalizeMiddleware, TurnContext } = require('../lib');
 
-describe(`Mention`, function () {
+describe('Mention', function () {
     this.timeout(5000);
 
-    it('should not change activity text when entity type is not a mention', async function() {
-        const mentionJson = '{\"mentioned\": {\"id\": \"recipientid\"},\"text\": \"<at id=\\\"28: 841caffa-9e92-425d-8d84-b503b3ded285\\\">botname</at>\"}';
+    it('should not change activity text when entity type is not a mention', async function () {
+        const mentionJson =
+            '{"mentioned": {"id": "recipientid"},"text": "<at id=\\"28: 841caffa-9e92-425d-8d84-b503b3ded285\\">botname</at>"}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'test';
 
@@ -18,8 +19,8 @@ describe(`Mention`, function () {
         assert(activity.text === 'botname sometext');
     });
 
-    it('should not change activity text when mention text is empty', async function() {
-        const mentionJson = '{\"mentioned\": {\"id\": \"recipientid\"},\"text\": \""}';
+    it('should not change activity text when mention text is empty', async function () {
+        const mentionJson = '{"mentioned": {"id": "recipientid"},"text": ""}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'mention';
 
@@ -32,8 +33,8 @@ describe(`Mention`, function () {
         assert(activity.text === 'botname sometext');
     });
 
-    it('should not change activity text when there is no matching mention', async function() {
-        const mentionJson = '{\"mentioned\": {\"id\": \"foo bar"},\"text\": \""}';
+    it('should not change activity text when there is no matching mention', async function () {
+        const mentionJson = '{"mentioned": {"id": "foo bar"},"text": ""}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'mention';
 
@@ -46,8 +47,9 @@ describe(`Mention`, function () {
         assert(activity.text === 'botname sometext');
     });
 
-    it(`should remove skype mention`, async function () {
-        const mentionJson = '{\"mentioned\": {\"id\": \"recipientid\"},\"text\": \"<at id=\\\"28: 841caffa-9e92-425d-8d84-b503b3ded285\\\">botname</at>\"}';
+    it('should remove skype mention', async function () {
+        const mentionJson =
+            '{"mentioned": {"id": "recipientid"},"text": "<at id=\\"28: 841caffa-9e92-425d-8d84-b503b3ded285\\">botname</at>"}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'mention';
 
@@ -61,8 +63,8 @@ describe(`Mention`, function () {
         assert(activity.text === 'sometext');
     });
 
-    it(`should remove teams mention`, async function () {
-        const mentionJson = '{\"mentioned\": {\"id\": \"recipientid\"},\"text\": \"<at>botname</at>\"}';
+    it('should remove teams mention', async function () {
+        const mentionJson = '{"mentioned": {"id": "recipientid"},"text": "<at>botname</at>"}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'mention';
 
@@ -75,8 +77,8 @@ describe(`Mention`, function () {
         assert(activity.text === 'sometext');
     });
 
-    it(`should remove slack mention`, async function () {
-        const mentionJson = '{\"mentioned\": {\"id\": \"recipientid\"},\"text\": \"@botname\"}';
+    it('should remove slack mention', async function () {
+        const mentionJson = '{"mentioned": {"id": "recipientid"},"text": "@botname"}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'mention';
 
@@ -89,8 +91,8 @@ describe(`Mention`, function () {
         assert(activity.text === 'sometext');
     });
 
-    it(`should remove GroupMe mention`, async function () {
-        const mentionJson = '{\"mentioned\": {\"id\": \"recipientid\"},\"text\": \"@bot name\"}';
+    it('should remove GroupMe mention', async function () {
+        const mentionJson = '{"mentioned": {"id": "recipientid"},"text": "@bot name"}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'mention';
 
@@ -103,8 +105,8 @@ describe(`Mention`, function () {
         assert(activity.text === 'sometext');
     });
 
-    it(`should remove Telegram mention`, async function () {
-        const mentionJson = '{\"mentioned\": {\"id\": \"recipientid\"},\"text\": \"botname\"}';
+    it('should remove Telegram mention', async function () {
+        const mentionJson = '{"mentioned": {"id": "recipientid"},"text": "botname"}';
         const entity = JSON.parse(mentionJson);
         entity.type = 'mention';
 

--- a/libraries/botbuilder-core/tests/messageFactory.test.js
+++ b/libraries/botbuilder-core/tests/messageFactory.test.js
@@ -2,13 +2,13 @@ const assert = require('assert');
 const { MessageFactory, InputHints, AttachmentLayoutTypes } = require('../');
 
 function assertMessage(activity) {
-    assert(typeof activity === 'object', `invalid activity returned.`);
-    assert(activity.type === 'message', `not a message activity.`);
+    assert(typeof activity === 'object', 'invalid activity returned.');
+    assert(activity.type === 'message', 'not a message activity.');
 }
 
 function assertActions(actions, count, titles) {
-    assert(Array.isArray(actions), `actions not array.`);
-    assert(actions.length === count, `wrong number of actions returned.`);
+    assert(Array.isArray(actions), 'actions not array.');
+    assert(actions.length === count, 'wrong number of actions returned.');
     for (let i = 0; i < count; i++) {
         assert(actions[i].title, `title[${i}] missing`);
         if (titles) {
@@ -20,8 +20,8 @@ function assertActions(actions, count, titles) {
 }
 
 function assertAttachments(activity, count, types) {
-    assert(Array.isArray(activity.attachments), `no attachments array.`);
-    assert(activity.attachments.length === count, `wrong number of attachments.`);
+    assert(Array.isArray(activity.attachments), 'no attachments array.');
+    assert(activity.attachments.length === count, 'wrong number of attachments.');
     if (types) {
         for (let i = 0; i < count; i++) {
             assert(activity.attachments[i].contentType === types[i], `attachment[${i}] has invalid contentType.`);
@@ -29,163 +29,177 @@ function assertAttachments(activity, count, types) {
     }
 }
 
-describe(`MessageFactory`, function () {
+describe('MessageFactory', function () {
     this.timeout(5000);
 
-    it(`should return a simple text() Activity.`, function () {
+    it('should return a simple text() Activity.', function () {
         const activity = MessageFactory.text('foo');
         assertMessage(activity);
-        assert(activity.text === 'foo', `invalid text field.`);
+        assert(activity.text === 'foo', 'invalid text field.');
     });
 
-    it(`should return a simple text() Activity with text and speak.`, function () {
+    it('should return a simple text() Activity with text and speak.', function () {
         const activity = MessageFactory.text('foo', 'bar');
         assertMessage(activity);
-        assert(activity.text === 'foo', `invalid text field.`);
-        assert(activity.speak === 'bar', `invalid speak field.`);
+        assert(activity.text === 'foo', 'invalid text field.');
+        assert(activity.speak === 'bar', 'invalid speak field.');
     });
 
-    it(`should return a simple text() Activity with text, speak and inputHint.`, function () {
+    it('should return a simple text() Activity with text, speak and inputHint.', function () {
         const activity = MessageFactory.text('foo', 'bar', InputHints.IgnoringInput);
         assertMessage(activity);
-        assert(activity.text === 'foo', `invalid text field.`);
-        assert(activity.speak === 'bar', `invalid speak field.`);
-        assert(activity.inputHint === InputHints.IgnoringInput, `invalid inputHint field.`);
+        assert(activity.text === 'foo', 'invalid text field.');
+        assert(activity.speak === 'bar', 'invalid speak field.');
+        assert(activity.inputHint === InputHints.IgnoringInput, 'invalid inputHint field.');
     });
 
-    it(`should return suggestedActions().`, function () {
+    it('should return suggestedActions().', function () {
         const activity = MessageFactory.suggestedActions(['a', 'b', 'c']);
         assertMessage(activity);
-        assert(activity.suggestedActions && activity.suggestedActions.actions, `actions not returned`);
+        assert(activity.suggestedActions && activity.suggestedActions.actions, 'actions not returned');
         assertActions(activity.suggestedActions.actions, 3, ['a', 'b', 'c']);
     });
 
-    it(`should return suggestedActions() with text.`, function () {
+    it('should return suggestedActions() with text.', function () {
         const activity = MessageFactory.suggestedActions(['a', 'b', 'c'], 'foo');
         assertMessage(activity);
-        assert(activity.suggestedActions && activity.suggestedActions.actions, `actions not returned`);
+        assert(activity.suggestedActions && activity.suggestedActions.actions, 'actions not returned');
         assertActions(activity.suggestedActions.actions, 3, ['a', 'b', 'c']);
-        assert(activity.text === 'foo', `invalid text field.`);
+        assert(activity.text === 'foo', 'invalid text field.');
     });
 
-    it(`should return suggestedActions() with text and speak.`, function () {
+    it('should return suggestedActions() with text and speak.', function () {
         const activity = MessageFactory.suggestedActions(['a', 'b', 'c'], 'foo', 'bar');
         assertMessage(activity);
-        assert(activity.suggestedActions && activity.suggestedActions.actions, `actions not returned`);
+        assert(activity.suggestedActions && activity.suggestedActions.actions, 'actions not returned');
         assertActions(activity.suggestedActions.actions, 3, ['a', 'b', 'c']);
-        assert(activity.text === 'foo', `invalid text field.`);
-        assert(activity.speak === 'bar', `invalid speak field.`);
+        assert(activity.text === 'foo', 'invalid text field.');
+        assert(activity.speak === 'bar', 'invalid speak field.');
     });
 
-    it(`should return suggestedActions() with text, speak, and inputHint.`, function () {
+    it('should return suggestedActions() with text, speak, and inputHint.', function () {
         const activity = MessageFactory.suggestedActions(['a', 'b', 'c'], 'foo', 'bar', InputHints.IgnoringInput);
         assertMessage(activity);
-        assert(activity.suggestedActions && activity.suggestedActions.actions, `actions not returned`);
+        assert(activity.suggestedActions && activity.suggestedActions.actions, 'actions not returned');
         assertActions(activity.suggestedActions.actions, 3, ['a', 'b', 'c']);
-        assert(activity.text === 'foo', `invalid text field.`);
-        assert(activity.speak === 'bar', `invalid speak field.`);
-        assert(activity.inputHint === InputHints.IgnoringInput, `invalid inputHint field.`);
+        assert(activity.text === 'foo', 'invalid text field.');
+        assert(activity.speak === 'bar', 'invalid speak field.');
+        assert(activity.inputHint === InputHints.IgnoringInput, 'invalid inputHint field.');
     });
 
-    it(`should return attachment().`, function () {
+    it('should return attachment().', function () {
         const activity = MessageFactory.attachment({ contentType: 'none' });
         assertMessage(activity);
         assertAttachments(activity, 1, ['none']);
     });
 
-    it(`should return attachment() with text.`, function () {
+    it('should return attachment() with text.', function () {
         const activity = MessageFactory.attachment({ contentType: 'none' }, 'foo');
         assertMessage(activity);
         assertAttachments(activity, 1, ['none']);
-        assert(activity.text === 'foo', `invalid text field.`);
+        assert(activity.text === 'foo', 'invalid text field.');
     });
 
-    it(`should return attachment() with text and speak.`, function () {
+    it('should return attachment() with text and speak.', function () {
         const activity = MessageFactory.attachment({ contentType: 'none' }, 'foo', 'bar');
         assertMessage(activity);
         assertAttachments(activity, 1, ['none']);
-        assert(activity.text === 'foo', `invalid text field.`);
-        assert(activity.speak === 'bar', `invalid speak field.`);
+        assert(activity.text === 'foo', 'invalid text field.');
+        assert(activity.speak === 'bar', 'invalid speak field.');
     });
 
-    it(`should return attachment() with text, speak, and inputHint.`, function () {
+    it('should return attachment() with text, speak, and inputHint.', function () {
         const activity = MessageFactory.attachment({ contentType: 'none' }, 'foo', 'bar', InputHints.IgnoringInput);
         assertMessage(activity);
         assertAttachments(activity, 1, ['none']);
-        assert(activity.text === 'foo', `invalid text field.`);
-        assert(activity.speak === 'bar', `invalid speak field.`);
-        assert(activity.inputHint === InputHints.IgnoringInput, `invalid inputHint field.`);
+        assert(activity.text === 'foo', 'invalid text field.');
+        assert(activity.speak === 'bar', 'invalid speak field.');
+        assert(activity.inputHint === InputHints.IgnoringInput, 'invalid inputHint field.');
     });
 
-    it(`should return a list().`, function () {
-        const activity = MessageFactory.list([
-            { contentType: 'a' },
-            { contentType: 'b' }
-        ]);
+    it('should return a list().', function () {
+        const activity = MessageFactory.list([{ contentType: 'a' }, { contentType: 'b' }]);
         assertMessage(activity);
         assertAttachments(activity, 2, ['a', 'b']);
-        assert(activity.attachmentLayout === AttachmentLayoutTypes.List, `invalid attachmentLayout.`);
+        assert(activity.attachmentLayout === AttachmentLayoutTypes.List, 'invalid attachmentLayout.');
     });
 
-    it(`should return list() with text, speak, and inputHint.`, function () {
-        const activity = MessageFactory.list([
-            { contentType: 'a' },
-            { contentType: 'b' }
-        ], 'foo', 'bar', InputHints.IgnoringInput);
+    it('should return list() with text, speak, and inputHint.', function () {
+        const activity = MessageFactory.list(
+            [{ contentType: 'a' }, { contentType: 'b' }],
+            'foo',
+            'bar',
+            InputHints.IgnoringInput
+        );
         assertMessage(activity);
         assertAttachments(activity, 2, ['a', 'b']);
-        assert(activity.attachmentLayout === AttachmentLayoutTypes.List, `invalid attachmentLayout.`);
-        assert(activity.text === 'foo', `invalid text field.`);
-        assert(activity.speak === 'bar', `invalid speak field.`);
-        assert(activity.inputHint === InputHints.IgnoringInput, `invalid inputHint field.`);
+        assert(activity.attachmentLayout === AttachmentLayoutTypes.List, 'invalid attachmentLayout.');
+        assert(activity.text === 'foo', 'invalid text field.');
+        assert(activity.speak === 'bar', 'invalid speak field.');
+        assert(activity.inputHint === InputHints.IgnoringInput, 'invalid inputHint field.');
     });
 
-    it(`should return a carousel().`, function () {
-        const activity = MessageFactory.carousel([
-            { contentType: 'a' },
-            { contentType: 'b' }
-        ]);
+    it('should return a carousel().', function () {
+        const activity = MessageFactory.carousel([{ contentType: 'a' }, { contentType: 'b' }]);
         assertMessage(activity);
         assertAttachments(activity, 2, ['a', 'b']);
-        assert(activity.attachmentLayout === AttachmentLayoutTypes.Carousel, `invalid attachmentLayout.`);
+        assert(activity.attachmentLayout === AttachmentLayoutTypes.Carousel, 'invalid attachmentLayout.');
     });
 
-    it(`should return carousel() with text, speak, and inputHint.`, function () {
-        const activity = MessageFactory.carousel([
-            { contentType: 'a' },
-            { contentType: 'b' }
-        ], 'foo', 'bar', InputHints.IgnoringInput);
+    it('should return carousel() with text, speak, and inputHint.', function () {
+        const activity = MessageFactory.carousel(
+            [{ contentType: 'a' }, { contentType: 'b' }],
+            'foo',
+            'bar',
+            InputHints.IgnoringInput
+        );
         assertMessage(activity);
         assertAttachments(activity, 2, ['a', 'b']);
-        assert(activity.attachmentLayout === AttachmentLayoutTypes.Carousel, `invalid attachmentLayout.`);
-        assert(activity.text === 'foo', `invalid text field.`);
-        assert(activity.speak === 'bar', `invalid speak field.`);
-        assert(activity.inputHint === InputHints.IgnoringInput, `invalid inputHint field.`);
+        assert(activity.attachmentLayout === AttachmentLayoutTypes.Carousel, 'invalid attachmentLayout.');
+        assert(activity.text === 'foo', 'invalid text field.');
+        assert(activity.speak === 'bar', 'invalid speak field.');
+        assert(activity.inputHint === InputHints.IgnoringInput, 'invalid inputHint field.');
     });
 
-    it(`should return a contentUrl().`, function () {
+    it('should return a contentUrl().', function () {
         const activity = MessageFactory.contentUrl('https://example.com/content', 'content-type');
         assertMessage(activity);
         assertAttachments(activity, 1, ['content-type']);
-        assert(activity.attachments[0].contentUrl === 'https://example.com/content', `invalid attachment[0].contentUrl.`);
+        assert(
+            activity.attachments[0].contentUrl === 'https://example.com/content',
+            'invalid attachment[0].contentUrl.'
+        );
     });
 
-    it(`should return a contentUrl() with a name.`, function () {
+    it('should return a contentUrl() with a name.', function () {
         const activity = MessageFactory.contentUrl('https://example.com/content', 'content-type', 'file name');
         assertMessage(activity);
         assertAttachments(activity, 1, ['content-type']);
-        assert(activity.attachments[0].contentUrl === 'https://example.com/content', `invalid attachment[0].contentUrl.`);
-        assert(activity.attachments[0].name === 'file name', `invalid attachment[0].name.`);
+        assert(
+            activity.attachments[0].contentUrl === 'https://example.com/content',
+            'invalid attachment[0].contentUrl.'
+        );
+        assert(activity.attachments[0].name === 'file name', 'invalid attachment[0].name.');
     });
 
-    it(`should return a contentUrl() with a name, text, speak, and inputHint.`, function () {
-        const activity = MessageFactory.contentUrl('https://example.com/content', 'content-type', 'file name', 'foo', 'bar', InputHints.IgnoringInput);
+    it('should return a contentUrl() with a name, text, speak, and inputHint.', function () {
+        const activity = MessageFactory.contentUrl(
+            'https://example.com/content',
+            'content-type',
+            'file name',
+            'foo',
+            'bar',
+            InputHints.IgnoringInput
+        );
         assertMessage(activity);
         assertAttachments(activity, 1, ['content-type']);
-        assert(activity.attachments[0].contentUrl === 'https://example.com/content', `invalid attachment[0].contentUrl.`);
-        assert(activity.attachments[0].name === 'file name', `invalid attachment[0].name.`);
-        assert(activity.text === 'foo', `invalid text field.`);
-        assert(activity.speak === 'bar', `invalid speak field.`);
-        assert(activity.inputHint === InputHints.IgnoringInput, `invalid inputHint field.`);
+        assert(
+            activity.attachments[0].contentUrl === 'https://example.com/content',
+            'invalid attachment[0].contentUrl.'
+        );
+        assert(activity.attachments[0].name === 'file name', 'invalid attachment[0].name.');
+        assert(activity.text === 'foo', 'invalid text field.');
+        assert(activity.speak === 'bar', 'invalid speak field.');
+        assert(activity.inputHint === InputHints.IgnoringInput, 'invalid inputHint field.');
     });
 });

--- a/libraries/botbuilder-core/tests/middlewareSet.test.js
+++ b/libraries/botbuilder-core/tests/middlewareSet.test.js
@@ -11,7 +11,7 @@ const noop = () => {
     // no-op
 };
 
-describe(`MiddlewareSet`, function () {
+describe('MiddlewareSet', function () {
     // Generates middleware helper that itself generates middleware that pushes a value
     // on a stack. Returns the middleware generator function, the stack, and a clean
     // MiddlewareSet instance for testing
@@ -28,17 +28,17 @@ describe(`MiddlewareSet`, function () {
         };
     };
 
-    it(`should use() middleware individually.`, function () {
+    it('should use() middleware individually.', function () {
         const { middleware, set } = stackMiddleware();
         set.use(middleware('a')).use(middleware('b'));
     });
 
-    it(`should use() a list of middleware.`, function () {
+    it('should use() a list of middleware.', function () {
         const { middleware, set } = stackMiddleware();
         set.use(middleware('a'), middleware('b'), middleware('c'));
     });
 
-    it(`should run all middleware in order.`, async function () {
+    it('should run all middleware in order.', async function () {
         const { middleware, set, stack } = stackMiddleware();
         set.use(middleware(1), middleware(2), middleware(3));
 
@@ -47,7 +47,7 @@ describe(`MiddlewareSet`, function () {
         });
     });
 
-    it(`should run a middleware set added to another middleware set.`, async function () {
+    it('should run a middleware set added to another middleware set.', async function () {
         const { middleware, set: child, stack } = stackMiddleware();
 
         child.use(middleware(1));
@@ -58,7 +58,7 @@ describe(`MiddlewareSet`, function () {
         });
     });
 
-    it(`should run middleware with a leading and trailing edge.`, async function () {
+    it('should run middleware with a leading and trailing edge.', async function () {
         const { set, stack } = stackMiddleware();
 
         set.use(async (_, next) => {
@@ -76,7 +76,7 @@ describe(`MiddlewareSet`, function () {
         assert.deepStrictEqual(stack, [2, 3, 1]);
     });
 
-    it(`should support middleware added as an object.`, async function () {
+    it('should support middleware added as an object.', async function () {
         const { middleware, set, stack } = stackMiddleware();
 
         set.use({ onTurn: middleware(1) }).use({ onTurn: middleware(2) });
@@ -86,7 +86,7 @@ describe(`MiddlewareSet`, function () {
         });
     });
 
-    it(`not calling next() should intercept other middleware and bot logic.`, async function () {
+    it('not calling next() should intercept other middleware and bot logic.', async function () {
         const { middleware, set, stack } = stackMiddleware();
 
         set.use(middleware(1), noop, middleware(2));
@@ -96,7 +96,7 @@ describe(`MiddlewareSet`, function () {
         });
     });
 
-    it(`should map an exception within middleware to a rejection.`, async function () {
+    it('should map an exception within middleware to a rejection.', async function () {
         const { middleware, set, stack } = stackMiddleware();
 
         set.use(middleware(1), () => Promise.reject(new Error('rejected')), middleware(2));
@@ -108,11 +108,11 @@ describe(`MiddlewareSet`, function () {
         });
     });
 
-    it(`should throw an error if an invalid plugin type is added.`, function () {
+    it('should throw an error if an invalid plugin type is added.', function () {
         assert.throws(() => new MiddlewareSet().use('bogus'));
     });
 
-    it(`should support passing middleware into the constructor of the set.`, async function () {
+    it('should support passing middleware into the constructor of the set.', async function () {
         const { middleware, stack } = stackMiddleware();
 
         const set = new MiddlewareSet(middleware(1), middleware(2), middleware(3));

--- a/libraries/botbuilder-core/tests/privateConversationState.test.js
+++ b/libraries/botbuilder-core/tests/privateConversationState.test.js
@@ -12,56 +12,56 @@ const missingChannelId = { text: 'received', type: 'message', conversation: { id
 const missingConversation = { text: 'received', type: 'message', channelId: 'test', from: { id: 'user' } };
 const missingFrom = { text: 'received', type: 'message', channelId: 'test', conversation: { id: 'convo' } };
 
-describe(`PrivateConversationState`, function () {
+describe('PrivateConversationState', function () {
     this.timeout(5000);
 
     const storage = new MemoryStorage();
     const adapter = new TestAdapter();
     const context = new TurnContext(adapter, receivedMessage);
     const privateConversationState = new PrivateConversationState(storage);
-    it(`should load and save state from storage.`, async function () {
+    it('should load and save state from storage.', async function () {
         // Simulate a "Turn" in a conversation by loading the state,
         // changing it and then saving the changes to state.
         await privateConversationState.load(context);
         const key = privateConversationState.getStorageKey(context);
         const state = privateConversationState.get(context);
-        assert(state, `State not loaded`);
-        assert(key, `Key not found`);
+        assert(state, 'State not loaded');
+        assert(key, 'Key not found');
         state.test = 'foo';
         await privateConversationState.saveChanges(context);
 
         // Check the storage to see if the changes to state were saved.
         const items = await storage.read([key]);
-        assert(items[key] != null, `Saved state not found in storage.`);
-        assert(items[key].test === 'foo', `Missing test value in stored state.`);
+        assert(items[key] != null, 'Saved state not found in storage.');
+        assert(items[key].test === 'foo', 'Missing test value in stored state.');
     });
 
-    it(`should ignore any activities that aren't "endOfConversation".`, async function () {
+    it('should ignore any activities that aren\'t "endOfConversation".', async function () {
         await privateConversationState.load(context);
         const key = privateConversationState.getStorageKey(context);
-        assert(privateConversationState.get(context).test === 'foo', `invalid initial state`);
+        assert(privateConversationState.get(context).test === 'foo', 'invalid initial state');
         await context.sendActivity({ type: ActivityTypes.Message, text: 'foo' });
 
         const items = await storage.read([key]);
-        assert(items[key].test != null, `state cleared and shouldn't have been.`);
+        assert(items[key].test != null, "state cleared and shouldn't have been.");
     });
 
-    it(`should reject with error if channelId missing.`, async function () {
+    it('should reject with error if channelId missing.', async function () {
         const ctx = new TurnContext(adapter, missingChannelId);
         assert.throws(() => privateConversationState.load(ctx), Error('missing activity.channelId'));
     });
 
-    it(`should reject with error if conversation missing.`, async function () {
+    it('should reject with error if conversation missing.', async function () {
         const ctx = new TurnContext(adapter, missingConversation);
         assert.throws(() => privateConversationState.load(ctx), Error('missing activity.conversation.id'));
     });
 
-    it(`should reject with error if from missing.`, async function () {
+    it('should reject with error if from missing.', async function () {
         const ctx = new TurnContext(adapter, missingFrom);
         assert.throws(() => privateConversationState.load(ctx), Error('missing activity.from.id'));
     });
 
-    it(`should throw NO_KEY error if getStorageKey() returns falsey value.`, async function () {
+    it('should throw NO_KEY error if getStorageKey() returns falsey value.', async function () {
         privateConversationState.getStorageKey = (_turnContext) => undefined;
         await assert.rejects(
             privateConversationState.load(context, true),

--- a/libraries/botbuilder-core/tests/showTypingMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/showTypingMiddleware.test.js
@@ -19,7 +19,7 @@ class TestSkillAdapter extends TestAdapter {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-describe(`ShowTypingMiddleware`, function () {
+describe('ShowTypingMiddleware', function () {
     this.timeout(10000);
 
     const adapter = new TestAdapter(async (context) => {

--- a/libraries/botbuilder-core/tests/storageBaseTests.js
+++ b/libraries/botbuilder-core/tests/storageBaseTests.js
@@ -94,7 +94,7 @@ class StorageBaseTests {
     }
 
     static async handleCrazyKeys(storage) {
-        const key = `!@#$%^&*()~/\\><,.?';\"\`~`;
+        const key = '!@#$%^&*()~/\\><,.?\';"`~';
         const storeItem = { id: 1 };
         const storeItems = { [key]: storeItem };
 

--- a/libraries/botbuilder-core/tests/stringUtils.test.js
+++ b/libraries/botbuilder-core/tests/stringUtils.test.js
@@ -4,10 +4,10 @@ const { StringUtils } = require('../');
 const test1 = 'asdlfkjasdflkjasdlfkjasldkfjasdf';
 const test2 = 'alskjdf lksjfd laksjdf lksjdfasdlfkjasdflkjasdlfkjasldkfjasdf';
 
-describe(`StringUtils`, function () {
+describe('StringUtils', function () {
     this.timeout(5000);
 
-    it('test hash', () => {
+    it('test hash', function () {
         let hash1 = StringUtils.hash(test1);
         let hash2 = StringUtils.hash(test1);
         assert(hash1);
@@ -30,16 +30,16 @@ describe(`StringUtils`, function () {
         assert.notEqual(hash1, hash2, 'case changes string should be different');
     });
 
-    it('test ellipsis', () => {
+    it('test ellipsis', function () {
         assert.equal(StringUtils.ellipsis(test1, 0), '...');
-        assert.equal(StringUtils.ellipsis(test1, 5), `${ test1.substr(0, 5) }...`);
+        assert.equal(StringUtils.ellipsis(test1, 5), `${test1.substr(0, 5)}...`);
         assert.equal(StringUtils.ellipsis(test1, 1000), test1);
     });
 
-    it('test ellipsis hash', () => {
+    it('test ellipsis hash', function () {
         const hash1 = StringUtils.hash(test1);
-        assert.equal(StringUtils.ellipsisHash(test1, 0), `...${ hash1 }`);
-        assert.equal(StringUtils.ellipsisHash(test1, 5), `${ test1.substr(0, 5) }...${ hash1 }`);
+        assert.equal(StringUtils.ellipsisHash(test1, 0), `...${hash1}`);
+        assert.equal(StringUtils.ellipsisHash(test1, 5), `${test1.substr(0, 5)}...${hash1}`);
         assert.equal(StringUtils.ellipsisHash(test1, 1000), test1);
     });
 });

--- a/libraries/botbuilder-core/tests/telemetryMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/telemetryMiddleware.test.js
@@ -21,13 +21,13 @@ const createReply = (activity, text, locale = null) => ({
     locale: locale || activity.locale,
 });
 
-describe(`TelemetryMiddleware`, () => {
+describe('TelemetryMiddleware', function () {
     let sandbox;
-    beforeEach(() => {
+    beforeEach(function () {
         sandbox = sinon.createSandbox();
     });
 
-    afterEach(() => {
+    afterEach(function () {
         sandbox.restore();
     });
 
@@ -89,7 +89,7 @@ describe(`TelemetryMiddleware`, () => {
             new TelemetryLoggerMiddleware(telemetryClient, logPersonalInformation),
     }) => new TestAdapter(adapterLogic).use(makeLogger());
 
-    it(`should log send and receive activities`, async () => {
+    it('should log send and receive activities', async function () {
         const { client, expectReceiveEvent, expectSendEvent } = makeTelemetryClient();
 
         expectReceiveEvent({
@@ -97,7 +97,7 @@ describe(`TelemetryMiddleware`, () => {
             fromName: sinon.match.string,
             recipientName: sinon.match.string,
             text: 'foo',
-            type: ActivityTypes.Message
+            type: ActivityTypes.Message,
         });
 
         expectSendEvent({ conversationId: sinon.match.string, type: ActivityTypes.Typing });
@@ -108,7 +108,7 @@ describe(`TelemetryMiddleware`, () => {
             fromName: sinon.match.string,
             recipientName: sinon.match.string,
             text: 'bar',
-            type: ActivityTypes.Message
+            type: ActivityTypes.Message,
         });
 
         expectSendEvent({ conversationId: sinon.match.string, type: ActivityTypes.Typing });
@@ -130,7 +130,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`should work with null telemetryClient`, async () => {
+    it('should work with null telemetryClient', async function () {
         const adapter = makeAdapter({
             makeLogger: () => new TelemetryLoggerMiddleware(null, true),
         });
@@ -147,7 +147,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`should not log PII properties for send and receive activities`, async () => {
+    it('should not log PII properties for send and receive activities', async function () {
         const { client, expectReceiveEvent, expectSendEvent } = makeTelemetryClient();
 
         expectReceiveEvent({ fromName: undefined, text: undefined });
@@ -167,7 +167,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`telemetry should log update activities`, async () => {
+    it('telemetry should log update activities', async function () {
         const { client, expectReceiveEvent, expectSendEvent, expectTrackEvent } = makeTelemetryClient();
 
         expectReceiveEvent({ text: 'foo', type: ActivityTypes.Message });
@@ -177,7 +177,7 @@ describe(`TelemetryMiddleware`, () => {
         expectTrackEvent(TelemetryLoggerMiddleware.botMsgUpdateEvent, {
             conversationId: sinon.match.string,
             text: 'new response',
-            type: ActivityTypes.Message
+            type: ActivityTypes.Message,
         });
 
         const adapter = makeAdapter({
@@ -197,7 +197,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`telemetry should log delete activities`, async () => {
+    it('telemetry should log delete activities', async function () {
         const { client, expectReceiveEvent, expectSendEvent, expectTrackEvent } = makeTelemetryClient();
 
         expectReceiveEvent({ text: 'foo', type: ActivityTypes.Message });
@@ -224,7 +224,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`telemetry override RECEIVE with custom derived logger class`, async () => {
+    it('telemetry override RECEIVE with custom derived logger class', async function () {
         class OverrideLogger extends TelemetryLoggerMiddleware {
             async onReceiveActivity(activity) {
                 this.telemetryClient.trackEvent({
@@ -266,7 +266,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`telemetry override SEND with custom derived logger class`, async () => {
+    it('telemetry override SEND with custom derived logger class', async function () {
         class OverrideLogger extends TelemetryLoggerMiddleware {
             async onSendActivity(activity) {
                 this.telemetryClient.trackEvent({
@@ -313,7 +313,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`telemetry override UPDATE with custom derived logger class`, async () => {
+    it('telemetry override UPDATE with custom derived logger class', async function () {
         class OverrideLogger extends TelemetryLoggerMiddleware {
             async onUpdateActivity() {
                 this.telemetryClient.trackEvent({
@@ -354,7 +354,7 @@ describe(`TelemetryMiddleware`, () => {
         sandbox.verify();
     });
 
-    it(`telemetry should log channel specific properties`, async () => {
+    it('telemetry should log channel specific properties', async function () {
         const { client, expectReceiveEvent } = makeTelemetryClient();
 
         expectReceiveEvent({

--- a/libraries/botbuilder-core/tests/testAdapter.test.js
+++ b/libraries/botbuilder-core/tests/testAdapter.test.js
@@ -1,31 +1,30 @@
 const assert = require('assert');
-const { TestAdapter, ActivityTypes, TestFlow, ActivityFactory, TurnContext } = require('../');
+const { TestAdapter, ActivityTypes, ActivityFactory, TurnContext } = require('../');
 
 const receivedMessage = { text: 'received', type: 'message' };
 const originalActivity = { text: 'original', type: 'message' };
 const updatedActivity = { text: 'update', type: 'message' };
-const deletedActivityId = '1234';
 
-describe(`TestAdapter`, function () {
+describe('TestAdapter', function () {
     this.timeout(5000);
 
-    it(`should call bot logic when receiveActivity() is called.`, async function () {
+    it('should call bot logic when receiveActivity() is called.', async function () {
         const adapter = new TestAdapter((context) => {
-            assert(context, `context not passed to bot logic.`);
-            assert(context.activity, `activity not passed through.`);
-            assert(context.activity.type === ActivityTypes.Message, `wrong type.`);
-            assert(context.activity.text === 'test', `wrong text.`);
-            assert(context.activity.id, `missing id.`);
-            assert(context.activity.from, `missing from.`);
-            assert(context.activity.recipient, `missing recipient.`);
-            assert(context.activity.conversation, `missing conversation.`);
-            assert(context.activity.channelId, `missing channelId.`);
-            assert(context.activity.serviceUrl, `missing serviceUrl.`);
+            assert(context, 'context not passed to bot logic.');
+            assert(context.activity, 'activity not passed through.');
+            assert(context.activity.type === ActivityTypes.Message, 'wrong type.');
+            assert(context.activity.text === 'test', 'wrong text.');
+            assert(context.activity.id, 'missing id.');
+            assert(context.activity.from, 'missing from.');
+            assert(context.activity.recipient, 'missing recipient.');
+            assert(context.activity.conversation, 'missing conversation.');
+            assert(context.activity.channelId, 'missing channelId.');
+            assert(context.activity.serviceUrl, 'missing serviceUrl.');
         });
         await adapter.receiveActivity('test');
     });
 
-    it(`should reject on unhandled error.`, async function () {
+    it('should reject on unhandled error.', async function () {
         const err = new Error('Intentional');
         const adapter = new TestAdapter(() => {
             throw err;
@@ -35,7 +34,7 @@ describe(`TestAdapter`, function () {
         }, err);
     });
 
-    it(`should call finally when no error happens`, async function () {
+    it('should call finally when no error happens', async function () {
         const adapter = new TestAdapter(async () => undefined);
         let runFinally = false;
 
@@ -45,7 +44,7 @@ describe(`TestAdapter`, function () {
         assert(runFinally, 'Finally was not called');
     });
 
-    it(`should call finally when an error happens`, async function () {
+    it('should call finally when an error happens', async function () {
         const err = new Error('Intentional');
         const adapter = new TestAdapter(() => {
             throw err;
@@ -60,34 +59,34 @@ describe(`TestAdapter`, function () {
         assert(runFinally, 'Finally was not called');
     });
 
-    it(`should support receiveActivity() called with an Activity.`, async function () {
+    it('should support receiveActivity() called with an Activity.', async function () {
         const adapter = new TestAdapter((context) => {
-            assert(context.activity.type === ActivityTypes.Message, `wrong type.`);
-            assert(context.activity.text === 'test', `wrong text.`);
+            assert(context.activity.type === ActivityTypes.Message, 'wrong type.');
+            assert(context.activity.text === 'test', 'wrong text.');
         });
         await adapter.receiveActivity({ text: 'test', type: ActivityTypes.Message });
     });
 
-    it(`should automatically set the type when receiveActivity() is called with an Activity.`, async function () {
+    it('should automatically set the type when receiveActivity() is called with an Activity.', async function () {
         const adapter = new TestAdapter((context) => {
-            assert(context.activity.type === ActivityTypes.Message, `wrong type.`);
-            assert(context.activity.text === 'test', `wrong text.`);
+            assert(context.activity.type === ActivityTypes.Message, 'wrong type.');
+            assert(context.activity.text === 'test', 'wrong text.');
         });
         await adapter.receiveActivity({ text: 'test' });
     });
 
-    it(`should support passing your own Activity.Id to receiveActivity().`, async function () {
+    it('should support passing your own Activity.Id to receiveActivity().', async function () {
         const adapter = new TestAdapter((context) => {
-            assert(context.activity.id === 'myId', `custom ID not passed through.`);
-            assert(context.activity.type === ActivityTypes.Message, `wrong type.`);
-            assert(context.activity.text === 'test', `wrong text.`);
+            assert(context.activity.id === 'myId', 'custom ID not passed through.');
+            assert(context.activity.type === ActivityTypes.Message, 'wrong type.');
+            assert(context.activity.text === 'test', 'wrong text.');
         });
         await adapter.receiveActivity({ text: 'test', type: ActivityTypes.Message, id: 'myId' });
     });
 
-    it(`should call bot logic when send() is called.`, async function () {
+    it('should call bot logic when send() is called.', async function () {
         let called = false;
-        const adapter = new TestAdapter((context) => {
+        const adapter = new TestAdapter(() => {
             called = true;
         });
 
@@ -96,14 +95,14 @@ describe(`TestAdapter`, function () {
         assert(called);
     });
 
-    it(`should return a message to assertReply().`, async function () {
+    it('should return a message to assertReply().', async function () {
         const adapter = new TestAdapter((context) => {
             return context.sendActivity(receivedMessage);
         });
         await adapter.send('test').assertReply('received').startTest();
     });
 
-    it(`async startTest().`, async function () {
+    it('async startTest().', async function () {
         const adapter = new TestAdapter((context) => {
             return context.sendActivity(receivedMessage);
         });
@@ -111,14 +110,14 @@ describe(`TestAdapter`, function () {
         await adapter.send('test').assertReply('received').startTest();
     });
 
-    it(`should send and receive when test() is called.`, async function () {
+    it('should send and receive when test() is called.', async function () {
         const adapter = new TestAdapter((context) => {
             return context.sendActivity(receivedMessage);
         });
         await adapter.test('test', 'received').startTest();
     });
 
-    it(`should support multiple calls to test().`, async function () {
+    it('should support multiple calls to test().', async function () {
         let count = 0;
         const adapter = new TestAdapter((context) => {
             count++;
@@ -134,7 +133,7 @@ describe(`TestAdapter`, function () {
         assert(count == 5, `incorrect count of "${count}".`);
     });
 
-    it(`should support context.updateActivity() calls.`, async function () {
+    it('should support context.updateActivity() calls.', async function () {
         let activityId;
         const adapter = new TestAdapter(async (context) => {
             if (context.activity.text == 'update') {
@@ -147,7 +146,7 @@ describe(`TestAdapter`, function () {
         await adapter.send('test').send('update').assertReply('update').startTest();
     });
 
-    it(`should support context.deleteActivity() calls.`, async function () {
+    it('should support context.deleteActivity() calls.', async function () {
         let activityId;
         const adapter = new TestAdapter(async (context) => {
             if (context.activity.text == 'delete') {
@@ -160,41 +159,41 @@ describe(`TestAdapter`, function () {
         await adapter.send('test').send('delete').assertNoReply().startTest();
     });
 
-    it(`should delay() before running another test.`, async function () {
+    it('should delay() before running another test.', async function () {
         const start = new Date().getTime();
         const adapter = new TestAdapter((context) => {
             return context.sendActivity(receivedMessage);
         });
         await adapter.test('test', 'received').delay(600).test('test', 'received').startTest();
         const end = new Date().getTime();
-        assert(end - start >= 500, `didn't delay before moving on.`);
+        assert(end - start >= 500, "didn't delay before moving on.");
     });
 
-    it(`should support calling assertReply() with an expected Activity.`, async function () {
+    it('should support calling assertReply() with an expected Activity.', async function () {
         const adapter = new TestAdapter((context) => {
             return context.sendActivity(receivedMessage);
         });
         await adapter.send('test').assertReply({ text: 'received' }).startTest();
     });
 
-    it(`should support calling assertReply() with a custom inspector.`, async function () {
+    it('should support calling assertReply() with a custom inspector.', async function () {
         let called = false;
         const adapter = new TestAdapter((context) => {
             return context.sendActivity(receivedMessage);
         });
         await adapter
             .send('test')
-            .assertReply((reply, description) => {
-                assert(reply, `reply not passed`);
+            .assertReply((reply) => {
+                assert(reply, 'reply not passed');
                 called = true;
             })
             .startTest();
-        assert(called, `inspector not called.`);
+        assert(called, 'inspector not called.');
     });
 
-    it(`should timeout waiting for assertReply() when a string is expected.`, async function () {
-        const adapter = new TestAdapter((context) => {
-            return new Promise((resolve, reject) => {
+    it('should timeout waiting for assertReply() when a string is expected.', async function () {
+        const adapter = new TestAdapter(() => {
+            return new Promise((resolve) => {
                 setTimeout(() => resolve(), 600);
             });
         });
@@ -204,9 +203,9 @@ describe(`TestAdapter`, function () {
         );
     });
 
-    it(`should timeout waiting for assertReply() when an Activity is expected.`, async function () {
-        const adapter = new TestAdapter((context) => {
-            return new Promise((resolve, reject) => {
+    it('should timeout waiting for assertReply() when an Activity is expected.', async function () {
+        const adapter = new TestAdapter(() => {
+            return new Promise((resolve) => {
                 setTimeout(() => resolve(), 600);
             });
         });
@@ -217,9 +216,9 @@ describe(`TestAdapter`, function () {
         );
     });
 
-    it(`should timeout waiting for assertReply() when a custom inspector is expected.`, async function () {
-        const adapter = new TestAdapter((context) => {
-            return new Promise((resolve, reject) => {
+    it('should timeout waiting for assertReply() when a custom inspector is expected.', async function () {
+        const adapter = new TestAdapter(() => {
+            return new Promise((resolve) => {
                 setTimeout(() => resolve(), 600);
             });
         });
@@ -227,15 +226,15 @@ describe(`TestAdapter`, function () {
             async () =>
                 await adapter
                     .send('test')
-                    .assertReply(() => assert(false, `inspector shouldn't be called.`), 'received failed', 500)
+                    .assertReply(() => assert(false, "inspector shouldn't be called."), 'received failed', 500)
                     .startTest(),
             /.*Timed out after.*/
         );
     });
 
-    it(`should timeout waiting for assertNoReply() when an Activity is not expected.`, async function () {
-        const adapter = new TestAdapter((context) => {
-            return new Promise((resolve, reject) => {
+    it('should timeout waiting for assertNoReply() when an Activity is not expected.', async function () {
+        const adapter = new TestAdapter(() => {
+            return new Promise((resolve) => {
                 setTimeout(() => resolve(), 600);
             });
         });
@@ -244,7 +243,7 @@ describe(`TestAdapter`, function () {
         );
     });
 
-    it(`should validate using assertNoReply() that no reply was received, when reply Activity not expected.`, async function () {
+    it('should validate using assertNoReply() that no reply was received, when reply Activity not expected.', async function () {
         const adapter = new TestAdapter((context) => {
             return context.sendActivity(receivedMessage);
         });
@@ -255,7 +254,7 @@ describe(`TestAdapter`, function () {
             .startTest();
     });
 
-    it(`should throw an error with assertNoReply() when no reply is expected, but reply Activity was received.`, async function () {
+    it('should throw an error with assertNoReply() when no reply is expected, but reply Activity was received.', async function () {
         const adapter = new TestAdapter((context) => {
             const activities = [receivedMessage, receivedMessage];
             return context.sendActivities(activities);
@@ -271,14 +270,14 @@ describe(`TestAdapter`, function () {
         );
     });
 
-    it(`should support calling assertReplyOneOf().`, async function () {
+    it('should support calling assertReplyOneOf().', async function () {
         const adapter = new TestAdapter((context) => {
             return context.sendActivity(receivedMessage);
         });
         await adapter.send('test').assertReplyOneOf(['foo', 'bar', 'received']).startTest();
     });
 
-    it(`should fail assertReplyOneOf() call for invalid response.`, async function () {
+    it('should fail assertReplyOneOf() call for invalid response.', async function () {
         const adapter = new TestAdapter((context) => {
             return context.sendActivity(receivedMessage);
         });
@@ -287,8 +286,8 @@ describe(`TestAdapter`, function () {
         });
     });
 
-    it(`should return an error from continueConversation().`, async function () {
-        const adapter = new TestAdapter((context) => {
+    it('should return an error from continueConversation().', async function () {
+        const adapter = new TestAdapter(() => {
             assert.fail("shouldn't run bot logic.");
         });
         await assert.rejects(async () => await adapter.continueConversation(), {
@@ -296,22 +295,22 @@ describe(`TestAdapter`, function () {
         });
     });
 
-    it(`should apply the user-defined Activity template.`, async function () {
+    it('should apply the user-defined Activity template.', async function () {
         const template = {
             channelId: 'foo',
             from: { id: 'foo', name: 'Foo' },
         };
         const adapter = new TestAdapter((context) => {
-            assert(context.activity.channelId === template.channelId, `activity channelId does not match template.`);
-            assert(context.activity.from.id === template.from.id, `activity from.id does not match template.`);
-            assert(context.activity.from.name === template.from.name, `activity from.name does not match template.`);
-            assert(context.activity.serviceUrl, `missing serviceUrl.`);
+            assert(context.activity.channelId === template.channelId, 'activity channelId does not match template.');
+            assert(context.activity.from.id === template.from.id, 'activity from.id does not match template.');
+            assert(context.activity.from.name === template.from.name, 'activity from.name does not match template.');
+            assert(context.activity.serviceUrl, 'missing serviceUrl.');
         }, template);
 
         await adapter.send('test');
     });
 
-    it(`should test activities that have a from.role normalized value of 'bot' via testActivities().`, async function () {
+    it("should test activities that have a from.role normalized value of 'bot' via testActivities().", async function () {
         // Counter to keep track of how many times the bot logic is run.
         let counter = 0;
         const adapter = new TestAdapter((context) => {
@@ -344,12 +343,12 @@ describe(`TestAdapter`, function () {
         ];
 
         await adapter.testActivities(activities);
-        assert(counter === 1, `should have only run bot logic once.`);
+        assert(counter === 1, 'should have only run bot logic once.');
     });
 
-    it(`should run the bot's logic to activities without a from property via testActivities().`, async function () {
+    it("should run the bot's logic to activities without a from property via testActivities().", async function () {
         let counter = 0;
-        const adapter = new TestAdapter((context) => {
+        const adapter = new TestAdapter(() => {
             counter++;
         });
 
@@ -373,10 +372,10 @@ describe(`TestAdapter`, function () {
         ];
 
         await adapter.testActivities(activities);
-        assert(counter === 3, `should have run bot logic for activities without the from property.`);
+        assert(counter === 3, 'should have run bot logic for activities without the from property.');
     });
 
-    it(`should throw error if activities is not passed to testActivities().`, async function () {
+    it('should throw error if activities is not passed to testActivities().', async function () {
         const adapter = new TestAdapter((context) => {
             return context.sendActivity(context.activity.text);
         });
@@ -385,7 +384,7 @@ describe(`TestAdapter`, function () {
         });
     });
 
-    it(`getUserToken returns null`, async function () {
+    it('getUserToken returns null', async function () {
         const adapter = new TestAdapter(async (context) => {
             const token = await context.adapter.getUserToken(context, 'myConnection');
             assert(!token);
@@ -393,7 +392,7 @@ describe(`TestAdapter`, function () {
         await adapter.send('hi');
     });
 
-    it(`getUserToken returns null with code`, async function () {
+    it('getUserToken returns null with code', async function () {
         const adapter = new TestAdapter(async (context) => {
             const token = await context.adapter.getUserToken(context, 'myConnection', '123456');
             assert(!token);
@@ -401,7 +400,7 @@ describe(`TestAdapter`, function () {
         await adapter.send('hi');
     });
 
-    it(`getUserToken returns token`, async function () {
+    it('getUserToken returns token', async function () {
         const adapter = new TestAdapter();
         const connectionName = 'myConnection';
         const channelId = 'directline';
@@ -422,7 +421,7 @@ describe(`TestAdapter`, function () {
         assert.strictEqual(tokenResponse.connectionName, connectionName);
     });
 
-    it(`getUserToken returns token with code`, async function () {
+    it('getUserToken returns token with code', async function () {
         const adapter = new TestAdapter();
         const connectionName = 'myConnection';
         const channelId = 'directline';
@@ -453,7 +452,7 @@ describe(`TestAdapter`, function () {
         assert.strictEqual(tokenResponse.token, token);
     });
 
-    it(`getSignInLink returns token with code`, async function () {
+    it('getSignInLink returns token with code', async function () {
         const adapter = new TestAdapter(async (context) => {
             const link = await context.adapter.getSignInLink(context, 'myConnection');
             assert(link);
@@ -461,14 +460,14 @@ describe(`TestAdapter`, function () {
         await adapter.send('hi');
     });
 
-    it(`signOutUser is noop`, async function () {
+    it('signOutUser is noop', async function () {
         const adapter = new TestAdapter(async (context) => {
             await context.adapter.signOutUser(context, 'myConnection');
         });
         await adapter.send('hi');
     });
 
-    it(`signOutUser logs out user`, async function () {
+    it('signOutUser logs out user', async function () {
         const adapter = new TestAdapter();
         const connectionName = 'myConnection';
         const channelId = 'directline';
@@ -492,7 +491,7 @@ describe(`TestAdapter`, function () {
         assert.equal(tokenResponse, undefined);
     });
 
-    it(`signOutUser with no connectionName signs all out`, async function () {
+    it('signOutUser with no connectionName signs all out', async function () {
         const adapter = new TestAdapter();
         const channelId = 'directline';
         const userId = 'testUser';
@@ -522,7 +521,7 @@ describe(`TestAdapter`, function () {
         assert.equal(tokenResponse, undefined);
     });
 
-    it(`should return statuses from getTokenStatus`, async function () {
+    it('should return statuses from getTokenStatus', async function () {
         const adapter = new TestAdapter(async (context) => {
             const statuses = await context.adapter.getTokenStatus(context, 'user');
             assert(statuses);
@@ -535,7 +534,7 @@ describe(`TestAdapter`, function () {
         await adapter.send('hi');
     });
 
-    it(`should throw when context parameter is not sent`, async function () {
+    it('should throw when context parameter is not sent', async function () {
         const adapter = new TestAdapter(async (context) => {
             await assert.rejects(async () => await context.adapter.getTokenStatus(), {
                 message: 'testAdapter.getTokenStatus(): context with activity is required',
@@ -546,7 +545,7 @@ describe(`TestAdapter`, function () {
         await adapter.send('hi');
     });
 
-    it(`should throw when userId parameter is not sent and context.activity.from.id is not present`, async function () {
+    it('should throw when userId parameter is not sent and context.activity.from.id is not present', async function () {
         const adapter = new TestAdapter(async (context) => {
             context.activity.from = undefined;
             await assert.rejects(async () => await context.adapter.getTokenStatus(context), {

--- a/libraries/botbuilder-core/tests/transcriptMiddleware.test.js
+++ b/libraries/botbuilder-core/tests/transcriptMiddleware.test.js
@@ -10,15 +10,15 @@ const {
     ActivityEventNames,
 } = require('../');
 
-describe(`TranscriptLoggerMiddleware`, function () {
+describe('TranscriptLoggerMiddleware', function () {
     this.timeout(5000);
 
-    it(`should log activities`, async function () {
+    it('should log activities', async function () {
         let conversationId = null;
         const transcriptStore = new MemoryTranscriptStore();
         const adapter = new TestAdapter(async (context) => {
             conversationId = context.activity.conversation.id;
-            var typingActivity = {
+            const typingActivity = {
                 type: ActivityTypes.Typing,
                 relatesTo: context.activity.relatesTo,
             };
@@ -49,7 +49,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         });
     });
 
-    it(`should log update activities`, async function () {
+    it('should log update activities', async function () {
         let conversationId = null;
         let activityToUpdate = null;
         const transcriptStore = new MemoryTranscriptStore();
@@ -59,7 +59,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
                 activityToUpdate.text = 'new response';
                 await context.updateActivity(activityToUpdate);
             } else {
-                var activity = createReply(context.activity, 'response');
+                const activity = createReply(context.activity, 'response');
                 const response = await context.sendActivity(activity);
                 activity.id = response.id;
 
@@ -78,7 +78,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         assert(pagedResult.items[3].text, 'update');
     });
 
-    it(`should log delete activities`, async function () {
+    it('should log delete activities', async function () {
         let conversationId = null;
         let activityId = null;
         const transcriptStore = new MemoryTranscriptStore();
@@ -104,7 +104,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         assert(pagedResult.items[3].type, ActivityTypes.MessageDelete);
     });
 
-    it('should filter continueConversation events', async () => {
+    it('should filter continueConversation events', async function () {
         let conversationId;
         const transcriptStore = new MemoryTranscriptStore();
         const adapter = new TestAdapter(async (context) => {
@@ -121,7 +121,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         assert.strictEqual(pagedResult.items.length, 2, 'only the two message activities should be logged');
     });
 
-    it(`should not error for sent activities if no ResourceResponses are received`, async () => {
+    it('should not error for sent activities if no ResourceResponses are received', async function () {
         class NoResourceResponseAdapter extends TestAdapter {
             constructor(logic) {
                 super(logic);
@@ -168,14 +168,14 @@ describe(`TranscriptLoggerMiddleware`, function () {
         });
     });
 
-    it(`should not error for sent activities if another handler does not return next()`, async () => {
+    it('should not error for sent activities if another handler does not return next()', async function () {
         class NoResourceResponseMiddleware {
             async onTurn(context, next) {
                 context.onSendActivities(async (context, activities, next) => {
                     // In SendActivitiesHandlers developers are supposed to call:
                     //      return next();
                     // If this is not returned, then the next handler will not have the ResourceResponses[].
-                    const responses = await next();
+                    await next();
                 });
 
                 // Run the bot's application logic.
@@ -222,14 +222,14 @@ describe(`TranscriptLoggerMiddleware`, function () {
         });
     });
 
-    it(`should not error for sent activities if another handler does not return an array`, async () => {
+    it('should not error for sent activities if another handler does not return an array', async function () {
         class NoResourceResponseMiddleware {
             async onTurn(context, next) {
                 context.onSendActivities(async (context, activities, next) => {
                     // In SendActivitiesHandlers developers are supposed to call:
                     //      return next();
                     // If this is not returned, then the next handler will not have the ResourceResponses[].
-                    const responses = await next();
+                    await next();
 
                     return {};
                 });
@@ -262,7 +262,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         });
     });
 
-    it(`should not error when logging sent activities and return the actual value from next()`, async () => {
+    it('should not error when logging sent activities and return the actual value from next()', async function () {
         // This middleware should receive 1 from `next()`
         class AssertionMiddleware {
             async onTurn(context, next) {
@@ -282,7 +282,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
                     // In SendActivitiesHandlers developers are supposed to call:
                     //      return next();
                     // If this is not returned, then the next handler will not have the ResourceResponses[].
-                    const responses = await next();
+                    await next();
 
                     return 1;
                 });
@@ -316,11 +316,11 @@ describe(`TranscriptLoggerMiddleware`, function () {
 
     describe("'s error handling", function () {
         let sandbox;
-        beforeEach(() => {
+        beforeEach(function () {
             sandbox = sinon.createSandbox();
         });
 
-        afterEach(() => {
+        afterEach(function () {
             sandbox.restore();
         });
 
@@ -375,7 +375,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         });
     });
 
-    it(`should add resource response id to activity when activity id is empty`, async function () {
+    it('should add resource response id to activity when activity id is empty', async function () {
         let conversationId = null;
         const transcriptStore = new MemoryTranscriptStore();
         const adapter = createTestAdapterWithNoResourceResponseId(async (context) => {
@@ -414,7 +414,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         });
     });
 
-    it(`should use outgoing activity's timestamp for activity id when activity id and resourceResponse is empty`, async () => {
+    it("should use outgoing activity's timestamp for activity id when activity id and resourceResponse is empty", async function () {
         let conversationId, timestamp;
         const transcriptStore = new MemoryTranscriptStore();
 
@@ -464,7 +464,7 @@ describe(`TranscriptLoggerMiddleware`, function () {
         });
     });
 
-    it(`should use current server time for activity id when activity and resourceResponse id is empty and no activity timestamp exists`, async function () {
+    it('should use current server time for activity id when activity and resourceResponse id is empty and no activity timestamp exists', async function () {
         let conversationId;
         const transcriptStore = new MemoryTranscriptStore();
 

--- a/libraries/botbuilder-core/tests/transcriptStoreBaseTest.js
+++ b/libraries/botbuilder-core/tests/transcriptStoreBaseTest.js
@@ -3,13 +3,14 @@ const { ActivityTypes } = require('../');
 
 function uuid() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-        var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+        const r = (Math.random() * 16) | 0,
+            v = c == 'x' ? r : (r & 0x3) | 0x8;
         return v.toString(16);
     });
 }
 
 function createActivities(conversationId, ts, count = 5) {
-    var activities = [];
+    const activities = [];
     for (let i = 1; i <= count; i++) {
         activities.push({
             type: ActivityTypes.Message,
@@ -20,7 +21,7 @@ function createActivities(conversationId, ts, count = 5) {
             from: { id: `User${i}` },
             conversation: { id: conversationId },
             recipient: { id: 'Bot1', name: '2' },
-            serviceUrl: 'http://foo.com/api/messages'
+            serviceUrl: 'http://foo.com/api/messages',
         });
         ts = new Date(ts.getTime() + 60000);
 
@@ -33,7 +34,7 @@ function createActivities(conversationId, ts, count = 5) {
             from: { id: 'Bot1', name: '2' },
             conversation: { id: conversationId },
             recipient: { id: `User${i}` },
-            serviceUrl: 'http://foo.com/api/messages'
+            serviceUrl: 'http://foo.com/api/messages',
         });
         ts = new Date(ts.getTime() + 60000);
     }
@@ -53,16 +54,12 @@ function group(array, size) {
 
 function promiseSeq(promiseFuncArray) {
     return promiseFuncArray.reduce((chain, promiseFunc) => {
-        return chain.then(chainResult =>
-            promiseFunc().then(currentResult =>
-                [ ...chainResult, currentResult ]
-            )
-        );
+        return chain.then((chainResult) => promiseFunc().then((currentResult) => [...chainResult, currentResult]));
     }, Promise.resolve([]));
 }
 
 function promiseParallel(promiseFuncArray) {
-    return Promise.all(promiseFuncArray.map(promiseFunc => promiseFunc()));
+    return Promise.all(promiseFuncArray.map((promiseFunc) => promiseFunc()));
 }
 
 function resolvePromises(promiseFuncArray, useParallel = true) {
@@ -74,16 +71,17 @@ function dateSorter(a, b) {
 }
 
 exports._badArgs = function _badArgs(store) {
-    var assertPromise = (promiseFunc, errMessage) => new Promise((resolve, reject) => {
-        try { promiseFunc().then(() => reject(errMessage)) }
-        catch (error) { resolve('expected error') }
-    });
+    const assertPromise = (promiseFunc, errMessage) =>
+        new Promise((resolve, reject) => {
+            try {
+                promiseFunc().then(() => reject(errMessage));
+            } catch {
+                resolve('expected error');
+            }
+        });
 
     return Promise.all([
-        assertPromise(
-            () => store.logActivity(null),
-            'logActivity should have thrown error about missing activity'
-        ),
+        assertPromise(() => store.logActivity(null), 'logActivity should have thrown error about missing activity'),
         assertPromise(
             () => store.getTranscriptActivities(null, null),
             'getTranscriptActivities should have thrown error about missing channelId'
@@ -103,214 +101,248 @@ exports._badArgs = function _badArgs(store) {
         assertPromise(
             () => store.deleteTranscript('foo', null),
             'deleteTranscript should have thrown error about missing conversationId'
-        )
+        ),
     ]);
-}
+};
 
 exports._logActivity = function _logActivity(store) {
-        var conversationId = '_logActivity';
-        var date = new Date();
-        var activity = createActivities(conversationId, date, 1).pop();
+    const conversationId = '_logActivity';
+    const date = new Date();
+    const activity = createActivities(conversationId, date, 1).pop();
 
-        return store.logActivity(activity)
-            .then(() => store.getTranscriptActivities('test', conversationId))
-            .then((result) => {
-                assert.equal(result.items.length, 1);
-                assert.equal(JSON.stringify(result.items[0]), JSON.stringify(activity));
-            });
-}
+    return store
+        .logActivity(activity)
+        .then(() => store.getTranscriptActivities('test', conversationId))
+        .then((result) => {
+            assert.equal(result.items.length, 1);
+            assert.equal(JSON.stringify(result.items[0]), JSON.stringify(activity));
+        });
+};
 
 exports._logMultipleActivities = function _logMultipleActivities(store, useParallel = true) {
-    var conversationId = '_logMultipleActivities';
-    var start = new Date();
-    var activities = createActivities(conversationId, start);
+    const conversationId = '_logMultipleActivities';
+    const start = new Date();
+    const activities = createActivities(conversationId, start);
 
     // log activities
-    var writes = activities.map(a => () => store.logActivity(a));
+    const writes = activities.map((a) => () => store.logActivity(a));
 
     // wait for all logs
     return resolvePromises(writes, useParallel).then(() => {
         // group the different queries into promises
         return Promise.all([
             // make sure other channels and conversations don't return results
-            store.getTranscriptActivities('bogus', conversationId).then(pagedResult => {
+            store.getTranscriptActivities('bogus', conversationId).then((pagedResult) => {
                 assert(!pagedResult.continuationToken);
                 assert.equal(pagedResult.items.length, 0);
             }),
             // make sure other channels and conversations don't return results
-            store.getTranscriptActivities('test', 'bogus').then(pagedResult => {
+            store.getTranscriptActivities('test', 'bogus').then((pagedResult) => {
                 assert(!pagedResult.continuationToken);
                 assert.equal(pagedResult.items.length, 0);
             }),
             // make sure all created activities where persisted
-            store.getTranscriptActivities('test', conversationId).then(pagedResult => {
+            store.getTranscriptActivities('test', conversationId).then((pagedResult) => {
                 assert(!pagedResult.continuationToken);
                 assert.equal(pagedResult.items.length, activities.length);
 
                 // assert all are equal
-                assert.equal(
-                    JSON.stringify(pagedResult.items.sort(dateSorter)),
-                    JSON.stringify(activities)
-                );
+                assert.equal(JSON.stringify(pagedResult.items.sort(dateSorter)), JSON.stringify(activities));
             }),
             // assert half page, get activities +5 minutes
-            store.getTranscriptActivities('test', conversationId, null, new Date(start.getTime() + 60000 * 5)).then(pagedResult => {
-                assert.equal(activities.length / 2, pagedResult.items.length);
-                var expected = activities.slice(5);
-                assert.equal(
-                    JSON.stringify(pagedResult.items.sort(dateSorter)),
-                    JSON.stringify(expected));
-            })
+            store
+                .getTranscriptActivities('test', conversationId, null, new Date(start.getTime() + 60000 * 5))
+                .then((pagedResult) => {
+                    assert.equal(activities.length / 2, pagedResult.items.length);
+                    const expected = activities.slice(5);
+                    assert.equal(JSON.stringify(pagedResult.items.sort(dateSorter)), JSON.stringify(expected));
+                }),
         ]);
     });
-}
+};
 
 exports._deleteTranscript = function _deleteTranscript(store, useParallel = true) {
-    var conversationId = '_deleteConversation';
-    var conversationId2 = '_deleteConversation2';
-    var start = new Date();
-    var activities = createActivities(conversationId, start);
-    var activities2 = createActivities(conversationId2, start);
+    const conversationId = '_deleteConversation';
+    const conversationId2 = '_deleteConversation2';
+    const start = new Date();
+    const activities = createActivities(conversationId, start);
+    const activities2 = createActivities(conversationId2, start);
 
     // log all activities
-    var writes = activities.concat(activities2)
-        .map(a => () => store.logActivity(a));
+    const writes = activities.concat(activities2).map((a) => () => store.logActivity(a));
 
     // wait for all writes
     return resolvePromises(writes, useParallel).then(() => {
         return Promise.all([
             // test A
-            store.getTranscriptActivities('test', conversationId).then(pagedResult => {
+            store.getTranscriptActivities('test', conversationId).then((pagedResult) => {
                 assert.equal(pagedResult.items.length, activities.length);
                 // delete!
                 store.deleteTranscript('test', conversationId).then(() => {
                     return Promise.all([
                         // check deleted
-                        store.getTranscriptActivities('test', conversationId).then(pagedResult => {
+                        store.getTranscriptActivities('test', conversationId).then((pagedResult) => {
                             assert.equal(pagedResult.items.length, 0);
                         }),
                         // check second transcript still exists
-                        store.getTranscriptActivities('test', conversationId2).then(pagedResult => {
+                        store.getTranscriptActivities('test', conversationId2).then((pagedResult) => {
                             assert.equal(pagedResult.items.length, activities2.length);
-                        })
-                    ])
-                })
+                        }),
+                    ]);
+                });
             }),
             // test B
-            store.getTranscriptActivities('test', conversationId2).then(pagedResult => {
+            store.getTranscriptActivities('test', conversationId2).then((pagedResult) => {
                 assert.equal(pagedResult.items.length, activities2.length);
-            })
+            }),
         ]);
     });
-}
+};
 
 exports._getTranscriptActivities = function _getTranscriptActivities(store, useParallel = true) {
     return new Promise((resolve, reject) => {
-        var conversationId = '_getTranscriptActivitiesPaging';
-        var date = new Date();
-        var activities = createActivities(conversationId, date, 50);
+        const conversationId = '_getTranscriptActivitiesPaging';
+        const date = new Date();
+        const activities = createActivities(conversationId, date, 50);
         // log in parallel batches of 10
-        var groups = group(activities, 10);
-        return promiseSeq(groups.map(group => () => resolvePromises(group.map(item => () => store.logActivity(item)), useParallel)))
-        .then(async () => {
-            var actualPageSize = 0;
-            var pagedResult = {};
-            var seen = [];
-            do {
-                pagedResult = await store.getTranscriptActivities('test', conversationId, pagedResult.continuationToken);
-                assert(pagedResult);
-                assert(pagedResult.items);
+        const groups = group(activities, 10);
+        return promiseSeq(
+            groups.map((group) => () =>
+                resolvePromises(
+                    group.map((item) => () => store.logActivity(item)),
+                    useParallel
+                )
+            )
+        )
+            .then(async () => {
+                let actualPageSize = 0;
+                let pagedResult = {};
+                const seen = [];
+                do {
+                    pagedResult = await store.getTranscriptActivities(
+                        'test',
+                        conversationId,
+                        pagedResult.continuationToken
+                    );
+                    assert(pagedResult);
+                    assert(pagedResult.items);
 
-                if (!actualPageSize) {
-                    actualPageSize = pagedResult.items.length;
-                } else if (actualPageSize === pagedResult.items.length) {
-                    assert(pagedResult.continuationToken)
-                }
-                pagedResult.items.forEach(item => {
-                    assert(!seen.includes(item.id));
-                    seen.push(item.id);
-                });
-            } while (pagedResult.continuationToken);
-            assert.equal(seen.length, activities.length);
-            activities.forEach(activity => assert(seen.includes(activity.id)));
-            resolve();
-        }).catch(error => reject(error));
+                    if (!actualPageSize) {
+                        actualPageSize = pagedResult.items.length;
+                    } else if (actualPageSize === pagedResult.items.length) {
+                        assert(pagedResult.continuationToken);
+                    }
+                    pagedResult.items.forEach((item) => {
+                        assert(!seen.includes(item.id));
+                        seen.push(item.id);
+                    });
+                } while (pagedResult.continuationToken);
+                assert.equal(seen.length, activities.length);
+                activities.forEach((activity) => assert(seen.includes(activity.id)));
+                resolve();
+            })
+            .catch((error) => reject(error));
     });
-}
+};
 
 exports._getTranscriptActivitiesStartDate = function _getTranscriptActivitiesStartDate(store, useParallel = true) {
     return new Promise((resolve, reject) => {
-        var conversationId = '_getTranscriptActivitiesStartDate';
-        var date = new Date();
-        var activities = createActivities(conversationId, date, 50);
+        const conversationId = '_getTranscriptActivitiesStartDate';
+        const date = new Date();
+        const activities = createActivities(conversationId, date, 50);
         // log in parallel batches of 10
-        var groups = group(activities, 10);
-        return promiseSeq(groups.map(group => () => resolvePromises(group.map(item => () => store.logActivity(item)), useParallel)))
-        .then(async () => {
-            var actualPageSize = 0;
-            var pagedResult = {};
-            var seen = [];
-            var referenceDate = new Date(date.getTime() + (50 * 60 * 1000));
-            do {
-                pagedResult = await store.getTranscriptActivities('test', conversationId, pagedResult.continuationToken, referenceDate);
-                assert(pagedResult);
-                assert(pagedResult.items);
+        const groups = group(activities, 10);
+        return promiseSeq(
+            groups.map((group) => () =>
+                resolvePromises(
+                    group.map((item) => () => store.logActivity(item)),
+                    useParallel
+                )
+            )
+        )
+            .then(async () => {
+                let actualPageSize = 0;
+                let pagedResult = {};
+                const seen = [];
+                const referenceDate = new Date(date.getTime() + 50 * 60 * 1000);
+                do {
+                    pagedResult = await store.getTranscriptActivities(
+                        'test',
+                        conversationId,
+                        pagedResult.continuationToken,
+                        referenceDate
+                    );
+                    assert(pagedResult);
+                    assert(pagedResult.items);
 
-                if (!actualPageSize) {
-                    actualPageSize = pagedResult.items.length;
-                } else if (actualPageSize === pagedResult.items.length) {
-                    assert(pagedResult.continuationToken)
-                }
-                pagedResult.items.forEach(item => {
-                    assert(!seen.includes(item.id));
-                    seen.push(item.id);
-                });
-            } while (pagedResult.continuationToken);
-            assert.equal(seen.length, activities.length / 2);
-            activities.filter(a => a.timestamp.getTime() >= referenceDate.getTime()).forEach(activity => assert(seen.includes(activity.id)));
-            activities.filter(a => a.timestamp.getTime() < referenceDate.getTime()).forEach(activity => assert(!seen.includes(activity.id)));
-            resolve();
-        }).catch(error => reject(error));
+                    if (!actualPageSize) {
+                        actualPageSize = pagedResult.items.length;
+                    } else if (actualPageSize === pagedResult.items.length) {
+                        assert(pagedResult.continuationToken);
+                    }
+                    pagedResult.items.forEach((item) => {
+                        assert(!seen.includes(item.id));
+                        seen.push(item.id);
+                    });
+                } while (pagedResult.continuationToken);
+                assert.equal(seen.length, activities.length / 2);
+                activities
+                    .filter((a) => a.timestamp.getTime() >= referenceDate.getTime())
+                    .forEach((activity) => assert(seen.includes(activity.id)));
+                activities
+                    .filter((a) => a.timestamp.getTime() < referenceDate.getTime())
+                    .forEach((activity) => assert(!seen.includes(activity.id)));
+                resolve();
+            })
+            .catch((error) => reject(error));
     });
-}
+};
 
 exports._listTranscripts = function _listTranscripts(store, useParallel = true) {
     return new Promise((resolve, reject) => {
-        var conversationIds = [];
-        var start = new Date();
+        const conversationIds = [];
+        const start = new Date();
         for (let i = 1; i <= 100; i++) {
-            conversationIds.push(`_ListConversations${i}`)
+            conversationIds.push(`_ListConversations${i}`);
         }
 
-        var activities = [].concat(...conversationIds.map(cId => createActivities(cId, start, 1)));
+        const activities = [].concat(...conversationIds.map((cId) => createActivities(cId, start, 1)));
 
         // log in parallel batches of 10
-        var groups = group(activities, 10);
-        return promiseSeq(groups.map(group => () => resolvePromises(group.map(item => () => store.logActivity(item)), useParallel)))
-        .then(async () => {
-            var actualPageSize = 0;
-            var pagedResult = {};
-            var seen = [];
-            do {
-                pagedResult = await store.listTranscripts('test', pagedResult.continuationToken);
-                assert(pagedResult);
-                assert(pagedResult.items);
+        const groups = group(activities, 10);
+        return promiseSeq(
+            groups.map((group) => () =>
+                resolvePromises(
+                    group.map((item) => () => store.logActivity(item)),
+                    useParallel
+                )
+            )
+        )
+            .then(async () => {
+                let actualPageSize = 0;
+                let pagedResult = {};
+                const seen = [];
+                do {
+                    pagedResult = await store.listTranscripts('test', pagedResult.continuationToken);
+                    assert(pagedResult);
+                    assert(pagedResult.items);
 
-                if (!actualPageSize) {
-                    actualPageSize = pagedResult.items.length;
-                } else if (actualPageSize === pagedResult.items.length) {
-                    assert(pagedResult.continuationToken)
-                }
-                pagedResult.items.forEach(item => {
-                    assert(!seen.includes(item.id));
-                    if (item.id.startsWith('_ListConversations')) {
-                        seen.push(item.id);
+                    if (!actualPageSize) {
+                        actualPageSize = pagedResult.items.length;
+                    } else if (actualPageSize === pagedResult.items.length) {
+                        assert(pagedResult.continuationToken);
                     }
-                });
-            } while (pagedResult.continuationToken);
-            assert.equal(seen.length, conversationIds.length);
-            conversationIds.forEach(cId => assert(seen.includes(cId)));
-            resolve();
-        }).catch(error => reject(error));
+                    pagedResult.items.forEach((item) => {
+                        assert(!seen.includes(item.id));
+                        if (item.id.startsWith('_ListConversations')) {
+                            seen.push(item.id);
+                        }
+                    });
+                } while (pagedResult.continuationToken);
+                assert.equal(seen.length, conversationIds.length);
+                conversationIds.forEach((cId) => assert(seen.includes(cId)));
+                resolve();
+            })
+            .catch((error) => reject(error));
     });
-}
+};

--- a/libraries/botbuilder-core/tests/transcriptUtilities.js
+++ b/libraries/botbuilder-core/tests/transcriptUtilities.js
@@ -58,7 +58,7 @@ function getActivitiesFromChat(chatFilePath) {
  * Creates a Mocha Test definition (Mocha.ITestDefinition) that will use the TestAdapter to test a bot logic against the specified transcript file.
  * Optionally, pass a third parameter (as function) to register middleware into the TestAdapter.
  *
- * @param {string} transcriptPath Path to the transcript file. Can be a .chat or .transcript file.
+ * @param {string} relativeTranscriptPath Path to the transcript file. Can be a .chat or .transcript file.
  * @param {Function} botLogicFactoryFun Function which accepts conversationState and userState and should return the bots logic to test.
  * @param {Function} middlewareRegistrationFun (Optional) Function which accepts the testAdapter, conversationState and userState.
  */
@@ -176,7 +176,7 @@ const isUrl = (possibleUrl) => {
     try {
         new url.URL(possibleUrl);
         return true;
-    } catch (e) {
+    } catch {
         return false;
     }
 };

--- a/libraries/botbuilder-core/tests/turnContext.test.js
+++ b/libraries/botbuilder-core/tests/turnContext.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const { ActivityTypes, BotAdapter, DeliveryModes, MessageFactory, TurnContext } = require('../');
 
-const activityId = `activity ID`;
+const activityId = 'activity ID';
 
 const testMessage = {
     type: 'message',
@@ -24,10 +24,10 @@ const testTraceMessage = {
 class SimpleAdapter extends BotAdapter {
     sendActivities(context, activities) {
         const responses = [];
-        assert(context, `SimpleAdapter.sendActivities: missing context.`);
-        assert(activities, `SimpleAdapter.sendActivities: missing activities.`);
-        assert(Array.isArray(activities), `SimpleAdapter.sendActivities: activities not array.`);
-        assert(activities.length > 0, `SimpleAdapter.sendActivities: empty activities array.`);
+        assert(context, 'SimpleAdapter.sendActivities: missing context.');
+        assert(activities, 'SimpleAdapter.sendActivities: missing activities.');
+        assert(Array.isArray(activities), 'SimpleAdapter.sendActivities: activities not array.');
+        assert(activities.length > 0, 'SimpleAdapter.sendActivities: empty activities array.');
         activities.forEach((a, i) => {
             assert(typeof a === 'object', `SimpleAdapter.sendActivities: activity[${i}] not an object.`);
             assert(typeof a.type === 'string', `SimpleAdapter.sendActivities: activity[${i}].type missing or invalid.`);
@@ -37,14 +37,14 @@ class SimpleAdapter extends BotAdapter {
     }
 
     updateActivity(context, activity) {
-        assert(context, `SimpleAdapter.updateActivity: missing context.`);
-        assert(activity, `SimpleAdapter.updateActivity: missing activity.`);
+        assert(context, 'SimpleAdapter.updateActivity: missing context.');
+        assert(activity, 'SimpleAdapter.updateActivity: missing activity.');
         return Promise.resolve();
     }
 
     deleteActivity(context, reference) {
-        assert(context, `SimpleAdapter.deleteActivity: missing context.`);
-        assert(reference, `SimpleAdapter.deleteActivity: missing reference.`);
+        assert(context, 'SimpleAdapter.deleteActivity: missing context.');
+        assert(reference, 'SimpleAdapter.deleteActivity: missing reference.');
         assert(
             reference.activityId === '1234',
             `SimpleAdapter.deleteActivity: invalid activityId of "${reference.activityId}".`
@@ -55,65 +55,65 @@ class SimpleAdapter extends BotAdapter {
 
 class SendAdapter extends BotAdapter {
     sendActivities(context, activities) {
-        assert(context, `SendAdapter.sendActivities: missing context.`);
-        assert(activities, `SendAdapter.sendActivities: missing activities.`);
-        assert(Array.isArray(activities), `SendAdapter.sendActivities: activities not array.`);
-        assert(activities.length > 0, `SendAdapter.sendActivities: empty activities array.`);
+        assert(context, 'SendAdapter.sendActivities: missing context.');
+        assert(activities, 'SendAdapter.sendActivities: missing activities.');
+        assert(Array.isArray(activities), 'SendAdapter.sendActivities: activities not array.');
+        assert(activities.length > 0, 'SendAdapter.sendActivities: empty activities array.');
         return Promise.resolve(activities);
     }
 
     updateActivity(context, activity) {
-        assert(context, `SendAdapter.updateActivity: missing context.`);
-        assert(activity, `SendAdapter.updateActivity: missing activity.`);
+        assert(context, 'SendAdapter.updateActivity: missing context.');
+        assert(activity, 'SendAdapter.updateActivity: missing activity.');
         return Promise.resolve();
     }
 
     deleteActivity(context, reference) {
-        assert(context, `SendAdapter.deleteActivity: missing context.`);
-        assert(reference, `SendAdapter.deleteActivity: missing reference.`);
+        assert(context, 'SendAdapter.deleteActivity: missing context.');
+        assert(reference, 'SendAdapter.deleteActivity: missing reference.');
         return Promise.resolve();
     }
 }
 
-describe(`TurnContext`, function () {
+describe('TurnContext', function () {
     this.timeout(5000);
 
-    it(`should have adapter.`, function () {
+    it('should have adapter.', function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        assert(context.adapter, `missing property.`);
-        assert(context.adapter.deleteActivity, `invalid property.`);
+        assert(context.adapter, 'missing property.');
+        assert(context.adapter.deleteActivity, 'invalid property.');
     });
 
-    it(`should have activity.`, function () {
+    it('should have activity.', function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        assert(context.activity, `missing property.`);
-        assert(context.activity.type === 'message', `invalid property.`);
+        assert(context.activity, 'missing property.');
+        assert(context.activity.type === 'message', 'invalid property.');
     });
 
-    it(`should clone a passed in context.`, function () {
+    it('should clone a passed in context.', function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
         const ctx = new TurnContext(context);
-        assert(ctx._adapter === context._adapter, `_adapter not cloned.`);
-        assert(ctx._activity === context._activity, `_activity not cloned.`);
-        assert(ctx._services === context._services, `_services not cloned.`);
-        assert(ctx._onDeleteActivity === context._onDeleteActivity, `_onDeleteActivity not cloned.`);
-        assert(ctx._onSendActivities === context._onSendActivities, `_onSendActivities not cloned.`);
-        assert(ctx._onUpdateActivity === context._onUpdateActivity, `_onUpdateActivity not cloned.`);
-        assert(ctx._respondedRef === context._respondedRef, `_respondedRef not cloned.`);
+        assert(ctx._adapter === context._adapter, '_adapter not cloned.');
+        assert(ctx._activity === context._activity, '_activity not cloned.');
+        assert(ctx._services === context._services, '_services not cloned.');
+        assert(ctx._onDeleteActivity === context._onDeleteActivity, '_onDeleteActivity not cloned.');
+        assert(ctx._onSendActivities === context._onSendActivities, '_onSendActivities not cloned.');
+        assert(ctx._onUpdateActivity === context._onUpdateActivity, '_onUpdateActivity not cloned.');
+        assert(ctx._respondedRef === context._respondedRef, '_respondedRef not cloned.');
     });
 
-    it(`responded should start as 'false'.`, function () {
+    it("responded should start as 'false'.", function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        assert(context.responded === false, `invalid value.`);
+        assert(context.responded === false, 'invalid value.');
     });
 
-    it(`should set responded.`, function () {
+    it('should set responded.', function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
         context.responded = true;
-        assert(context.responded === true, `responded not set.`);
+        assert(context.responded === true, 'responded not set.');
     });
 
-    it(`should throw if you set responded to false.`, function () {
+    it('should throw if you set responded to false.', function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
         context.responded = true;
         assert.throws(() => (context.responded = false), {
@@ -121,9 +121,9 @@ describe(`TurnContext`, function () {
         });
     });
 
-    it(`should cache a value using turnState.set() and services.get().`, function () {
+    it('should cache a value using turnState.set() and services.get().', function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        assert(context.turnState.get('foo') === undefined, `invalid initial state.`);
+        assert(context.turnState.get('foo') === undefined, 'invalid initial state.');
         context.turnState.set('foo', 'bar');
         assert(
             context.turnState.get('foo') === 'bar',
@@ -131,26 +131,26 @@ describe(`TurnContext`, function () {
         );
     });
 
-    it(`should inspect a value using has().`, function () {
+    it('should inspect a value using has().', function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        assert(!context.turnState.has('bar'), `invalid initial state for has().`);
+        assert(!context.turnState.has('bar'), 'invalid initial state for has().');
         context.turnState.set('bar', 'foo');
-        assert(context.turnState.has('bar'), `invalid initial state for has() after set().`);
+        assert(context.turnState.has('bar'), 'invalid initial state for has() after set().');
         context.turnState.set('bar', undefined);
-        assert(context.turnState.has('bar'), `invalid initial state for has() after set(undefined).`);
+        assert(context.turnState.has('bar'), 'invalid initial state for has() after set(undefined).');
     });
 
-    it(`should be able to use a Symbol with set(), get(), and has().`, function () {
+    it('should be able to use a Symbol with set(), get(), and has().', function () {
         const key = Symbol('foo');
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        assert(!context.turnState.has(key), `invalid initial state for has().`);
+        assert(!context.turnState.has(key), 'invalid initial state for has().');
         context.turnState.set(key, 'bar');
         assert(context.turnState.get(key) === 'bar', `invalid value of "${context.turnState.get(key)}" after set().`);
         context.turnState.set(key, undefined);
-        assert(context.turnState.has(key), `invalid initial state for has() after set(undefined).`);
+        assert(context.turnState.has(key), 'invalid initial state for has() after set(undefined).');
     });
 
-    it(`should push() and pop() a new turn state.`, function () {
+    it('should push() and pop() a new turn state.', function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
         context.turnState.set('foo', 'a');
         context.turnState.push('foo', 'b');
@@ -159,145 +159,145 @@ describe(`TurnContext`, function () {
             `invalid value of "${context.turnState.get('foo')}" after push().`
         );
         const old = context.turnState.pop('foo');
-        assert(old == 'b', `popped value not returned.`);
+        assert(old == 'b', 'popped value not returned.');
         assert(context.turnState.get('foo') === 'a', `invalid value of "${context.turnState.get('foo')}" after pop().`);
     });
 
-    it(`should sendActivity() and set responded.`, async function () {
+    it('should sendActivity() and set responded.', async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
         const response = await context.sendActivity(testMessage);
-        assert(response, `response is missing.`);
+        assert(response, 'response is missing.');
         assert(response.id === '5678', `invalid response id of "${response.id}" sent back.`);
-        assert(context.responded === true, `context.responded not set after send.`);
+        assert(context.responded === true, 'context.responded not set after send.');
     });
 
-    it(`should send a text message via sendActivity().`, async function () {
+    it('should send a text message via sendActivity().', async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
         const response = await context.sendActivity('test');
-        assert(response, `response is missing.`);
+        assert(response, 'response is missing.');
         assert(response.id === '5678', `invalid response id of "${response.id}" sent back.`);
     });
 
-    it(`should send a text message with speak and inputHint added.`, async function () {
+    it('should send a text message with speak and inputHint added.', async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        context.onSendActivities((ctx, activities, next) => {
-            assert(Array.isArray(activities), `activities not array.`);
-            assert(activities.length === 1, `invalid count of activities.`);
-            assert(activities[0].text === 'test', `text wrong.`);
-            assert(activities[0].speak === 'say test', `speak worng.`);
-            assert(activities[0].inputHint === 'ignoringInput', `inputHint wrong.`);
+        context.onSendActivities((ctx, activities, _next) => {
+            assert(Array.isArray(activities), 'activities not array.');
+            assert(activities.length === 1, 'invalid count of activities.');
+            assert(activities[0].text === 'test', 'text wrong.');
+            assert(activities[0].speak === 'say test', 'speak worng.');
+            assert(activities[0].inputHint === 'ignoringInput', 'inputHint wrong.');
             return [];
         });
         await context.sendActivity('test', 'say test', 'ignoringInput');
     });
 
-    it(`should send a trace activity.`, async function () {
+    it('should send a trace activity.', async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        context.onSendActivities((ctx, activities, next) => {
-            assert(Array.isArray(activities), `activities not array.`);
-            assert(activities.length === 1, `invalid count of activities.`);
-            assert(activities[0].type === ActivityTypes.Trace, `type wrong.`);
-            assert(activities[0].name === 'name-text', `name wrong.`);
-            assert(activities[0].value === 'value-text', `value worng.`);
-            assert(activities[0].valueType === 'valueType-text', `valeuType wrong.`);
-            assert(activities[0].label === 'label-text', `label wrong.`);
+        context.onSendActivities((ctx, activities, _next) => {
+            assert(Array.isArray(activities), 'activities not array.');
+            assert(activities.length === 1, 'invalid count of activities.');
+            assert(activities[0].type === ActivityTypes.Trace, 'type wrong.');
+            assert(activities[0].name === 'name-text', 'name wrong.');
+            assert(activities[0].value === 'value-text', 'value worng.');
+            assert(activities[0].valueType === 'valueType-text', 'valeuType wrong.');
+            assert(activities[0].label === 'label-text', 'label wrong.');
             return [];
         });
         await context.sendTraceActivity('name-text', 'value-text', 'valueType-text', 'label-text');
     });
 
-    it(`should send multiple activities via sendActivities().`, async function () {
+    it('should send multiple activities via sendActivities().', async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
         const responses = await context.sendActivities([testMessage, testMessage, testMessage]);
-        assert(Array.isArray(responses), `responses isn't an array.`);
-        assert(responses.length > 0, `empty responses array returned.`);
+        assert(Array.isArray(responses), "responses isn't an array.");
+        assert(responses.length > 0, 'empty responses array returned.');
         assert(responses.length === 3, `invalid responses array length of "${responses.length}" returned.`);
         assert(responses[0].id === '5678', `invalid response id of "${responses[0].id}" sent back.`);
     });
 
-    it(`should call onSendActivity() hook before delivery.`, async function () {
+    it('should call onSendActivity() hook before delivery.', async function () {
         let count = 0;
         const context = new TurnContext(new SimpleAdapter(), testMessage);
         context.onSendActivities((ctx, activities, next) => {
-            assert(ctx, `context not passed to hook`);
-            assert(activities, `activity not passed to hook`);
+            assert(ctx, 'context not passed to hook');
+            assert(activities, 'activity not passed to hook');
             count = activities.length;
             return next();
         });
         await context.sendActivity(testMessage);
-        assert(count === 1, `send hook not called.`);
+        assert(count === 1, 'send hook not called.');
     });
 
-    it(`should allow interception of delivery in onSendActivity() hook.`, async function () {
+    it('should allow interception of delivery in onSendActivity() hook.', async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        context.onSendActivities((ctx, activities, next) => {
+        context.onSendActivities((_ctx, _activities, _next) => {
             return [];
         });
         const response = await context.sendActivity(testMessage);
-        assert(response === undefined, `call not intercepted.`);
+        assert(response === undefined, 'call not intercepted.');
     });
 
-    it(`should call onUpdateActivity() hook before update.`, async function () {
+    it('should call onUpdateActivity() hook before update.', async function () {
         let called = false;
         const context = new TurnContext(new SimpleAdapter(), testMessage);
         context.onUpdateActivity((ctx, activity, next) => {
-            assert(ctx, `context not passed to hook`);
-            assert(activity, `activity not passed to hook`);
+            assert(ctx, 'context not passed to hook');
+            assert(activity, 'activity not passed to hook');
             called = true;
             return next();
         });
         await context.updateActivity(testMessage);
-        assert(called, `update hook not called.`);
+        assert(called, 'update hook not called.');
     });
 
-    it(`should be able to update an activity with MessageFactory`, async function () {
+    it('should be able to update an activity with MessageFactory', async function () {
         let called = false;
         const context = new TurnContext(new SimpleAdapter(), testMessage);
         context.onUpdateActivity((ctx, activity, next) => {
-            assert(ctx, `context not passed to hook`);
-            assert(activity, `activity not passed to hook`);
-            assert(activity.id === activityId, `wrong activity passed to hook`);
-            assert(activity.conversation.id === testMessage.conversation.id, `conversation ID not applied to activity`);
-            assert(activity.serviceUrl === testMessage.serviceUrl, `service URL not applied to activity`);
+            assert(ctx, 'context not passed to hook');
+            assert(activity, 'activity not passed to hook');
+            assert(activity.id === activityId, 'wrong activity passed to hook');
+            assert(activity.conversation.id === testMessage.conversation.id, 'conversation ID not applied to activity');
+            assert(activity.serviceUrl === testMessage.serviceUrl, 'service URL not applied to activity');
             called = true;
             return next();
         });
-        const message = MessageFactory.text(`test text`);
+        const message = MessageFactory.text('test text');
         message.id = activityId;
         await context.updateActivity(message);
-        assert(called, `update hook not called.`);
+        assert(called, 'update hook not called.');
     });
 
-    it(`should call onDeleteActivity() hook before delete by "id".`, async function () {
+    it('should call onDeleteActivity() hook before delete by "id".', async function () {
         let called = false;
         const context = new TurnContext(new SimpleAdapter(), testMessage);
         context.onDeleteActivity((ctx, reference, next) => {
-            assert(ctx, `context not passed to hook`);
-            assert(reference, `missing reference`);
-            assert(reference.activityId === '1234', `invalid activityId passed to hook`);
+            assert(ctx, 'context not passed to hook');
+            assert(reference, 'missing reference');
+            assert(reference.activityId === '1234', 'invalid activityId passed to hook');
             called = true;
             return next();
         });
         await context.deleteActivity('1234');
-        assert(called, `delete hook not called.`);
+        assert(called, 'delete hook not called.');
     });
 
-    it(`should call onDeleteActivity() hook before delete by "reference".`, async function () {
+    it('should call onDeleteActivity() hook before delete by "reference".', async function () {
         let called = false;
         const context = new TurnContext(new SimpleAdapter(), testMessage);
         context.onDeleteActivity((ctx, reference, next) => {
-            assert(reference, `missing reference`);
-            assert(reference.activityId === '1234', `invalid activityId passed to hook`);
+            assert(reference, 'missing reference');
+            assert(reference.activityId === '1234', 'invalid activityId passed to hook');
             called = true;
             return next();
         });
         await context.deleteActivity({ activityId: '1234' });
-        assert(called, `delete hook not called.`);
+        assert(called, 'delete hook not called.');
     });
 
-    it(`should map an exception raised by a hook to a rejection.`, async function () {
+    it('should map an exception raised by a hook to a rejection.', async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
-        context.onDeleteActivity((ctx, reference, next) => {
+        context.onDeleteActivity((_ctx, _reference, _next) => {
             throw new Error('failed');
         });
         await assert.rejects(async () => await context.deleteActivity('1234'), {
@@ -305,81 +305,81 @@ describe(`TurnContext`, function () {
         });
     });
 
-    it(`should round trip a conversation reference using getConversationReference() and applyConversationRefernce().`, function () {
+    it('should round trip a conversation reference using getConversationReference() and applyConversationRefernce().', function () {
         // Convert to reference
         const testMessageWithLocale = JSON.parse(JSON.stringify(testMessage));
         testMessageWithLocale.locale = 'en_uS'; // Intentionally oddly-cased to check that it isn't defaulted somewhere, but tests stay in English
         const reference = TurnContext.getConversationReference(testMessageWithLocale);
-        assert(reference.activityId, `reference missing activityId.`);
-        assert(reference.bot, `reference missing bot.`);
-        assert(reference.bot.id === testMessage.recipient.id, `reference bot.id doesn't match recipient.id.`);
-        assert(reference.channelId, `reference missing channelId.`);
-        assert(reference.conversation, `reference missing conversation.`);
-        assert(reference.locale, `reference missing locale.`);
-        assert(reference.locale === testMessageWithLocale.locale, `reference locale doesn't match locale`);
-        assert(reference.serviceUrl, `reference missing serviceUrl.`);
-        assert(reference.user, `reference missing user.`);
-        assert(reference.user.id === testMessage.from.id, `reference user.id doesn't match from.id.`);
+        assert(reference.activityId, 'reference missing activityId.');
+        assert(reference.bot, 'reference missing bot.');
+        assert(reference.bot.id === testMessage.recipient.id, "reference bot.id doesn't match recipient.id.");
+        assert(reference.channelId, 'reference missing channelId.');
+        assert(reference.conversation, 'reference missing conversation.');
+        assert(reference.locale, 'reference missing locale.');
+        assert(reference.locale === testMessageWithLocale.locale, "reference locale doesn't match locale");
+        assert(reference.serviceUrl, 'reference missing serviceUrl.');
+        assert(reference.user, 'reference missing user.');
+        assert(reference.user.id === testMessage.from.id, "reference user.id doesn't match from.id.");
 
         // Round trip back to outgoing activity
         const activity = TurnContext.applyConversationReference({ text: 'foo', type: 'message' }, reference);
-        assert(activity.text, `activity missing text`);
-        assert(activity.type, `activity missing type`);
-        assert(activity.replyToId, `activity missing replyToId`);
-        assert(activity.from, `activity missing from`);
-        assert(activity.from.id === reference.bot.id, `activity from.id doesn't match bot.id`);
-        assert(activity.channelId, `activity missing channelId`);
-        assert(activity.conversation, `activity missing conversation`);
-        assert(activity.locale, `activity missing locale.`);
-        assert(activity.locale === testMessageWithLocale.locale, `activity locale doesn't match locale`);
-        assert(activity.serviceUrl, `activity missing serviceUrl`);
-        assert(activity.recipient, `activity missing recipient`);
-        assert(activity.recipient.id === reference.user.id, `activity recipient.id doesn't match user.id`);
+        assert(activity.text, 'activity missing text');
+        assert(activity.type, 'activity missing type');
+        assert(activity.replyToId, 'activity missing replyToId');
+        assert(activity.from, 'activity missing from');
+        assert(activity.from.id === reference.bot.id, "activity from.id doesn't match bot.id");
+        assert(activity.channelId, 'activity missing channelId');
+        assert(activity.conversation, 'activity missing conversation');
+        assert(activity.locale, 'activity missing locale.');
+        assert(activity.locale === testMessageWithLocale.locale, "activity locale doesn't match locale");
+        assert(activity.serviceUrl, 'activity missing serviceUrl');
+        assert(activity.recipient, 'activity missing recipient');
+        assert(activity.recipient.id === reference.user.id, "activity recipient.id doesn't match user.id");
 
         // Round trip back to incoming activity
         const activity2 = TurnContext.applyConversationReference({ text: 'foo', type: 'message' }, reference, true);
-        assert(activity2.id, `activity2 missing id`);
-        assert(activity2.from, `activity2 missing from`);
-        assert(activity2.from.id === reference.user.id, `activity2 from.id doesn't match user.id`);
-        assert(activity2.recipient, `activity2 missing recipient`);
-        assert(activity2.recipient.id === reference.bot.id, `activity2 recipient.id doesn't match bot.id`);
-        assert(activity2.locale, `activity2 missing locale.`);
-        assert(activity2.locale === testMessageWithLocale.locale, `activity2 locale doesn't match locale`);
+        assert(activity2.id, 'activity2 missing id');
+        assert(activity2.from, 'activity2 missing from');
+        assert(activity2.from.id === reference.user.id, "activity2 from.id doesn't match user.id");
+        assert(activity2.recipient, 'activity2 missing recipient');
+        assert(activity2.recipient.id === reference.bot.id, "activity2 recipient.id doesn't match bot.id");
+        assert(activity2.locale, 'activity2 missing locale.');
+        assert(activity2.locale === testMessageWithLocale.locale, "activity2 locale doesn't match locale");
 
         // Round trip outgoing activity without a replyToId
         delete reference.activityId;
         const activity3 = TurnContext.applyConversationReference({ text: 'foo', type: 'message' }, reference);
-        assert(!activity3.hasOwnProperty('replyToId'), `activity3 has replyToId`);
+        assert(!Object.prototype.hasOwnProperty.call(activity3, 'replyToId'), 'activity3 has replyToId');
 
         // Round trip incoming activity without an id
         delete reference.activityId;
         const activity4 = TurnContext.applyConversationReference({ text: 'foo', type: 'message' }, reference, true);
-        assert(!activity4.hasOwnProperty('id'), `activity4 has id`);
+        assert(!Object.prototype.hasOwnProperty.call(activity4, 'id'), 'activity4 has id');
     });
 
-    it(`should not set TurnContext.responded to true if Trace activity is sent.`, async function () {
+    it('should not set TurnContext.responded to true if Trace activity is sent.', async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
         await context.sendActivities([testTraceMessage]);
-        assert(context.responded === false, `responded was set to true.`);
+        assert(context.responded === false, 'responded was set to true.');
     });
 
-    it(`should not set TurnContext.responded to true if multiple Trace activities are sent.`, async function () {
+    it('should not set TurnContext.responded to true if multiple Trace activities are sent.', async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
         await context.sendActivities([testTraceMessage, testTraceMessage]);
-        assert(context.responded === false, `responded was set to true.`);
+        assert(context.responded === false, 'responded was set to true.');
     });
 
-    it(`should set TurnContext.responded to true if Trace and message activities are sent.`, async function () {
+    it('should set TurnContext.responded to true if Trace and message activities are sent.', async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
 
         await context.sendActivities([testTraceMessage, testTraceMessage]);
-        assert(context.responded === false, `responded was set to true.`);
+        assert(context.responded === false, 'responded was set to true.');
 
         await context.sendActivities([testMessage]);
-        assert(context.responded, `responded was not set to true.`);
+        assert(context.responded, 'responded was not set to true.');
     });
 
-    it(`should get a conversation reference from a sent activity using getReplyConversationReference.`, async function () {
+    it('should get a conversation reference from a sent activity using getReplyConversationReference.', async function () {
         const context = new TurnContext(new SimpleAdapter(), testMessage);
 
         const reply = await context.sendActivity({ text: 'test' });
@@ -399,10 +399,10 @@ describe(`TurnContext`, function () {
             entities: [
                 {
                     type: 'mention',
-                    text: `<at>TestOAuth619</at>`,
+                    text: '<at>TestOAuth619</at>',
                     mentioned: {
                         name: 'Bot',
-                        id: `TestOAuth619`,
+                        id: 'TestOAuth619',
                     },
                 },
             ],
@@ -414,14 +414,14 @@ describe(`TurnContext`, function () {
         assert(activity.text, ' test activity');
     });
 
-    it(`should clear existing activity.id in context.sendActivity().`, async function () {
+    it('should clear existing activity.id in context.sendActivity().', async function () {
         const context = new TurnContext(new SendAdapter(), testMessage);
         const response = await context.sendActivity(testMessage);
-        assert(response, `response is missing.`);
+        assert(response, 'response is missing.');
         assert(response.id === undefined, `invalid response id of "${response.id}" sent back. Should be 'undefined'`);
     });
 
-    it('should add to bufferedReplyActivities if TurnContext.activity.deliveryMode === DeliveryModes.ExpectReplies', async () => {
+    it('should add to bufferedReplyActivities if TurnContext.activity.deliveryMode === DeliveryModes.ExpectReplies', async function () {
         const activity = JSON.parse(JSON.stringify(testMessage));
         activity.deliveryMode = DeliveryModes.ExpectReplies;
         const context = new TurnContext(new SimpleAdapter(), activity);

--- a/libraries/botbuilder-core/tests/userState.test.js
+++ b/libraries/botbuilder-core/tests/userState.test.js
@@ -5,44 +5,42 @@ const receivedMessage = { text: 'received', type: 'message', channelId: 'test', 
 const missingChannelId = { text: 'received', type: 'message', from: { id: 'user' } };
 const missingFrom = { text: 'received', type: 'message', channelId: 'test' };
 
-describe(`UserState`, function () {
+describe('UserState', function () {
     this.timeout(5000);
 
     const storage = new MemoryStorage();
     const adapter = new TestAdapter();
     const context = new TurnContext(adapter, receivedMessage);
     const userState = new UserState(storage);
-    it(`should load and save state from storage.`, async function () {
-        let key;
-
+    it('should load and save state from storage.', async function () {
         // Simulate a "Turn" in a conversation by loading the state,
         // changing it and then saving the changes to state.
         await userState.load(context);
-        key = userState.getStorageKey(context);
+        const key = userState.getStorageKey(context);
         const state = userState.get(context);
-        assert(state, `State not loaded`);
-        assert(key, `Key not found`);
+        assert(state, 'State not loaded');
+        assert(key, 'Key not found');
         state.test = 'foo';
         await userState.saveChanges(context);
 
         // Check the storage to see if the changes to state were saved.
         const items = await storage.read([key]);
-        assert(items.hasOwnProperty(key), `Saved state not found in storage.`);
-        assert(items[key].test === 'foo', `Missing test value in stored state.`);
+        assert(Object.prototype.hasOwnProperty.call(items, key), 'Saved state not found in storage.');
+        assert(items[key].test === 'foo', 'Missing test value in stored state.');
     });
 
-    it(`should reject with error if channelId missing.`, function () {
+    it('should reject with error if channelId missing.', function () {
         const ctx = new TurnContext(adapter, missingChannelId);
         assert.throws(() => userState.load(ctx), Error('missing activity.channelId'));
     });
 
-    it(`should reject with error if from missing.`, function () {
+    it('should reject with error if from missing.', function () {
         const ctx = new TurnContext(adapter, missingFrom);
         assert.throws(() => userState.load(ctx), Error('missing activity.from.id'));
     });
 
-    it(`should throw NO_KEY error if getStorageKey() returns falsey value.`, async function () {
-        userState.getStorageKey = (turnContext) => undefined;
+    it('should throw NO_KEY error if getStorageKey() returns falsey value.', async function () {
+        userState.getStorageKey = (_turnContext) => undefined;
         await assert.rejects(
             userState.load(context, true),
             new Error('UserState: overridden getStorageKey method did not return a key.')


### PR DESCRIPTION
Addresses #4204
#minor

## Description
This PR fixes the ESLint and JSDoc issues in the `botbuilder-core` library.

**_Note: we excluded the @typescript-eslint/no-explicit-any and @typescript-eslint/explicit-module-boundary-types to tackle those issues as a separate task as they require deeper analysis and testing._**

## Specific Changes
- Applied auto-fixes with `yarn lint --fix`
   - Fix spacing.
   - Fix indentation.
   - Fix quoting.
   - Replace arrow functions:   () => with function ().
   - Replace let with const. 
- Applied manual fixes for: 
  - Unused parameters and imports.
  - Replacing _hasOwnProperty_ calls.
  - Removing unused test class BotStateMock in _botStateSet.test.js_.
- Removed unused `lodash` devDependency.

## Testing
Here we can see the eslint status before and after.
![image](https://user-images.githubusercontent.com/44245136/165594750-1663c15c-70d8-4b94-87bb-6af884e981b2.png)
