### PR TITLE
fix: [#4204] Fix remaining eslint warnings - botbuilder-dialogs-adaptive

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/package.json
+++ b/libraries/botbuilder-dialogs-adaptive/package.json
@@ -35,6 +35,9 @@
     "@microsoft/recognizers-text-choice": "~1.1.4",
     "@microsoft/recognizers-text-date-time": "~1.1.4",
     "@microsoft/recognizers-text-suite": "1.1.4",
+    "adaptive-expressions": "4.1.6",
+    "botbuilder": "4.1.6",
+    "botbuilder-dialogs": "4.1.6",
     "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
     "botbuilder-dialogs-declarative": "4.1.6",
     "botbuilder-lg": "4.1.6",
@@ -43,10 +46,7 @@
     "node-fetch": "^2.6.7"
   },
   "devDependencies": {
-    "@types/node-fetch": "^2.5.3",
-    "adaptive-expressions": "4.1.6",
-    "botbuilder": "4.1.6",
-    "botbuilder-dialogs": "4.1.6"
+    "@types/node-fetch": "^2.5.3"
   },
   "scripts": {
     "build": "npm-run-all build:src build:tests",

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/baseInvokeDialog.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/baseInvokeDialog.ts
@@ -42,6 +42,7 @@ export class BaseInvokeDialog<O extends object = {}>
     implements DialogDependencies, BaseInvokeDialogConfiguration {
     /**
      * Initializes a new instance of the [BaseInvokeDialog](xref:botbuilder-dialogs-adaptive.BaseInvokeDialog) class.
+     *
      * @param dialogIdToCall The dialog id.
      * @param bindingOptions (optional) Binding options.
      */

--- a/libraries/botbuilder-dialogs-adaptive/src/entityAssignmentComparer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/entityAssignmentComparer.ts
@@ -10,7 +10,7 @@ import { EntityAssignment } from './entityAssignment';
 
 /**
  * Compare two entity assignments to determine their relative priority.
- 
+ *
  * @remarks
  * Compare by event: assignEntity, chooseProperty, chooseEntity
  * Then by operations in order from schema (usually within assignEntity).

--- a/libraries/botbuilder-dialogs-adaptive/src/entityAssignmentComparer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/entityAssignmentComparer.ts
@@ -10,7 +10,7 @@ import { EntityAssignment } from './entityAssignment';
 
 /**
  * Compare two entity assignments to determine their relative priority.
-
+ 
  * @remarks
  * Compare by event: assignEntity, chooseProperty, chooseEntity
  * Then by operations in order from schema (usually within assignEntity).

--- a/libraries/botbuilder-dialogs-adaptive/src/input/choiceInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/choiceInput.ts
@@ -134,6 +134,10 @@ export class ChoiceInput extends InputDialog implements ChoiceInputConfiguration
 
     /**
      * {@inheritDoc InputDialog.trackGeneratorResultEvent}
+     *
+     * @param dc The [DialogContext](xref:botbuilder-dialogs.DialogContext) for the current turn of conversation.
+     * @param activityTemplate Used to create the Activity.
+     * @param msg The Partial [Activity](xref:botframework-schema.Activity) which will be sent.
      */
     protected trackGeneratorResultEvent(
         dc: DialogContext,

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/valueRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/valueRecognizer.ts
@@ -13,7 +13,7 @@ import { TelemetryLoggerConstants } from '../telemetryLoggerConstants';
 
 /**
  * ValueRecognizer - Recognizer for mapping message activity. Value payload into intent/entities.
- * 
+ *
  * @remarks
  * This recognizer will map MessageActivity Value payloads into intents and entities.
  *      activity.Value.intent => RecognizerResult.Intents.


### PR DESCRIPTION
Addresses #4204
#minor

## Description
This PR fixes the ESLint and JSDoc issues in the `botbuilder-dialogs-adaptive` library.

**_Note: we excluded the @typescript-eslint/no-explicit-any and @typescript-eslint/explicit-module-boundary-types to tackle those issues as a separate task as they require deeper analysis and testing._**

## Specific Changes
- Applied auto-fixes with `yarn lint --fix`
   - Fix spacing.
- Applied manual fixes for: 
  - Missing documentation.
- Moved devDependencies to the Dependencies section.

## Testing
Here we can see the eslint status before and after.
![image](https://user-images.githubusercontent.com/44245136/165793386-fd4c2bea-21dd-41f0-96c3-93cd5db26049.png)

