### PR TITLE
fix: Pass qnaId in payload body.

### DIFF
--- a/libraries/botbuilder-ai/src/qnamaker-utils/languageServiceUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/languageServiceUtils.ts
@@ -94,6 +94,7 @@ export class LanguageServiceUtils {
                 queryOptions.strictFiltersJoinOperator,
                 queryOptions.filters
             ),
+            qnaId: queryOptions.qnaId,
             rankerType: queryOptions.rankerType,
             context: queryOptions.context,
             answerSpanRequest: { enable: queryOptions.enablePreciseAnswer },


### PR DESCRIPTION
Fixes #4242

## Description
QnAId passed in the payload body for the correct functioning of multi-turn prompts.
In the source code in botbuilder-ai, languageServiceUtils.ts, function queryKnowledgebaseRaw, the code does not pass properly queryOptions.qnaId to the custom question answering REST call. This gives wrong behavior when using prompts in the knowledge base.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->