### PR TITLE
port: [#4245] Mark deprecated channels as obsolete in Channels enum

### DIFF
--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -423,7 +423,7 @@ export interface ChannelInfo {
 export enum Channels {
     // (undocumented)
     Alexa = "alexa",
-    // (undocumented)
+    // @deprecated (undocumented)
     Console = "console",
     // (undocumented)
     Directline = "directline",
@@ -437,7 +437,7 @@ export enum Channels {
     Facebook = "facebook",
     // (undocumented)
     Groupme = "groupme",
-    // (undocumented)
+    // @deprecated (undocumented)
     Kik = "kik",
     // (undocumented)
     Line = "line",
@@ -447,7 +447,7 @@ export enum Channels {
     Omni = "omnichannel",
     // (undocumented)
     Skype = "skype",
-    // (undocumented)
+    // @deprecated (undocumented)
     Skypeforbusiness = "skypeforbusiness",
     // (undocumented)
     Slack = "slack",
@@ -455,7 +455,7 @@ export enum Channels {
     Sms = "sms",
     // (undocumented)
     Telegram = "telegram",
-    // (undocumented)
+    // @deprecated (undocumented)
     Telephony = "telephony",
     // (undocumented)
     Test = "test",

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -423,7 +423,7 @@ export interface ChannelInfo {
 export enum Channels {
     // (undocumented)
     Alexa = "alexa",
-    // @deprecated (undocumented)
+    // (undocumented)
     Console = "console",
     // (undocumented)
     Directline = "directline",
@@ -446,6 +446,8 @@ export enum Channels {
     // (undocumented)
     Omni = "omnichannel",
     // (undocumented)
+    Outlook = "outlook",
+    // (undocumented)
     Skype = "skype",
     // @deprecated (undocumented)
     Skypeforbusiness = "skypeforbusiness",
@@ -455,11 +457,11 @@ export enum Channels {
     Sms = "sms",
     // (undocumented)
     Telegram = "telegram",
-    // @deprecated (undocumented)
+    // (undocumented)
     Telephony = "telephony",
     // (undocumented)
     Test = "test",
-    // (undocumented)
+    // @deprecated (undocumented)
     Twilio = "twilio-sms",
     // (undocumented)
     Webchat = "webchat"

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -2246,6 +2246,9 @@ export enum SemanticActionStateTypes {
  */
 export enum Channels {
     Alexa = 'alexa',
+    /**
+     * @deprecated This channel is no longer available for bot developers.
+     */
     Console = 'console',
     Directline = 'directline',
     DirectlineSpeech = 'directlinespeech',
@@ -2253,15 +2256,24 @@ export enum Channels {
     Emulator = 'emulator',
     Facebook = 'facebook',
     Groupme = 'groupme',
+    /**
+     * @deprecated This channel is no longer available for bot developers.
+     */
     Kik = 'kik',
     Line = 'line',
     Msteams = 'msteams',
     Omni = 'omnichannel',
     Skype = 'skype',
+    /**
+     * @deprecated This channel is no longer available for bot developers.
+     */
     Skypeforbusiness = 'skypeforbusiness',
     Slack = 'slack',
     Sms = 'sms',
     Telegram = 'telegram',
+    /**
+     * @deprecated This channel is no longer available for bot developers.
+     */
     Telephony = 'telephony',
     Test = 'test',
     Twilio = 'twilio-sms',

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -2238,7 +2238,7 @@ export enum SemanticActionStateTypes {
 /**
  * Defines values for ChannelIds for Channels.
  * Possible values include: 'alexa', 'console', 'cortana', 'directline', 'directlinespeech', 'email',
- * 'emulator', 'facebook', 'groupme', 'kik', 'line', 'msteams', 'onmichannel', 'skype', 'skypeforbusiness',
+ * 'emulator', 'facebook', 'groupme', 'kik', 'line', 'msteams', 'onmichannel', 'outlook', 'skype', 'skypeforbusiness',
  * 'slack', 'sms', 'telegram', 'test', 'twilio-sms', 'webchat'
  *
  * @readonly
@@ -2246,9 +2246,6 @@ export enum SemanticActionStateTypes {
  */
 export enum Channels {
     Alexa = 'alexa',
-    /**
-     * @deprecated This channel is no longer available for bot developers.
-     */
     Console = 'console',
     Directline = 'directline',
     DirectlineSpeech = 'directlinespeech',
@@ -2263,6 +2260,7 @@ export enum Channels {
     Line = 'line',
     Msteams = 'msteams',
     Omni = 'omnichannel',
+    Outlook = 'outlook',
     Skype = 'skype',
     /**
      * @deprecated This channel is no longer available for bot developers.
@@ -2271,11 +2269,11 @@ export enum Channels {
     Slack = 'slack',
     Sms = 'sms',
     Telegram = 'telegram',
+    Telephony = 'telephony',
+    Test = 'test',
     /**
      * @deprecated This channel is no longer available for bot developers.
      */
-    Telephony = 'telephony',
-    Test = 'test',
     Twilio = 'twilio-sms',
     Webchat = 'webchat',
 }


### PR DESCRIPTION
Fixes #4245

## Description
This PR marks the unsupported channels as deprecated and adds the new channel Outlook.

Unsupported channels:
- Kik
- SkypeForBusiness
- Twilio-sms

New supported channels:
- Outlook

## Specific Changes
  - Unsupported channels are marked as deprecated in BotFramework-schema.

## Testing
This screenshot shows the unit tests passing
<img width="516" alt="image" src="https://user-images.githubusercontent.com/64815358/170067163-1c0e5929-1857-4312-b766-ee0d239a70c5.png">
