### PR TITLE
Use Typescript 4.3.2

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
@@ -27,6 +27,6 @@
         "@types/restify": "8.4.2",
         "nodemon": "^2.0.4",
         "tslint": "^6.1.2",
-        "typescript": "^3.9.2"
+        "typescript": "^4.3.2"
     }
 }


### PR DESCRIPTION
Fixes #4251 

## Description
Resolves Typescript errors during build

81 export declare type Resolved<T> = T extends {
                       ~~~~~~~~

node_modules/@azure/core-rest-pipeline/node_modules/@azure/core-tracing/types/core-tracing.d.ts:83:41 - error TS2315: Type 'Resolved' is not generic.

83 } ? F extends (value: infer V) => any ? Resolved<V> : never : T;
                                           ~~~~~~~~~~~

node_modules/@azure/core-rest-pipeline/node_modules/@azure/core-tracing/types/core-tracing.d.ts:131:212 - error TS2315: Type 'Resolved' is not generic.

131     }, Callback extends (updatedOptions: Options, span: Omit<TracingSpan, "end">) => ReturnType<Callback>>(name: string, operationOptions: Options, callback: Callback, spanOptions?: TracingSpanOptions): Promise<Resolved<ReturnType<Callback>>>;
     

## Specific Changes
Updated TypeScript to version 4.3.2

## Testing
