### PR TITLE
fix: Keep chromedriver up to date

### DIFF
--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -27,6 +27,41 @@ steps:
   displayName: 'Create DateTimeTag for Resource Group'
   # Get-Date on Azure DevOps returns a datetime relative to UTC-0, so "Z" is being used instead of the dynamic "K".
 
+- powershell: |
+    $packageName = "chromedriver";
+
+    Write-Host "Get $packageName preview version tagged 'latest' from npmjs.com";
+
+    $dist = npm dist-tag ls $packageName;
+    $next = $dist.Where({$_.StartsWith("latest:")});
+    [string]$latestVersion = $next.Split(':')[-1].Trim();
+
+    $packageName;
+    $latestVersion;
+    "##vso[task.setvariable variable=LatestVersion;]$latestVersion";
+  displayName: 'Get latest chromedriver version number from npmjs.com'
+
+- powershell: |
+    # This lets the pipeline automatically update when a new chromedriver is released.
+    # Expect a 1 or 2 day delay between a new Chrome browser relase and the matching driver release.
+    # Expect the pipeline to temporarily break about every 6 weeks during the driver gap.
+
+    $path = "$(System.DefaultWorkingDirectory)/testing/browser-functional/package.json";
+    $package = 'chromedriver';
+    $newVersion = "$(LatestVersion)";
+
+    $find = "$package`": `"\S*`"";
+    $replace = "$package`": `"$newVersion`"";
+
+    Get-ChildItem -Path "$path" | % {
+        $_.FullName;
+        $content = Get-Content -Raw $_.FullName;
+
+        $content -Replace "$find", "$replace" | Set-Content $_.FullName;
+        '-------------'; get-content $_.FullName; '==================='
+    }
+  displayName: 'Set chromedriver dependency to latest version'
+
 - task: NodeTool@0
   displayName: use node 12.x
   inputs:

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -20,14 +20,14 @@ variables:
 
 steps:
 
-- powershell: |
+- task: PowerShell@2 |
    # Create DateTimeTag for Resource Group
    $DateTimeTag=Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ"
    "##vso[task.setvariable variable=DateTimeTag]$DateTimeTag";
   displayName: 'Create DateTimeTag for Resource Group'
   # Get-Date on Azure DevOps returns a datetime relative to UTC-0, so "Z" is being used instead of the dynamic "K".
 
-- powershell: |
+- task: PowerShell@2 |
     $packageName = "chromedriver";
 
     Write-Host "Get $packageName version tagged 'latest' from npmjs.com";
@@ -41,7 +41,7 @@ steps:
     "##vso[task.setvariable variable=LatestVersion;]$latestVersion";
   displayName: 'Get latest chromedriver version number from npmjs.com'
 
-- powershell: |
+- task: PowerShell@2 |
     # This lets the pipeline automatically keep up with Chrome browser releases.
     # New Chrome browser releases happen about every 4 weeks.
 
@@ -69,7 +69,7 @@ steps:
 - script: cd testing/browser-functional/browser-echo-bot && yarn && yarn build
   displayName: yarn install and build browser-echo-bot
 
-- powershell: |
+- task: PowerShell@2 |
    # Compress Bot Source Code
    cd $(System.DefaultWorkingDirectory)/testing/browser-functional/browser-echo-bot/dist
    $DirToCompress = "$(System.DefaultWorkingDirectory)/testing/browser-functional/browser-echo-bot/dist"

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -30,7 +30,7 @@ steps:
 - powershell: |
     $packageName = "chromedriver";
 
-    Write-Host "Get $packageName preview version tagged 'latest' from npmjs.com";
+    Write-Host "Get $packageName version tagged 'latest' from npmjs.com";
 
     $dist = npm dist-tag ls $packageName;
     $next = $dist.Where({$_.StartsWith("latest:")});

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -42,9 +42,8 @@ steps:
   displayName: 'Get latest chromedriver version number from npmjs.com'
 
 - powershell: |
-    # This lets the pipeline automatically update when a new chromedriver is released.
-    # Expect a 1 or 2 day delay between a new Chrome browser relase and the matching driver release.
-    # Expect the pipeline to temporarily break about every 6 weeks during the driver gap.
+    # This lets the pipeline automatically keep up with Chrome browser releases.
+    # New Chrome browser releases happen about every 4 weeks.
 
     $path = "$(System.DefaultWorkingDirectory)/testing/browser-functional/package.json";
     $package = 'chromedriver';
@@ -60,7 +59,7 @@ steps:
         $content -Replace "$find", "$replace" | Set-Content $_.FullName;
         '-------------'; get-content $_.FullName; '==================='
     }
-  displayName: 'Set chromedriver dependency to latest version'
+  displayName: 'Upgrade chromedriver reference to latest version'
 
 - task: NodeTool@0
   displayName: use node 12.x


### PR DESCRIPTION
Fixes #minor

## Description
This fixes [Run-JS-Functional-Tests-BrowserBot-yaml/20220602.3](https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=307061&view=results), broken because chromedriver is out of date. New Chrome browser releases break this pipeline about every 4 weeks.

This lets the pipeline automatically keep up with Chrome browser releases.

## Specific Changes
Add update script to pipeline