### PR TITLE
fix: Update TypeScript Version in Yeoman Templates to 4.0.7

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package-with-tests.json.ts
@@ -54,6 +54,6 @@
       "nyc": "^15.0.1",
       "ts-node": "^8.10.1",
       "tslint": "^6.1.2",
-      "typescript": "^3.9.2"
+      "typescript": "^4.0.7"
   }
 }

--- a/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/core/package.json.ts
@@ -34,6 +34,6 @@
         "nyc": "^15.0.1",
         "ts-node": "^8.10.1",
         "tslint": "^6.1.2",
-        "typescript": "^3.9.2"
+        "typescript": "^4.0.7"
     }
 }

--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.ts
@@ -27,6 +27,6 @@
         "@types/restify": "8.4.2",
         "nodemon": "^2.0.4",
         "tslint": "^6.1.2",
-        "typescript": "^3.9.2"
+        "typescript": "^4.0.7"
     }
 }

--- a/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
+++ b/generators/generator-botbuilder/generators/app/templates/empty/package.json.ts
@@ -26,6 +26,6 @@
         "@types/restify": "8.4.2",
         "nodemon": "^2.0.4",
         "tslint": "^6.1.2",
-        "typescript": "^3.9.2"
+        "typescript": "^4.0.7"
     }
 }


### PR DESCRIPTION
Fixes #4251 <!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
Updates the TypeScript version of the generators for empty, echo, and core bot templates to the earliest supported version, `4.0.7`, to resolve the bug.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Update TS version `package.json.ts` and `package-with-tests.json.ts` in core bot template from `3.9.2` to `4.0.7`.
  - Update TS version `package.json.ts` in echo  bot template from `3.9.2` to `4.0.7`.
  - Update TS version `package.json.ts` in empty bot template from `3.9.2` to `4.0.7`.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
`npm install` fails on version `3.9.2`. Updating the version and rerunning the install results in a success and the bot then runs.