### PR TITLE
fix: Removed unused method in teamsActivityHandler

### DIFF
--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -356,7 +356,6 @@ export class StreamingHttpClient implements HttpClient {
 export class TeamsActivityHandler extends ActivityHandler {
     protected dispatchConversationUpdateActivity(context: TurnContext): Promise<void>;
     protected dispatchEventActivity(context: TurnContext): Promise<void>;
-    protected handleAdaptiveCardAction(_context: TurnContext): Promise<AdaptiveCardInvokeResponse>;
     protected handleTeamsAppBasedLinkQuery(_context: TurnContext, _query: AppBasedLinkQuery): Promise<MessagingExtensionResponse>;
     protected handleTeamsCardActionInvoke(_context: TurnContext): Promise<InvokeResponse>;
     protected handleTeamsFileConsent(context: TurnContext, fileConsentCardResponse: FileConsentCardResponse): Promise<void>;

--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -7,6 +7,7 @@
 import { Activity } from 'botbuilder-core';
 import { ActivityHandler } from 'botbuilder-core';
 import { ActivityHandlerBase } from 'botbuilder-core';
+import { AdaptiveCardInvokeResponse } from 'botbuilder-core';
 import { AppBasedLinkQuery } from 'botbuilder-core';
 import { AppCredentials } from 'botframework-connector';
 import { AttachmentData } from 'botbuilder-core';

--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -7,7 +7,6 @@
 import { Activity } from 'botbuilder-core';
 import { ActivityHandler } from 'botbuilder-core';
 import { ActivityHandlerBase } from 'botbuilder-core';
-import { AdaptiveCardInvokeResponse } from 'botbuilder-core';
 import { AppBasedLinkQuery } from 'botbuilder-core';
 import { AppCredentials } from 'botframework-connector';
 import { AttachmentData } from 'botbuilder-core';

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -515,16 +515,6 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * Receives invoke activities with the name 'adaptiveCard/action'
-     *
-     * @param _context A context object for this turn.
-     * @returns The Messaging Extension Action Response for the query.
-     */
-    protected async handleAdaptiveCardAction(_context: TurnContext): Promise<AdaptiveCardInvokeResponse> {
-        throw new Error('NotImplemented');
-    }
-
-    /**
      * Receives invoke activities with the name 'composeExtension/setting'
      *
      * @param _context A context object for this turn.

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -8,7 +8,6 @@
 
 import {
     ActivityHandler,
-    AdaptiveCardInvokeResponse,
     AppBasedLinkQuery,
     ChannelInfo,
     Channels,


### PR DESCRIPTION
Fixes #4259

## Description
Invoke activity with the name `adaptiveCard/action` is supported in [ActivityHandler](https://github.com/microsoft/botbuilder-js/blob/e7d845eeacb32824af93652d07e46aabf30e800e/libraries/botbuilder-core/src/activityHandler.ts#L508) class, the method [`handleAdaptiveCardAction`](https://github.com/microsoft/botbuilder-js/blob/e7d845eeacb32824af93652d07e46aabf30e800e/libraries/botbuilder/src/teamsActivityHandler.ts#L523) is not needed in [teamsActivityHandler](https://github.com/microsoft/botbuilder-js/blob/main/libraries/botbuilder/src/teamsActivityHandler.ts) class.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Removed unused method `handleAdaptiveCardAction` in [teamsActivityHandler](https://github.com/microsoft/botbuilder-js/blob/main/libraries/botbuilder/src/teamsActivityHandler.ts) class.
