### PR TITLE
Pass qnaId in value attribute of multiturn prompts

### DIFF
--- a/libraries/botbuilder-ai/src/qnaCardBuilder.ts
+++ b/libraries/botbuilder-ai/src/qnaCardBuilder.ts
@@ -76,9 +76,11 @@ export class QnACardBuilder {
 
         result.context?.prompts?.forEach((prompt) => {
             buttonList.push({
-                value: prompt.displayText,
-                type: 'imBack',
+                value: prompt.qnaId,
+                type: 'messageBack',
                 title: prompt.displayText,
+                text: prompt.displayText,
+                displayText: prompt.displayText,
             });
         });
 

--- a/libraries/botbuilder-ai/src/qnaMakerDialog.ts
+++ b/libraries/botbuilder-ai/src/qnaMakerDialog.ts
@@ -749,8 +749,16 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
     }
 
     private resetOptions(dc: DialogContext, dialogOptions: QnAMakerDialogOptions) {
-        // Resetting context and QnAId
-        dialogOptions.qnaMakerOptions.qnaId = 0;
+        // Resetting QnAId if not present in value
+        const qnaIdFromContext = dc.context.activity.value;
+
+        if (qnaIdFromContext != null) {
+            dialogOptions.qnaMakerOptions.qnaId = qnaIdFromContext;
+        } else {
+            dialogOptions.qnaMakerOptions.qnaId = 0;
+        }
+
+        // Resetting context
         dialogOptions.qnaMakerOptions.context = { previousQnAId: 0, previousUserQuery: '' };
 
         // Check if previous context is present, if yes then put it with the query


### PR DESCRIPTION
Fixes #4253

## Description
Store qnaId in the prompts so that its readily available everytime the prompt is clicked

## Specific Changes
- Changed prompt type from "imBack" to "messageBack"
- pass qnaId as value in prompts
- Check if value has qnaId before resetting dialogOptions.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->