### PR TITLE
fix: DockerFile security analysis warning

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,5 +1,5 @@
-FROM gitpod/workspace-full
-                    
+FROM mcr.microsoft.com/gitpod/workspace-full
+
 USER gitpod
 
 # Install custom tools, runtime, etc. using apt-get


### PR DESCRIPTION
Fixes #minor

## Description
The warning: 
##[warning]Container security analysis found 1 violations. This repo has one or more docker files having references to images from external registries.

Example: [E2E_BF-Streaming-DL-ASE_Test](https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=308669&view=logs&j=d5b5af1a-869d-573b-472a-ffabae9d9839&t=51855cca-14c1-52e0-304d-d12bc21cabbb&l=73)
## Specific Changes
Change the FROM in .gitpod.Dockerfile to reference the appropriate container image in the Microsoft Artifact Registry.
