### PR TITLE
fix: chromedriver version updater

### DIFF
--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -30,6 +30,9 @@ steps:
   displayName: 'Create DateTimeTag for Resource Group'
   # Get-Date on Azure DevOps returns a datetime relative to UTC-0, so "Z" is being used instead of the dynamic "K".
 
+- script: yarn browser-functional-test chrome
+  displayName: run chrome tests
+
 - task: PowerShell@2
   inputs:
     targetType: inline
@@ -76,22 +79,6 @@ steps:
   displayName: use node 12.x
   inputs:
     versionSpec: 12.x
-
-- task: PowerShell@2
-  inputs:
-    targetType: inline
-    script: |
-      $registryInfo = reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version
-      $chromeVersion = ($registryInfo.Split())[-2]
-      $driverVersion = ($chromeVersion.Split("."))[0] + ".0.0";
-
-      Write-Host "Chrome registry info:" $registryInfo
-      Write-Host "chromedriver version needed:" $driverVersion
-      "##vso[task.setvariable variable=DriverVersion;]$driverVersion";
-  displayName: 'Get chromedriver version for the installed Chrome'
-  continueOnError: true
-  condition: succeededOrFailed()
-  enabled: false
 
 - script: cd testing/browser-functional/browser-echo-bot && yarn && yarn build
   displayName: yarn install and build browser-echo-bot
@@ -161,22 +148,6 @@ steps:
 - script: yarn
   displayName: yarn install
 
-- task: PowerShell@2
-  inputs:
-    targetType: inline
-    script: |
-      $registryInfo = reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version
-      $chromeVersion = ($registryInfo.Split())[-2]
-      $driverVersion = ($chromeVersion.Split("."))[0] + ".0.0";
-
-      Write-Host "Chrome registry info:" $registryInfo
-      Write-Host "chromedriver version needed:" $driverVersion
-      "##vso[task.setvariable variable=DriverVersion;]$driverVersion";
-  displayName: 'Get chromedriver version for the installed Chrome'
-  continueOnError: true
-  condition: succeededOrFailed()
-  enabled: false
-
 - script: yarn browser-functional-test chrome
   displayName: run chrome tests
 
@@ -195,6 +166,19 @@ steps:
       Write-Host "chromedriver version needed:" $driverVersion
       "##vso[task.setvariable variable=DriverVersion;]$driverVersion";
   displayName: 'Get chromedriver version for the installed Chrome'
+  continueOnError: true
+  condition: succeededOrFailed()
+
+- powershell: |
+   cd ..
+   ls -R
+  displayName: Dir workspace
+  enabled: false
+  continueOnError: true
+  condition: succeededOrFailed()
+
+- powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
+  displayName: 'Display env vars'
   continueOnError: true
   condition: succeededOrFailed()
 

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -46,20 +46,7 @@ steps:
       $latestVersion;
       "##vso[task.setvariable variable=LatestVersion;]$latestVersion";
   displayName: 'Get latest chromedriver version number from npmjs.com'
-  enabled: false
-
-- task: PowerShell@2
-  inputs:
-    targetType: inline
-    script: |
-      $registryInfo = reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version
-      $chromeVersion = ($registryInfo.Split())[-2]
-      $driverVersion = ($chromeVersion.Split("."))[0] + ".0.0";
-
-      Write-Host "Chrome registry info:" $registryInfo
-      Write-Host "chromedriver version needed:" $driverVersion
-      "##vso[task.setvariable variable=LatestVersion;]$driverVersion";
-  displayName: 'Get chromedriver version for the installed Chrome'
+  enabled: true
 
 - task: PowerShell@2
   inputs:
@@ -130,6 +117,20 @@ steps:
 
 - script: yarn browser-functional-test firefox
   displayName: run firefox tests
+
+- task: PowerShell@2
+  inputs:
+    targetType: inline
+    script: |
+      $registryInfo = reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version
+      $chromeVersion = ($registryInfo.Split())[-2]
+      $driverVersion = ($chromeVersion.Split("."))[0] + ".0.0";
+
+      Write-Host "Chrome registry info:" $registryInfo
+      Write-Host "chromedriver version needed:" $driverVersion
+      "##vso[task.setvariable variable=DriverVersion;]$driverVersion";
+  displayName: 'Get chromedriver version for the installed Chrome'
+  condition: succeededOrFailed()
 
 - task: AzureCLI@1
   displayName: 'Delete Resource Group'

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -180,7 +180,6 @@ steps:
    cd ..
    ls -R
   displayName: Dir workspace
-  enabled: false
   continueOnError: true
   condition: succeededOrFailed()
 

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -46,6 +46,20 @@ steps:
       $latestVersion;
       "##vso[task.setvariable variable=LatestVersion;]$latestVersion";
   displayName: 'Get latest chromedriver version number from npmjs.com'
+  enabled: false
+
+- task: PowerShell@2
+  inputs:
+    targetType: inline
+    script: |
+      $registryInfo = reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version
+      $chromeVersion = ($registryInfo.Split())[-2]
+      $driverVersion = ($chromeVersion.Split("."))[0] + ".0.0";
+
+      Write-Host "Chrome registry info:" $registryInfo
+      Write-Host "chromedriver version needed:" $driverVersion
+      "##vso[task.setvariable variable=LatestVersion;]$driverVersion";
+  displayName: 'Get chromedriver version for the installed Chrome'
 
 - task: PowerShell@2
   inputs:

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -30,16 +30,6 @@ steps:
   displayName: 'Create DateTimeTag for Resource Group'
   # Get-Date on Azure DevOps returns a datetime relative to UTC-0, so "Z" is being used instead of the dynamic "K".
 
-- script: yarn
-  displayName: yarn install
-  continueOnError: true
-  enabled: false
-
-- script: yarn browser-functional-test chrome
-  displayName: run chrome tests
-  continueOnError: true
-  enabled: false
-
 - task: PowerShell@2
   inputs:
     targetType: inline
@@ -51,23 +41,27 @@ steps:
       $dist = npm dist-tag ls $packageName;
       $next = $dist.Where({$_.StartsWith("latest:")});
       [string]$latestVersion = $next.Split(':')[-1].Trim();
+      Write-Host "$packageName latest = $latestVersion";
 
-      $packageName;
-      $latestVersion;
-      "##vso[task.setvariable variable=LatestVersion;]$latestVersion";
-  displayName: 'Get latest chromedriver version number from npmjs.com'
-  enabled: false
+      $splitVersion = $latestVersion.Split(".");
+      $splitVersion[0] = $splitVersion[0] - 1;
+      $secondLatestVersion = $splitVersion -Join ".";
+      Write-Host "$packageName second latest = $secondLatestVersion";
+
+      "##vso[task.setvariable variable=DriverVersion;]$secondLatestVersion";
+  displayName: 'Get second latest chromedriver version number from npmjs.com'
 
 - task: PowerShell@2
   inputs:
     targetType: inline
     script: |
-      # This lets the pipeline automatically keep up with Chrome browser releases.
-      # New Chrome browser releases happen about every 4 weeks.
+      # This lets the pipeline automatically keep up with Chrome browser upgrades.
+      # Chrome browser upgrades on ADO agents lag behind chromedriver upgrades, so
+      # if we use the second latest chromedriver, that should keep the tests working.
 
       $path = "$(System.DefaultWorkingDirectory)/testing/browser-functional/package.json";
       $package = 'chromedriver';
-      $newVersion = "$(LatestVersion)";
+      $newVersion = "$(DriverVersion)";
 
       $find = "$package`": `"\S*`"";
       $replace = "$package`": `"$newVersion`"";
@@ -79,8 +73,7 @@ steps:
           $content -Replace "$find", "$replace" | Set-Content $_.FullName;
           '-------------'; get-content $_.FullName; '==================='
       }
-  displayName: 'Upgrade chromedriver reference to latest version'
-  enabled: false
+  displayName: 'Upgrade chromedriver reference to second latest version'
 
 - task: NodeTool@0
   displayName: use node 12.x

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -33,10 +33,12 @@ steps:
 - script: yarn
   displayName: yarn install
   continueOnError: true
+  enabled: false
 
 - script: yarn browser-functional-test chrome
   displayName: run chrome tests
   continueOnError: true
+  enabled: false
 
 - task: PowerShell@2
   inputs:

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -87,22 +87,6 @@ steps:
   inputs:
     targetType: inline
     script: |
-      $registryInfo = reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version
-      $chromeVersion = ($registryInfo.Split())[-2]
-      $driverVersion = ($chromeVersion.Split("."))[0] + ".0.0";
-
-      Write-Host "Chrome registry info:" $registryInfo
-      Write-Host "chromedriver version needed:" $driverVersion
-      "##vso[task.setvariable variable=DriverVersion;]$driverVersion";
-  displayName: 'Get chromedriver version for the installed Chrome'
-  continueOnError: true
-  condition: succeededOrFailed()
-  enabled: false
-
-- task: PowerShell@2
-  inputs:
-    targetType: inline
-    script: |
       # Compress Bot Source Code
       cd $(System.DefaultWorkingDirectory)/testing/browser-functional/browser-echo-bot/dist
       $DirToCompress = "$(System.DefaultWorkingDirectory)/testing/browser-functional/browser-echo-bot/dist"
@@ -129,22 +113,6 @@ steps:
      echo "# Deploy source code"
      call az webapp deployment source config-zip --resource-group "$(TestResourceGroup)" --name "$(TestWebApp)" --src "$(System.DefaultWorkingDirectory)/testing/browser-functional/browser-echo-bot/browser-echo-bot.zip"
 
-- task: PowerShell@2
-  inputs:
-    targetType: inline
-    script: |
-      $registryInfo = reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version
-      $chromeVersion = ($registryInfo.Split())[-2]
-      $driverVersion = ($chromeVersion.Split("."))[0] + ".0.0";
-
-      Write-Host "Chrome registry info:" $registryInfo
-      Write-Host "chromedriver version needed:" $driverVersion
-      "##vso[task.setvariable variable=DriverVersion;]$driverVersion";
-  displayName: 'Get chromedriver version for the installed Chrome'
-  continueOnError: true
-  condition: succeededOrFailed()
-  enabled: false
-
 - script: yarn
   displayName: yarn install
 
@@ -153,33 +121,6 @@ steps:
 
 - script: yarn browser-functional-test firefox
   displayName: run firefox tests
-
-- task: PowerShell@2
-  inputs:
-    targetType: inline
-    script: |
-      $registryInfo = reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version
-      $chromeVersion = ($registryInfo.Split())[-2]
-      $driverVersion = ($chromeVersion.Split("."))[0] + ".0.0";
-
-      Write-Host "Chrome registry info:" $registryInfo
-      Write-Host "chromedriver version needed:" $driverVersion
-      "##vso[task.setvariable variable=DriverVersion;]$driverVersion";
-  displayName: 'Get chromedriver version for the installed Chrome'
-  continueOnError: true
-  condition: succeededOrFailed()
-
-- powershell: |
-   cd ..
-   ls -R
-  displayName: Dir workspace
-  continueOnError: true
-  condition: succeededOrFailed()
-
-- powershell: 'gci env:* | sort-object name | Format-Table -AutoSize -Wrap'
-  displayName: 'Display env vars'
-  continueOnError: true
-  condition: succeededOrFailed()
 
 - task: AzureCLI@1
   displayName: 'Delete Resource Group'

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -76,8 +76,38 @@ steps:
   inputs:
     versionSpec: 12.x
 
+- task: PowerShell@2
+  inputs:
+    targetType: inline
+    script: |
+      $registryInfo = reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version
+      $chromeVersion = ($registryInfo.Split())[-2]
+      $driverVersion = ($chromeVersion.Split("."))[0] + ".0.0";
+
+      Write-Host "Chrome registry info:" $registryInfo
+      Write-Host "chromedriver version needed:" $driverVersion
+      "##vso[task.setvariable variable=DriverVersion;]$driverVersion";
+  displayName: 'Get chromedriver version for the installed Chrome'
+  continueOnError: true
+  condition: succeededOrFailed()
+
 - script: cd testing/browser-functional/browser-echo-bot && yarn && yarn build
   displayName: yarn install and build browser-echo-bot
+
+- task: PowerShell@2
+  inputs:
+    targetType: inline
+    script: |
+      $registryInfo = reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version
+      $chromeVersion = ($registryInfo.Split())[-2]
+      $driverVersion = ($chromeVersion.Split("."))[0] + ".0.0";
+
+      Write-Host "Chrome registry info:" $registryInfo
+      Write-Host "chromedriver version needed:" $driverVersion
+      "##vso[task.setvariable variable=DriverVersion;]$driverVersion";
+  displayName: 'Get chromedriver version for the installed Chrome'
+  continueOnError: true
+  condition: succeededOrFailed()
 
 - task: PowerShell@2
   inputs:
@@ -109,8 +139,38 @@ steps:
      echo "# Deploy source code"
      call az webapp deployment source config-zip --resource-group "$(TestResourceGroup)" --name "$(TestWebApp)" --src "$(System.DefaultWorkingDirectory)/testing/browser-functional/browser-echo-bot/browser-echo-bot.zip"
 
+- task: PowerShell@2
+  inputs:
+    targetType: inline
+    script: |
+      $registryInfo = reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version
+      $chromeVersion = ($registryInfo.Split())[-2]
+      $driverVersion = ($chromeVersion.Split("."))[0] + ".0.0";
+
+      Write-Host "Chrome registry info:" $registryInfo
+      Write-Host "chromedriver version needed:" $driverVersion
+      "##vso[task.setvariable variable=DriverVersion;]$driverVersion";
+  displayName: 'Get chromedriver version for the installed Chrome'
+  continueOnError: true
+  condition: succeededOrFailed()
+
 - script: yarn
   displayName: yarn install
+
+- task: PowerShell@2
+  inputs:
+    targetType: inline
+    script: |
+      $registryInfo = reg query "HKEY_CURRENT_USER\Software\Google\Chrome\BLBeacon" /v version
+      $chromeVersion = ($registryInfo.Split())[-2]
+      $driverVersion = ($chromeVersion.Split("."))[0] + ".0.0";
+
+      Write-Host "Chrome registry info:" $registryInfo
+      Write-Host "chromedriver version needed:" $driverVersion
+      "##vso[task.setvariable variable=DriverVersion;]$driverVersion";
+  displayName: 'Get chromedriver version for the installed Chrome'
+  continueOnError: true
+  condition: succeededOrFailed()
 
 - script: yarn browser-functional-test chrome
   displayName: run chrome tests
@@ -130,6 +190,7 @@ steps:
       Write-Host "chromedriver version needed:" $driverVersion
       "##vso[task.setvariable variable=DriverVersion;]$driverVersion";
   displayName: 'Get chromedriver version for the installed Chrome'
+  continueOnError: true
   condition: succeededOrFailed()
 
 - task: AzureCLI@1

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -30,8 +30,13 @@ steps:
   displayName: 'Create DateTimeTag for Resource Group'
   # Get-Date on Azure DevOps returns a datetime relative to UTC-0, so "Z" is being used instead of the dynamic "K".
 
+- script: yarn
+  displayName: yarn install
+  continueOnError: true
+
 - script: yarn browser-functional-test chrome
   displayName: run chrome tests
+  continueOnError: true
 
 - task: PowerShell@2
   inputs:

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -46,7 +46,7 @@ steps:
       $latestVersion;
       "##vso[task.setvariable variable=LatestVersion;]$latestVersion";
   displayName: 'Get latest chromedriver version number from npmjs.com'
-  enabled: true
+  enabled: false
 
 - task: PowerShell@2
   inputs:
@@ -70,6 +70,7 @@ steps:
           '-------------'; get-content $_.FullName; '==================='
       }
   displayName: 'Upgrade chromedriver reference to latest version'
+  enabled: false
 
 - task: NodeTool@0
   displayName: use node 12.x
@@ -90,6 +91,7 @@ steps:
   displayName: 'Get chromedriver version for the installed Chrome'
   continueOnError: true
   condition: succeededOrFailed()
+  enabled: false
 
 - script: cd testing/browser-functional/browser-echo-bot && yarn && yarn build
   displayName: yarn install and build browser-echo-bot
@@ -108,6 +110,7 @@ steps:
   displayName: 'Get chromedriver version for the installed Chrome'
   continueOnError: true
   condition: succeededOrFailed()
+  enabled: false
 
 - task: PowerShell@2
   inputs:
@@ -153,6 +156,7 @@ steps:
   displayName: 'Get chromedriver version for the installed Chrome'
   continueOnError: true
   condition: succeededOrFailed()
+  enabled: false
 
 - script: yarn
   displayName: yarn install
@@ -171,6 +175,7 @@ steps:
   displayName: 'Get chromedriver version for the installed Chrome'
   continueOnError: true
   condition: succeededOrFailed()
+  enabled: false
 
 - script: yarn browser-functional-test chrome
   displayName: run chrome tests

--- a/testing/browser-functional/package.json
+++ b/testing/browser-functional/package.json
@@ -12,10 +12,10 @@
     "selenium-server": "^3.141.59"
   },
   "directories": {
-    "test": "."
+    "test": ""
   },
   "scripts": {
-    "test": "node nightwatch.js -e"
+    "test": "node nightwatch.js"
   },
   "author": "Microsoft Corp.",
   "license": "MIT"

--- a/testing/browser-functional/package.json
+++ b/testing/browser-functional/package.json
@@ -5,7 +5,7 @@
   "description": "Test to check browser compatibility",
   "main": "",
   "devDependencies": {
-    "chromedriver": "^101.0.0",
+    "chromedriver": "^100.0.0",
     "dotenv": "^8.6.0",
     "geckodriver": "^1.19.1",
     "nightwatch": "^1.7.13",

--- a/testing/browser-functional/package.json
+++ b/testing/browser-functional/package.json
@@ -12,10 +12,10 @@
     "selenium-server": "^3.141.59"
   },
   "directories": {
-    "test": ""
+    "test": "tests"
   },
   "scripts": {
-    "test": "node nightwatch.js"
+    "test": "node nightwatch.js -e"
   },
   "author": "Microsoft Corp.",
   "license": "MIT"

--- a/testing/browser-functional/package.json
+++ b/testing/browser-functional/package.json
@@ -12,7 +12,7 @@
     "selenium-server": "^3.141.59"
   },
   "directories": {
-    "test": "tests"
+    "test": "."
   },
   "scripts": {
     "test": "node nightwatch.js -e"

--- a/testing/browser-functional/package.json
+++ b/testing/browser-functional/package.json
@@ -5,7 +5,7 @@
   "description": "Test to check browser compatibility",
   "main": "",
   "devDependencies": {
-    "chromedriver": "^100.0.0",
+    "chromedriver": ">100.0.0",
     "dotenv": "^8.6.0",
     "geckodriver": "^1.19.1",
     "nightwatch": "^1.7.13",

--- a/testing/browser-functional/package.json
+++ b/testing/browser-functional/package.json
@@ -5,7 +5,7 @@
   "description": "Test to check browser compatibility",
   "main": "",
   "devDependencies": {
-    "chromedriver": ">100.0.0",
+    "chromedriver": "^101.0.0",
     "dotenv": "^8.6.0",
     "geckodriver": "^1.19.1",
     "nightwatch": "^1.7.13",


### PR DESCRIPTION
Fixes #minor

## Description
JS-Functional-Tests-BrowserBot-yaml started failing when a new chromedriver version was released, because the driver version is now ahead of the Chrome browser version.

My tests indicate auto updating to the second latest driver version will keep driver and browser versions in better sync.

## Specific Changes
Tweak "Upgrade chromedriver reference" step to use the 2nd latest version.