### PR TITLE
port: [#5837] Fix sentiment values not being set for None / Unknown intent (#6348)

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-testing/package.json
+++ b/libraries/botbuilder-dialogs-adaptive-testing/package.json
@@ -38,6 +38,7 @@
     "zod": "~1.11.17"
   },
   "devDependencies": {
+    "botbuilder": "4.1.6",
     "@microsoft/recognizers-text-suite": "1.1.4",
     "@types/nock": "^11.1.0"
   },

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/crossTrainedRecognizerSet.ts
@@ -137,6 +137,7 @@ export class CrossTrainedRecognizerSet extends AdaptiveRecognizer implements Cro
                     const recognizerResult: RecognizerResult = {
                         text: recognizerResults[recognizer.id].text,
                         intents: { None: { score: 1.0 } },
+                        sentiment: recognizerResults[recognizer.id].sentiment,
                     };
                     return recognizerResult;
                 }
@@ -175,12 +176,14 @@ export class CrossTrainedRecognizerSet extends AdaptiveRecognizer implements Cro
 
         //find if matched entities found when hits the none intent
         const mergedEntities = results.reduce((acc, curr) => merge(acc, curr.entities), {});
+        const sentiment = results.reduce((acc, curr) => merge(acc, curr.sentiment), {});
 
         // return none
         const recognizerResult: RecognizerResult = {
             text,
             intents: { None: { score: 1.0 } },
             entities: mergedEntities,
+            sentiment: sentiment,
         };
         return recognizerResult;
     }

--- a/libraries/botbuilder-dialogs/src/recognizer.ts
+++ b/libraries/botbuilder-dialogs/src/recognizer.ts
@@ -64,9 +64,11 @@ export class Recognizer extends Configurable implements RecognizerConfiguration 
      */
     protected createChooseIntentResult(recognizerResults: Record<string, RecognizerResult>): RecognizerResult {
         let text: string;
+        let sentiment: Record<string, any> = null;
         type candidateType = { id: string; intent: string; score: number; result: RecognizerResult };
         const candidates = Object.entries(recognizerResults).reduce((candidates: candidateType[], [key, result]) => {
             text = result.text;
+            sentiment = result.sentiment;
             const { intent, score } = getTopScoringIntent(result);
             if (intent !== 'None') {
                 candidates.push({
@@ -95,6 +97,7 @@ export class Recognizer extends Configurable implements RecognizerConfiguration 
             text,
             intents: { None: { score: 1.0 } },
             entities: {},
+            sentiment: sentiment,
         };
         return recognizerResult;
     }


### PR DESCRIPTION
Fixes #4261

## Description
This PR ports the changes from [PR#6348](https://github.com/microsoft/botbuilder-dotnet/pull/6348) to include the sentiment properties into the RecognizerResult when the None intent is triggered.

## Specific Changes
- Added sentiment properties for None intents in:
   - botbuilder-dialogs-adaptive/recognizers/crossTrainedRecognizerSet.ts
   - botbuilder-dialogs/recognizer.ts
- Added unit tests in `crossTrainedRecognizerSet.test.js` to cover the new code.
- Added `botbuilder` as _dev-dependency_ for the new tests.

## Testing
These images show the bot trace with the sentiment block and the new tests passing.
![image](https://user-images.githubusercontent.com/44245136/178033577-47d21045-a127-4803-9fb8-6cfe17570bee.png)