### PR TITLE
fix: [#4204] Fix remaining eslint warnings - remaining issues

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/stringTransformEvaluator.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/stringTransformEvaluator.ts
@@ -23,11 +23,7 @@ export class StringTransformEvaluator extends ExpressionEvaluator {
      * @param func The string transformation function, it takes a list of objects and returns an string.
      * @param validator The validation function.
      */
-    constructor(
-        type: string,
-        func: (arg0: any[], options: Options) => string,
-        validator?: (expr: Expression) => void
-    ) {
+    constructor(type: string, func: (arg0: any[], options: Options) => string, validator?: (expr: Expression) => void) {
         super(
             type,
             FunctionUtils.applyWithOptions(func, FunctionUtils.verifyStringOrNull),

--- a/libraries/adaptive-expressions/src/functionUtils.ts
+++ b/libraries/adaptive-expressions/src/functionUtils.ts
@@ -652,10 +652,7 @@ export class FunctionUtils {
      * @param verify Function to check each arg for validity.
      * @returns Delegate for evaluating an expression.
      */
-    static applySequenceWithError(
-        func: (arg0: any[]) => any,
-        verify?: VerifyExpression
-    ): EvaluateExpressionDelegate {
+    static applySequenceWithError(func: (arg0: any[]) => any, verify?: VerifyExpression): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError((args: any[]): any => {
             const binaryArgs: any[] = [undefined, undefined];
             let soFar: any = args[0];

--- a/libraries/adaptive-expressions/src/parser/expressionParser.ts
+++ b/libraries/adaptive-expressions/src/parser/expressionParser.ts
@@ -123,8 +123,7 @@ export class ExpressionParser implements ExpressionParserInterface {
             throw new Error(`${context.text} is not a number.`);
         }
 
-        visitParenthesisExp = (context: ep.ParenthesisExpContext): Expression =>
-            this.visit(context.expression());
+        visitParenthesisExp = (context: ep.ParenthesisExpContext): Expression => this.visit(context.expression());
 
         visitArrayCreationExp(context: ep.ArrayCreationExpContext): Expression {
             const parameters: Expression[] = this.processArgsList(context.argsList());

--- a/libraries/botbuilder-core/src/cardFactory.ts
+++ b/libraries/botbuilder-core/src/cardFactory.ts
@@ -223,13 +223,7 @@ export class CardFactory {
      * );
      * ```
      */
-    static heroCard(
-        title: string,
-        text?: any,
-        images?: any,
-        buttons?: any,
-        other?: Partial<HeroCard>
-    ): Attachment {
+    static heroCard(title: string, text?: any, images?: any, buttons?: any, other?: Partial<HeroCard>): Attachment {
         const a: Attachment = CardFactory.thumbnailCard(title, text, images, buttons, other);
         a.contentType = CardFactory.contentTypes.heroCard;
         return a;

--- a/libraries/botbuilder-core/src/skills/skillConversationIdFactoryBase.ts
+++ b/libraries/botbuilder-core/src/skills/skillConversationIdFactoryBase.ts
@@ -33,7 +33,7 @@ export abstract class SkillConversationIdFactoryBase {
      * @remarks It should be possible to use the returned string on a request URL and it should not contain special characters.
      * Returns A unique conversation ID used to communicate with the skill.
      */
-    public createSkillConversationId(_conversationReference: ConversationReference): Promise<string> {
+    createSkillConversationId(_conversationReference: ConversationReference): Promise<string> {
         throw new Error('Not Implemented');
     }
 

--- a/libraries/botbuilder-core/src/testAdapter.ts
+++ b/libraries/botbuilder-core/src/testAdapter.ts
@@ -523,11 +523,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
      * @param magicCode (Optional) Optional user entered code to validate.
      * @returns The OAuth token for a user that is in a sign-in flow.
      */
-    async getUserToken(
-        context: TurnContext,
-        connectionName: string,
-        magicCode?: string
-    ): Promise<TokenResponse> {
+    async getUserToken(context: TurnContext, connectionName: string, magicCode?: string): Promise<TokenResponse> {
         const key: UserToken = new UserToken();
         key.channelId = context.activity.channelId;
         key.connectionName = connectionName;
@@ -696,12 +692,7 @@ export class TestAdapter extends BotAdapter implements ExtendedUserTokenProvider
      * @param userId The user id.
      * @param exchangeableItem The exchangeable token or resource URI.
      */
-    throwOnExchangeRequest(
-        connectionName: string,
-        channelId: string,
-        userId: string,
-        exchangeableItem: string
-    ): void {
+    throwOnExchangeRequest(connectionName: string, channelId: string, userId: string, exchangeableItem: string): void {
         const token: ExchangeableToken = new ExchangeableToken();
         token.channelId = channelId;
         token.connectionName = connectionName;

--- a/libraries/botbuilder-core/src/turnContext.ts
+++ b/libraries/botbuilder-core/src/turnContext.ts
@@ -798,7 +798,7 @@ export class TurnContext {
         }
         this._respondedRef.responded = true;
     }
-    
+
     /**
      * Gets the locale stored in the turnState.
      *

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onAssignEntity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onAssignEntity.ts
@@ -31,13 +31,7 @@ export class OnAssignEntity extends OnDialogEvent implements OnAssignEntityConfi
      * @param actions Optional, actions to add to the plan when the rule constraints are met.
      * @param condition Optional, condition which needs to be met for the actions to be executed.
      */
-    constructor(
-        property?: string,
-        value?: string,
-        operation?: string,
-        actions: Dialog[] = [],
-        condition?: string
-    ) {
+    constructor(property?: string, value?: string, operation?: string, actions: Dialog[] = [], condition?: string) {
         super(AdaptiveEvents.assignEntity, actions, condition);
         this.property = property;
         this.value = value;

--- a/libraries/botbuilder-dialogs-adaptive/src/conditions/onChooseEntity.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/conditions/onChooseEntity.ts
@@ -31,13 +31,7 @@ export class OnChooseEntity extends OnDialogEvent implements OnChooseEntityConfi
      * @param {Dialog[]} actions Optional, actions to add to the plan when the rule constraints are met.
      * @param {string} condition Optional, condition which needs to be met for the actions to be executed.
      */
-    constructor(
-        property?: string,
-        value?: string,
-        operation?: string,
-        actions: Dialog[] = [],
-        condition?: string
-    ) {
+    constructor(property?: string, value?: string, operation?: string, actions: Dialog[] = [], condition?: string) {
         super(AdaptiveEvents.chooseEntity, actions, condition);
         this.property = property;
         this.value = value;

--- a/libraries/botbuilder-dialogs-adaptive/src/dynamicBeginDialogDeserializer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/dynamicBeginDialogDeserializer.ts
@@ -30,10 +30,7 @@ export class DynamicBeginDialogDeserializer
      * @param type The object type that the configuration will be deserialized to.
      * @returns A `DynamicBeginDialog` object created from the configuration.
      */
-    load(
-        config: BeginDialogConfiguration,
-        type: { new (...args: unknown[]): DynamicBeginDialog }
-    ): DynamicBeginDialog {
+    load(config: BeginDialogConfiguration, type: { new (...args: unknown[]): DynamicBeginDialog }): DynamicBeginDialog {
         config.dialog = this._resourceExplorer.loadType<Dialog>(this._resourceId);
         return Object.entries(config).reduce((instance, [key, value]) => {
             let converter = instance.getConverter(key as keyof BeginDialogConfiguration);

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/languageGeneratorManager.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/languageGeneratorManager.ts
@@ -72,10 +72,7 @@ export class LanguageGeneratorManager<T = unknown, D extends Record<string, unkn
      * @param resourceMapping Template resource loader delegate.
      * @returns The delegate to resolve the resource.
      */
-    static resourceExplorerResolver(
-        locale: string,
-        resourceMapping: Map<string, Resource[]>
-    ): ImportResolverDelegate {
+    static resourceExplorerResolver(locale: string, resourceMapping: Map<string, Resource[]>): ImportResolverDelegate {
         return (lgResource: LGResource, id: string): LGResource => {
             const fallbackLocale = LanguageResourceLoader.fallbackLocale(locale, Array.from(resourceMapping.keys()));
             const resources: Resource[] = resourceMapping.get(fallbackLocale.toLowerCase());

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/multiLanguageGenerator.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/multiLanguageGenerator.ts
@@ -29,10 +29,7 @@ export class MultiLanguageGenerator extends MultiLanguageGeneratorBase {
      * @param locale Locale to lookup.
      * @returns An object with a boolean showing existence and the language generator.
      */
-    tryGetGenerator(
-        dialogContext: DialogContext,
-        locale: string
-    ): { exist: boolean; result: LanguageGenerator } {
+    tryGetGenerator(dialogContext: DialogContext, locale: string): { exist: boolean; result: LanguageGenerator } {
         if (this.languageGenerators.has(locale)) {
             return { exist: true, result: this.languageGenerators.get(locale) };
         } else {

--- a/libraries/botbuilder-dialogs-adaptive/src/generators/resourceMultiLanguageGenerator.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/generators/resourceMultiLanguageGenerator.ts
@@ -51,10 +51,7 @@ export class ResourceMultiLanguageGenerator<T = unknown, D extends Record<string
      * @param locale Locale to lookup.
      * @returns An object with a boolean showing existence and the language generator.
      */
-    tryGetGenerator(
-        dialogContext: DialogContext,
-        locale: string
-    ): { exist: boolean; result: LanguageGenerator<T, D> } {
+    tryGetGenerator(dialogContext: DialogContext, locale: string): { exist: boolean; result: LanguageGenerator<T, D> } {
         const manager = dialogContext.services.get(languageGeneratorManagerKey) as LanguageGeneratorManager<T, D>;
 
         const resourceId =

--- a/libraries/botbuilder-dialogs-adaptive/src/input/choiceInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/choiceInput.ts
@@ -94,9 +94,7 @@ export class ChoiceInput extends InputDialog implements ChoiceInputConfiguration
     /**
      * Control the format of the response (value or index of the choice).
      */
-    outputFormat: EnumExpression<ChoiceOutputFormat> = new EnumExpression<ChoiceOutputFormat>(
-        ChoiceOutputFormat.value
-    );
+    outputFormat: EnumExpression<ChoiceOutputFormat> = new EnumExpression<ChoiceOutputFormat>(ChoiceOutputFormat.value);
 
     /**
      * Additional options passed to the `ChoiceFactory` and used to tweak the style of choices

--- a/libraries/botbuilder-dialogs-declarative/src/resources/folderResourceProvider.ts
+++ b/libraries/botbuilder-dialogs-declarative/src/resources/folderResourceProvider.ts
@@ -29,12 +29,7 @@ export class FolderResourceProvider extends ResourceProvider {
      * @param includeSubFolders Whether include its sub folders.
      * @param monitorChanges Whether monitor changes.
      */
-    constructor(
-        resourceExplorer: ResourceExplorer,
-        folder: string,
-        includeSubFolders = true,
-        monitorChanges = true
-    ) {
+    constructor(resourceExplorer: ResourceExplorer, folder: string, includeSubFolders = true, monitorChanges = true) {
         super(resourceExplorer);
 
         this.includeSubFolders = includeSubFolders;

--- a/libraries/botbuilder-dialogs/src/dialogContext.ts
+++ b/libraries/botbuilder-dialogs/src/dialogContext.ts
@@ -286,11 +286,7 @@ export class DialogContext {
      * **See also**
      * - [endDialog](xref:botbuilder-dialogs.DialogContext.endDialog)
      */
-    async cancelAllDialogs(
-        cancelParents = false,
-        eventName?: string,
-        eventValue?: any
-    ): Promise<DialogTurnResult> {
+    async cancelAllDialogs(cancelParents = false, eventName?: string, eventValue?: any): Promise<DialogTurnResult> {
         eventName = eventName || DialogEvents.cancelDialog;
         if (this.stack.length > 0 || this.parent != undefined) {
             // Cancel all local and parent dialogs while checking for interception

--- a/libraries/botbuilder-lg/src/templateErrors.ts
+++ b/libraries/botbuilder-lg/src/templateErrors.ts
@@ -16,7 +16,7 @@ export class TemplateErrors {
 
     static readonly missingStrucEnd: string = "Invalid structure body. Expecting ']' at the end of the body.";
 
-    public static readonly emptyStrucContent: string = 'Invalid structure body. Body cannot be empty.';
+    static readonly emptyStrucContent: string = 'Invalid structure body. Body cannot be empty.';
 
     static readonly invalidWhitespaceInCondition: string =
         "Invalid condition: At most 1 whitespace allowed between 'IF/ELSEIF/ELSE' and ':'.";
@@ -56,8 +56,7 @@ export class TemplateErrors {
     static readonly notEndWithDefaultInSwitchCase: string =
         "Conditional response template does not end with 'DEFAULT' condition.";
 
-    static readonly missingCaseInSwitchCase: string =
-        "Invalid template body. Expecting at least one 'CASE' statement.";
+    static readonly missingCaseInSwitchCase: string = "Invalid template body. Expecting at least one 'CASE' statement.";
 
     static readonly invalidExpressionInSwiathCase: string =
         "Invalid condition. 'SWITCH' and 'CASE' statements must include a valid expression.";
@@ -78,8 +77,7 @@ export class TemplateErrors {
 
     static readonly staticFailure: string = 'Static failure with the following error.';
 
-    static readonly invalidTemplateNameType: string =
-        'Expected string type for the parameter of template function.';
+    static readonly invalidTemplateNameType: string = 'Expected string type for the parameter of template function.';
 
     static readonly importFormatError: string = "Import format should follow '[x](y)' or '[x](y) as z'.";
 
@@ -114,11 +112,7 @@ export class TemplateErrors {
 
     static readonly nullExpression = (expression: string): string => `'${expression}' evaluated to null.`;
 
-    static readonly argumentMismatch = (
-        templateName: string,
-        expectedCount: number,
-        actualCount: number
-    ): string =>
+    static readonly argumentMismatch = (templateName: string, expectedCount: number, actualCount: number): string =>
         "arguments mismatch for template '" +
         `${templateName}` +
         "'. Expecting '" +
@@ -127,9 +121,7 @@ export class TemplateErrors {
         `${actualCount}` +
         "'.";
 
-    static readonly templateExist = (templateName: string): string =>
-        `template '${templateName}' already exists.`;
+    static readonly templateExist = (templateName: string): string => `template '${templateName}' already exists.`;
 
-    static readonly expressionParseError = (exp: string): string =>
-        `Error occurred when parsing expression '${exp}'.`;
+    static readonly expressionParseError = (exp: string): string => `Error occurred when parsing expression '${exp}'.`;
 }

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -1302,10 +1302,7 @@ export class BotFrameworkAdapter
      * [middleware](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-middleware) articles.
      * Use the adapter's [use](xref:botbuilder-core.BotAdapter.use) method to add middleware to the adapter.
      */
-    async processActivityDirect(
-        activity: Activity,
-        logic: (context: TurnContext) => Promise<any>
-    ): Promise<void> {
+    async processActivityDirect(activity: Activity, logic: (context: TurnContext) => Promise<any>): Promise<void> {
         let processError: Error;
         try {
             // Process activity
@@ -1445,10 +1442,7 @@ export class BotFrameworkAdapter
      * @param serviceUrl The client's service URL.
      * @param identity ClaimsIdentity
      */
-    async createConnectorClientWithIdentity(
-        serviceUrl: string,
-        identity: ClaimsIdentity
-    ): Promise<ConnectorClient>;
+    async createConnectorClientWithIdentity(serviceUrl: string, identity: ClaimsIdentity): Promise<ConnectorClient>;
     /**
      * Create a ConnectorClient with a ClaimsIdentity and an explicit audience.
      *

--- a/libraries/botbuilder/src/channelServiceHandlerBase.ts
+++ b/libraries/botbuilder/src/channelServiceHandlerBase.ts
@@ -177,11 +177,7 @@ export abstract class ChannelServiceHandlerBase {
      * @param conversationId The conversation Id.
      * @param memberId Id of the member to delete from this conversation.
      */
-    async handleDeleteConversationMember(
-        authHeader: string,
-        conversationId: string,
-        memberId: string
-    ): Promise<void> {
+    async handleDeleteConversationMember(authHeader: string, conversationId: string, memberId: string): Promise<void> {
         const claimsIdentity = await this.authenticate(authHeader);
         await this.onDeleteConversationMember(claimsIdentity, conversationId, memberId);
     }

--- a/libraries/botbuilder/src/streaming/tokenResolver.ts
+++ b/libraries/botbuilder/src/streaming/tokenResolver.ts
@@ -37,12 +37,7 @@ export class TokenResolver {
      * @param activity The [Activity](xref:botframework-schema.Activity) to be checked.
      * @param log Optional. The log to write on.
      */
-    static checkForOAuthCards(
-        adapter: BotFrameworkAdapter,
-        context: TurnContext,
-        activity: Activity,
-        log?: string[]
-    ) {
+    static checkForOAuthCards(adapter: BotFrameworkAdapter, context: TurnContext, activity: Activity, log?: string[]) {
         if (!activity || !activity.attachments) {
             return;
         }

--- a/libraries/botbuilder/src/teamsInfo.ts
+++ b/libraries/botbuilder/src/teamsInfo.ts
@@ -325,11 +325,7 @@ export class TeamsInfo {
      * @param userId ID of the Teams user.
      * @returns The [TeamsChannelAccount](xref:botframework-schema.TeamsChannelAccount) of the member.
      */
-    static async getTeamMember(
-        context: TurnContext,
-        teamId?: string,
-        userId?: string
-    ): Promise<TeamsChannelAccount> {
+    static async getTeamMember(context: TurnContext, teamId?: string, userId?: string): Promise<TeamsChannelAccount> {
         const t = teamId || this.getTeamId(context);
         if (!t) {
             throw new Error('This method is only valid within the scope of a MS Teams Team.');

--- a/libraries/botframework-connector/src/auth/appCredentials.ts
+++ b/libraries/botframework-connector/src/auth/appCredentials.ts
@@ -117,6 +117,10 @@ export abstract class AppCredentials implements msrest.ServiceClientCredentials 
      * @param  {Date} expiration? The expiration date after which this service url is not trusted anymore
      */
     static trustServiceUrl(serviceUrl: string, expiration?: Date): void;
+    /**
+     * Adds the host of service url to trusted hosts.
+     * If expiration time is not provided, the expiration date will be current (utc) date + 1 day.
+     */
     static trustServiceUrl(): void {
         // no-op
     }
@@ -130,6 +134,11 @@ export abstract class AppCredentials implements msrest.ServiceClientCredentials 
      * @returns {boolean} True if the host of the service url is trusted; False otherwise.
      */
     static isTrustedServiceUrl(serviceUrl: string): boolean;
+    /**
+     * Checks if the service url is for a trusted host or not.
+     *
+     * @returns {boolean} True if the host of the service url is trusted; False otherwise.
+     */
     static isTrustedServiceUrl(): boolean {
         return true;
     }


### PR DESCRIPTION
Addresses #4204
#minor

## Description
This PR fixes the new ESLint and JSDoc issues introduced before enabling lint check.

## Specific Changes
- Applied auto-fixes with yarn lint --fix
	- Fix indentation
- Applied manual fixes for:
	- Missing documentation in the _appCredentials_ class.

## Testing
Here we can see the yarn lint command running without issues.
![image](https://user-images.githubusercontent.com/44245136/178829204-f7ad3a7f-23cb-41dc-9d8f-3034b8663fb0.png)