### PR TITLE
port: [#4274] Add settings.selectedChannel to TeamsChannelData and Type to ChannelInfo and TeamDetails (#6360)

### DIFF
--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -413,6 +413,9 @@ export class TeamsActivityHandler extends ActivityHandler {
 export function teamsGetChannelId(activity: Activity): string | null;
 
 // @public
+export function teamsGetSelectedChannelId(activity: Activity): string;
+
+// @public
 export function teamsGetTeamId(activity: Activity): string | null;
 
 // @public

--- a/libraries/botbuilder/src/teamsActivityHelpers.ts
+++ b/libraries/botbuilder/src/teamsActivityHelpers.ts
@@ -19,6 +19,18 @@ function validateActivity(activity: Partial<Activity>): void {
 }
 
 /**
+ * Gets the Team's selected channel id from the current activity.
+ *
+ * @param activity The current [Activity](xref:botframework-schema.Activity).
+ * @returns The current activity's team's selected channel, or empty string.
+ */
+export function teamsGetSelectedChannelId(activity: Activity): string {
+    validateActivity(activity);
+
+    return activity.channelData?.settings?.selectedChannel?.id ?? '';
+}
+
+/**
  * Gets the TeamsMeetingInfo object from the current [Activity](xref:botframework-schema.Activity).
  *
  * @param activity The current [Activity](xref:botframework-schema.Activity).

--- a/libraries/botbuilder/tests/teamsHelpers.test.js
+++ b/libraries/botbuilder/tests/teamsHelpers.test.js
@@ -6,10 +6,10 @@
 const assert = require('assert');
 const {
     teamsGetChannelId,
-    teamsGetTeamId,
-    teamsNotifyUser,
-    teamsGetTeamInfo,
     teamsGetSelectedChannelId,
+    teamsGetTeamId,
+    teamsGetTeamInfo,
+    teamsNotifyUser,
 } = require('../');
 
 function createActivityTeamId() {

--- a/libraries/botbuilder/tests/teamsHelpers.test.js
+++ b/libraries/botbuilder/tests/teamsHelpers.test.js
@@ -4,7 +4,13 @@
  */
 
 const assert = require('assert');
-const { teamsGetChannelId, teamsGetTeamId, teamsNotifyUser, teamsGetTeamInfo } = require('../');
+const {
+    teamsGetChannelId,
+    teamsGetTeamId,
+    teamsNotifyUser,
+    teamsGetTeamInfo,
+    teamsGetSelectedChannelId,
+} = require('../');
 
 function createActivityTeamId() {
     return {
@@ -173,6 +179,20 @@ describe('TeamsActivityHelpers method', function () {
 
         it('should throw an error if no activity is passed in', function () {
             assert.throws(() => teamsGetTeamInfo(undefined), Error('Missing activity parameter'));
+        });
+    });
+
+    describe('teamsGetSelectedChannelId()', function () {
+        it('should return channel id', async function () {
+            const activity = { channelData: { settings: { selectedChannel: { id: 'channel123' } } } };
+            const channelId = teamsGetSelectedChannelId(activity);
+            assert.strictEqual(channelId, 'channel123');
+        });
+
+        it('should return channel id with null settings', async function () {
+            const activity = { channelData: { settings: null } };
+            const channelId = teamsGetSelectedChannelId(activity);
+            assert.strictEqual(channelId, '');
         });
     });
 });

--- a/libraries/botbuilder/tests/teamsInfo.test.js
+++ b/libraries/botbuilder/tests/teamsInfo.test.js
@@ -427,6 +427,7 @@ describe('TeamsInfo', function () {
                 id: '19:generalChannelIdgeneralChannelId@thread.skype',
                 name: 'TeamName',
                 aadGroupId: 'Team-aadGroupId',
+                type: 'standard',
             };
 
             const { expectedAuthHeader, expectation: fetchOauthToken } = nockOauth();
@@ -447,6 +448,7 @@ describe('TeamsInfo', function () {
             assert(fetchedTeamDetails.id === '19:generalChannelIdgeneralChannelId@thread.skype');
             assert(fetchedTeamDetails.name === 'TeamName');
             assert(fetchedTeamDetails.aadGroupId === 'Team-aadGroupId');
+            assert(fetchedTeamDetails.type === 'standard');
         });
 
         it('should work with a teamId passed in', async function () {

--- a/libraries/botframework-connector/src/teams/models/mappers.ts
+++ b/libraries/botframework-connector/src/teams/models/mappers.ts
@@ -23,6 +23,12 @@ export const ChannelInfo: msRest.CompositeMapper = {
                     name: 'String',
                 },
             },
+            type: {
+                serializedName: 'type',
+                type: {
+                    name: 'String',
+                },
+            },
         },
     },
 };
@@ -69,6 +75,12 @@ export const TeamDetails: msRest.CompositeMapper = {
             },
             aadGroupId: {
                 serializedName: 'aadGroupId',
+                type: {
+                    name: 'String',
+                },
+            },
+            type: {
+                serializedName: 'type',
                 type: {
                     name: 'String',
                 },
@@ -187,6 +199,30 @@ export const TeamsChannelData: msRest.CompositeMapper = {
                 type: {
                     name: 'Composite',
                     className: 'TenantInfo',
+                },
+            },
+            settings: {
+                serializedName: 'settings',
+                type: {
+                    name: 'Composite',
+                    className: 'TeamsChannelDataSettings',
+                },
+            },
+        },
+    },
+};
+
+export const TeamsChannelDataSettings: msRest.CompositeMapper = {
+    serializedName: 'TeamsChannelDataSettings',
+    type: {
+        name: 'Composite',
+        className: 'TeamsChannelDataSettings',
+        modelProperties: {
+            selectedChannel: {
+                serializedName: 'selectedChannel',
+                type: {
+                    name: 'Composite',
+                    className: 'ChannelInfo',
                 },
             },
         },

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -417,6 +417,7 @@ export interface ChannelAccount {
 export interface ChannelInfo {
     id?: string;
     name?: string;
+    type?: string;
 }
 
 // @public
@@ -1667,6 +1668,7 @@ export interface TeamDetails {
     id?: string;
     memberCount?: number;
     name?: string;
+    type?: string;
 }
 
 // @public
@@ -1698,8 +1700,15 @@ export interface TeamsChannelData {
     eventType?: string;
     meeting?: TeamsMeetingInfo;
     notification?: NotificationInfo;
+    settings?: TeamsChannelDataSettings;
     team?: TeamInfo;
     tenant?: TenantInfo;
+}
+
+// @public
+export interface TeamsChannelDataSettings {
+    [properties: string]: unknown;
+    selectedChannel?: ChannelInfo;
 }
 
 // @public

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -157,7 +157,7 @@ export interface TeamsMeetingInfo {
 export interface TeamsChannelData {
     /**
      * @member {ChannelInfo} [channel] Information about the channel in which the
-     * message was sent
+     * message was sent.
      */
     channel?: ChannelInfo;
     /**
@@ -166,27 +166,27 @@ export interface TeamsChannelData {
     eventType?: string;
     /**
      * @member {TeamInfo} [team] Information about the team in which the message
-     * was sent
+     * was sent.
      */
     team?: TeamInfo;
     /**
      * @member {NotificationInfo} [notification] Notification settings for the
-     * message
+     * message.
      */
     notification?: NotificationInfo;
     /**
      * @member {TenantInfo} [tenant] Information about the tenant in which the
-     * message was sent
+     * message was sent.
      */
     tenant?: TenantInfo;
     /**
      * @member {TeamsMeetingInfo} [meeting] Information about the tenant in which the
-     * message was sent
+     * message was sent.
      */
     meeting?: TeamsMeetingInfo;
     /**
      * @member {TeamsChannelDataSettings} [settings] Information about the settings in which the
-     * message was sent
+     * message was sent.
      */
     settings?: TeamsChannelDataSettings;
 }

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -24,6 +24,10 @@ export interface ChannelInfo {
      * @member {string} [name] Name of the channel
      */
     name?: string;
+    /**
+     * @member {string} [type] The type of the channel. Valid values are standard, shared and private.
+     */
+    type?: string;
 }
 
 /**
@@ -68,6 +72,10 @@ export interface TeamDetails {
      * the team.
      */
     memberCount?: number;
+    /**
+     * @member {string} [type] The type of the team. Valid values are standard, sharedChannel and privateChannel.
+     */
+    type?: string;
 }
 
 /**
@@ -176,6 +184,11 @@ export interface TeamsChannelData {
      * message was sent
      */
     meeting?: TeamsMeetingInfo;
+    /**
+     * @member {TeamsChannelDataSettings} [settings] Information about the settings in which the
+     * message was sent
+     */
+    settings?: TeamsChannelDataSettings;
 }
 
 /**
@@ -210,6 +223,25 @@ export interface TeamsChannelAccount extends ChannelAccount {
      * @member {string} [userRole] User Role of the user.
      */
     userRole?: string;
+}
+
+/**
+ * @interface
+ * Settings within teams channel data specific to messages received in Microsoft Teams.
+ */
+export interface TeamsChannelDataSettings {
+    /**
+     * @member {ChannelInfo} [selectedChannel] Information about the selected Teams channel.
+     */
+    selectedChannel?: ChannelInfo;
+    /**
+     * @member {any} [any] Additional properties that are not otherwise defined by the TeamsChannelDataSettings
+     * type but that might appear in the REST JSON object.
+     * @remarks With this, properties not represented in the defined type are not dropped when
+     * the JSON object is deserialized, but are instead stored in this property. Such properties
+     * will be written to a JSON object when the instance is serialized.
+     */
+    [properties: string]: unknown;
 }
 
 /**


### PR DESCRIPTION
Fixes #4274

## Description
This PR adds the ability to gather the selected MS Team's channel id when available in the incoming Activity. (Available in Install and Uninstall the teams' bot events).

## Specific Changes
- Added the `teamsGetSelectedChannelId` helper function.
- Added the `TeamsChannelDataSettings` interface and all its related properties to be accessible from the Activity.
- Added unit tests around this implementation.
- Updated mappers to include the new added properties.
- Updated compatibility Markdown document.

## Testing
The following images show the tests passing successfully and the selected channel id being gathered successfully from a teams' bot.
![imagen](https://user-images.githubusercontent.com/62260472/180462193-43725a1d-e0cc-4721-bc64-2e3230ae1236.png)
![imagen](https://user-images.githubusercontent.com/62260472/180462210-b00bdc70-3233-4d72-a834-b53bdb2d529a.png)
