### PR TITLE
fix: Update package.json

### DIFF
--- a/libraries/botbuilder-azure/package.json
+++ b/libraries/botbuilder-azure/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@azure/cosmos": "^3.3.1",
-    "azure-storage": "2.10.2",
+    "azure-storage": "2.10.7",
     "botbuilder": "4.1.6",
     "lodash": "^4.17.20"
   },


### PR DESCRIPTION
Fixes #4300

## Description
botbuilder-azure v4.16.0 depends on azure-storage v2.10.2 which has a dependency on validator v9.4.1

validator.js prior to 13.7.0 is vulnerable to "Inefficient Regular Expression Complexity"
More details: https://github.com/advisories/GHSA-qgmg-gppg-76g5

The ask is to bump up the version of azure-storage to v2.10.7 which depends on validator v13.7.0

## Specific Changes
  - Updated the version number of azure-storage to 2.10.7 in package.json
