### PR TITLE
fix: [#4296] MessagingExtensionResultType missing silentAuth Type

### DIFF
--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -1119,7 +1119,7 @@ export interface MessagingExtensionResult {
 }
 
 // @public
-export type MessagingExtensionResultType = 'result' | 'auth' | 'config' | 'message' | 'botMessagePreview';
+export type MessagingExtensionResultType = 'result' | 'auth' | 'config' | 'message' | 'botMessagePreview' | 'silentAuth';
 
 // @public
 export interface MessagingExtensionSuggestedAction {

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -1700,12 +1700,18 @@ export type AttachmentLayout = 'list' | 'grid';
 
 /**
  * Defines values for MessagingExtensionResultType.
- * Possible values include: 'result', 'auth', 'config', 'message', 'botMessagePreview'
+ * Possible values include: 'result', 'auth', 'config', 'message', 'botMessagePreview', 'silentAuth'.
  *
  * @readonly
  * @enum {string}
  */
-export type MessagingExtensionResultType = 'result' | 'auth' | 'config' | 'message' | 'botMessagePreview';
+export type MessagingExtensionResultType =
+    | 'result'
+    | 'auth'
+    | 'config'
+    | 'message'
+    | 'botMessagePreview'
+    | 'silentAuth';
 
 /**
  * @deprecated Use MessagingExtensionResultType instead


### PR DESCRIPTION
Fixes #4296

## Description
This PR adds the '_silentAuth_' value to the **_MessagingExtensionResultType_**'s enum.

_Note: In .NET the type for MessagingExtensionResult is a string._ 

## Specific Changes
- Updated `MessagingExtensionResultType` in _botframework-schema/teams/index.ts_ to include the new value '_silentAuth_'.
- Updated documentation in `botframework-schema.api.md`.

## Testing
These images show the error shown when using '_silentAuth_' as the type and the type being correctly assigned after the changes.
![image](https://user-images.githubusercontent.com/44245136/182642861-e6e93997-1166-4ae7-b119-1d27607c5be6.png)
