### PR TITLE
fix: [#4288] CustomQuestionAnswering answers return empty metadata

### DIFF
--- a/libraries/botbuilder-ai/src/qnamaker-utils/languageServiceUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/languageServiceUtils.ts
@@ -176,7 +176,7 @@ export class LanguageServiceUtils {
                 answer: kbAnswer.answer,
                 score: kbAnswer.confidenceScore,
                 metadata: kbAnswer.metadata
-                    ? Array.from(kbAnswer.metadata)?.map((nv) => {
+                    ? Object.entries(kbAnswer.metadata).map((nv) => {
                           return { name: nv[0], value: nv[1] };
                       })
                     : null,

--- a/libraries/botbuilder-ai/tests/TestData/LanguageService/returns_answer_with_metadata.json
+++ b/libraries/botbuilder-ai/tests/TestData/LanguageService/returns_answer_with_metadata.json
@@ -1,0 +1,16 @@
+{
+    "answers": [
+      {
+        "confidenceScore": 0.4854820341616869,
+        "Id": 20,
+        "answer": "They're frolicking merrily in the verdant garden!",
+        "source": "Custom Editorial",
+        "questions": [
+          "where are the unicorns?"
+        ],
+        "metadata": {
+            "title": "mythical unicorns"
+        }
+      }
+    ]
+  }

--- a/libraries/botbuilder-ai/tests/languageService.test.js
+++ b/libraries/botbuilder-ai/tests/languageService.test.js
@@ -221,6 +221,7 @@ describe('LanguageService', function () {
             const results = await qna.getAnswers(context, options);
             assert.strictEqual(results.length, 1);
         });
+
         it('returns answer without any options specified', async function () {
             const qna = new CustomQuestionAnswering(endpoint);
             const context = new TestContext({ text: 'where are the unicorns?' });
@@ -228,6 +229,18 @@ describe('LanguageService', function () {
             const results = await qna.getAnswers(context);
 
             assert.strictEqual(results.length, 1);
+        });
+
+        it('returns answer with metadata', async function () {
+            const qna = new CustomQuestionAnswering(endpoint);
+            const context = new TestContext({ text: 'where are the unicorns?' });
+
+            const results = await qna.getAnswers(context);
+
+            assert.strictEqual(results.length, 1);
+            assert.strictEqual(results[0].metadata.length, 1);
+            assert.strictEqual(results[0].metadata[0].name, 'title');
+            assert.strictEqual(results[0].metadata[0].value, 'mythical unicorns');
         });
 
         it('returns answer and active learning flag', async function () {


### PR DESCRIPTION
Fixes #4288

## Description
This PR fixes the formatting made over the answer's _metadata_, causing the information to get lost. The _metadata_ field was treated as an array and it is actually an object.

## Specific Changes
  - Updated the _formatQnaResult_ method of the `languageServiceUtils` class to format the _metadata_ field treating it as an object.
  - Added a new unit test in the `languageService.test` class to verify the metadata field gets properly mapped.
  - Added `returns_answer_with_metadata.json` test data file.

## Testing
These images show the answer the bot received before and after the changes.
![image](https://user-images.githubusercontent.com/44245136/185150541-4ee7c5d5-cece-4941-a755-2e1d4c1db3f4.png)
