### PR TITLE
port: [#4309] AdaptiveExpression Bool function is not very useful because it doesn't convert anything but ints (#6431)

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/bool.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/bool.ts
@@ -30,6 +30,10 @@ export class Bool extends ComparisonEvaluator {
             return args[0] !== 0;
         }
 
+        if (/false/i.test(args[0])) {
+            return false;
+        }
+
         return InternalFunctionUtils.isLogicTrue(args[0]);
     }
 }

--- a/libraries/adaptive-expressions/tests/expressionParser.test.js
+++ b/libraries/adaptive-expressions/tests/expressionParser.test.js
@@ -419,7 +419,8 @@ const testCases = [
             ['bool(0)', false],
             ['bool(null)', false],
             ['bool(hello * 5)', false],
-            ["bool('false')", true], // we make it true, because it is not empty
+            ["bool('false')", false],
+            ["bool('true')", true],
             ["bool('hi')", true],
             ['[1,2,3]', [1, 2, 3]],
             ['[1,2,3, [4,5]]', [1, 2, 3, [4, 5]]],


### PR DESCRIPTION
Fixes #4309

## Description
This PR ports the changes in botbuilder-dotnet to evaluate 'true' and 'false' strings.

## Specific Changes
- Updated _func()_ method of AdaptiveExpressions/BuiltinFunctions/bool to evaluate 'false' string
- Updated AdaptiveExpressions/Tests/expressionParser.test.js

## Testing
This image shows the unit tests passing.
<img width="284" alt="image" src="https://user-images.githubusercontent.com/64815358/188169971-03377fec-1346-4a9a-b26f-cf4b6ff8ba44.png">
