### PR TITLE
fix: [#4314] CloudAdapter: messages are not sorted correctly

### DIFF
--- a/libraries/botbuilder-core/src/cloudAdapterBase.ts
+++ b/libraries/botbuilder-core/src/cloudAdapterBase.ts
@@ -67,36 +67,45 @@ export abstract class CloudAdapterBase extends BotAdapter {
             throw new Error('Expecting one or more activities, but the array was empty.');
         }
 
-        return Promise.all(
-            activities.map(async (activity) => {
-                delete activity.id;
+        const responses: ResourceResponse[] = [];
+        for (const activity of activities) {
+            delete activity.id;
+            let response: ResourceResponse;
 
-                if (activity.type === 'delay') {
-                    await delay(typeof activity.value === 'number' ? activity.value : 1000);
-                } else if (activity.type === ActivityTypes.InvokeResponse) {
-                    context.turnState.set(INVOKE_RESPONSE_KEY, activity);
-                } else if (activity.type === ActivityTypes.Trace && activity.channelId !== Channels.Emulator) {
-                    // no-op
-                } else {
-                    const connectorClient = context.turnState.get<ConnectorClient>(this.ConnectorClientKey);
-                    if (!connectorClient) {
-                        throw new Error('Unable to extract ConnectorClient from turn context.');
-                    }
-
-                    if (activity.replyToId) {
-                        return connectorClient.conversations.replyToActivity(
-                            activity.conversation.id,
-                            activity.replyToId,
-                            activity
-                        );
-                    } else {
-                        return connectorClient.conversations.sendToConversation(activity.conversation.id, activity);
-                    }
+            if (activity.type === 'delay') {
+                await delay(typeof activity.value === 'number' ? activity.value : 1000);
+            } else if (activity.type === ActivityTypes.InvokeResponse) {
+                context.turnState.set(INVOKE_RESPONSE_KEY, activity);
+            } else if (activity.type === ActivityTypes.Trace && activity.channelId !== Channels.Emulator) {
+                // no-op
+            } else {
+                const connectorClient = context.turnState.get<ConnectorClient>(this.ConnectorClientKey);
+                if (!connectorClient) {
+                    throw new Error('Unable to extract ConnectorClient from turn context.');
                 }
 
-                return { id: activity.id ?? '' };
-            })
-        );
+                if (activity.replyToId) {
+                    response = await connectorClient.conversations.replyToActivity(
+                        activity.conversation.id,
+                        activity.replyToId,
+                        activity
+                    );
+                } else {
+                    response = await connectorClient.conversations.sendToConversation(
+                        activity.conversation.id,
+                        activity
+                    );
+                }
+            }
+
+            if (!response) {
+                response = { id: activity.id ?? '' };
+            }
+
+            responses.push(response);
+        }
+
+        return responses;
     }
 
     /**


### PR DESCRIPTION
Fixes #4314

## Description
This PR fixes an issue where multiple message activities were sent in different orders using WebChat or Emulator.
The problem was in the [sendActivities](https://github.com/microsoft/botbuilder-js/blob/main/libraries/botbuilder-core/src/cloudAdapterBase.ts#L71) method, where the activities were processed in parallel, and thus sent in different order.
To solve this issue, we basically ported the functionality changes from [DotNet's SendActivities](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs#L69) implementation.

## Specific Changes
- Replaced promise loop from `map` to `for of`, so activities are processed sequentially and not in parallel.
- Ported changes from [DotNet's SendActivities](https://github.com/microsoft/botbuilder-dotnet/blob/main/libraries/Microsoft.Bot.Builder/CloudAdapterBase.cs#L69) implementation.

## Testing
The following image shows the comparison between the actual and expected behavior.
![image](https://user-images.githubusercontent.com/62260472/189164793-65b04edf-350e-4eb2-ae5a-2896147bd043.png)
