### PR TITLE
chore: Update Ubuntu vmImage version

### DIFF
--- a/build/yaml/botbuilder-js-daily.yml
+++ b/build/yaml/botbuilder-js-daily.yml
@@ -3,7 +3,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  vmImage: 'ubuntu-latest'
 
 variables:
   NodeVersion: 12.x


### PR DESCRIPTION
Fixes #minor

## Description
ubuntu-18.04 is deprecated. This sets it to latest for the daily build.