### PR TITLE
fix: get chrome version task in browser test pipeline

### DIFF
--- a/build/yaml/botbuilder-js-daily.yml
+++ b/build/yaml/botbuilder-js-daily.yml
@@ -3,7 +3,7 @@
 name: $(Build.BuildId)
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  vmImage: 'ubuntu-latest'
 
 variables:
   NodeVersion: 12.x

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -41,7 +41,6 @@ steps:
       $versions = npm view $packageName versions | ConvertFrom-Json;
 
       $secondLatestVersion = $versions[-2];
-      Write-Host "Second latest version: $secondLatestVersion";
       Write-Host "$packageName second latest = $secondLatestVersion";
 
       "##vso[task.setvariable variable=DriverVersion;]$secondLatestVersion";

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -36,16 +36,12 @@ steps:
     script: |
       $packageName = "chromedriver";
 
-      Write-Host "Get $packageName version tagged 'latest' from npmjs.com";
+      Write-Host "Get $packageName second latest version from npmjs.com";
+      " "
+      $versions = npm view $packageName versions | ConvertFrom-Json;
 
-      $dist = npm dist-tag ls $packageName;
-      $next = $dist.Where({$_.StartsWith("latest:")});
-      [string]$latestVersion = $next.Split(':')[-1].Trim();
-      Write-Host "$packageName latest = $latestVersion";
-
-      $splitVersion = $latestVersion.Split(".");
-      $splitVersion[0] = $splitVersion[0] - 1;
-      $secondLatestVersion = $splitVersion -Join ".";
+      $secondLatestVersion = $versions[-2];
+      Write-Host "Second latest version: $secondLatestVersion";
       Write-Host "$packageName second latest = $secondLatestVersion";
 
       "##vso[task.setvariable variable=DriverVersion;]$secondLatestVersion";


### PR DESCRIPTION
Fixes #minor

## Description
In pipeline JS-Functional-Tests-BrowserBot-yaml, task 'Get second latest chromedriver version number from npmjs.com' is not getting the correct version. This fixes that.