### PR TITLE
fix: change req to res in process method

### DIFF
--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -1876,7 +1876,7 @@ export class BotFrameworkAdapter
      * Process a web request by applying a logic function.
      *
      * @param req An incoming HTTP [Request](xref:botbuilder.Request)
-     * @param req The corresponding HTTP [Response](xref:botbuilder.Response)
+     * @param res The corresponding HTTP [Response](xref:botbuilder.Response)
      * @param logic The logic function to apply
      * @returns a promise representing the asynchronous operation.
      */


### PR DESCRIPTION
Fixes #4332 

## Description
Fixing a very small typo from `req` to `res` to denote the correct `Response` object in the process method

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Change `req` to `res`

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->