### PR TITLE
fix: [#4324] Explicit error logging inside jwtTokenExtractor in botframework-connector

### DIFF
--- a/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
+++ b/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
@@ -99,13 +99,7 @@ export class JwtTokenExtractor {
             return null;
         }
 
-        try {
-            return await this.validateToken(parameter, channelId, requiredEndorsements);
-        } catch (err) {
-            // tslint:disable-next-line:no-console
-            console.error('JwtTokenExtractor.getIdentity:err!', err);
-            throw err;
-        }
+        return await this.validateToken(parameter, channelId, requiredEndorsements);
     }
 
     /**


### PR DESCRIPTION
Fixes #4324

## Description
This PR removes the unnecessary `console.error` statement in the **_jwtTokenExtractor_** class.

## Specific Changes
  - Deleted `console.error` statement in the **_jwtTokenExtractor_** class. The try-catch block was no longer necessary either.

## Testing
Here we can see the unit tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/195133692-fc0e1bf0-7c35-4c5d-80ad-c8a4c8baab4b.png)