### PR TITLE
port: [#6354] isMatch adaptive expression returns error when value is null or empty string (#6426)

### DIFF
--- a/libraries/adaptive-expressions/src/builtinFunctions/isMatch.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isMatch.ts
@@ -30,17 +30,10 @@ export class IsMatch extends ExpressionEvaluator {
      */
     private static evaluator(): EvaluateExpressionDelegate {
         return FunctionUtils.applyWithError((args: any[]): any => {
-            let value = false;
-            let error: string;
-            if (args[0] === undefined || args[0] === '') {
-                value = false;
-                error = 'regular expression is empty.';
-            } else {
-                const regex: RegExp = CommonRegex.CreateRegex(args[1].toString());
-                value = regex.test(args[0].toString());
-            }
-
-            return { value, error };
+            const regex: RegExp = CommonRegex.CreateRegex(args[1].toString());
+            const inputString = args[0] ? args[0].toString() : '';
+            const value = regex.test(inputString);
+            return { value, undefined };
         }, FunctionUtils.verifyStringOrNull);
     }
 

--- a/libraries/adaptive-expressions/tests/expressionParser.test.js
+++ b/libraries/adaptive-expressions/tests/expressionParser.test.js
@@ -895,6 +895,8 @@ const testCases = [
             ['isMatch("1", "\\\\d{1}")', true], // "\d" (match [0-9])
             ['isMatch("12.5", "[0-9]+(\\\\.5)")', true], // "\." (match .)
             ['isMatch("12x5", "[0-9]+(\\\\.5)")', false], // "\." (match .)
+            ["isMatch('', '[0-9]')", false], // empty string
+            ["isMatch(nullObj, '[0-9]')", false], // null object
         ],
     },
     {


### PR DESCRIPTION
Fixes #4310

## Description
This PR ports the changes in [PR#6426](https://github.com/microsoft/botbuilder-dotnet/pull/6426) to fix the error in the **_isMatch_** built-in function when the value is null or an empty string.

## Specific Changes
- Updated the `IsMatch` built-in function to handle empty strings and null values by the evaluator.
- Added 2 new unit tests for empty string and null values for the _IsMatch_ function.

## Testing
Here we can see the new unit tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/195648751-1f60d8df-d724-4092-a9f1-bdba03223c09.png)