### PR TITLE
port: [#6432] TeamsInfo.GetMemberAsync(...) doesn't work properly in Skill Bot scenario, it returns http 405 error (#6443)

### DIFF
--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -196,6 +196,7 @@ export abstract class ChannelServiceHandlerBase {
     handleDeleteActivity(authHeader: string, conversationId: string, activityId: string): Promise<void>;
     handleDeleteConversationMember(authHeader: string, conversationId: string, memberId: string): Promise<void>;
     handleGetActivityMembers(authHeader: string, conversationId: string, activityId: string): Promise<ChannelAccount[]>;
+    handleGetConversationMember(authHeader: string, userId: string, conversationId: string): Promise<ChannelAccount>;
     handleGetConversationMembers(authHeader: string, conversationId: string): Promise<ChannelAccount[]>;
     handleGetConversationPagedMembers(authHeader: string, conversationId: string, pageSize?: number, continuationToken?: string): Promise<PagedMembersResult>;
     handleGetConversations(authHeader: string, conversationId: string, continuationToken?: string): Promise<ConversationsResult>;
@@ -208,6 +209,7 @@ export abstract class ChannelServiceHandlerBase {
     protected onDeleteActivity(_claimsIdentity: ClaimsIdentity, _conversationId: string, _activityId: string): Promise<void>;
     protected onDeleteConversationMember(_claimsIdentity: ClaimsIdentity, _conversationId: string, _memberId: string): Promise<void>;
     protected onGetActivityMembers(_claimsIdentity: ClaimsIdentity, _conversationId: string, _activityId: string): Promise<ChannelAccount[]>;
+    protected onGetConversationMember(_claimsIdentity: ClaimsIdentity, _userId: string, _conversationId: string): Promise<ChannelAccount>;
     protected onGetConversationMembers(_claimsIdentity: ClaimsIdentity, _conversationId: string): Promise<ChannelAccount[]>;
     protected onGetConversationPagedMembers(_claimsIdentity: ClaimsIdentity, _conversationId: string, _pageSize?: number, _continuationToken?: string): Promise<PagedMembersResult>;
     protected onGetConversations(_claimsIdentity: ClaimsIdentity, _conversationId: string, _continuationToken?: string): Promise<ConversationsResult>;
@@ -238,6 +240,7 @@ export class CloudAdapter extends CloudAdapterBase implements BotFrameworkHttpAd
 export class CloudSkillHandler extends CloudChannelServiceHandler {
     constructor(adapter: BotAdapter, logic: (context: TurnContext) => Promise<void>, conversationIdFactory: SkillConversationIdFactoryBase, auth: BotFrameworkAuthentication);
     protected onDeleteActivity(claimsIdentity: ClaimsIdentity, conversationId: string, activityId: string): Promise<void>;
+    protected onGetConversationMember(claimsIdentity: ClaimsIdentity, userId: string, conversationId: string): Promise<ChannelAccount>;
     protected onReplyToActivity(claimsIdentity: ClaimsIdentity, conversationId: string, activityId: string, activity: Activity): Promise<ResourceResponse>;
     protected onSendToConversation(claimsIdentity: ClaimsIdentity, conversationId: string, activity: Activity): Promise<ResourceResponse>;
     protected onUpdateActivity(claimsIdentity: ClaimsIdentity, conversationId: string, activityId: string, activity: Activity): Promise<ResourceResponse>;

--- a/libraries/botbuilder/src/channelServiceHandlerBase.ts
+++ b/libraries/botbuilder/src/channelServiceHandlerBase.ts
@@ -152,6 +152,23 @@ export abstract class ChannelServiceHandlerBase {
     }
 
     /**
+     * Gets the account of a single conversation member.
+     *
+     * @param authHeader The authentication header.
+     * @param userId The user Id.
+     * @param conversationId The conversation Id.
+     * @returns The [ChannelAccount](xref:botframework-schema.ChannelAccount) for the provided user id.
+     */
+    async handleGetConversationMember(
+        authHeader: string,
+        userId: string,
+        conversationId: string
+    ): Promise<ChannelAccount> {
+        const claimsIdentity = await this.authenticate(authHeader);
+        return this.onGetConversationMember(claimsIdentity, userId, conversationId);
+    }
+
+    /**
      * Enumerates the members of a conversation one page at a time.
      *
      * @param authHeader The authentication header.
@@ -450,6 +467,31 @@ export abstract class ChannelServiceHandlerBase {
         throw new StatusCodeError(
             StatusCodes.NOT_IMPLEMENTED,
             `ChannelServiceHandler.onGetConversationMembers(): ${StatusCodes.NOT_IMPLEMENTED}: ${
+                STATUS_CODES[StatusCodes.NOT_IMPLEMENTED]
+            }`
+        );
+    }
+
+    /**
+     * getConversationMember() API for Skill.
+     *
+     * @remarks
+     * Get the account of a single conversation member.
+     *
+     * This REST API takes a ConversationId and UserId and returns the ChannelAccount
+     * object representing the member of the conversation.
+     * @param _claimsIdentity ClaimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.
+     * @param _userId User ID.
+     * @param _conversationId Conversation ID.
+     */
+    protected async onGetConversationMember(
+        _claimsIdentity: ClaimsIdentity,
+        _userId: string,
+        _conversationId: string
+    ): Promise<ChannelAccount> {
+        throw new StatusCodeError(
+            StatusCodes.NOT_IMPLEMENTED,
+            `ChannelServiceHandler.onGetConversationMember(): ${StatusCodes.NOT_IMPLEMENTED}: ${
                 STATUS_CODES[StatusCodes.NOT_IMPLEMENTED]
             }`
         );

--- a/libraries/botbuilder/src/channelServiceRoutes.ts
+++ b/libraries/botbuilder/src/channelServiceRoutes.ts
@@ -55,6 +55,7 @@ export class ChannelServiceRoutes {
         server.post(basePath + RouteConstants.Conversations, this.processCreateConversation.bind(this));
         server.get(basePath + RouteConstants.Conversations, this.processGetConversations.bind(this));
         server.get(basePath + RouteConstants.ConversationMembers, this.processGetConversationMembers.bind(this));
+        server.get(basePath + RouteConstants.ConversationMember, this.processGetConversationMember.bind(this));
         server.get(
             basePath + RouteConstants.ConversationPagedMembers,
             this.processGetConversationPagedMembers.bind(this)
@@ -237,6 +238,25 @@ export class ChannelServiceRoutes {
                 res.status(200);
                 if (channelAccounts) {
                     res.send(channelAccounts);
+                }
+                res.end();
+            })
+            .catch((err) => {
+                ChannelServiceRoutes.handleError(err, res);
+            });
+    }
+
+    /**
+     * @private
+     */
+    private processGetConversationMember(req: WebRequest, res: WebResponse): void {
+        const authHeader = req.headers.authorization || req.headers.Authorization || '';
+        this.channelServiceHandler
+            .handleGetConversationMember(authHeader, req.params.memberId, req.params.conversationId)
+            .then((channelAccount) => {
+                res.status(200);
+                if (channelAccount) {
+                    res.send(channelAccount);
                 }
                 res.end();
             })

--- a/libraries/botbuilder/src/skills/cloudSkillHandler.ts
+++ b/libraries/botbuilder/src/skills/cloudSkillHandler.ts
@@ -8,6 +8,7 @@ import { SkillHandlerImpl } from './skillHandlerImpl';
 import {
     Activity,
     BotAdapter,
+    ChannelAccount,
     ResourceResponse,
     SkillConversationIdFactoryBase,
     SkillConversationReferenceKey,
@@ -170,5 +171,27 @@ export class CloudSkillHandler extends CloudChannelServiceHandler {
         activityId: string
     ): Promise<void> {
         return this.inner.onDeleteActivity(claimsIdentity, conversationId, activityId);
+    }
+
+    /**
+     * getConversationMember() API for Skill.
+     *
+     * @remarks
+     * Get the account of a single conversation member.
+     *
+     * This REST API takes a ConversationId and UserId and returns the ChannelAccount
+     * object representing the member of the conversation.
+     * @param claimsIdentity ClaimsIdentity for the bot, should have AudienceClaim, AppIdClaim and ServiceUrlClaim.
+     * @param userId User ID.
+     * @param conversationId Conversation ID.
+     *
+     * @returns The ChannelAccount object representing the member of the conversation.
+     */
+    protected async onGetConversationMember(
+        claimsIdentity: ClaimsIdentity,
+        userId: string,
+        conversationId: string
+    ): Promise<ChannelAccount> {
+        return this.inner.onGetMember(claimsIdentity, userId, conversationId);
     }
 }

--- a/libraries/botbuilder/src/skills/skillHandlerImpl.ts
+++ b/libraries/botbuilder/src/skills/skillHandlerImpl.ts
@@ -9,6 +9,7 @@ import {
     ActivityTypes,
     BotAdapter,
     CallerIdConstants,
+    ChannelAccount,
     ResourceResponse,
     SkillConversationIdFactoryBase,
     SkillConversationReference,
@@ -85,6 +86,21 @@ export class SkillHandlerImpl {
         return this.continueConversation(claimsIdentity, conversationId, (context) =>
             context.deleteActivity(activityId)
         );
+    }
+
+    /**
+     * @internal
+     */
+    async onGetMember(claimsIdentity: ClaimsIdentity, userId: string, conversationId: string): Promise<ChannelAccount> {
+        let member: ChannelAccount = null;
+
+        await this.continueConversation(claimsIdentity, conversationId, async (context) => {
+            const client = context.turnState.get(context.adapter.ConnectorClientKey);
+            const conversationId = context.activity.conversation.id;
+            member = await client.conversations.getConversationMember(conversationId, userId);
+        });
+
+        return member;
     }
 
     private async getSkillConversationReference(conversationId: string): Promise<SkillConversationReference> {

--- a/libraries/botbuilder/tests/skills/cloudSkillHandler.test.js
+++ b/libraries/botbuilder/tests/skills/cloudSkillHandler.test.js
@@ -1,0 +1,65 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const { CloudAdapter, CloudSkillHandler } = require('../../');
+const { ConversationIdFactory } = require('./conversationIdFactory');
+const { ActivityHandler } = require('botbuilder-core');
+const { ClaimsIdentity, BotFrameworkAuthenticationFactory } = require('botframework-connector');
+
+describe('CloudSkillHandler', function () {
+    const authConfig = BotFrameworkAuthenticationFactory.create();
+    const adapter = new CloudAdapter();
+    const bot = new ActivityHandler();
+    const factory = new ConversationIdFactory();
+    const handler = new CloudSkillHandler(adapter, bot, factory, authConfig);
+
+    let sandbox;
+    beforeEach(function () {
+        sandbox = sinon.createSandbox();
+    });
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    // Registers expectation that handler.onGetMember is invoked with a particular set of arguments
+    const expectsGetConversationMember = (...args) =>
+        sandbox
+            .mock(handler.inner)
+            .expects('onGetMember')
+            .withArgs(...args)
+            .once()
+            .resolves({ id: 'memberId', name: 'memberName' });
+
+    describe('constructor()', function () {
+        const testCases = [
+            { label: 'adapter', args: [undefined, bot, factory, authConfig] },
+            { label: 'logic', args: [adapter, undefined, factory, authConfig] },
+            { label: 'conversationIdFactory', args: [adapter, bot, undefined, authConfig] },
+        ];
+
+        testCases.forEach((testCase) => {
+            it(`should fail without required ${testCase.label}`, function () {
+                assert.throws(() => new CloudSkillHandler(...testCase.args), Error(`missing ${testCase.label}.`));
+            });
+        });
+
+        it('should succeed', function () {
+            new CloudSkillHandler(adapter, bot, factory, authConfig);
+        });
+    });
+
+    describe('onGetConversationMember()', function () {
+        it('should call onGetMember()', async function () {
+            const identity = new ClaimsIdentity([]);
+            const userId = 'memberId';
+            const convId = 'convId';
+
+            expectsGetConversationMember(identity, userId, convId);
+
+            const member = await handler.onGetConversationMember(identity, userId, convId);
+
+            assert.strictEqual(member.id, 'memberId');
+            assert.strictEqual(member.name, 'memberName');
+            sandbox.verify();
+        });
+    });
+});


### PR DESCRIPTION
Fixes #4317

## Description
This PR ports the changes in [PR#6443](https://github.com/microsoft/botbuilder-dotnet/pull/6443) to fix the error thrown when executing the _TeamsInfo.GetMember_ in a root-skill scenario.

## Specific Changes
- Added the _handleGetConversationMember_ and _onGetConversationMember_ methods in `ChannelServiceHandlerBase`.
- Added the _processGetConversationMember_ method in `channelServiceRoutes`.
- Added the _onGetConversationMember_ method in the `CloudSkillHandler` class.
- Added the implementation of the _onGetMember_ method in the `SkillHandlerImpl` class.
- Added the `cloudSkillHandler.test.js` file with unit test for _CloudSkillHandler_ constructor and _onGetConversationMember_ methods.

## Testing
These images show the skill bot retrieving the member's information successfully and the new unit test passing.
![image](https://user-images.githubusercontent.com/44245136/195690773-68956b01-37f1-4328-9e7f-f566ea0086f6.png)
