### PR TITLE
Add manual chromedriver version override to  JS-Functional-Tests-BrowserBot-yaml

### DIFF
--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -36,12 +36,14 @@ steps:
     targetType: inline
     script: |
       if ($null -ne $Env:ChromeDriverVersionOverride -and $Env:ChromeDriverVersionOverride.Trim() -ne '') {
+        Write-Host "Pipeline var ChromeDriverVersionOverride is set.";
         $secondLatestVersion = $Env:ChromeDriverVersionOverride;
         Write-Host "Using var ChromeDriverVersionOverride = $secondLatestVersion";
       } else {
+        Write-Host "Pipeline var ChromeDriverVersionOverride is not set.";
         $packageName = "chromedriver";
 
-        Write-Host "Get $packageName second latest version from npmjs.com";
+        Write-Host "Getting $packageName second latest version from npmjs.com";
         " "
         $versions = npm view $packageName versions | ConvertFrom-Json;
 

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -17,6 +17,7 @@ variables:
   TestWebApp: 'BrowserBotWebApp$(Build.BuildId)'
   TESTURI: 'https://$(TestWebApp).azurewebsites.net/'
 #  AzureSubscription: define this in Azure
+#  ChromeDriverVersionOverride: define this in Azure. Sample values: '107.0.1' No override = ''.
 
 steps:
 
@@ -34,14 +35,19 @@ steps:
   inputs:
     targetType: inline
     script: |
-      $packageName = "chromedriver";
+      if ($(ChromeDriverVersionOverride)) {
+        $secondLatestVersion = $(ChromeDriverVersionOverride);
+        Write-Host "$packageName version override = $secondLatestVersion";
+      } else {
+        $packageName = "chromedriver";
 
-      Write-Host "Get $packageName second latest version from npmjs.com";
-      " "
-      $versions = npm view $packageName versions | ConvertFrom-Json;
+        Write-Host "Get $packageName second latest version from npmjs.com";
+        " "
+        $versions = npm view $packageName versions | ConvertFrom-Json;
 
-      $secondLatestVersion = $versions[-2];
-      Write-Host "$packageName second latest = $secondLatestVersion";
+        $secondLatestVersion = $versions[-2];
+        Write-Host "$packageName second latest = $secondLatestVersion";
+      }
 
       "##vso[task.setvariable variable=DriverVersion;]$secondLatestVersion";
   displayName: 'Get second latest chromedriver version number from npmjs.com'

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -16,8 +16,8 @@ variables:
   TestAppServicePlan: 'BrowserBotServicePlan$(Build.BuildId)'
   TestWebApp: 'BrowserBotWebApp$(Build.BuildId)'
   TESTURI: 'https://$(TestWebApp).azurewebsites.net/'
-# AzureSubscription: define this in Azure
-# ChromeDriverVersionOverride: (optional) define this in Azure. Sample values: '107.0.1'; No override: ''
+  # AzureSubscription: define this in Azure
+  # ChromeDriverVersionOverride: (optional) define this in Azure. Sample values: '107.0.1'; '' (= no override)
 
 steps:
 
@@ -38,12 +38,12 @@ steps:
       if ($null -ne $Env:ChromeDriverVersionOverride -and $Env:ChromeDriverVersionOverride.Trim() -ne '') {
         Write-Host "Pipeline var ChromeDriverVersionOverride is set.";
         $secondLatestVersion = $Env:ChromeDriverVersionOverride;
-        Write-Host "Using var ChromeDriverVersionOverride = $secondLatestVersion";
+        Write-Host "Use override value = $secondLatestVersion";
       } else {
         Write-Host "Pipeline var ChromeDriverVersionOverride is not set.";
         $packageName = "chromedriver";
 
-        Write-Host "Getting $packageName second latest version from npmjs.com";
+        Write-Host "Get $packageName second latest version from npmjs.com";
         " "
         $versions = npm view $packageName versions | ConvertFrom-Json;
 

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -16,8 +16,8 @@ variables:
   TestAppServicePlan: 'BrowserBotServicePlan$(Build.BuildId)'
   TestWebApp: 'BrowserBotWebApp$(Build.BuildId)'
   TESTURI: 'https://$(TestWebApp).azurewebsites.net/'
-#  AzureSubscription: define this in Azure
-#  ChromeDriverVersionOverride: define this in Azure. Sample values: '107.0.1' No override = ''.
+# AzureSubscription: define this in Azure
+# ChromeDriverVersionOverride: (optional) define this in Azure. Sample values: '107.0.1'; No override: ''
 
 steps:
 

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -36,7 +36,7 @@ steps:
     targetType: inline
     script: |
       if ($null -ne $Env:ChromeDriverVersionOverride -and $Env:ChromeDriverVersionOverride.Trim() -ne '') {
-        $secondLatestVersion = $(ChromeDriverVersionOverride);
+        $secondLatestVersion = $Env:ChromeDriverVersionOverride;
         Write-Host "Using var ChromeDriverVersionOverride = $secondLatestVersion";
       } else {
         $packageName = "chromedriver";

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -37,7 +37,7 @@ steps:
     script: |
       if ($(ChromeDriverVersionOverride)) {
         $secondLatestVersion = $(ChromeDriverVersionOverride);
-        Write-Host "Using ChromeDriverVersionOverride = $secondLatestVersion";
+        Write-Host "Using var ChromeDriverVersionOverride = $secondLatestVersion";
       } else {
         $packageName = "chromedriver";
 

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -37,7 +37,7 @@ steps:
     script: |
       if ($(ChromeDriverVersionOverride)) {
         $secondLatestVersion = $(ChromeDriverVersionOverride);
-        Write-Host "$packageName version override = $secondLatestVersion";
+        Write-Host "Using ChromeDriverVersionOverride = $secondLatestVersion";
       } else {
         $packageName = "chromedriver";
 

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -35,7 +35,7 @@ steps:
   inputs:
     targetType: inline
     script: |
-      if ($(ChromeDriverVersionOverride)) {
+      if ($null -ne $Env:ChromeDriverVersionOverride -and $Env:ChromeDriverVersionOverride.Trim() -ne '') {
         $secondLatestVersion = $(ChromeDriverVersionOverride);
         Write-Host "Using var ChromeDriverVersionOverride = $secondLatestVersion";
       } else {


### PR DESCRIPTION
Fixes #minor

## Description
This adds a manual override that lets the build admin quickly adjust the chromedriver version when the build is broken. 

## Background
New Chrome browser versions are released about monthly. The latest chromedriver versions released on npmjs.com are often ahead of the browser version releases, and the relationship is erratic.

Our pipeline gets the 2nd-latest chromedriver version. That works most of the time, but still the pipeline occasionally breaks.

## Specific Changes
Add pipeline var ChromeDriverVersionOverride. When set, it forces the chromedriver to a specific version.
