### PR TITLE
chore: Upgrade node to v 16 in JS pipelines

### DIFF
--- a/build/yaml/botbuilder-js-daily.yml
+++ b/build/yaml/botbuilder-js-daily.yml
@@ -6,7 +6,7 @@ pool:
   vmImage: 'ubuntu-latest'
 
 variables:
-  NodeVersion: 12.x
+  NodeVersion: 16.x
   Packaging.EnableSBOMSigning: true
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
 #  SDK_JS_org_registry_Url: define this in Azure

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -79,9 +79,9 @@ steps:
   displayName: 'Upgrade chromedriver reference to second latest version'
 
 - task: NodeTool@0
-  displayName: use node 12.x
+  displayName: use node 16.x
   inputs:
-    versionSpec: 12.x
+    versionSpec: 16.x
 
 - script: cd testing/browser-functional/browser-echo-bot && yarn && yarn build
   displayName: yarn install and build browser-echo-bot


### PR DESCRIPTION
Fixes #minor

## Description
Upgrade the node version used in JS pipelines from 12 to 16.

This upgrade was prompted by discovering that the latest chromedriver, v 107.0.3, errors on 12:
```
error chromedriver@107.0.3: The engine "node" is incompatible with this module. Expected version ">=14". Got "12.22.12"
error Found incompatible module.
```
(chromedriver is used in pipeline JS-Functional-Tests-BrowserBot-yaml.)