### PR TITLE
chore: Improve 'Get second latest chromedriver' logging

### DIFF
--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -38,20 +38,21 @@ steps:
       $packageName = "chromedriver";
       Write-Host "Get $packageName second latest version from npmjs.com";
       $versions = npm view $packageName versions | ConvertFrom-Json;
-      $secondLatestVersion = $versions[-2];
-      Write-Host "$packageName second latest = $secondLatestVersion";
+      $versionToUse = $versions[-2];
+      Write-Host "$packageName second latest = $versionToUse";
       " "
 
       if ($null -ne $Env:ChromeDriverVersionOverride -and $Env:ChromeDriverVersionOverride.Trim() -ne '') {
         Write-Host "Pipeline var ChromeDriverVersionOverride is set.";
-        $secondLatestVersion = $Env:ChromeDriverVersionOverride;
-        Write-Host "Use override value = $secondLatestVersion";
+        $versionToUse = $Env:ChromeDriverVersionOverride;
+        Write-Host "Use override value = $versionToUse";
       } else {
         Write-Host "Pipeline var ChromeDriverVersionOverride is not set.";
+        Write-Host "Use value = $versionToUse";
       }
 
-      "##vso[task.setvariable variable=DriverVersion;]$secondLatestVersion";
-  displayName: 'Get second latest chromedriver version number from npmjs.com'
+      "##vso[task.setvariable variable=DriverVersion;]$versionToUse";
+  displayName: 'Get chromedriver version number to use'
 
 - task: PowerShell@2
   inputs:

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -37,10 +37,10 @@ steps:
     script: |
       $packageName = "chromedriver";
       Write-Host "Get $packageName second latest version from npmjs.com";
-      " "
       $versions = npm view $packageName versions | ConvertFrom-Json;
       $secondLatestVersion = $versions[-2];
       Write-Host "$packageName second latest = $secondLatestVersion";
+      " "
 
       if ($null -ne $Env:ChromeDriverVersionOverride -and $Env:ChromeDriverVersionOverride.Trim() -ne '') {
         Write-Host "Pipeline var ChromeDriverVersionOverride is set.";

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -75,7 +75,7 @@ steps:
           $content -Replace "$find", "$replace" | Set-Content $_.FullName;
           '-------------'; get-content $_.FullName; '==================='
       }
-  displayName: 'Upgrade chromedriver reference to second latest version'
+  displayName: 'Upgrade chromedriver version reference'
 
 - task: NodeTool@0
   displayName: use node 16.x

--- a/testing/browser-functional/browser-tests-build-ci.yml
+++ b/testing/browser-functional/browser-tests-build-ci.yml
@@ -35,20 +35,19 @@ steps:
   inputs:
     targetType: inline
     script: |
+      $packageName = "chromedriver";
+      Write-Host "Get $packageName second latest version from npmjs.com";
+      " "
+      $versions = npm view $packageName versions | ConvertFrom-Json;
+      $secondLatestVersion = $versions[-2];
+      Write-Host "$packageName second latest = $secondLatestVersion";
+
       if ($null -ne $Env:ChromeDriverVersionOverride -and $Env:ChromeDriverVersionOverride.Trim() -ne '') {
         Write-Host "Pipeline var ChromeDriverVersionOverride is set.";
         $secondLatestVersion = $Env:ChromeDriverVersionOverride;
         Write-Host "Use override value = $secondLatestVersion";
       } else {
         Write-Host "Pipeline var ChromeDriverVersionOverride is not set.";
-        $packageName = "chromedriver";
-
-        Write-Host "Get $packageName second latest version from npmjs.com";
-        " "
-        $versions = npm view $packageName versions | ConvertFrom-Json;
-
-        $secondLatestVersion = $versions[-2];
-        Write-Host "$packageName second latest = $secondLatestVersion";
       }
 
       "##vso[task.setvariable variable=DriverVersion;]$secondLatestVersion";


### PR DESCRIPTION
Fixes #minor

Improved logging makes it easier for build admin to monitor available versions and adjust driver version when needed.
