### PR TITLE
feat: teams message update & message delete events

### DIFF
--- a/libraries/botbuilder-core/etc/botbuilder-core.api.md
+++ b/libraries/botbuilder-core/etc/botbuilder-core.api.md
@@ -60,7 +60,9 @@ export class ActivityHandler extends ActivityHandlerBase {
     protected dispatchConversationUpdateActivity(context: TurnContext): Promise<void>;
     protected dispatchEventActivity(context: TurnContext): Promise<void>;
     protected dispatchInstallationUpdateActivity(context: TurnContext): Promise<void>;
+    protected dispatchMessageDeleteActivity(context: TurnContext): Promise<void>;
     protected dispatchMessageReactionActivity(context: TurnContext): Promise<void>;
+    protected dispatchMessageUpdateActivity(context: TurnContext): Promise<void>;
     protected handle(context: TurnContext, type: string, onNext: () => Promise<void>): Promise<any>;
     // (undocumented)
     protected readonly handlers: {
@@ -90,8 +92,12 @@ export class ActivityHandler extends ActivityHandlerBase {
     onMembersRemoved(handler: BotHandler): this;
     onMessage(handler: BotHandler): this;
     protected onMessageActivity(context: TurnContext): Promise<void>;
+    onMessageDelete(handler: BotHandler): this;
+    protected onMessageDeleteActivity(context: TurnContext): Promise<void>;
     onMessageReaction(handler: BotHandler): this;
     protected onMessageReactionActivity(context: TurnContext): Promise<void>;
+    onMessageUpdate(handler: BotHandler): this;
+    protected onMessageUpdateActivity(context: TurnContext): Promise<void>;
     onReactionsAdded(handler: BotHandler): this;
     protected onReactionsAddedActivity(reactionsAdded: MessageReaction[], context: TurnContext): Promise<void>;
     onReactionsRemoved(handler: BotHandler): this;
@@ -122,7 +128,9 @@ export class ActivityHandlerBase {
     protected onMembersAddedActivity(_membersAdded: ChannelAccount[], _context: TurnContext): Promise<void>;
     protected onMembersRemovedActivity(_membersRemoved: ChannelAccount[], _context: TurnContext): Promise<void>;
     protected onMessageActivity(_context: TurnContext): Promise<void>;
+    protected onMessageDeleteActivity(_context: TurnContext): Promise<void>;
     protected onMessageReactionActivity(context: TurnContext): Promise<void>;
+    protected onMessageUpdateActivity(_context: TurnContext): Promise<void>;
     protected onReactionsAddedActivity(_reactionsAdded: MessageReaction[], _context: TurnContext): Promise<void>;
     protected onReactionsRemovedActivity(_reactionsRemoved: MessageReaction[], _context: TurnContext): Promise<void>;
     protected onTurnActivity(context: TurnContext): Promise<void>;

--- a/libraries/botbuilder-core/src/activityHandler.ts
+++ b/libraries/botbuilder-core/src/activityHandler.ts
@@ -3,1113 +3,1112 @@
  * Licensed under the MIT License.
  */
 
- import { ActivityHandlerBase } from './activityHandlerBase';
- import { InvokeException } from './invokeException';
- import { InvokeResponse } from './invokeResponse';
- import { TurnContext } from './turnContext';
- import { verifyStateOperationName, tokenExchangeOperationName, tokenResponseEventName } from './signInConstants';
- 
- import {
-     Activity,
-     AdaptiveCardInvokeResponse,
-     AdaptiveCardInvokeValue,
-     Channels,
-     SearchInvokeResponse,
-     SearchInvokeValue,
-     MessageReaction,
-     StatusCodes,
- } from 'botframework-schema';
- 
- /**
-  * Describes a bot activity event handler, for use with an [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-  *
-  * @remarks
-  * **Parameters**
-  *
-  * | Name | Type | Description |
-  * | :--- | :--- | :--- |
-  * | `context` | [TurnContext](xref:botbuilder-core.TurnContext) | The context object for the turn. |
-  * | `next` | () => Promise<void> | A continuation function for handling the activity. |
-  *
-  * **Returns**
-  *
-  * `any`
-  *
-  * The incoming activity is contained in the `context` object's [activity](xref:botbuilder-core.TurnContext.activity) property.
-  * Call the `next` function to continue the processing of activity events. Not doing so will stop propagation of events for this activity.
-  *
-  * A bot activity handler can return a value, to support _invoke_ activities.
-  */
- export type BotHandler = (context: TurnContext, next: () => Promise<void>) => Promise<any>;
- 
- /**
-  * Event-emitting activity handler for bots. Extends [ActivityHandlerBase](xref:botbuilder-core.ActivityHandlerBase).
-  *
-  * @remarks
-  * This provides an extensible class for handling incoming activities in an event-driven way.
-  * You can register an arbitrary set of handlers for each event type.
-  *
-  * To register a handler for an event, use the corresponding _on event_ method. If multiple handlers are
-  * registered for an event, they are run in the order in which they were registered.
-  *
-  * This object emits a series of _events_ as it processes an incoming activity.
-  * A handler can stop the propagation of the event by not calling the continuation function.
-  *
-  * | Event type | Description |
-  * | :--- | :--- |
-  * | Turn | Emitted first for every activity. |
-  * | Type-specific | Emitted for the specific activity type, before emitting an event for any sub-type. |
-  * | Sub-type | Emitted for certain specialized events, based on activity content. |
-  * | Dialog | Emitted as the final activity processing event. |
-  *
-  * For example:
-  *
-  * ```typescript
-  * const bot = new ActivityHandler();
-  *
-  * server.post('/api/messages', (req, res) => {
-  *     adapter.processActivity(req, res, async (context) => {
-  *         // Route to bot's activity logic.
-  *         await bot.run(context);
-  *     });
-  * });
-  *
-  * bot.onTurn(async (context, next) => {
-  *         // Handle a "turn" event.
-  *         await context.sendActivity(`${ context.activity.type } activity received.`);
-  *         // Continue with further processing.
-  *         await next();
-  *     })
-  *     .onMessage(async (context, next) => {
-  *         // Handle a message activity.
-  *         await context.sendActivity(`Echo: ${ context.activity.text }`);
-  *         // Continue with further processing.
-  *         await next();
-  *     });
-  * ```
-  *
-  * **See also**
-  * - The [Bot Framework Activity schema](https://aka.ms/botSpecs-activitySchema)
-  */
- export class ActivityHandler extends ActivityHandlerBase {
-     protected readonly handlers: { [type: string]: BotHandler[] } = {};
- 
-     /**
-      * Registers an activity event handler for the _turn_ event, emitted for every incoming activity, regardless of type.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      */
-     onTurn(handler: BotHandler): this {
-         return this.on('Turn', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _message_ event, emitted for every incoming message activity.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * Message activities represent content intended to be shown within a conversational interface
-      * and can contain text, speech, interactive cards, and binary or unknown attachments.
-      * Not all message activities contain text, the activity's [text](xref:botframework-schema.Activity.text)
-      * property can be `null` or `undefined`.
-      */
-     onMessage(handler: BotHandler): this {
-         return this.on('Message', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _message update_ event, emitted for every incoming message activity.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * Message update activities represent an update of an existing message activity within a conversation.
-      * The updated activity is referred to by the [id](xref:botbuilder-core.TurnContext.activity.id) and 
-      * [conversation](xref:botbuilder-core.TurnContext.activity.conversation) fields within the activity, and the 
-      * message update activity contains all fields in the revised message activity.
-      * Message update activities are identified by a [type](xref:botbuilder-core.TurnContext.activity.type) value of 
-      * `messageUpdate`.
-      */
-     onMessageUpdate(handler: BotHandler): this {
-         return this.on('MessageUpdate', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _message delete_ event, emitted for every incoming message activity.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * Message delete activities represent a deletion of an existing message activity within a conversation. 
-      * The deleted activity is referred to by the [id](xref:botbuilder-core.TurnContext.activity.id) and 
-      * [conversation](xref:botbuilder-core.TurnContext.activity.conversation) fields within the activity.
-      * Message delete activities are identified by a [type](xref:botbuilder-core.TurnContext.activity.type) value of 
-      * `messageDelete`.
-      */
-     onMessageDelete(handler: BotHandler): this {
-         return this.on('MessageDelete', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _conversation update_ event, emitted for every incoming
-      * conversation update activity.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * Conversation update activities describe a changes to a conversation's metadata, such as title, participants,
-      * or other channel-specific information.
-      *
-      * To handle when members are added to or removed from the conversation, use the
-      * [onMembersAdded](xref:botbuilder-core.ActivityHandler.onMembersAdded) and
-      * [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved) sub-type event handlers.
-      */
-     onConversationUpdate(handler: BotHandler): this {
-         return this.on('ConversationUpdate', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _members added_ event, emitted for any incoming
-      * conversation update activity that includes members added to the conversation.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * The activity's [membersAdded](xref:botframework-schema.Activity.membersAdded) property
-      * contains the members added to the conversation, which can include the bot.
-      *
-      * To handle conversation update events in general, use the
-      * [onConversationUpdate](xref:botbuilder-core.ActivityHandler.onConversationUpdate) type-specific event handler.
-      */
-     onMembersAdded(handler: BotHandler): this {
-         return this.on('MembersAdded', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _members removed_ event, emitted for any incoming
-      * conversation update activity that includes members removed from the conversation.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * The activity's [membersRemoved](xref:botframework-schema.Activity.membersRemoved) property
-      * contains the members removed from the conversation, which can include the bot.
-      *
-      * To handle conversation update events in general, use the
-      * [onConversationUpdate](xref:botbuilder-core.ActivityHandler.onConversationUpdate) type-specific event handler.
-      */
-     onMembersRemoved(handler: BotHandler): this {
-         return this.on('MembersRemoved', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _message reaction_ event, emitted for every incoming
-      * message reaction activity.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * Message reaction activities represent a social interaction on an existing message activity
-      * within a conversation. The original activity is referred to by the message reaction activity's
-      * [replyToId](xref:botframework-schema.Activity.replyToId) property. The
-      * [from](xref:botframework-schema.Activity.from) property represents the source of the reaction,
-      * such as the user that reacted to the message.
-      *
-      * To handle when reactions are added to or removed from messages in the conversation, use the
-      * [onReactionsAdded](xref:botbuilder-core.ActivityHandler.onReactionsAdded) and
-      * [onReactionsRemoved](xref:botbuilder-core.ActivityHandler.onReactionsRemoved) sub-type event handlers.
-      */
-     onMessageReaction(handler: BotHandler): this {
-         return this.on('MessageReaction', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _reactions added_ event, emitted for any incoming
-      * message reaction activity that describes reactions added to a message.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * The activity's [reactionsAdded](xref:botframework-schema.Activity.reactionsAdded) property
-      * includes one or more reactions that were added.
-      *
-      * To handle message reaction events in general, use the
-      * [onMessageReaction](xref:botbuilder-core.ActivityHandler.onMessageReaction) type-specific event handler.
-      */
-     onReactionsAdded(handler: BotHandler): this {
-         return this.on('ReactionsAdded', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _reactions removed_ event, emitted for any incoming
-      * message reaction activity that describes reactions removed from a message.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * The activity's [reactionsRemoved](xref:botframework-schema.Activity.reactionsRemoved) property
-      * includes one or more reactions that were removed.
-      *
-      * To handle message reaction events in general, use the
-      * [onMessageReaction](xref:botbuilder-core.ActivityHandler.onMessageReaction) type-specific event handler.
-      */
-     onReactionsRemoved(handler: BotHandler): this {
-         return this.on('ReactionsRemoved', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _event_ event, emitted for every incoming event activity.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * Event activities communicate programmatic information from a client or channel to a bot.
-      * The meaning of an event activity is defined by the activity's
-      * [name](xref:botframework-schema.Activity.name) property, which is meaningful within the scope
-      * of a channel. Event activities are designed to carry both interactive information (such as
-      * button clicks) and non-interactive information (such as a notification of a client
-      * automatically updating an embedded speech model).
-      *
-      * To handle a `tokens/response` event event, use the
-      * [onTokenResponseEvent](xref:botbuilder-core.ActivityHandler.onTokenResponseEvent) sub-type
-      * event handler. To handle other named events, add logic to this handler.
-      */
-     onEvent(handler: BotHandler): this {
-         return this.on('Event', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _end of conversation_ activity.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * This activity is typically send from a Skill to a Skill caller indicating the end of that particular child conversation.
-      *
-      * To handle an End of Conversation, use the
-      * [onEndOfConversation](xref:botbuilder-core.ActivityHandler.onEndOfConversation) type-specific event handler.
-      */
-     onEndOfConversation(handler: BotHandler): this {
-         return this.on('EndOfConversation', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _typing_ activity.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * To handle a Typing event, use the
-      * [onTyping](xref:botbuilder-core.ActivityHandler.onTyping) type-specific event handler.
-      */
-     onTyping(handler: BotHandler): this {
-         return this.on('Typing', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _installationupdate_ activity.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * To handle a InstallationUpdate event, use the
-      * [onInstallationUpdate](xref:botbuilder-core.ActivityHandler.onInstallationUpdate) type-specific event handler.
-      */
-     onInstallationUpdate(handler: BotHandler): this {
-         return this.on('InstallationUpdate', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _installationupdate add_ activity.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * To handle a InstallationUpdateAdd event, use the
-      * [onInstallationUpdateAdd](xref:botbuilder-core.ActivityHandler.onInstallationUpdateAdd) type-specific event handler.
-      */
-     onInstallationUpdateAdd(handler: BotHandler): this {
-         return this.on('InstallationUpdateAdd', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _installationupdate remove_ activity.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * To handle a InstallationUpdateRemove event, use the
-      * [onInstallationUpdateRemove](xref:botbuilder-core.ActivityHandler.onInstallationUpdateRemove) type-specific event handler.
-      */
-     onInstallationUpdateRemove(handler: BotHandler): this {
-         return this.on('InstallationUpdateRemove', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _tokens-response_ event, emitted for any incoming
-      * `tokens/response` event activity. These are generated as part of the OAuth authentication flow.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * The activity's [value](xref:botframework-schema.Activity.value) property contains the user token.
-      *
-      * If your bot handles authentication using an [OAuthPrompt](xref:botbuilder-dialogs.OAuthPrompt)
-      * within a dialog, then the dialog will need to receive this activity to complete the authentication flow.
-      *
-      * To handle other named events and event events in general, use the
-      * [onEvent](xref:botbuilder-core.ActivityHandler.onEvent) type-specific event handler.
-      */
-     onTokenResponseEvent(handler: BotHandler): this {
-         return this.on('TokenResponseEvent', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _command_ activity.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * To handle a Command event, use the
-      * [onCommand](xref:botbuilder-core.ActivityHandler.onCommand) type-specific event handler.
-      */
-     onCommand(handler: BotHandler): this {
-         return this.on('Command', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _CommandResult_ activity.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * To handle a CommandResult event, use the
-      * [onCommandResult](xref:botbuilder-core.ActivityHandler.onCommandResult) type-specific event handler.
-      */
-     onCommandResult(handler: BotHandler): this {
-         return this.on('CommandResult', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _unrecognized activity type_ event, emitted for an
-      * incoming activity with a type for which the [ActivityHandler](xref:botbuilder-core.ActivityHandler)
-      * doesn't provide an event handler.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      * @remarks
-      * The `ActivityHandler` does not define events for all activity types defined in the
-      * [Bot Framework Activity schema](http://aka.ms/botSpecs-activitySchema). In addition,
-      * channels and custom adapters can create [Activities](xref:botframework-schema.Activity) with
-      * types not in the schema. When the activity handler receives such an event, it emits an unrecognized activity type event.
-      *
-      * The activity's [type](xref:botframework-schema.Activity.type) property contains the activity type.
-      */
-     onUnrecognizedActivityType(handler: BotHandler): this {
-         return this.on('UnrecognizedActivityType', handler);
-     }
- 
-     /**
-      * Registers an activity event handler for the _dialog_ event, emitted as the last event for an incoming activity.
-      *
-      * @param handler The event handler.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      */
-     onDialog(handler: BotHandler): this {
-         return this.on('Dialog', handler);
-     }
- 
-     /**
-      * Called to initiate the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Typically, you would provide this method as the function handler that the adapter calls
-      * to perform the bot's logic after the received activity has been pre-processed by the adapter
-      * and routed through any middleware.
-      *
-      * For example:
-      * ```javascript
-      *  server.post('/api/messages', (req, res) => {
-      *      adapter.processActivity(req, res, async (context) => {
-      *          // Route to bot's activity logic.
-      *          await bot.run(context);
-      *      });
-      * });
-      * ```
-      *
-      * **See also**
-      * - [BotFrameworkAdapter.processActivity](xref:botbuilder.BotFrameworkAdapter.processActivity)
-      */
-     async run(context: TurnContext): Promise<void> {
-         await super.run(context);
-     }
- 
-     /**
-      * Called at the start of the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to use custom logic for emitting events.
-      *
-      * The default logic is to call any handlers registered via [onTurn](xref:botbuilder-core.ActivityHandler.onTurn),
-      * and then continue by calling [ActivityHandlerBase.onTurnActivity](xref:botbuilder-core.ActivityHandlerBase.onTurnActivity).
-      */
-     protected async onTurnActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'Turn', async () => {
-             await super.onTurnActivity(context);
-         });
-     }
- 
-     /**
-      * Runs all registered _message_ handlers and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      *
-      * The default logic is to call any handlers registered via
-      * [onMessage](xref:botbuilder-core.ActivityHandler.onMessage),
-      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async onMessageActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'Message', this.defaultNextEvent(context));
-     }
- 
-     /**
-      * Runs all registered _message update_ handlers and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      *
-      * The default logic is to call any handlers registered via
-      * [onMessageUpdate](xref:botbuilder-core.ActivityHandler.onMessageUpdate),
-      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async onMessageUpdateActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'MessageUpdate', async () => {
-             await this.dispatchMessageUpdateActivity(context);
-         });
-     }
- 
-     /**
-      * Runs all registered _message delete_ handlers and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      *
-      * The default logic is to call any handlers registered via
-      * [onMessageDelete](xref:botbuilder-core.ActivityHandler.onMessageDelete),
-      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-      protected async onMessageDeleteActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'MessageDelete', async () => {
+import { ActivityHandlerBase } from './activityHandlerBase';
+import { InvokeException } from './invokeException';
+import { InvokeResponse } from './invokeResponse';
+import { TurnContext } from './turnContext';
+import { verifyStateOperationName, tokenExchangeOperationName, tokenResponseEventName } from './signInConstants';
+
+import {
+    Activity,
+    AdaptiveCardInvokeResponse,
+    AdaptiveCardInvokeValue,
+    Channels,
+    SearchInvokeResponse,
+    SearchInvokeValue,
+    MessageReaction,
+    StatusCodes,
+} from 'botframework-schema';
+
+/**
+ * Describes a bot activity event handler, for use with an [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+ *
+ * @remarks
+ * **Parameters**
+ *
+ * | Name | Type | Description |
+ * | :--- | :--- | :--- |
+ * | `context` | [TurnContext](xref:botbuilder-core.TurnContext) | The context object for the turn. |
+ * | `next` | () => Promise<void> | A continuation function for handling the activity. |
+ *
+ * **Returns**
+ *
+ * `any`
+ *
+ * The incoming activity is contained in the `context` object's [activity](xref:botbuilder-core.TurnContext.activity) property.
+ * Call the `next` function to continue the processing of activity events. Not doing so will stop propagation of events for this activity.
+ *
+ * A bot activity handler can return a value, to support _invoke_ activities.
+ */
+export type BotHandler = (context: TurnContext, next: () => Promise<void>) => Promise<any>;
+
+/**
+ * Event-emitting activity handler for bots. Extends [ActivityHandlerBase](xref:botbuilder-core.ActivityHandlerBase).
+ *
+ * @remarks
+ * This provides an extensible class for handling incoming activities in an event-driven way.
+ * You can register an arbitrary set of handlers for each event type.
+ *
+ * To register a handler for an event, use the corresponding _on event_ method. If multiple handlers are
+ * registered for an event, they are run in the order in which they were registered.
+ *
+ * This object emits a series of _events_ as it processes an incoming activity.
+ * A handler can stop the propagation of the event by not calling the continuation function.
+ *
+ * | Event type | Description |
+ * | :--- | :--- |
+ * | Turn | Emitted first for every activity. |
+ * | Type-specific | Emitted for the specific activity type, before emitting an event for any sub-type. |
+ * | Sub-type | Emitted for certain specialized events, based on activity content. |
+ * | Dialog | Emitted as the final activity processing event. |
+ *
+ * For example:
+ *
+ * ```typescript
+ * const bot = new ActivityHandler();
+ *
+ * server.post('/api/messages', (req, res) => {
+ *     adapter.processActivity(req, res, async (context) => {
+ *         // Route to bot's activity logic.
+ *         await bot.run(context);
+ *     });
+ * });
+ *
+ * bot.onTurn(async (context, next) => {
+ *         // Handle a "turn" event.
+ *         await context.sendActivity(`${ context.activity.type } activity received.`);
+ *         // Continue with further processing.
+ *         await next();
+ *     })
+ *     .onMessage(async (context, next) => {
+ *         // Handle a message activity.
+ *         await context.sendActivity(`Echo: ${ context.activity.text }`);
+ *         // Continue with further processing.
+ *         await next();
+ *     });
+ * ```
+ *
+ * **See also**
+ * - The [Bot Framework Activity schema](https://aka.ms/botSpecs-activitySchema)
+ */
+export class ActivityHandler extends ActivityHandlerBase {
+    protected readonly handlers: { [type: string]: BotHandler[] } = {};
+
+    /**
+     * Registers an activity event handler for the _turn_ event, emitted for every incoming activity, regardless of type.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     */
+    onTurn(handler: BotHandler): this {
+        return this.on('Turn', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _message_ event, emitted for every incoming message activity.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * Message activities represent content intended to be shown within a conversational interface
+     * and can contain text, speech, interactive cards, and binary or unknown attachments.
+     * Not all message activities contain text, the activity's [text](xref:botframework-schema.Activity.text)
+     * property can be `null` or `undefined`.
+     */
+    onMessage(handler: BotHandler): this {
+        return this.on('Message', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _message update_ event, emitted for every incoming message activity.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * Message update activities represent an update of an existing message activity within a conversation.
+     * The updated activity is referred to by the [id](xref:botbuilder-core.TurnContext.activity.id) and
+     * [conversation](xref:botbuilder-core.TurnContext.activity.conversation) fields within the activity, and the
+     * message update activity contains all fields in the revised message activity.
+     * Message update activities are identified by a [type](xref:botbuilder-core.TurnContext.activity.type) value of
+     * `messageUpdate`.
+     */
+    onMessageUpdate(handler: BotHandler): this {
+        return this.on('MessageUpdate', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _message delete_ event, emitted for every incoming message activity.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * Message delete activities represent a deletion of an existing message activity within a conversation.
+     * The deleted activity is referred to by the [id](xref:botbuilder-core.TurnContext.activity.id) and
+     * [conversation](xref:botbuilder-core.TurnContext.activity.conversation) fields within the activity.
+     * Message delete activities are identified by a [type](xref:botbuilder-core.TurnContext.activity.type) value of
+     * `messageDelete`.
+     */
+    onMessageDelete(handler: BotHandler): this {
+        return this.on('MessageDelete', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _conversation update_ event, emitted for every incoming
+     * conversation update activity.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * Conversation update activities describe a changes to a conversation's metadata, such as title, participants,
+     * or other channel-specific information.
+     *
+     * To handle when members are added to or removed from the conversation, use the
+     * [onMembersAdded](xref:botbuilder-core.ActivityHandler.onMembersAdded) and
+     * [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved) sub-type event handlers.
+     */
+    onConversationUpdate(handler: BotHandler): this {
+        return this.on('ConversationUpdate', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _members added_ event, emitted for any incoming
+     * conversation update activity that includes members added to the conversation.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * The activity's [membersAdded](xref:botframework-schema.Activity.membersAdded) property
+     * contains the members added to the conversation, which can include the bot.
+     *
+     * To handle conversation update events in general, use the
+     * [onConversationUpdate](xref:botbuilder-core.ActivityHandler.onConversationUpdate) type-specific event handler.
+     */
+    onMembersAdded(handler: BotHandler): this {
+        return this.on('MembersAdded', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _members removed_ event, emitted for any incoming
+     * conversation update activity that includes members removed from the conversation.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * The activity's [membersRemoved](xref:botframework-schema.Activity.membersRemoved) property
+     * contains the members removed from the conversation, which can include the bot.
+     *
+     * To handle conversation update events in general, use the
+     * [onConversationUpdate](xref:botbuilder-core.ActivityHandler.onConversationUpdate) type-specific event handler.
+     */
+    onMembersRemoved(handler: BotHandler): this {
+        return this.on('MembersRemoved', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _message reaction_ event, emitted for every incoming
+     * message reaction activity.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * Message reaction activities represent a social interaction on an existing message activity
+     * within a conversation. The original activity is referred to by the message reaction activity's
+     * [replyToId](xref:botframework-schema.Activity.replyToId) property. The
+     * [from](xref:botframework-schema.Activity.from) property represents the source of the reaction,
+     * such as the user that reacted to the message.
+     *
+     * To handle when reactions are added to or removed from messages in the conversation, use the
+     * [onReactionsAdded](xref:botbuilder-core.ActivityHandler.onReactionsAdded) and
+     * [onReactionsRemoved](xref:botbuilder-core.ActivityHandler.onReactionsRemoved) sub-type event handlers.
+     */
+    onMessageReaction(handler: BotHandler): this {
+        return this.on('MessageReaction', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _reactions added_ event, emitted for any incoming
+     * message reaction activity that describes reactions added to a message.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * The activity's [reactionsAdded](xref:botframework-schema.Activity.reactionsAdded) property
+     * includes one or more reactions that were added.
+     *
+     * To handle message reaction events in general, use the
+     * [onMessageReaction](xref:botbuilder-core.ActivityHandler.onMessageReaction) type-specific event handler.
+     */
+    onReactionsAdded(handler: BotHandler): this {
+        return this.on('ReactionsAdded', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _reactions removed_ event, emitted for any incoming
+     * message reaction activity that describes reactions removed from a message.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * The activity's [reactionsRemoved](xref:botframework-schema.Activity.reactionsRemoved) property
+     * includes one or more reactions that were removed.
+     *
+     * To handle message reaction events in general, use the
+     * [onMessageReaction](xref:botbuilder-core.ActivityHandler.onMessageReaction) type-specific event handler.
+     */
+    onReactionsRemoved(handler: BotHandler): this {
+        return this.on('ReactionsRemoved', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _event_ event, emitted for every incoming event activity.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * Event activities communicate programmatic information from a client or channel to a bot.
+     * The meaning of an event activity is defined by the activity's
+     * [name](xref:botframework-schema.Activity.name) property, which is meaningful within the scope
+     * of a channel. Event activities are designed to carry both interactive information (such as
+     * button clicks) and non-interactive information (such as a notification of a client
+     * automatically updating an embedded speech model).
+     *
+     * To handle a `tokens/response` event event, use the
+     * [onTokenResponseEvent](xref:botbuilder-core.ActivityHandler.onTokenResponseEvent) sub-type
+     * event handler. To handle other named events, add logic to this handler.
+     */
+    onEvent(handler: BotHandler): this {
+        return this.on('Event', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _end of conversation_ activity.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * This activity is typically send from a Skill to a Skill caller indicating the end of that particular child conversation.
+     *
+     * To handle an End of Conversation, use the
+     * [onEndOfConversation](xref:botbuilder-core.ActivityHandler.onEndOfConversation) type-specific event handler.
+     */
+    onEndOfConversation(handler: BotHandler): this {
+        return this.on('EndOfConversation', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _typing_ activity.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * To handle a Typing event, use the
+     * [onTyping](xref:botbuilder-core.ActivityHandler.onTyping) type-specific event handler.
+     */
+    onTyping(handler: BotHandler): this {
+        return this.on('Typing', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _installationupdate_ activity.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * To handle a InstallationUpdate event, use the
+     * [onInstallationUpdate](xref:botbuilder-core.ActivityHandler.onInstallationUpdate) type-specific event handler.
+     */
+    onInstallationUpdate(handler: BotHandler): this {
+        return this.on('InstallationUpdate', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _installationupdate add_ activity.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * To handle a InstallationUpdateAdd event, use the
+     * [onInstallationUpdateAdd](xref:botbuilder-core.ActivityHandler.onInstallationUpdateAdd) type-specific event handler.
+     */
+    onInstallationUpdateAdd(handler: BotHandler): this {
+        return this.on('InstallationUpdateAdd', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _installationupdate remove_ activity.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * To handle a InstallationUpdateRemove event, use the
+     * [onInstallationUpdateRemove](xref:botbuilder-core.ActivityHandler.onInstallationUpdateRemove) type-specific event handler.
+     */
+    onInstallationUpdateRemove(handler: BotHandler): this {
+        return this.on('InstallationUpdateRemove', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _tokens-response_ event, emitted for any incoming
+     * `tokens/response` event activity. These are generated as part of the OAuth authentication flow.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * The activity's [value](xref:botframework-schema.Activity.value) property contains the user token.
+     *
+     * If your bot handles authentication using an [OAuthPrompt](xref:botbuilder-dialogs.OAuthPrompt)
+     * within a dialog, then the dialog will need to receive this activity to complete the authentication flow.
+     *
+     * To handle other named events and event events in general, use the
+     * [onEvent](xref:botbuilder-core.ActivityHandler.onEvent) type-specific event handler.
+     */
+    onTokenResponseEvent(handler: BotHandler): this {
+        return this.on('TokenResponseEvent', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _command_ activity.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * To handle a Command event, use the
+     * [onCommand](xref:botbuilder-core.ActivityHandler.onCommand) type-specific event handler.
+     */
+    onCommand(handler: BotHandler): this {
+        return this.on('Command', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _CommandResult_ activity.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * To handle a CommandResult event, use the
+     * [onCommandResult](xref:botbuilder-core.ActivityHandler.onCommandResult) type-specific event handler.
+     */
+    onCommandResult(handler: BotHandler): this {
+        return this.on('CommandResult', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _unrecognized activity type_ event, emitted for an
+     * incoming activity with a type for which the [ActivityHandler](xref:botbuilder-core.ActivityHandler)
+     * doesn't provide an event handler.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     * @remarks
+     * The `ActivityHandler` does not define events for all activity types defined in the
+     * [Bot Framework Activity schema](http://aka.ms/botSpecs-activitySchema). In addition,
+     * channels and custom adapters can create [Activities](xref:botframework-schema.Activity) with
+     * types not in the schema. When the activity handler receives such an event, it emits an unrecognized activity type event.
+     *
+     * The activity's [type](xref:botframework-schema.Activity.type) property contains the activity type.
+     */
+    onUnrecognizedActivityType(handler: BotHandler): this {
+        return this.on('UnrecognizedActivityType', handler);
+    }
+
+    /**
+     * Registers an activity event handler for the _dialog_ event, emitted as the last event for an incoming activity.
+     *
+     * @param handler The event handler.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     */
+    onDialog(handler: BotHandler): this {
+        return this.on('Dialog', handler);
+    }
+
+    /**
+     * Called to initiate the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Typically, you would provide this method as the function handler that the adapter calls
+     * to perform the bot's logic after the received activity has been pre-processed by the adapter
+     * and routed through any middleware.
+     *
+     * For example:
+     * ```javascript
+     *  server.post('/api/messages', (req, res) => {
+     *      adapter.processActivity(req, res, async (context) => {
+     *          // Route to bot's activity logic.
+     *          await bot.run(context);
+     *      });
+     * });
+     * ```
+     *
+     * **See also**
+     * - [BotFrameworkAdapter.processActivity](xref:botbuilder.BotFrameworkAdapter.processActivity)
+     */
+    async run(context: TurnContext): Promise<void> {
+        await super.run(context);
+    }
+
+    /**
+     * Called at the start of the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to use custom logic for emitting events.
+     *
+     * The default logic is to call any handlers registered via [onTurn](xref:botbuilder-core.ActivityHandler.onTurn),
+     * and then continue by calling [ActivityHandlerBase.onTurnActivity](xref:botbuilder-core.ActivityHandlerBase.onTurnActivity).
+     */
+    protected async onTurnActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'Turn', async () => {
+            await super.onTurnActivity(context);
+        });
+    }
+
+    /**
+     * Runs all registered _message_ handlers and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     *
+     * The default logic is to call any handlers registered via
+     * [onMessage](xref:botbuilder-core.ActivityHandler.onMessage),
+     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async onMessageActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'Message', this.defaultNextEvent(context));
+    }
+
+    /**
+     * Runs all registered _message update_ handlers and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     *
+     * The default logic is to call any handlers registered via
+     * [onMessageUpdate](xref:botbuilder-core.ActivityHandler.onMessageUpdate),
+     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async onMessageUpdateActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'MessageUpdate', async () => {
+            await this.dispatchMessageUpdateActivity(context);
+        });
+    }
+
+    /**
+     * Runs all registered _message delete_ handlers and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     *
+     * The default logic is to call any handlers registered via
+     * [onMessageDelete](xref:botbuilder-core.ActivityHandler.onMessageDelete),
+     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async onMessageDeleteActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'MessageDelete', async () => {
             await this.dispatchMessageDeleteActivity(context);
         });
-     }
- 
-     /**
-      * Provides default behavior for invoke activities.
-      *
-      * @param context The context object for the current turn.
-      * @returns {Promise<InvokeResponse>} An Invoke Response for the activity.
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      * The default logic is to check for a signIn invoke and handle that
-      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async onInvokeActivity(context: TurnContext): Promise<InvokeResponse> {
-         try {
-             switch (context.activity.name) {
-                 case 'application/search': {
-                     const invokeValue = this.getSearchInvokeValue(context.activity);
-                     const response = await this.onSearchInvoke(context, invokeValue);
-                     return { status: response.statusCode, body: response };
-                 }
- 
-                 case 'adaptiveCard/action': {
-                     const invokeValue = this.getAdaptiveCardInvokeValue(context.activity);
-                     const response = await this.onAdaptiveCardInvoke(context, invokeValue);
-                     return { status: response.statusCode, body: response };
-                 }
- 
-                 case verifyStateOperationName:
-                 case tokenExchangeOperationName:
-                     await this.onSignInInvoke(context);
-                     return { status: StatusCodes.OK };
- 
-                 default:
-                     throw new InvokeException(StatusCodes.NOT_IMPLEMENTED);
-             }
-         } catch (err) {
-             if (err.message === 'NotImplemented') {
-                 return { status: StatusCodes.NOT_IMPLEMENTED };
-             }
- 
-             if (err instanceof InvokeException) {
-                 return err.createInvokeResponse();
-             }
- 
-             throw err;
-         } finally {
-             this.defaultNextEvent(context)();
-         }
-     }
- 
-     /**
-      * Handle _signin invoke activity type_.
-      *
-      * @param _context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      */
-     protected async onSignInInvoke(_context: TurnContext): Promise<void> {
-         throw new InvokeException(StatusCodes.NOT_IMPLEMENTED);
-     }
- 
-     /**
-      * Invoked when the bot is sent an Adaptive Card Action Execute.
-      *
-      * @param _context the context object for the current turn
-      * @param _invokeValue incoming activity value
-      * @returns {Promise<AdaptiveCardInvokeResponse>} An Adaptive Card Invoke Response for the activity.
-      */
-     protected onAdaptiveCardInvoke(
-         _context: TurnContext,
-         _invokeValue: AdaptiveCardInvokeValue
-     ): Promise<AdaptiveCardInvokeResponse> {
-         return Promise.reject(new InvokeException(StatusCodes.NOT_IMPLEMENTED));
-     }
- 
-     /**
-      * Invoked when the bot is sent an invoke activity with name of 'application/search'.
-      *
-      * @param _context the context object for the current turn.
-      * @param _invokeValue incoming activity value.
-      * @returns {Promise<SearchInvokeResponse>} A Search Invoke Response for the activity.
-      */
-     protected onSearchInvoke(_context: TurnContext, _invokeValue: SearchInvokeValue): Promise<SearchInvokeResponse> {
-         return Promise.reject(new InvokeException(StatusCodes.NOT_IMPLEMENTED));
-     }
- 
-     /**
-      * Runs all registered _endOfConversation_ handlers and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      *
-      * The default logic is to call any handlers registered via
-      * [onEndOfConversationActivity](xref:botbuilder-core.ActivityHandler.onMessage),
-      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async onEndOfConversationActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'EndOfConversation', this.defaultNextEvent(context));
-     }
- 
-     /**
-      * Runs all registered _typing_ handlers and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      *
-      * The default logic is to call any handlers registered via
-      * [onTypingActivity](xref:botbuilder-core.ActivityHandler.onTypingActivity),
-      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async onTypingActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'Typing', this.defaultNextEvent(context));
-     }
- 
-     /**
-      * Runs all registered _instllationupdate_ handlers and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      *
-      * The default logic is to call any handlers registered via
-      * [onInstallationUpdateActivity](xref:botbuilder-core.ActivityHandler.onInstallationUpdateActivity),
-      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async onInstallationUpdateActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'InstallationUpdate', async () => {
-             await this.dispatchInstallationUpdateActivity(context);
-         });
-     }
- 
-     /**
-      * Runs all registered _command_ handlers and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      */
-     protected async onCommandActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'Command', this.defaultNextEvent(context));
-     }
- 
-     /**
-      * Runs all registered _commandresult_ handlers and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      */
-     protected async onCommandResultActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'CommandResult', this.defaultNextEvent(context));
-     }
- 
-     /**
-      * Runs the _installation update_ sub-type handlers, as appropriate, and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels or to add
-      * custom conversation update sub-type events.
-      *
-      * The default logic is:
-      * - If any members were added, call handlers registered via [onMembersAdded](xref:botbuilder-core.ActivityHandler.onMembersAdded).
-      * - If any members were removed, call handlers registered via [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved).
-      * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async dispatchInstallationUpdateActivity(context: TurnContext): Promise<void> {
-         switch (context.activity.action) {
-             case 'add':
-             case 'add-upgrade':
-             case 'remove':
-             case 'remove-upgrade':
-                 await super.onInstallationUpdateActivity(context);
-                 break;
-             default:
-                 await this.defaultNextEvent(context)();
-         }
-     }
- 
-     /**
-      * Runs all registered _installation update add_ handlers and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      *
-      * The default logic is to call any handlers registered via
-      * [onInstallationUpdateAdd](xref:botbuilder-core.ActivityHandler.onInstallationUpdateAdd),
-      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async onInstallationUpdateAddActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'InstallationUpdateAdd', this.defaultNextEvent(context));
-     }
- 
-     /**
-      * Runs all registered _installation update remove_ handlers and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      *
-      * The default logic is to call any handlers registered via
-      * [onInstallationUpdateRemove](xref:botbuilder-core.ActivityHandler.onInstallationUpdateRemove),
-      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async onInstallationUpdateRemoveActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'InstallationUpdateRemove', this.defaultNextEvent(context));
-     }
- 
-     /**
-      * Runs all registered _unrecognized activity type_ handlers and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      *
-      * The default logic is to call any handlers registered via
-      * [onUnrecognizedActivityType](xref:botbuilder-core.ActivityHandler.onUnrecognizedActivityType),
-      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async onUnrecognizedActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'UnrecognizedActivityType', this.defaultNextEvent(context));
-     }
- 
-     private getSearchInvokeValue(activity: Activity): SearchInvokeValue {
-         const { value }: { value?: SearchInvokeValue } = activity;
-         if (!value) {
-             const response = this.createAdaptiveCardInvokeErrorResponse(
-                 StatusCodes.BAD_REQUEST,
-                 'BadRequest',
-                 'Missing value property for search'
-             );
- 
-             throw new InvokeException(StatusCodes.BAD_REQUEST, response);
-         }
- 
-         if (!value.kind) {
-             if (activity.channelId === Channels.Msteams) {
-                 value.kind = 'search';
-             } else {
-                 const response = this.createAdaptiveCardInvokeErrorResponse(
-                     StatusCodes.BAD_REQUEST,
-                     'BadRequest',
-                     'Missing kind property for search.'
-                 );
- 
-                 throw new InvokeException(StatusCodes.BAD_REQUEST, response);
-             }
-         }
- 
-         if (!value.queryText) {
-             const response = this.createAdaptiveCardInvokeErrorResponse(
-                 StatusCodes.BAD_REQUEST,
-                 'BadRequest',
-                 'Missing queryText for search.'
-             );
- 
-             throw new InvokeException(StatusCodes.BAD_REQUEST, response);
-         }
- 
-         return value;
-     }
- 
-     private getAdaptiveCardInvokeValue(activity: Activity): AdaptiveCardInvokeValue {
-         const { value }: { value?: AdaptiveCardInvokeValue } = activity;
-         if (!value) {
-             const response = this.createAdaptiveCardInvokeErrorResponse(
-                 StatusCodes.BAD_REQUEST,
-                 'BadRequest',
-                 'Missing value property'
-             );
- 
-             throw new InvokeException(StatusCodes.BAD_REQUEST, response);
-         }
- 
-         if (value.action.type !== 'Action.Execute') {
-             const response = this.createAdaptiveCardInvokeErrorResponse(
-                 StatusCodes.BAD_REQUEST,
-                 'NotSupported',
-                 `The action '${value.action.type}' is not supported.`
-             );
- 
-             throw new InvokeException(StatusCodes.BAD_REQUEST, response);
-         }
- 
-         const { action, authentication, state } = value;
-         const { data, id: actionId, type, verb } = action ?? {};
-         const { connectionName, id: authenticationId, token } = authentication ?? {};
- 
-         return {
-             action: {
-                 data,
-                 id: actionId,
-                 type,
-                 verb,
-             },
-             authentication: {
-                 connectionName,
-                 id: authenticationId,
-                 token,
-             },
-             state,
-         };
-     }
- 
-     private createAdaptiveCardInvokeErrorResponse(
-         statusCode: StatusCodes,
-         code: string,
-         message: string
-     ): AdaptiveCardInvokeResponse {
-         return {
-             statusCode,
-             type: 'application/vnd.microsoft.error',
-             value: { code, message },
-         };
-     }
- 
-     /**
-      * Runs all registered _conversation update_ handlers and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      *
-      * The default logic is to call any handlers registered via
-      * [onConversationUpdate](xref:botbuilder-core.ActivityHandler.onConversationUpdate),
-      * and then continue by calling
-      * [dispatchConversationUpdateActivity](xref:botbuilder-core.ActivityHandler.dispatchConversationUpdateActivity).
-      */
-     protected async onConversationUpdateActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'ConversationUpdate', async () => {
-             await this.dispatchConversationUpdateActivity(context);
-         });
-     }
- 
-     /**
-      * Runs the _conversation update_ sub-type handlers, as appropriate, and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels or to add
-      * custom conversation update sub-type events.
-      *
-      * The default logic is:
-      * - If any members were added, call handlers registered via [onMembersAdded](xref:botbuilder-core.ActivityHandler.onMembersAdded).
-      * - If any members were removed, call handlers registered via [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved).
-      * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async dispatchConversationUpdateActivity(context: TurnContext): Promise<void> {
-         if (context.activity.membersAdded && context.activity.membersAdded.length > 0) {
-             await this.handle(context, 'MembersAdded', this.defaultNextEvent(context));
-         } else if (context.activity.membersRemoved && context.activity.membersRemoved.length > 0) {
-             await this.handle(context, 'MembersRemoved', this.defaultNextEvent(context));
-         } else {
-             await this.defaultNextEvent(context)();
-         }
-     }
- 
-     /**
-      * Runs the _message update_ sub-type handlers, as appropriate, and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels or to add
-      * custom conversation update sub-type events.
-      *
-      * The default logic to simple call [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async dispatchMessageUpdateActivity(context: TurnContext): Promise<void> {
-         await this.defaultNextEvent(context)();
-     }
- 
-     /**
-      * Runs the _message delete_ sub-type handlers, as appropriate, and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels or to add
-      * custom conversation update sub-type events.
-      *
-      * The default logic to simple call [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async dispatchMessageDeleteActivity(context: TurnContext): Promise<void> {
+    }
+
+    /**
+     * Provides default behavior for invoke activities.
+     *
+     * @param context The context object for the current turn.
+     * @returns {Promise<InvokeResponse>} An Invoke Response for the activity.
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     * The default logic is to check for a signIn invoke and handle that
+     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async onInvokeActivity(context: TurnContext): Promise<InvokeResponse> {
+        try {
+            switch (context.activity.name) {
+                case 'application/search': {
+                    const invokeValue = this.getSearchInvokeValue(context.activity);
+                    const response = await this.onSearchInvoke(context, invokeValue);
+                    return { status: response.statusCode, body: response };
+                }
+
+                case 'adaptiveCard/action': {
+                    const invokeValue = this.getAdaptiveCardInvokeValue(context.activity);
+                    const response = await this.onAdaptiveCardInvoke(context, invokeValue);
+                    return { status: response.statusCode, body: response };
+                }
+
+                case verifyStateOperationName:
+                case tokenExchangeOperationName:
+                    await this.onSignInInvoke(context);
+                    return { status: StatusCodes.OK };
+
+                default:
+                    throw new InvokeException(StatusCodes.NOT_IMPLEMENTED);
+            }
+        } catch (err) {
+            if (err.message === 'NotImplemented') {
+                return { status: StatusCodes.NOT_IMPLEMENTED };
+            }
+
+            if (err instanceof InvokeException) {
+                return err.createInvokeResponse();
+            }
+
+            throw err;
+        } finally {
+            this.defaultNextEvent(context)();
+        }
+    }
+
+    /**
+     * Handle _signin invoke activity type_.
+     *
+     * @param _context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     */
+    protected async onSignInInvoke(_context: TurnContext): Promise<void> {
+        throw new InvokeException(StatusCodes.NOT_IMPLEMENTED);
+    }
+
+    /**
+     * Invoked when the bot is sent an Adaptive Card Action Execute.
+     *
+     * @param _context the context object for the current turn
+     * @param _invokeValue incoming activity value
+     * @returns {Promise<AdaptiveCardInvokeResponse>} An Adaptive Card Invoke Response for the activity.
+     */
+    protected onAdaptiveCardInvoke(
+        _context: TurnContext,
+        _invokeValue: AdaptiveCardInvokeValue
+    ): Promise<AdaptiveCardInvokeResponse> {
+        return Promise.reject(new InvokeException(StatusCodes.NOT_IMPLEMENTED));
+    }
+
+    /**
+     * Invoked when the bot is sent an invoke activity with name of 'application/search'.
+     *
+     * @param _context the context object for the current turn.
+     * @param _invokeValue incoming activity value.
+     * @returns {Promise<SearchInvokeResponse>} A Search Invoke Response for the activity.
+     */
+    protected onSearchInvoke(_context: TurnContext, _invokeValue: SearchInvokeValue): Promise<SearchInvokeResponse> {
+        return Promise.reject(new InvokeException(StatusCodes.NOT_IMPLEMENTED));
+    }
+
+    /**
+     * Runs all registered _endOfConversation_ handlers and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     *
+     * The default logic is to call any handlers registered via
+     * [onEndOfConversationActivity](xref:botbuilder-core.ActivityHandler.onMessage),
+     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async onEndOfConversationActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'EndOfConversation', this.defaultNextEvent(context));
+    }
+
+    /**
+     * Runs all registered _typing_ handlers and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     *
+     * The default logic is to call any handlers registered via
+     * [onTypingActivity](xref:botbuilder-core.ActivityHandler.onTypingActivity),
+     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async onTypingActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'Typing', this.defaultNextEvent(context));
+    }
+
+    /**
+     * Runs all registered _instllationupdate_ handlers and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     *
+     * The default logic is to call any handlers registered via
+     * [onInstallationUpdateActivity](xref:botbuilder-core.ActivityHandler.onInstallationUpdateActivity),
+     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async onInstallationUpdateActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'InstallationUpdate', async () => {
+            await this.dispatchInstallationUpdateActivity(context);
+        });
+    }
+
+    /**
+     * Runs all registered _command_ handlers and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     */
+    protected async onCommandActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'Command', this.defaultNextEvent(context));
+    }
+
+    /**
+     * Runs all registered _commandresult_ handlers and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     */
+    protected async onCommandResultActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'CommandResult', this.defaultNextEvent(context));
+    }
+
+    /**
+     * Runs the _installation update_ sub-type handlers, as appropriate, and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels or to add
+     * custom conversation update sub-type events.
+     *
+     * The default logic is:
+     * - If any members were added, call handlers registered via [onMembersAdded](xref:botbuilder-core.ActivityHandler.onMembersAdded).
+     * - If any members were removed, call handlers registered via [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved).
+     * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async dispatchInstallationUpdateActivity(context: TurnContext): Promise<void> {
+        switch (context.activity.action) {
+            case 'add':
+            case 'add-upgrade':
+            case 'remove':
+            case 'remove-upgrade':
+                await super.onInstallationUpdateActivity(context);
+                break;
+            default:
+                await this.defaultNextEvent(context)();
+        }
+    }
+
+    /**
+     * Runs all registered _installation update add_ handlers and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     *
+     * The default logic is to call any handlers registered via
+     * [onInstallationUpdateAdd](xref:botbuilder-core.ActivityHandler.onInstallationUpdateAdd),
+     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async onInstallationUpdateAddActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'InstallationUpdateAdd', this.defaultNextEvent(context));
+    }
+
+    /**
+     * Runs all registered _installation update remove_ handlers and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     *
+     * The default logic is to call any handlers registered via
+     * [onInstallationUpdateRemove](xref:botbuilder-core.ActivityHandler.onInstallationUpdateRemove),
+     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async onInstallationUpdateRemoveActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'InstallationUpdateRemove', this.defaultNextEvent(context));
+    }
+
+    /**
+     * Runs all registered _unrecognized activity type_ handlers and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     *
+     * The default logic is to call any handlers registered via
+     * [onUnrecognizedActivityType](xref:botbuilder-core.ActivityHandler.onUnrecognizedActivityType),
+     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async onUnrecognizedActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'UnrecognizedActivityType', this.defaultNextEvent(context));
+    }
+
+    private getSearchInvokeValue(activity: Activity): SearchInvokeValue {
+        const { value }: { value?: SearchInvokeValue } = activity;
+        if (!value) {
+            const response = this.createAdaptiveCardInvokeErrorResponse(
+                StatusCodes.BAD_REQUEST,
+                'BadRequest',
+                'Missing value property for search'
+            );
+
+            throw new InvokeException(StatusCodes.BAD_REQUEST, response);
+        }
+
+        if (!value.kind) {
+            if (activity.channelId === Channels.Msteams) {
+                value.kind = 'search';
+            } else {
+                const response = this.createAdaptiveCardInvokeErrorResponse(
+                    StatusCodes.BAD_REQUEST,
+                    'BadRequest',
+                    'Missing kind property for search.'
+                );
+
+                throw new InvokeException(StatusCodes.BAD_REQUEST, response);
+            }
+        }
+
+        if (!value.queryText) {
+            const response = this.createAdaptiveCardInvokeErrorResponse(
+                StatusCodes.BAD_REQUEST,
+                'BadRequest',
+                'Missing queryText for search.'
+            );
+
+            throw new InvokeException(StatusCodes.BAD_REQUEST, response);
+        }
+
+        return value;
+    }
+
+    private getAdaptiveCardInvokeValue(activity: Activity): AdaptiveCardInvokeValue {
+        const { value }: { value?: AdaptiveCardInvokeValue } = activity;
+        if (!value) {
+            const response = this.createAdaptiveCardInvokeErrorResponse(
+                StatusCodes.BAD_REQUEST,
+                'BadRequest',
+                'Missing value property'
+            );
+
+            throw new InvokeException(StatusCodes.BAD_REQUEST, response);
+        }
+
+        if (value.action.type !== 'Action.Execute') {
+            const response = this.createAdaptiveCardInvokeErrorResponse(
+                StatusCodes.BAD_REQUEST,
+                'NotSupported',
+                `The action '${value.action.type}' is not supported.`
+            );
+
+            throw new InvokeException(StatusCodes.BAD_REQUEST, response);
+        }
+
+        const { action, authentication, state } = value;
+        const { data, id: actionId, type, verb } = action ?? {};
+        const { connectionName, id: authenticationId, token } = authentication ?? {};
+
+        return {
+            action: {
+                data,
+                id: actionId,
+                type,
+                verb,
+            },
+            authentication: {
+                connectionName,
+                id: authenticationId,
+                token,
+            },
+            state,
+        };
+    }
+
+    private createAdaptiveCardInvokeErrorResponse(
+        statusCode: StatusCodes,
+        code: string,
+        message: string
+    ): AdaptiveCardInvokeResponse {
+        return {
+            statusCode,
+            type: 'application/vnd.microsoft.error',
+            value: { code, message },
+        };
+    }
+
+    /**
+     * Runs all registered _conversation update_ handlers and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     *
+     * The default logic is to call any handlers registered via
+     * [onConversationUpdate](xref:botbuilder-core.ActivityHandler.onConversationUpdate),
+     * and then continue by calling
+     * [dispatchConversationUpdateActivity](xref:botbuilder-core.ActivityHandler.dispatchConversationUpdateActivity).
+     */
+    protected async onConversationUpdateActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'ConversationUpdate', async () => {
+            await this.dispatchConversationUpdateActivity(context);
+        });
+    }
+
+    /**
+     * Runs the _conversation update_ sub-type handlers, as appropriate, and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels or to add
+     * custom conversation update sub-type events.
+     *
+     * The default logic is:
+     * - If any members were added, call handlers registered via [onMembersAdded](xref:botbuilder-core.ActivityHandler.onMembersAdded).
+     * - If any members were removed, call handlers registered via [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved).
+     * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async dispatchConversationUpdateActivity(context: TurnContext): Promise<void> {
+        if (context.activity.membersAdded && context.activity.membersAdded.length > 0) {
+            await this.handle(context, 'MembersAdded', this.defaultNextEvent(context));
+        } else if (context.activity.membersRemoved && context.activity.membersRemoved.length > 0) {
+            await this.handle(context, 'MembersRemoved', this.defaultNextEvent(context));
+        } else {
+            await this.defaultNextEvent(context)();
+        }
+    }
+
+    /**
+     * Runs the _message update_ sub-type handlers, as appropriate, and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels or to add
+     * custom conversation update sub-type events.
+     *
+     * The default logic to simple call [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async dispatchMessageUpdateActivity(context: TurnContext): Promise<void> {
         await this.defaultNextEvent(context)();
-     }
-     /**
-      * Runs all registered _message reaction_ handlers and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      *
-      * The default logic is to call any handlers registered via
-      * [onMessageReaction](xref:botbuilder-core.ActivityHandler.onMessageReaction),
-      * and then continue by calling
-      * [dispatchMessageReactionActivity](xref:botbuilder-core.ActivityHandler.dispatchMessageReactionActivity).
-      */
-     protected async onMessageReactionActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'MessageReaction', async () => {
-             await this.dispatchMessageReactionActivity(context);
-         });
-     }
- 
-     /**
-      * Runs all registered _reactions added_ handlers and then continues the event emission process.
-      *
-      * @param reactionsAdded The list of reactions added.
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      *
-      * The default logic is to call any handlers registered via
-      * [onReactionsAdded](xref:botbuilder-core.ActivityHandler.onReactionsAdded),
-      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async onReactionsAddedActivity(reactionsAdded: MessageReaction[], context: TurnContext): Promise<void> {
-         await this.handle(context, 'ReactionsAdded', this.defaultNextEvent(context));
-     }
- 
-     /**
-      * Runs all registered _reactions removed_ handlers and then continues the event emission process.
-      *
-      * @param reactionsRemoved The list of reactions removed.
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      *
-      * The default logic is to call any handlers registered via
-      * [onReactionsRemoved](xref:botbuilder-core.ActivityHandler.onReactionsRemoved),
-      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async onReactionsRemovedActivity(
-         reactionsRemoved: MessageReaction[],
-         context: TurnContext
-     ): Promise<void> {
-         await this.handle(context, 'ReactionsRemoved', this.defaultNextEvent(context));
-     }
- 
-     /**
-      * Runs the _message reaction_ sub-type handlers, as appropriate, and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels or to add
-      * custom message reaction sub-type events.
-      *
-      * The default logic is:
-      * - If reactions were added, call handlers registered via [onReactionsAdded](xref:botbuilder-core.ActivityHandler.onReactionsAdded).
-      * - If reactions were removed, call handlers registered via [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved).
-      * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async dispatchMessageReactionActivity(context: TurnContext): Promise<void> {
-         if (context.activity.reactionsAdded || context.activity.reactionsRemoved) {
-             await super.onMessageReactionActivity(context);
-         } else {
-             await this.defaultNextEvent(context)();
-         }
-     }
- 
-     /**
-      * Runs all registered event_ handlers and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels.
-      *
-      * The default logic is to call any handlers registered via
-      * [onEvent](xref:botbuilder-core.ActivityHandler.onEvent),
-      * and then continue by calling
-      * [dispatchEventActivity](xref:botbuilder-core.ActivityHandler.dispatchEventActivity).
-      */
-     protected async onEventActivity(context: TurnContext): Promise<void> {
-         await this.handle(context, 'Event', async () => {
-             await this.dispatchEventActivity(context);
-         });
-     }
- 
-     /**
-      * Runs the _event_ sub-type handlers, as appropriate, and then continues the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to support channel-specific behavior across multiple channels or to add custom event sub-type events.
-      * For certain channels, such as  Web Chat and custom Direct Line clients, developers can emit custom event activities from the client.
-      *
-      * The default logic is:
-      * - If the activity is a 'tokens/response' event, call handlers registered via
-      *   [onTokenResponseEvent](xref:botbuilder-core.ActivityHandler.onTokenResponseEvent).
-      * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-      */
-     protected async dispatchEventActivity(context: TurnContext): Promise<void> {
-         if (context.activity.name === tokenResponseEventName) {
-             await this.handle(context, 'TokenResponseEvent', this.defaultNextEvent(context));
-         } else {
-             await this.defaultNextEvent(context)();
-         }
-     }
- 
-     /**
-      * Called at the end of the event emission process.
-      *
-      * @param context The context object for the current turn.
-      * @returns {Promise<void>} A promise representing the async operation.
-      * @remarks
-      * Override this method to use custom logic for emitting events.
-      *
-      * The default logic is to call any handlers registered via [onDialog](xref:botbuilder-core.ActivityHandler.onDialog),
-      * and then complete the event emission process.
-      */
-     protected defaultNextEvent(context: TurnContext): () => Promise<void> {
-         const runDialogs = async (): Promise<void> => {
-             await this.handle(context, 'Dialog', async () => {
-                 // noop
-             });
-         };
-         return runDialogs;
-     }
- 
-     /**
-      * Registers a bot event handler to receive a specific event.
-      *
-      * @param type The identifier for the event type.
-      * @param handler The event handler to register.
-      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-      */
-     protected on(type: string, handler: BotHandler) {
-         if (!this.handlers[type]) {
-             this.handlers[type] = [handler];
-         } else {
-             this.handlers[type].push(handler);
-         }
-         return this;
-     }
- 
-     /**
-      * Emits an event and executes any registered handlers.
-      *
-      * @param context The context object for the current turn.
-      * @param type The identifier for the event type.
-      * @param onNext The continuation function to call after all registered handlers for this event complete.
-      * @returns {Promise<any>} The handler's return value.
-      * @remarks
-      * Runs any registered handlers for this event type and then calls the continuation function.
-      *
-      * This optionally produces a return value, to support _invoke_ activities. If multiple handlers
-      * produce a return value, the first one produced is returned.
-      */
-     protected async handle(context: TurnContext, type: string, onNext: () => Promise<void>): Promise<any> {
-         let returnValue: any = null;
- 
-         async function runHandler(index: number): Promise<void> {
-             if (index < handlers.length) {
-                 const val = await handlers[index](context, () => runHandler(index + 1));
-                 // if a value is returned, and we have not yet set the return value,
-                 // capture it.  This is used to allow InvokeResponses to be returned.
-                 if (typeof val !== 'undefined' && returnValue === null) {
-                     returnValue = val;
-                 }
-             } else {
-                 const val = await onNext();
-                 if (typeof val !== 'undefined') {
-                     returnValue = val;
-                 }
-             }
-         }
- 
-         const handlers = this.handlers[type] || [];
-         await runHandler(0);
- 
-         return returnValue;
-     }
- 
-     /**
-      * An [InvokeResponse](xref:botbuilder.InvokeResponse) factory that initializes the body to the parameter passed and status equal to OK.
-      *
-      * @param body JSON serialized content from a POST response.
-      * @returns A new [InvokeResponse](xref:botbuilder.InvokeResponse) object.
-      */
-     protected static createInvokeResponse(body?: any): InvokeResponse {
-         return { status: 200, body };
-     }
- }
- 
+    }
+
+    /**
+     * Runs the _message delete_ sub-type handlers, as appropriate, and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels or to add
+     * custom conversation update sub-type events.
+     *
+     * The default logic to simple call [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async dispatchMessageDeleteActivity(context: TurnContext): Promise<void> {
+        await this.defaultNextEvent(context)();
+    }
+    /**
+     * Runs all registered _message reaction_ handlers and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     *
+     * The default logic is to call any handlers registered via
+     * [onMessageReaction](xref:botbuilder-core.ActivityHandler.onMessageReaction),
+     * and then continue by calling
+     * [dispatchMessageReactionActivity](xref:botbuilder-core.ActivityHandler.dispatchMessageReactionActivity).
+     */
+    protected async onMessageReactionActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'MessageReaction', async () => {
+            await this.dispatchMessageReactionActivity(context);
+        });
+    }
+
+    /**
+     * Runs all registered _reactions added_ handlers and then continues the event emission process.
+     *
+     * @param reactionsAdded The list of reactions added.
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     *
+     * The default logic is to call any handlers registered via
+     * [onReactionsAdded](xref:botbuilder-core.ActivityHandler.onReactionsAdded),
+     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async onReactionsAddedActivity(reactionsAdded: MessageReaction[], context: TurnContext): Promise<void> {
+        await this.handle(context, 'ReactionsAdded', this.defaultNextEvent(context));
+    }
+
+    /**
+     * Runs all registered _reactions removed_ handlers and then continues the event emission process.
+     *
+     * @param reactionsRemoved The list of reactions removed.
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     *
+     * The default logic is to call any handlers registered via
+     * [onReactionsRemoved](xref:botbuilder-core.ActivityHandler.onReactionsRemoved),
+     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async onReactionsRemovedActivity(
+        reactionsRemoved: MessageReaction[],
+        context: TurnContext
+    ): Promise<void> {
+        await this.handle(context, 'ReactionsRemoved', this.defaultNextEvent(context));
+    }
+
+    /**
+     * Runs the _message reaction_ sub-type handlers, as appropriate, and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels or to add
+     * custom message reaction sub-type events.
+     *
+     * The default logic is:
+     * - If reactions were added, call handlers registered via [onReactionsAdded](xref:botbuilder-core.ActivityHandler.onReactionsAdded).
+     * - If reactions were removed, call handlers registered via [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved).
+     * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async dispatchMessageReactionActivity(context: TurnContext): Promise<void> {
+        if (context.activity.reactionsAdded || context.activity.reactionsRemoved) {
+            await super.onMessageReactionActivity(context);
+        } else {
+            await this.defaultNextEvent(context)();
+        }
+    }
+
+    /**
+     * Runs all registered event_ handlers and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels.
+     *
+     * The default logic is to call any handlers registered via
+     * [onEvent](xref:botbuilder-core.ActivityHandler.onEvent),
+     * and then continue by calling
+     * [dispatchEventActivity](xref:botbuilder-core.ActivityHandler.dispatchEventActivity).
+     */
+    protected async onEventActivity(context: TurnContext): Promise<void> {
+        await this.handle(context, 'Event', async () => {
+            await this.dispatchEventActivity(context);
+        });
+    }
+
+    /**
+     * Runs the _event_ sub-type handlers, as appropriate, and then continues the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to support channel-specific behavior across multiple channels or to add custom event sub-type events.
+     * For certain channels, such as  Web Chat and custom Direct Line clients, developers can emit custom event activities from the client.
+     *
+     * The default logic is:
+     * - If the activity is a 'tokens/response' event, call handlers registered via
+     *   [onTokenResponseEvent](xref:botbuilder-core.ActivityHandler.onTokenResponseEvent).
+     * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+     */
+    protected async dispatchEventActivity(context: TurnContext): Promise<void> {
+        if (context.activity.name === tokenResponseEventName) {
+            await this.handle(context, 'TokenResponseEvent', this.defaultNextEvent(context));
+        } else {
+            await this.defaultNextEvent(context)();
+        }
+    }
+
+    /**
+     * Called at the end of the event emission process.
+     *
+     * @param context The context object for the current turn.
+     * @returns {Promise<void>} A promise representing the async operation.
+     * @remarks
+     * Override this method to use custom logic for emitting events.
+     *
+     * The default logic is to call any handlers registered via [onDialog](xref:botbuilder-core.ActivityHandler.onDialog),
+     * and then complete the event emission process.
+     */
+    protected defaultNextEvent(context: TurnContext): () => Promise<void> {
+        const runDialogs = async (): Promise<void> => {
+            await this.handle(context, 'Dialog', async () => {
+                // noop
+            });
+        };
+        return runDialogs;
+    }
+
+    /**
+     * Registers a bot event handler to receive a specific event.
+     *
+     * @param type The identifier for the event type.
+     * @param handler The event handler to register.
+     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+     */
+    protected on(type: string, handler: BotHandler) {
+        if (!this.handlers[type]) {
+            this.handlers[type] = [handler];
+        } else {
+            this.handlers[type].push(handler);
+        }
+        return this;
+    }
+
+    /**
+     * Emits an event and executes any registered handlers.
+     *
+     * @param context The context object for the current turn.
+     * @param type The identifier for the event type.
+     * @param onNext The continuation function to call after all registered handlers for this event complete.
+     * @returns {Promise<any>} The handler's return value.
+     * @remarks
+     * Runs any registered handlers for this event type and then calls the continuation function.
+     *
+     * This optionally produces a return value, to support _invoke_ activities. If multiple handlers
+     * produce a return value, the first one produced is returned.
+     */
+    protected async handle(context: TurnContext, type: string, onNext: () => Promise<void>): Promise<any> {
+        let returnValue: any = null;
+
+        async function runHandler(index: number): Promise<void> {
+            if (index < handlers.length) {
+                const val = await handlers[index](context, () => runHandler(index + 1));
+                // if a value is returned, and we have not yet set the return value,
+                // capture it.  This is used to allow InvokeResponses to be returned.
+                if (typeof val !== 'undefined' && returnValue === null) {
+                    returnValue = val;
+                }
+            } else {
+                const val = await onNext();
+                if (typeof val !== 'undefined') {
+                    returnValue = val;
+                }
+            }
+        }
+
+        const handlers = this.handlers[type] || [];
+        await runHandler(0);
+
+        return returnValue;
+    }
+
+    /**
+     * An [InvokeResponse](xref:botbuilder.InvokeResponse) factory that initializes the body to the parameter passed and status equal to OK.
+     *
+     * @param body JSON serialized content from a POST response.
+     * @returns A new [InvokeResponse](xref:botbuilder.InvokeResponse) object.
+     */
+    protected static createInvokeResponse(body?: any): InvokeResponse {
+        return { status: 200, body };
+    }
+}

--- a/libraries/botbuilder-core/src/activityHandler.ts
+++ b/libraries/botbuilder-core/src/activityHandler.ts
@@ -3,1014 +3,1113 @@
  * Licensed under the MIT License.
  */
 
-import { ActivityHandlerBase } from './activityHandlerBase';
-import { InvokeException } from './invokeException';
-import { InvokeResponse } from './invokeResponse';
-import { TurnContext } from './turnContext';
-import { verifyStateOperationName, tokenExchangeOperationName, tokenResponseEventName } from './signInConstants';
-
-import {
-    Activity,
-    AdaptiveCardInvokeResponse,
-    AdaptiveCardInvokeValue,
-    Channels,
-    SearchInvokeResponse,
-    SearchInvokeValue,
-    MessageReaction,
-    StatusCodes,
-} from 'botframework-schema';
-
-/**
- * Describes a bot activity event handler, for use with an [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
- *
- * @remarks
- * **Parameters**
- *
- * | Name | Type | Description |
- * | :--- | :--- | :--- |
- * | `context` | [TurnContext](xref:botbuilder-core.TurnContext) | The context object for the turn. |
- * | `next` | () => Promise<void> | A continuation function for handling the activity. |
- *
- * **Returns**
- *
- * `any`
- *
- * The incoming activity is contained in the `context` object's [activity](xref:botbuilder-core.TurnContext.activity) property.
- * Call the `next` function to continue the processing of activity events. Not doing so will stop propagation of events for this activity.
- *
- * A bot activity handler can return a value, to support _invoke_ activities.
- */
-export type BotHandler = (context: TurnContext, next: () => Promise<void>) => Promise<any>;
-
-/**
- * Event-emitting activity handler for bots. Extends [ActivityHandlerBase](xref:botbuilder-core.ActivityHandlerBase).
- *
- * @remarks
- * This provides an extensible class for handling incoming activities in an event-driven way.
- * You can register an arbitrary set of handlers for each event type.
- *
- * To register a handler for an event, use the corresponding _on event_ method. If multiple handlers are
- * registered for an event, they are run in the order in which they were registered.
- *
- * This object emits a series of _events_ as it processes an incoming activity.
- * A handler can stop the propagation of the event by not calling the continuation function.
- *
- * | Event type | Description |
- * | :--- | :--- |
- * | Turn | Emitted first for every activity. |
- * | Type-specific | Emitted for the specific activity type, before emitting an event for any sub-type. |
- * | Sub-type | Emitted for certain specialized events, based on activity content. |
- * | Dialog | Emitted as the final activity processing event. |
- *
- * For example:
- *
- * ```typescript
- * const bot = new ActivityHandler();
- *
- * server.post('/api/messages', (req, res) => {
- *     adapter.processActivity(req, res, async (context) => {
- *         // Route to bot's activity logic.
- *         await bot.run(context);
- *     });
- * });
- *
- * bot.onTurn(async (context, next) => {
- *         // Handle a "turn" event.
- *         await context.sendActivity(`${ context.activity.type } activity received.`);
- *         // Continue with further processing.
- *         await next();
- *     })
- *     .onMessage(async (context, next) => {
- *         // Handle a message activity.
- *         await context.sendActivity(`Echo: ${ context.activity.text }`);
- *         // Continue with further processing.
- *         await next();
- *     });
- * ```
- *
- * **See also**
- * - The [Bot Framework Activity schema](https://aka.ms/botSpecs-activitySchema)
- */
-export class ActivityHandler extends ActivityHandlerBase {
-    protected readonly handlers: { [type: string]: BotHandler[] } = {};
-
-    /**
-     * Registers an activity event handler for the _turn_ event, emitted for every incoming activity, regardless of type.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     */
-    onTurn(handler: BotHandler): this {
-        return this.on('Turn', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _message_ event, emitted for every incoming message activity.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * Message activities represent content intended to be shown within a conversational interface
-     * and can contain text, speech, interactive cards, and binary or unknown attachments.
-     * Not all message activities contain text, the activity's [text](xref:botframework-schema.Activity.text)
-     * property can be `null` or `undefined`.
-     */
-    onMessage(handler: BotHandler): this {
-        return this.on('Message', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _conversation update_ event, emitted for every incoming
-     * conversation update activity.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * Conversation update activities describe a changes to a conversation's metadata, such as title, participants,
-     * or other channel-specific information.
-     *
-     * To handle when members are added to or removed from the conversation, use the
-     * [onMembersAdded](xref:botbuilder-core.ActivityHandler.onMembersAdded) and
-     * [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved) sub-type event handlers.
-     */
-    onConversationUpdate(handler: BotHandler): this {
-        return this.on('ConversationUpdate', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _members added_ event, emitted for any incoming
-     * conversation update activity that includes members added to the conversation.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * The activity's [membersAdded](xref:botframework-schema.Activity.membersAdded) property
-     * contains the members added to the conversation, which can include the bot.
-     *
-     * To handle conversation update events in general, use the
-     * [onConversationUpdate](xref:botbuilder-core.ActivityHandler.onConversationUpdate) type-specific event handler.
-     */
-    onMembersAdded(handler: BotHandler): this {
-        return this.on('MembersAdded', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _members removed_ event, emitted for any incoming
-     * conversation update activity that includes members removed from the conversation.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * The activity's [membersRemoved](xref:botframework-schema.Activity.membersRemoved) property
-     * contains the members removed from the conversation, which can include the bot.
-     *
-     * To handle conversation update events in general, use the
-     * [onConversationUpdate](xref:botbuilder-core.ActivityHandler.onConversationUpdate) type-specific event handler.
-     */
-    onMembersRemoved(handler: BotHandler): this {
-        return this.on('MembersRemoved', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _message reaction_ event, emitted for every incoming
-     * message reaction activity.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * Message reaction activities represent a social interaction on an existing message activity
-     * within a conversation. The original activity is referred to by the message reaction activity's
-     * [replyToId](xref:botframework-schema.Activity.replyToId) property. The
-     * [from](xref:botframework-schema.Activity.from) property represents the source of the reaction,
-     * such as the user that reacted to the message.
-     *
-     * To handle when reactions are added to or removed from messages in the conversation, use the
-     * [onReactionsAdded](xref:botbuilder-core.ActivityHandler.onReactionsAdded) and
-     * [onReactionsRemoved](xref:botbuilder-core.ActivityHandler.onReactionsRemoved) sub-type event handlers.
-     */
-    onMessageReaction(handler: BotHandler): this {
-        return this.on('MessageReaction', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _reactions added_ event, emitted for any incoming
-     * message reaction activity that describes reactions added to a message.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * The activity's [reactionsAdded](xref:botframework-schema.Activity.reactionsAdded) property
-     * includes one or more reactions that were added.
-     *
-     * To handle message reaction events in general, use the
-     * [onMessageReaction](xref:botbuilder-core.ActivityHandler.onMessageReaction) type-specific event handler.
-     */
-    onReactionsAdded(handler: BotHandler): this {
-        return this.on('ReactionsAdded', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _reactions removed_ event, emitted for any incoming
-     * message reaction activity that describes reactions removed from a message.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * The activity's [reactionsRemoved](xref:botframework-schema.Activity.reactionsRemoved) property
-     * includes one or more reactions that were removed.
-     *
-     * To handle message reaction events in general, use the
-     * [onMessageReaction](xref:botbuilder-core.ActivityHandler.onMessageReaction) type-specific event handler.
-     */
-    onReactionsRemoved(handler: BotHandler): this {
-        return this.on('ReactionsRemoved', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _event_ event, emitted for every incoming event activity.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * Event activities communicate programmatic information from a client or channel to a bot.
-     * The meaning of an event activity is defined by the activity's
-     * [name](xref:botframework-schema.Activity.name) property, which is meaningful within the scope
-     * of a channel. Event activities are designed to carry both interactive information (such as
-     * button clicks) and non-interactive information (such as a notification of a client
-     * automatically updating an embedded speech model).
-     *
-     * To handle a `tokens/response` event event, use the
-     * [onTokenResponseEvent](xref:botbuilder-core.ActivityHandler.onTokenResponseEvent) sub-type
-     * event handler. To handle other named events, add logic to this handler.
-     */
-    onEvent(handler: BotHandler): this {
-        return this.on('Event', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _end of conversation_ activity.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * This activity is typically send from a Skill to a Skill caller indicating the end of that particular child conversation.
-     *
-     * To handle an End of Conversation, use the
-     * [onEndOfConversation](xref:botbuilder-core.ActivityHandler.onEndOfConversation) type-specific event handler.
-     */
-    onEndOfConversation(handler: BotHandler): this {
-        return this.on('EndOfConversation', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _typing_ activity.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * To handle a Typing event, use the
-     * [onTyping](xref:botbuilder-core.ActivityHandler.onTyping) type-specific event handler.
-     */
-    onTyping(handler: BotHandler): this {
-        return this.on('Typing', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _installationupdate_ activity.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * To handle a InstallationUpdate event, use the
-     * [onInstallationUpdate](xref:botbuilder-core.ActivityHandler.onInstallationUpdate) type-specific event handler.
-     */
-    onInstallationUpdate(handler: BotHandler): this {
-        return this.on('InstallationUpdate', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _installationupdate add_ activity.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * To handle a InstallationUpdateAdd event, use the
-     * [onInstallationUpdateAdd](xref:botbuilder-core.ActivityHandler.onInstallationUpdateAdd) type-specific event handler.
-     */
-    onInstallationUpdateAdd(handler: BotHandler): this {
-        return this.on('InstallationUpdateAdd', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _installationupdate remove_ activity.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * To handle a InstallationUpdateRemove event, use the
-     * [onInstallationUpdateRemove](xref:botbuilder-core.ActivityHandler.onInstallationUpdateRemove) type-specific event handler.
-     */
-    onInstallationUpdateRemove(handler: BotHandler): this {
-        return this.on('InstallationUpdateRemove', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _tokens-response_ event, emitted for any incoming
-     * `tokens/response` event activity. These are generated as part of the OAuth authentication flow.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * The activity's [value](xref:botframework-schema.Activity.value) property contains the user token.
-     *
-     * If your bot handles authentication using an [OAuthPrompt](xref:botbuilder-dialogs.OAuthPrompt)
-     * within a dialog, then the dialog will need to receive this activity to complete the authentication flow.
-     *
-     * To handle other named events and event events in general, use the
-     * [onEvent](xref:botbuilder-core.ActivityHandler.onEvent) type-specific event handler.
-     */
-    onTokenResponseEvent(handler: BotHandler): this {
-        return this.on('TokenResponseEvent', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _command_ activity.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * To handle a Command event, use the
-     * [onCommand](xref:botbuilder-core.ActivityHandler.onCommand) type-specific event handler.
-     */
-    onCommand(handler: BotHandler): this {
-        return this.on('Command', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _CommandResult_ activity.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * To handle a CommandResult event, use the
-     * [onCommandResult](xref:botbuilder-core.ActivityHandler.onCommandResult) type-specific event handler.
-     */
-    onCommandResult(handler: BotHandler): this {
-        return this.on('CommandResult', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _unrecognized activity type_ event, emitted for an
-     * incoming activity with a type for which the [ActivityHandler](xref:botbuilder-core.ActivityHandler)
-     * doesn't provide an event handler.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     * @remarks
-     * The `ActivityHandler` does not define events for all activity types defined in the
-     * [Bot Framework Activity schema](http://aka.ms/botSpecs-activitySchema). In addition,
-     * channels and custom adapters can create [Activities](xref:botframework-schema.Activity) with
-     * types not in the schema. When the activity handler receives such an event, it emits an unrecognized activity type event.
-     *
-     * The activity's [type](xref:botframework-schema.Activity.type) property contains the activity type.
-     */
-    onUnrecognizedActivityType(handler: BotHandler): this {
-        return this.on('UnrecognizedActivityType', handler);
-    }
-
-    /**
-     * Registers an activity event handler for the _dialog_ event, emitted as the last event for an incoming activity.
-     *
-     * @param handler The event handler.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     */
-    onDialog(handler: BotHandler): this {
-        return this.on('Dialog', handler);
-    }
-
-    /**
-     * Called to initiate the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Typically, you would provide this method as the function handler that the adapter calls
-     * to perform the bot's logic after the received activity has been pre-processed by the adapter
-     * and routed through any middleware.
-     *
-     * For example:
-     * ```javascript
-     *  server.post('/api/messages', (req, res) => {
-     *      adapter.processActivity(req, res, async (context) => {
-     *          // Route to bot's activity logic.
-     *          await bot.run(context);
-     *      });
-     * });
-     * ```
-     *
-     * **See also**
-     * - [BotFrameworkAdapter.processActivity](xref:botbuilder.BotFrameworkAdapter.processActivity)
-     */
-    async run(context: TurnContext): Promise<void> {
-        await super.run(context);
-    }
-
-    /**
-     * Called at the start of the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to use custom logic for emitting events.
-     *
-     * The default logic is to call any handlers registered via [onTurn](xref:botbuilder-core.ActivityHandler.onTurn),
-     * and then continue by calling [ActivityHandlerBase.onTurnActivity](xref:botbuilder-core.ActivityHandlerBase.onTurnActivity).
-     */
-    protected async onTurnActivity(context: TurnContext): Promise<void> {
-        await this.handle(context, 'Turn', async () => {
-            await super.onTurnActivity(context);
+ import { ActivityHandlerBase } from './activityHandlerBase';
+ import { InvokeException } from './invokeException';
+ import { InvokeResponse } from './invokeResponse';
+ import { TurnContext } from './turnContext';
+ import { verifyStateOperationName, tokenExchangeOperationName, tokenResponseEventName } from './signInConstants';
+ 
+ import {
+     Activity,
+     AdaptiveCardInvokeResponse,
+     AdaptiveCardInvokeValue,
+     Channels,
+     SearchInvokeResponse,
+     SearchInvokeValue,
+     MessageReaction,
+     StatusCodes,
+ } from 'botframework-schema';
+ 
+ /**
+  * Describes a bot activity event handler, for use with an [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+  *
+  * @remarks
+  * **Parameters**
+  *
+  * | Name | Type | Description |
+  * | :--- | :--- | :--- |
+  * | `context` | [TurnContext](xref:botbuilder-core.TurnContext) | The context object for the turn. |
+  * | `next` | () => Promise<void> | A continuation function for handling the activity. |
+  *
+  * **Returns**
+  *
+  * `any`
+  *
+  * The incoming activity is contained in the `context` object's [activity](xref:botbuilder-core.TurnContext.activity) property.
+  * Call the `next` function to continue the processing of activity events. Not doing so will stop propagation of events for this activity.
+  *
+  * A bot activity handler can return a value, to support _invoke_ activities.
+  */
+ export type BotHandler = (context: TurnContext, next: () => Promise<void>) => Promise<any>;
+ 
+ /**
+  * Event-emitting activity handler for bots. Extends [ActivityHandlerBase](xref:botbuilder-core.ActivityHandlerBase).
+  *
+  * @remarks
+  * This provides an extensible class for handling incoming activities in an event-driven way.
+  * You can register an arbitrary set of handlers for each event type.
+  *
+  * To register a handler for an event, use the corresponding _on event_ method. If multiple handlers are
+  * registered for an event, they are run in the order in which they were registered.
+  *
+  * This object emits a series of _events_ as it processes an incoming activity.
+  * A handler can stop the propagation of the event by not calling the continuation function.
+  *
+  * | Event type | Description |
+  * | :--- | :--- |
+  * | Turn | Emitted first for every activity. |
+  * | Type-specific | Emitted for the specific activity type, before emitting an event for any sub-type. |
+  * | Sub-type | Emitted for certain specialized events, based on activity content. |
+  * | Dialog | Emitted as the final activity processing event. |
+  *
+  * For example:
+  *
+  * ```typescript
+  * const bot = new ActivityHandler();
+  *
+  * server.post('/api/messages', (req, res) => {
+  *     adapter.processActivity(req, res, async (context) => {
+  *         // Route to bot's activity logic.
+  *         await bot.run(context);
+  *     });
+  * });
+  *
+  * bot.onTurn(async (context, next) => {
+  *         // Handle a "turn" event.
+  *         await context.sendActivity(`${ context.activity.type } activity received.`);
+  *         // Continue with further processing.
+  *         await next();
+  *     })
+  *     .onMessage(async (context, next) => {
+  *         // Handle a message activity.
+  *         await context.sendActivity(`Echo: ${ context.activity.text }`);
+  *         // Continue with further processing.
+  *         await next();
+  *     });
+  * ```
+  *
+  * **See also**
+  * - The [Bot Framework Activity schema](https://aka.ms/botSpecs-activitySchema)
+  */
+ export class ActivityHandler extends ActivityHandlerBase {
+     protected readonly handlers: { [type: string]: BotHandler[] } = {};
+ 
+     /**
+      * Registers an activity event handler for the _turn_ event, emitted for every incoming activity, regardless of type.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      */
+     onTurn(handler: BotHandler): this {
+         return this.on('Turn', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _message_ event, emitted for every incoming message activity.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * Message activities represent content intended to be shown within a conversational interface
+      * and can contain text, speech, interactive cards, and binary or unknown attachments.
+      * Not all message activities contain text, the activity's [text](xref:botframework-schema.Activity.text)
+      * property can be `null` or `undefined`.
+      */
+     onMessage(handler: BotHandler): this {
+         return this.on('Message', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _message update_ event, emitted for every incoming message activity.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * Message update activities represent an update of an existing message activity within a conversation.
+      * The updated activity is referred to by the [id](xref:botbuilder-core.TurnContext.activity.id) and 
+      * [conversation](xref:botbuilder-core.TurnContext.activity.conversation) fields within the activity, and the 
+      * message update activity contains all fields in the revised message activity.
+      * Message update activities are identified by a [type](xref:botbuilder-core.TurnContext.activity.type) value of 
+      * `messageUpdate`.
+      */
+     onMessageUpdate(handler: BotHandler): this {
+         return this.on('MessageUpdate', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _message delete_ event, emitted for every incoming message activity.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * Message delete activities represent a deletion of an existing message activity within a conversation. 
+      * The deleted activity is referred to by the [id](xref:botbuilder-core.TurnContext.activity.id) and 
+      * [conversation](xref:botbuilder-core.TurnContext.activity.conversation) fields within the activity.
+      * Message delete activities are identified by a [type](xref:botbuilder-core.TurnContext.activity.type) value of 
+      * `messageDelete`.
+      */
+     onMessageDelete(handler: BotHandler): this {
+         return this.on('MessageDelete', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _conversation update_ event, emitted for every incoming
+      * conversation update activity.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * Conversation update activities describe a changes to a conversation's metadata, such as title, participants,
+      * or other channel-specific information.
+      *
+      * To handle when members are added to or removed from the conversation, use the
+      * [onMembersAdded](xref:botbuilder-core.ActivityHandler.onMembersAdded) and
+      * [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved) sub-type event handlers.
+      */
+     onConversationUpdate(handler: BotHandler): this {
+         return this.on('ConversationUpdate', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _members added_ event, emitted for any incoming
+      * conversation update activity that includes members added to the conversation.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * The activity's [membersAdded](xref:botframework-schema.Activity.membersAdded) property
+      * contains the members added to the conversation, which can include the bot.
+      *
+      * To handle conversation update events in general, use the
+      * [onConversationUpdate](xref:botbuilder-core.ActivityHandler.onConversationUpdate) type-specific event handler.
+      */
+     onMembersAdded(handler: BotHandler): this {
+         return this.on('MembersAdded', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _members removed_ event, emitted for any incoming
+      * conversation update activity that includes members removed from the conversation.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * The activity's [membersRemoved](xref:botframework-schema.Activity.membersRemoved) property
+      * contains the members removed from the conversation, which can include the bot.
+      *
+      * To handle conversation update events in general, use the
+      * [onConversationUpdate](xref:botbuilder-core.ActivityHandler.onConversationUpdate) type-specific event handler.
+      */
+     onMembersRemoved(handler: BotHandler): this {
+         return this.on('MembersRemoved', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _message reaction_ event, emitted for every incoming
+      * message reaction activity.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * Message reaction activities represent a social interaction on an existing message activity
+      * within a conversation. The original activity is referred to by the message reaction activity's
+      * [replyToId](xref:botframework-schema.Activity.replyToId) property. The
+      * [from](xref:botframework-schema.Activity.from) property represents the source of the reaction,
+      * such as the user that reacted to the message.
+      *
+      * To handle when reactions are added to or removed from messages in the conversation, use the
+      * [onReactionsAdded](xref:botbuilder-core.ActivityHandler.onReactionsAdded) and
+      * [onReactionsRemoved](xref:botbuilder-core.ActivityHandler.onReactionsRemoved) sub-type event handlers.
+      */
+     onMessageReaction(handler: BotHandler): this {
+         return this.on('MessageReaction', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _reactions added_ event, emitted for any incoming
+      * message reaction activity that describes reactions added to a message.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * The activity's [reactionsAdded](xref:botframework-schema.Activity.reactionsAdded) property
+      * includes one or more reactions that were added.
+      *
+      * To handle message reaction events in general, use the
+      * [onMessageReaction](xref:botbuilder-core.ActivityHandler.onMessageReaction) type-specific event handler.
+      */
+     onReactionsAdded(handler: BotHandler): this {
+         return this.on('ReactionsAdded', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _reactions removed_ event, emitted for any incoming
+      * message reaction activity that describes reactions removed from a message.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * The activity's [reactionsRemoved](xref:botframework-schema.Activity.reactionsRemoved) property
+      * includes one or more reactions that were removed.
+      *
+      * To handle message reaction events in general, use the
+      * [onMessageReaction](xref:botbuilder-core.ActivityHandler.onMessageReaction) type-specific event handler.
+      */
+     onReactionsRemoved(handler: BotHandler): this {
+         return this.on('ReactionsRemoved', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _event_ event, emitted for every incoming event activity.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * Event activities communicate programmatic information from a client or channel to a bot.
+      * The meaning of an event activity is defined by the activity's
+      * [name](xref:botframework-schema.Activity.name) property, which is meaningful within the scope
+      * of a channel. Event activities are designed to carry both interactive information (such as
+      * button clicks) and non-interactive information (such as a notification of a client
+      * automatically updating an embedded speech model).
+      *
+      * To handle a `tokens/response` event event, use the
+      * [onTokenResponseEvent](xref:botbuilder-core.ActivityHandler.onTokenResponseEvent) sub-type
+      * event handler. To handle other named events, add logic to this handler.
+      */
+     onEvent(handler: BotHandler): this {
+         return this.on('Event', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _end of conversation_ activity.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * This activity is typically send from a Skill to a Skill caller indicating the end of that particular child conversation.
+      *
+      * To handle an End of Conversation, use the
+      * [onEndOfConversation](xref:botbuilder-core.ActivityHandler.onEndOfConversation) type-specific event handler.
+      */
+     onEndOfConversation(handler: BotHandler): this {
+         return this.on('EndOfConversation', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _typing_ activity.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * To handle a Typing event, use the
+      * [onTyping](xref:botbuilder-core.ActivityHandler.onTyping) type-specific event handler.
+      */
+     onTyping(handler: BotHandler): this {
+         return this.on('Typing', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _installationupdate_ activity.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * To handle a InstallationUpdate event, use the
+      * [onInstallationUpdate](xref:botbuilder-core.ActivityHandler.onInstallationUpdate) type-specific event handler.
+      */
+     onInstallationUpdate(handler: BotHandler): this {
+         return this.on('InstallationUpdate', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _installationupdate add_ activity.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * To handle a InstallationUpdateAdd event, use the
+      * [onInstallationUpdateAdd](xref:botbuilder-core.ActivityHandler.onInstallationUpdateAdd) type-specific event handler.
+      */
+     onInstallationUpdateAdd(handler: BotHandler): this {
+         return this.on('InstallationUpdateAdd', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _installationupdate remove_ activity.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * To handle a InstallationUpdateRemove event, use the
+      * [onInstallationUpdateRemove](xref:botbuilder-core.ActivityHandler.onInstallationUpdateRemove) type-specific event handler.
+      */
+     onInstallationUpdateRemove(handler: BotHandler): this {
+         return this.on('InstallationUpdateRemove', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _tokens-response_ event, emitted for any incoming
+      * `tokens/response` event activity. These are generated as part of the OAuth authentication flow.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * The activity's [value](xref:botframework-schema.Activity.value) property contains the user token.
+      *
+      * If your bot handles authentication using an [OAuthPrompt](xref:botbuilder-dialogs.OAuthPrompt)
+      * within a dialog, then the dialog will need to receive this activity to complete the authentication flow.
+      *
+      * To handle other named events and event events in general, use the
+      * [onEvent](xref:botbuilder-core.ActivityHandler.onEvent) type-specific event handler.
+      */
+     onTokenResponseEvent(handler: BotHandler): this {
+         return this.on('TokenResponseEvent', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _command_ activity.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * To handle a Command event, use the
+      * [onCommand](xref:botbuilder-core.ActivityHandler.onCommand) type-specific event handler.
+      */
+     onCommand(handler: BotHandler): this {
+         return this.on('Command', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _CommandResult_ activity.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * To handle a CommandResult event, use the
+      * [onCommandResult](xref:botbuilder-core.ActivityHandler.onCommandResult) type-specific event handler.
+      */
+     onCommandResult(handler: BotHandler): this {
+         return this.on('CommandResult', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _unrecognized activity type_ event, emitted for an
+      * incoming activity with a type for which the [ActivityHandler](xref:botbuilder-core.ActivityHandler)
+      * doesn't provide an event handler.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      * @remarks
+      * The `ActivityHandler` does not define events for all activity types defined in the
+      * [Bot Framework Activity schema](http://aka.ms/botSpecs-activitySchema). In addition,
+      * channels and custom adapters can create [Activities](xref:botframework-schema.Activity) with
+      * types not in the schema. When the activity handler receives such an event, it emits an unrecognized activity type event.
+      *
+      * The activity's [type](xref:botframework-schema.Activity.type) property contains the activity type.
+      */
+     onUnrecognizedActivityType(handler: BotHandler): this {
+         return this.on('UnrecognizedActivityType', handler);
+     }
+ 
+     /**
+      * Registers an activity event handler for the _dialog_ event, emitted as the last event for an incoming activity.
+      *
+      * @param handler The event handler.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      */
+     onDialog(handler: BotHandler): this {
+         return this.on('Dialog', handler);
+     }
+ 
+     /**
+      * Called to initiate the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Typically, you would provide this method as the function handler that the adapter calls
+      * to perform the bot's logic after the received activity has been pre-processed by the adapter
+      * and routed through any middleware.
+      *
+      * For example:
+      * ```javascript
+      *  server.post('/api/messages', (req, res) => {
+      *      adapter.processActivity(req, res, async (context) => {
+      *          // Route to bot's activity logic.
+      *          await bot.run(context);
+      *      });
+      * });
+      * ```
+      *
+      * **See also**
+      * - [BotFrameworkAdapter.processActivity](xref:botbuilder.BotFrameworkAdapter.processActivity)
+      */
+     async run(context: TurnContext): Promise<void> {
+         await super.run(context);
+     }
+ 
+     /**
+      * Called at the start of the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to use custom logic for emitting events.
+      *
+      * The default logic is to call any handlers registered via [onTurn](xref:botbuilder-core.ActivityHandler.onTurn),
+      * and then continue by calling [ActivityHandlerBase.onTurnActivity](xref:botbuilder-core.ActivityHandlerBase.onTurnActivity).
+      */
+     protected async onTurnActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'Turn', async () => {
+             await super.onTurnActivity(context);
+         });
+     }
+ 
+     /**
+      * Runs all registered _message_ handlers and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      *
+      * The default logic is to call any handlers registered via
+      * [onMessage](xref:botbuilder-core.ActivityHandler.onMessage),
+      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async onMessageActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'Message', this.defaultNextEvent(context));
+     }
+ 
+     /**
+      * Runs all registered _message update_ handlers and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      *
+      * The default logic is to call any handlers registered via
+      * [onMessageUpdate](xref:botbuilder-core.ActivityHandler.onMessageUpdate),
+      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async onMessageUpdateActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'MessageUpdate', async () => {
+             await this.dispatchMessageUpdateActivity(context);
+         });
+     }
+ 
+     /**
+      * Runs all registered _message delete_ handlers and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      *
+      * The default logic is to call any handlers registered via
+      * [onMessageDelete](xref:botbuilder-core.ActivityHandler.onMessageDelete),
+      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+      protected async onMessageDeleteActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'MessageDelete', async () => {
+            await this.dispatchMessageDeleteActivity(context);
         });
-    }
-
-    /**
-     * Runs all registered _message_ handlers and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels.
-     *
-     * The default logic is to call any handlers registered via
-     * [onMessage](xref:botbuilder-core.ActivityHandler.onMessage),
-     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-     */
-    protected async onMessageActivity(context: TurnContext): Promise<void> {
-        await this.handle(context, 'Message', this.defaultNextEvent(context));
-    }
-
-    /**
-     * Provides default behavior for invoke activities.
-     *
-     * @param context The context object for the current turn.
-     * @returns {Promise<InvokeResponse>} An Invoke Response for the activity.
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels.
-     * The default logic is to check for a signIn invoke and handle that
-     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-     */
-    protected async onInvokeActivity(context: TurnContext): Promise<InvokeResponse> {
-        try {
-            switch (context.activity.name) {
-                case 'application/search': {
-                    const invokeValue = this.getSearchInvokeValue(context.activity);
-                    const response = await this.onSearchInvoke(context, invokeValue);
-                    return { status: response.statusCode, body: response };
-                }
-
-                case 'adaptiveCard/action': {
-                    const invokeValue = this.getAdaptiveCardInvokeValue(context.activity);
-                    const response = await this.onAdaptiveCardInvoke(context, invokeValue);
-                    return { status: response.statusCode, body: response };
-                }
-
-                case verifyStateOperationName:
-                case tokenExchangeOperationName:
-                    await this.onSignInInvoke(context);
-                    return { status: StatusCodes.OK };
-
-                default:
-                    throw new InvokeException(StatusCodes.NOT_IMPLEMENTED);
-            }
-        } catch (err) {
-            if (err.message === 'NotImplemented') {
-                return { status: StatusCodes.NOT_IMPLEMENTED };
-            }
-
-            if (err instanceof InvokeException) {
-                return err.createInvokeResponse();
-            }
-
-            throw err;
-        } finally {
-            this.defaultNextEvent(context)();
-        }
-    }
-
-    /**
-     * Handle _signin invoke activity type_.
-     *
-     * @param _context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels.
-     */
-    protected async onSignInInvoke(_context: TurnContext): Promise<void> {
-        throw new InvokeException(StatusCodes.NOT_IMPLEMENTED);
-    }
-
-    /**
-     * Invoked when the bot is sent an Adaptive Card Action Execute.
-     *
-     * @param _context the context object for the current turn
-     * @param _invokeValue incoming activity value
-     * @returns {Promise<AdaptiveCardInvokeResponse>} An Adaptive Card Invoke Response for the activity.
-     */
-    protected onAdaptiveCardInvoke(
-        _context: TurnContext,
-        _invokeValue: AdaptiveCardInvokeValue
-    ): Promise<AdaptiveCardInvokeResponse> {
-        return Promise.reject(new InvokeException(StatusCodes.NOT_IMPLEMENTED));
-    }
-
-    /**
-     * Invoked when the bot is sent an invoke activity with name of 'application/search'.
-     *
-     * @param _context the context object for the current turn.
-     * @param _invokeValue incoming activity value.
-     * @returns {Promise<SearchInvokeResponse>} A Search Invoke Response for the activity.
-     */
-    protected onSearchInvoke(_context: TurnContext, _invokeValue: SearchInvokeValue): Promise<SearchInvokeResponse> {
-        return Promise.reject(new InvokeException(StatusCodes.NOT_IMPLEMENTED));
-    }
-
-    /**
-     * Runs all registered _endOfConversation_ handlers and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels.
-     *
-     * The default logic is to call any handlers registered via
-     * [onEndOfConversationActivity](xref:botbuilder-core.ActivityHandler.onMessage),
-     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-     */
-    protected async onEndOfConversationActivity(context: TurnContext): Promise<void> {
-        await this.handle(context, 'EndOfConversation', this.defaultNextEvent(context));
-    }
-
-    /**
-     * Runs all registered _typing_ handlers and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels.
-     *
-     * The default logic is to call any handlers registered via
-     * [onTypingActivity](xref:botbuilder-core.ActivityHandler.onTypingActivity),
-     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-     */
-    protected async onTypingActivity(context: TurnContext): Promise<void> {
-        await this.handle(context, 'Typing', this.defaultNextEvent(context));
-    }
-
-    /**
-     * Runs all registered _instllationupdate_ handlers and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels.
-     *
-     * The default logic is to call any handlers registered via
-     * [onInstallationUpdateActivity](xref:botbuilder-core.ActivityHandler.onInstallationUpdateActivity),
-     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-     */
-    protected async onInstallationUpdateActivity(context: TurnContext): Promise<void> {
-        await this.handle(context, 'InstallationUpdate', async () => {
-            await this.dispatchInstallationUpdateActivity(context);
-        });
-    }
-
-    /**
-     * Runs all registered _command_ handlers and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     */
-    protected async onCommandActivity(context: TurnContext): Promise<void> {
-        await this.handle(context, 'Command', this.defaultNextEvent(context));
-    }
-
-    /**
-     * Runs all registered _commandresult_ handlers and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     */
-    protected async onCommandResultActivity(context: TurnContext): Promise<void> {
-        await this.handle(context, 'CommandResult', this.defaultNextEvent(context));
-    }
-
-    /**
-     * Runs the _installation update_ sub-type handlers, as appropriate, and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels or to add
-     * custom conversation update sub-type events.
-     *
-     * The default logic is:
-     * - If any members were added, call handlers registered via [onMembersAdded](xref:botbuilder-core.ActivityHandler.onMembersAdded).
-     * - If any members were removed, call handlers registered via [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved).
-     * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-     */
-    protected async dispatchInstallationUpdateActivity(context: TurnContext): Promise<void> {
-        switch (context.activity.action) {
-            case 'add':
-            case 'add-upgrade':
-            case 'remove':
-            case 'remove-upgrade':
-                await super.onInstallationUpdateActivity(context);
-                break;
-            default:
-                await this.defaultNextEvent(context)();
-        }
-    }
-
-    /**
-     * Runs all registered _installation update add_ handlers and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels.
-     *
-     * The default logic is to call any handlers registered via
-     * [onInstallationUpdateAdd](xref:botbuilder-core.ActivityHandler.onInstallationUpdateAdd),
-     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-     */
-    protected async onInstallationUpdateAddActivity(context: TurnContext): Promise<void> {
-        await this.handle(context, 'InstallationUpdateAdd', this.defaultNextEvent(context));
-    }
-
-    /**
-     * Runs all registered _installation update remove_ handlers and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels.
-     *
-     * The default logic is to call any handlers registered via
-     * [onInstallationUpdateRemove](xref:botbuilder-core.ActivityHandler.onInstallationUpdateRemove),
-     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-     */
-    protected async onInstallationUpdateRemoveActivity(context: TurnContext): Promise<void> {
-        await this.handle(context, 'InstallationUpdateRemove', this.defaultNextEvent(context));
-    }
-
-    /**
-     * Runs all registered _unrecognized activity type_ handlers and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels.
-     *
-     * The default logic is to call any handlers registered via
-     * [onUnrecognizedActivityType](xref:botbuilder-core.ActivityHandler.onUnrecognizedActivityType),
-     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-     */
-    protected async onUnrecognizedActivity(context: TurnContext): Promise<void> {
-        await this.handle(context, 'UnrecognizedActivityType', this.defaultNextEvent(context));
-    }
-
-    private getSearchInvokeValue(activity: Activity): SearchInvokeValue {
-        const { value }: { value?: SearchInvokeValue } = activity;
-        if (!value) {
-            const response = this.createAdaptiveCardInvokeErrorResponse(
-                StatusCodes.BAD_REQUEST,
-                'BadRequest',
-                'Missing value property for search'
-            );
-
-            throw new InvokeException(StatusCodes.BAD_REQUEST, response);
-        }
-
-        if (!value.kind) {
-            if (activity.channelId === Channels.Msteams) {
-                value.kind = 'search';
-            } else {
-                const response = this.createAdaptiveCardInvokeErrorResponse(
-                    StatusCodes.BAD_REQUEST,
-                    'BadRequest',
-                    'Missing kind property for search.'
-                );
-
-                throw new InvokeException(StatusCodes.BAD_REQUEST, response);
-            }
-        }
-
-        if (!value.queryText) {
-            const response = this.createAdaptiveCardInvokeErrorResponse(
-                StatusCodes.BAD_REQUEST,
-                'BadRequest',
-                'Missing queryText for search.'
-            );
-
-            throw new InvokeException(StatusCodes.BAD_REQUEST, response);
-        }
-
-        return value;
-    }
-
-    private getAdaptiveCardInvokeValue(activity: Activity): AdaptiveCardInvokeValue {
-        const { value }: { value?: AdaptiveCardInvokeValue } = activity;
-        if (!value) {
-            const response = this.createAdaptiveCardInvokeErrorResponse(
-                StatusCodes.BAD_REQUEST,
-                'BadRequest',
-                'Missing value property'
-            );
-
-            throw new InvokeException(StatusCodes.BAD_REQUEST, response);
-        }
-
-        if (value.action.type !== 'Action.Execute') {
-            const response = this.createAdaptiveCardInvokeErrorResponse(
-                StatusCodes.BAD_REQUEST,
-                'NotSupported',
-                `The action '${value.action.type}' is not supported.`
-            );
-
-            throw new InvokeException(StatusCodes.BAD_REQUEST, response);
-        }
-
-        const { action, authentication, state } = value;
-        const { data, id: actionId, type, verb } = action ?? {};
-        const { connectionName, id: authenticationId, token } = authentication ?? {};
-
-        return {
-            action: {
-                data,
-                id: actionId,
-                type,
-                verb,
-            },
-            authentication: {
-                connectionName,
-                id: authenticationId,
-                token,
-            },
-            state,
-        };
-    }
-
-    private createAdaptiveCardInvokeErrorResponse(
-        statusCode: StatusCodes,
-        code: string,
-        message: string
-    ): AdaptiveCardInvokeResponse {
-        return {
-            statusCode,
-            type: 'application/vnd.microsoft.error',
-            value: { code, message },
-        };
-    }
-
-    /**
-     * Runs all registered _conversation update_ handlers and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels.
-     *
-     * The default logic is to call any handlers registered via
-     * [onConversationUpdate](xref:botbuilder-core.ActivityHandler.onConversationUpdate),
-     * and then continue by calling
-     * [dispatchConversationUpdateActivity](xref:botbuilder-core.ActivityHandler.dispatchConversationUpdateActivity).
-     */
-    protected async onConversationUpdateActivity(context: TurnContext): Promise<void> {
-        await this.handle(context, 'ConversationUpdate', async () => {
-            await this.dispatchConversationUpdateActivity(context);
-        });
-    }
-
-    /**
-     * Runs the _conversation update_ sub-type handlers, as appropriate, and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels or to add
-     * custom conversation update sub-type events.
-     *
-     * The default logic is:
-     * - If any members were added, call handlers registered via [onMembersAdded](xref:botbuilder-core.ActivityHandler.onMembersAdded).
-     * - If any members were removed, call handlers registered via [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved).
-     * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-     */
-    protected async dispatchConversationUpdateActivity(context: TurnContext): Promise<void> {
-        if (context.activity.membersAdded && context.activity.membersAdded.length > 0) {
-            await this.handle(context, 'MembersAdded', this.defaultNextEvent(context));
-        } else if (context.activity.membersRemoved && context.activity.membersRemoved.length > 0) {
-            await this.handle(context, 'MembersRemoved', this.defaultNextEvent(context));
-        } else {
-            await this.defaultNextEvent(context)();
-        }
-    }
-
-    /**
-     * Runs all registered _message reaction_ handlers and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels.
-     *
-     * The default logic is to call any handlers registered via
-     * [onMessageReaction](xref:botbuilder-core.ActivityHandler.onMessageReaction),
-     * and then continue by calling
-     * [dispatchMessageReactionActivity](xref:botbuilder-core.ActivityHandler.dispatchMessageReactionActivity).
-     */
-    protected async onMessageReactionActivity(context: TurnContext): Promise<void> {
-        await this.handle(context, 'MessageReaction', async () => {
-            await this.dispatchMessageReactionActivity(context);
-        });
-    }
-
-    /**
-     * Runs all registered _reactions added_ handlers and then continues the event emission process.
-     *
-     * @param reactionsAdded The list of reactions added.
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels.
-     *
-     * The default logic is to call any handlers registered via
-     * [onReactionsAdded](xref:botbuilder-core.ActivityHandler.onReactionsAdded),
-     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-     */
-    protected async onReactionsAddedActivity(reactionsAdded: MessageReaction[], context: TurnContext): Promise<void> {
-        await this.handle(context, 'ReactionsAdded', this.defaultNextEvent(context));
-    }
-
-    /**
-     * Runs all registered _reactions removed_ handlers and then continues the event emission process.
-     *
-     * @param reactionsRemoved The list of reactions removed.
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels.
-     *
-     * The default logic is to call any handlers registered via
-     * [onReactionsRemoved](xref:botbuilder-core.ActivityHandler.onReactionsRemoved),
-     * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-     */
-    protected async onReactionsRemovedActivity(
-        reactionsRemoved: MessageReaction[],
-        context: TurnContext
-    ): Promise<void> {
-        await this.handle(context, 'ReactionsRemoved', this.defaultNextEvent(context));
-    }
-
-    /**
-     * Runs the _message reaction_ sub-type handlers, as appropriate, and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels or to add
-     * custom message reaction sub-type events.
-     *
-     * The default logic is:
-     * - If reactions were added, call handlers registered via [onReactionsAdded](xref:botbuilder-core.ActivityHandler.onReactionsAdded).
-     * - If reactions were removed, call handlers registered via [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved).
-     * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-     */
-    protected async dispatchMessageReactionActivity(context: TurnContext): Promise<void> {
-        if (context.activity.reactionsAdded || context.activity.reactionsRemoved) {
-            await super.onMessageReactionActivity(context);
-        } else {
-            await this.defaultNextEvent(context)();
-        }
-    }
-
-    /**
-     * Runs all registered event_ handlers and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels.
-     *
-     * The default logic is to call any handlers registered via
-     * [onEvent](xref:botbuilder-core.ActivityHandler.onEvent),
-     * and then continue by calling
-     * [dispatchEventActivity](xref:botbuilder-core.ActivityHandler.dispatchEventActivity).
-     */
-    protected async onEventActivity(context: TurnContext): Promise<void> {
-        await this.handle(context, 'Event', async () => {
-            await this.dispatchEventActivity(context);
-        });
-    }
-
-    /**
-     * Runs the _event_ sub-type handlers, as appropriate, and then continues the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to support channel-specific behavior across multiple channels or to add custom event sub-type events.
-     * For certain channels, such as  Web Chat and custom Direct Line clients, developers can emit custom event activities from the client.
-     *
-     * The default logic is:
-     * - If the activity is a 'tokens/response' event, call handlers registered via
-     *   [onTokenResponseEvent](xref:botbuilder-core.ActivityHandler.onTokenResponseEvent).
-     * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
-     */
-    protected async dispatchEventActivity(context: TurnContext): Promise<void> {
-        if (context.activity.name === tokenResponseEventName) {
-            await this.handle(context, 'TokenResponseEvent', this.defaultNextEvent(context));
-        } else {
-            await this.defaultNextEvent(context)();
-        }
-    }
-
-    /**
-     * Called at the end of the event emission process.
-     *
-     * @param context The context object for the current turn.
-     * @returns {Promise<void>} A promise representing the async operation.
-     * @remarks
-     * Override this method to use custom logic for emitting events.
-     *
-     * The default logic is to call any handlers registered via [onDialog](xref:botbuilder-core.ActivityHandler.onDialog),
-     * and then complete the event emission process.
-     */
-    protected defaultNextEvent(context: TurnContext): () => Promise<void> {
-        const runDialogs = async (): Promise<void> => {
-            await this.handle(context, 'Dialog', async () => {
-                // noop
-            });
-        };
-        return runDialogs;
-    }
-
-    /**
-     * Registers a bot event handler to receive a specific event.
-     *
-     * @param type The identifier for the event type.
-     * @param handler The event handler to register.
-     * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
-     */
-    protected on(type: string, handler: BotHandler) {
-        if (!this.handlers[type]) {
-            this.handlers[type] = [handler];
-        } else {
-            this.handlers[type].push(handler);
-        }
-        return this;
-    }
-
-    /**
-     * Emits an event and executes any registered handlers.
-     *
-     * @param context The context object for the current turn.
-     * @param type The identifier for the event type.
-     * @param onNext The continuation function to call after all registered handlers for this event complete.
-     * @returns {Promise<any>} The handler's return value.
-     * @remarks
-     * Runs any registered handlers for this event type and then calls the continuation function.
-     *
-     * This optionally produces a return value, to support _invoke_ activities. If multiple handlers
-     * produce a return value, the first one produced is returned.
-     */
-    protected async handle(context: TurnContext, type: string, onNext: () => Promise<void>): Promise<any> {
-        let returnValue: any = null;
-
-        async function runHandler(index: number): Promise<void> {
-            if (index < handlers.length) {
-                const val = await handlers[index](context, () => runHandler(index + 1));
-                // if a value is returned, and we have not yet set the return value,
-                // capture it.  This is used to allow InvokeResponses to be returned.
-                if (typeof val !== 'undefined' && returnValue === null) {
-                    returnValue = val;
-                }
-            } else {
-                const val = await onNext();
-                if (typeof val !== 'undefined') {
-                    returnValue = val;
-                }
-            }
-        }
-
-        const handlers = this.handlers[type] || [];
-        await runHandler(0);
-
-        return returnValue;
-    }
-
-    /**
-     * An [InvokeResponse](xref:botbuilder.InvokeResponse) factory that initializes the body to the parameter passed and status equal to OK.
-     *
-     * @param body JSON serialized content from a POST response.
-     * @returns A new [InvokeResponse](xref:botbuilder.InvokeResponse) object.
-     */
-    protected static createInvokeResponse(body?: any): InvokeResponse {
-        return { status: 200, body };
-    }
-}
+     }
+ 
+     /**
+      * Provides default behavior for invoke activities.
+      *
+      * @param context The context object for the current turn.
+      * @returns {Promise<InvokeResponse>} An Invoke Response for the activity.
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      * The default logic is to check for a signIn invoke and handle that
+      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async onInvokeActivity(context: TurnContext): Promise<InvokeResponse> {
+         try {
+             switch (context.activity.name) {
+                 case 'application/search': {
+                     const invokeValue = this.getSearchInvokeValue(context.activity);
+                     const response = await this.onSearchInvoke(context, invokeValue);
+                     return { status: response.statusCode, body: response };
+                 }
+ 
+                 case 'adaptiveCard/action': {
+                     const invokeValue = this.getAdaptiveCardInvokeValue(context.activity);
+                     const response = await this.onAdaptiveCardInvoke(context, invokeValue);
+                     return { status: response.statusCode, body: response };
+                 }
+ 
+                 case verifyStateOperationName:
+                 case tokenExchangeOperationName:
+                     await this.onSignInInvoke(context);
+                     return { status: StatusCodes.OK };
+ 
+                 default:
+                     throw new InvokeException(StatusCodes.NOT_IMPLEMENTED);
+             }
+         } catch (err) {
+             if (err.message === 'NotImplemented') {
+                 return { status: StatusCodes.NOT_IMPLEMENTED };
+             }
+ 
+             if (err instanceof InvokeException) {
+                 return err.createInvokeResponse();
+             }
+ 
+             throw err;
+         } finally {
+             this.defaultNextEvent(context)();
+         }
+     }
+ 
+     /**
+      * Handle _signin invoke activity type_.
+      *
+      * @param _context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      */
+     protected async onSignInInvoke(_context: TurnContext): Promise<void> {
+         throw new InvokeException(StatusCodes.NOT_IMPLEMENTED);
+     }
+ 
+     /**
+      * Invoked when the bot is sent an Adaptive Card Action Execute.
+      *
+      * @param _context the context object for the current turn
+      * @param _invokeValue incoming activity value
+      * @returns {Promise<AdaptiveCardInvokeResponse>} An Adaptive Card Invoke Response for the activity.
+      */
+     protected onAdaptiveCardInvoke(
+         _context: TurnContext,
+         _invokeValue: AdaptiveCardInvokeValue
+     ): Promise<AdaptiveCardInvokeResponse> {
+         return Promise.reject(new InvokeException(StatusCodes.NOT_IMPLEMENTED));
+     }
+ 
+     /**
+      * Invoked when the bot is sent an invoke activity with name of 'application/search'.
+      *
+      * @param _context the context object for the current turn.
+      * @param _invokeValue incoming activity value.
+      * @returns {Promise<SearchInvokeResponse>} A Search Invoke Response for the activity.
+      */
+     protected onSearchInvoke(_context: TurnContext, _invokeValue: SearchInvokeValue): Promise<SearchInvokeResponse> {
+         return Promise.reject(new InvokeException(StatusCodes.NOT_IMPLEMENTED));
+     }
+ 
+     /**
+      * Runs all registered _endOfConversation_ handlers and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      *
+      * The default logic is to call any handlers registered via
+      * [onEndOfConversationActivity](xref:botbuilder-core.ActivityHandler.onMessage),
+      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async onEndOfConversationActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'EndOfConversation', this.defaultNextEvent(context));
+     }
+ 
+     /**
+      * Runs all registered _typing_ handlers and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      *
+      * The default logic is to call any handlers registered via
+      * [onTypingActivity](xref:botbuilder-core.ActivityHandler.onTypingActivity),
+      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async onTypingActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'Typing', this.defaultNextEvent(context));
+     }
+ 
+     /**
+      * Runs all registered _instllationupdate_ handlers and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      *
+      * The default logic is to call any handlers registered via
+      * [onInstallationUpdateActivity](xref:botbuilder-core.ActivityHandler.onInstallationUpdateActivity),
+      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async onInstallationUpdateActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'InstallationUpdate', async () => {
+             await this.dispatchInstallationUpdateActivity(context);
+         });
+     }
+ 
+     /**
+      * Runs all registered _command_ handlers and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      */
+     protected async onCommandActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'Command', this.defaultNextEvent(context));
+     }
+ 
+     /**
+      * Runs all registered _commandresult_ handlers and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      */
+     protected async onCommandResultActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'CommandResult', this.defaultNextEvent(context));
+     }
+ 
+     /**
+      * Runs the _installation update_ sub-type handlers, as appropriate, and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels or to add
+      * custom conversation update sub-type events.
+      *
+      * The default logic is:
+      * - If any members were added, call handlers registered via [onMembersAdded](xref:botbuilder-core.ActivityHandler.onMembersAdded).
+      * - If any members were removed, call handlers registered via [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved).
+      * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async dispatchInstallationUpdateActivity(context: TurnContext): Promise<void> {
+         switch (context.activity.action) {
+             case 'add':
+             case 'add-upgrade':
+             case 'remove':
+             case 'remove-upgrade':
+                 await super.onInstallationUpdateActivity(context);
+                 break;
+             default:
+                 await this.defaultNextEvent(context)();
+         }
+     }
+ 
+     /**
+      * Runs all registered _installation update add_ handlers and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      *
+      * The default logic is to call any handlers registered via
+      * [onInstallationUpdateAdd](xref:botbuilder-core.ActivityHandler.onInstallationUpdateAdd),
+      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async onInstallationUpdateAddActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'InstallationUpdateAdd', this.defaultNextEvent(context));
+     }
+ 
+     /**
+      * Runs all registered _installation update remove_ handlers and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      *
+      * The default logic is to call any handlers registered via
+      * [onInstallationUpdateRemove](xref:botbuilder-core.ActivityHandler.onInstallationUpdateRemove),
+      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async onInstallationUpdateRemoveActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'InstallationUpdateRemove', this.defaultNextEvent(context));
+     }
+ 
+     /**
+      * Runs all registered _unrecognized activity type_ handlers and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      *
+      * The default logic is to call any handlers registered via
+      * [onUnrecognizedActivityType](xref:botbuilder-core.ActivityHandler.onUnrecognizedActivityType),
+      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async onUnrecognizedActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'UnrecognizedActivityType', this.defaultNextEvent(context));
+     }
+ 
+     private getSearchInvokeValue(activity: Activity): SearchInvokeValue {
+         const { value }: { value?: SearchInvokeValue } = activity;
+         if (!value) {
+             const response = this.createAdaptiveCardInvokeErrorResponse(
+                 StatusCodes.BAD_REQUEST,
+                 'BadRequest',
+                 'Missing value property for search'
+             );
+ 
+             throw new InvokeException(StatusCodes.BAD_REQUEST, response);
+         }
+ 
+         if (!value.kind) {
+             if (activity.channelId === Channels.Msteams) {
+                 value.kind = 'search';
+             } else {
+                 const response = this.createAdaptiveCardInvokeErrorResponse(
+                     StatusCodes.BAD_REQUEST,
+                     'BadRequest',
+                     'Missing kind property for search.'
+                 );
+ 
+                 throw new InvokeException(StatusCodes.BAD_REQUEST, response);
+             }
+         }
+ 
+         if (!value.queryText) {
+             const response = this.createAdaptiveCardInvokeErrorResponse(
+                 StatusCodes.BAD_REQUEST,
+                 'BadRequest',
+                 'Missing queryText for search.'
+             );
+ 
+             throw new InvokeException(StatusCodes.BAD_REQUEST, response);
+         }
+ 
+         return value;
+     }
+ 
+     private getAdaptiveCardInvokeValue(activity: Activity): AdaptiveCardInvokeValue {
+         const { value }: { value?: AdaptiveCardInvokeValue } = activity;
+         if (!value) {
+             const response = this.createAdaptiveCardInvokeErrorResponse(
+                 StatusCodes.BAD_REQUEST,
+                 'BadRequest',
+                 'Missing value property'
+             );
+ 
+             throw new InvokeException(StatusCodes.BAD_REQUEST, response);
+         }
+ 
+         if (value.action.type !== 'Action.Execute') {
+             const response = this.createAdaptiveCardInvokeErrorResponse(
+                 StatusCodes.BAD_REQUEST,
+                 'NotSupported',
+                 `The action '${value.action.type}' is not supported.`
+             );
+ 
+             throw new InvokeException(StatusCodes.BAD_REQUEST, response);
+         }
+ 
+         const { action, authentication, state } = value;
+         const { data, id: actionId, type, verb } = action ?? {};
+         const { connectionName, id: authenticationId, token } = authentication ?? {};
+ 
+         return {
+             action: {
+                 data,
+                 id: actionId,
+                 type,
+                 verb,
+             },
+             authentication: {
+                 connectionName,
+                 id: authenticationId,
+                 token,
+             },
+             state,
+         };
+     }
+ 
+     private createAdaptiveCardInvokeErrorResponse(
+         statusCode: StatusCodes,
+         code: string,
+         message: string
+     ): AdaptiveCardInvokeResponse {
+         return {
+             statusCode,
+             type: 'application/vnd.microsoft.error',
+             value: { code, message },
+         };
+     }
+ 
+     /**
+      * Runs all registered _conversation update_ handlers and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      *
+      * The default logic is to call any handlers registered via
+      * [onConversationUpdate](xref:botbuilder-core.ActivityHandler.onConversationUpdate),
+      * and then continue by calling
+      * [dispatchConversationUpdateActivity](xref:botbuilder-core.ActivityHandler.dispatchConversationUpdateActivity).
+      */
+     protected async onConversationUpdateActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'ConversationUpdate', async () => {
+             await this.dispatchConversationUpdateActivity(context);
+         });
+     }
+ 
+     /**
+      * Runs the _conversation update_ sub-type handlers, as appropriate, and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels or to add
+      * custom conversation update sub-type events.
+      *
+      * The default logic is:
+      * - If any members were added, call handlers registered via [onMembersAdded](xref:botbuilder-core.ActivityHandler.onMembersAdded).
+      * - If any members were removed, call handlers registered via [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved).
+      * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async dispatchConversationUpdateActivity(context: TurnContext): Promise<void> {
+         if (context.activity.membersAdded && context.activity.membersAdded.length > 0) {
+             await this.handle(context, 'MembersAdded', this.defaultNextEvent(context));
+         } else if (context.activity.membersRemoved && context.activity.membersRemoved.length > 0) {
+             await this.handle(context, 'MembersRemoved', this.defaultNextEvent(context));
+         } else {
+             await this.defaultNextEvent(context)();
+         }
+     }
+ 
+     /**
+      * Runs the _message update_ sub-type handlers, as appropriate, and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels or to add
+      * custom conversation update sub-type events.
+      *
+      * The default logic to simple call [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async dispatchMessageUpdateActivity(context: TurnContext): Promise<void> {
+         await this.defaultNextEvent(context)();
+     }
+ 
+     /**
+      * Runs the _message delete_ sub-type handlers, as appropriate, and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels or to add
+      * custom conversation update sub-type events.
+      *
+      * The default logic to simple call [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async dispatchMessageDeleteActivity(context: TurnContext): Promise<void> {
+        await this.defaultNextEvent(context)();
+     }
+     /**
+      * Runs all registered _message reaction_ handlers and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      *
+      * The default logic is to call any handlers registered via
+      * [onMessageReaction](xref:botbuilder-core.ActivityHandler.onMessageReaction),
+      * and then continue by calling
+      * [dispatchMessageReactionActivity](xref:botbuilder-core.ActivityHandler.dispatchMessageReactionActivity).
+      */
+     protected async onMessageReactionActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'MessageReaction', async () => {
+             await this.dispatchMessageReactionActivity(context);
+         });
+     }
+ 
+     /**
+      * Runs all registered _reactions added_ handlers and then continues the event emission process.
+      *
+      * @param reactionsAdded The list of reactions added.
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      *
+      * The default logic is to call any handlers registered via
+      * [onReactionsAdded](xref:botbuilder-core.ActivityHandler.onReactionsAdded),
+      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async onReactionsAddedActivity(reactionsAdded: MessageReaction[], context: TurnContext): Promise<void> {
+         await this.handle(context, 'ReactionsAdded', this.defaultNextEvent(context));
+     }
+ 
+     /**
+      * Runs all registered _reactions removed_ handlers and then continues the event emission process.
+      *
+      * @param reactionsRemoved The list of reactions removed.
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      *
+      * The default logic is to call any handlers registered via
+      * [onReactionsRemoved](xref:botbuilder-core.ActivityHandler.onReactionsRemoved),
+      * and then continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async onReactionsRemovedActivity(
+         reactionsRemoved: MessageReaction[],
+         context: TurnContext
+     ): Promise<void> {
+         await this.handle(context, 'ReactionsRemoved', this.defaultNextEvent(context));
+     }
+ 
+     /**
+      * Runs the _message reaction_ sub-type handlers, as appropriate, and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels or to add
+      * custom message reaction sub-type events.
+      *
+      * The default logic is:
+      * - If reactions were added, call handlers registered via [onReactionsAdded](xref:botbuilder-core.ActivityHandler.onReactionsAdded).
+      * - If reactions were removed, call handlers registered via [onMembersRemoved](xref:botbuilder-core.ActivityHandler.onMembersRemoved).
+      * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async dispatchMessageReactionActivity(context: TurnContext): Promise<void> {
+         if (context.activity.reactionsAdded || context.activity.reactionsRemoved) {
+             await super.onMessageReactionActivity(context);
+         } else {
+             await this.defaultNextEvent(context)();
+         }
+     }
+ 
+     /**
+      * Runs all registered event_ handlers and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels.
+      *
+      * The default logic is to call any handlers registered via
+      * [onEvent](xref:botbuilder-core.ActivityHandler.onEvent),
+      * and then continue by calling
+      * [dispatchEventActivity](xref:botbuilder-core.ActivityHandler.dispatchEventActivity).
+      */
+     protected async onEventActivity(context: TurnContext): Promise<void> {
+         await this.handle(context, 'Event', async () => {
+             await this.dispatchEventActivity(context);
+         });
+     }
+ 
+     /**
+      * Runs the _event_ sub-type handlers, as appropriate, and then continues the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to support channel-specific behavior across multiple channels or to add custom event sub-type events.
+      * For certain channels, such as  Web Chat and custom Direct Line clients, developers can emit custom event activities from the client.
+      *
+      * The default logic is:
+      * - If the activity is a 'tokens/response' event, call handlers registered via
+      *   [onTokenResponseEvent](xref:botbuilder-core.ActivityHandler.onTokenResponseEvent).
+      * - Continue by calling [defaultNextEvent](xref:botbuilder-core.ActivityHandler.defaultNextEvent).
+      */
+     protected async dispatchEventActivity(context: TurnContext): Promise<void> {
+         if (context.activity.name === tokenResponseEventName) {
+             await this.handle(context, 'TokenResponseEvent', this.defaultNextEvent(context));
+         } else {
+             await this.defaultNextEvent(context)();
+         }
+     }
+ 
+     /**
+      * Called at the end of the event emission process.
+      *
+      * @param context The context object for the current turn.
+      * @returns {Promise<void>} A promise representing the async operation.
+      * @remarks
+      * Override this method to use custom logic for emitting events.
+      *
+      * The default logic is to call any handlers registered via [onDialog](xref:botbuilder-core.ActivityHandler.onDialog),
+      * and then complete the event emission process.
+      */
+     protected defaultNextEvent(context: TurnContext): () => Promise<void> {
+         const runDialogs = async (): Promise<void> => {
+             await this.handle(context, 'Dialog', async () => {
+                 // noop
+             });
+         };
+         return runDialogs;
+     }
+ 
+     /**
+      * Registers a bot event handler to receive a specific event.
+      *
+      * @param type The identifier for the event type.
+      * @param handler The event handler to register.
+      * @returns A reference to the [ActivityHandler](xref:botbuilder-core.ActivityHandler) object.
+      */
+     protected on(type: string, handler: BotHandler) {
+         if (!this.handlers[type]) {
+             this.handlers[type] = [handler];
+         } else {
+             this.handlers[type].push(handler);
+         }
+         return this;
+     }
+ 
+     /**
+      * Emits an event and executes any registered handlers.
+      *
+      * @param context The context object for the current turn.
+      * @param type The identifier for the event type.
+      * @param onNext The continuation function to call after all registered handlers for this event complete.
+      * @returns {Promise<any>} The handler's return value.
+      * @remarks
+      * Runs any registered handlers for this event type and then calls the continuation function.
+      *
+      * This optionally produces a return value, to support _invoke_ activities. If multiple handlers
+      * produce a return value, the first one produced is returned.
+      */
+     protected async handle(context: TurnContext, type: string, onNext: () => Promise<void>): Promise<any> {
+         let returnValue: any = null;
+ 
+         async function runHandler(index: number): Promise<void> {
+             if (index < handlers.length) {
+                 const val = await handlers[index](context, () => runHandler(index + 1));
+                 // if a value is returned, and we have not yet set the return value,
+                 // capture it.  This is used to allow InvokeResponses to be returned.
+                 if (typeof val !== 'undefined' && returnValue === null) {
+                     returnValue = val;
+                 }
+             } else {
+                 const val = await onNext();
+                 if (typeof val !== 'undefined') {
+                     returnValue = val;
+                 }
+             }
+         }
+ 
+         const handlers = this.handlers[type] || [];
+         await runHandler(0);
+ 
+         return returnValue;
+     }
+ 
+     /**
+      * An [InvokeResponse](xref:botbuilder.InvokeResponse) factory that initializes the body to the parameter passed and status equal to OK.
+      *
+      * @param body JSON serialized content from a POST response.
+      * @returns A new [InvokeResponse](xref:botbuilder.InvokeResponse) object.
+      */
+     protected static createInvokeResponse(body?: any): InvokeResponse {
+         return { status: 200, body };
+     }
+ }
+ 

--- a/libraries/botbuilder-core/src/activityHandlerBase.ts
+++ b/libraries/botbuilder-core/src/activityHandlerBase.ts
@@ -407,4 +407,3 @@
          await this.onTurnActivity(context);
      }
  }
- 

--- a/libraries/botbuilder-core/src/activityHandlerBase.ts
+++ b/libraries/botbuilder-core/src/activityHandlerBase.ts
@@ -2,408 +2,440 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
- import { ActivityTypes, ChannelAccount, MessageReaction, TurnContext } from '.';
- import { InvokeResponse } from './invokeResponse';
- import { StatusCodes } from 'botframework-schema';
- 
- // This key is exported internally so that subclassed ActivityHandlers and BotAdapters will not override any already set InvokeResponses.
- export const INVOKE_RESPONSE_KEY = Symbol('invokeResponse');
- 
- /**
-  * Defines the core behavior for event-emitting activity handlers for bots.
-  *
-  * @remarks
-  * This provides an extensible class for handling incoming activities in an event-driven way.
-  * You can register an arbitrary set of handlers for each event type.
-  *
-  * To register a handler for an event, use the corresponding _on event_ method. If multiple handlers are
-  * registered for an event, they are run in the order in which they were registered.
-  *
-  * This object emits a series of _events_ as it processes an incoming activity.
-  * A handler can stop the propagation of the event by not calling the continuation function.
-  *
-  * | Event type | Description |
-  * | :--- | :--- |
-  * | Type-specific | Emitted for the specific activity type, before emitting an event for any sub-type. |
-  * | Sub-type | Emitted for certain specialized events, based on activity content. |
-  *
-  * **See also**
-  * - The [Bot Framework Activity schema](https://aka.ms/botSpecs-activitySchema)
-  */
- export class ActivityHandlerBase {
-     /**
-      * Called at the start of the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to use custom logic for emitting events.
-      *
-      * The default logic is to call any type-specific and sub-type handlers registered via
-      * the various _on event_ methods. Type-specific events are defined for:
-      * - Message activities
-      * - Conversation update activities
-      * - Message reaction activities
-      * - Event activities
-      * - Invoke activities
-      * - _Unrecognized_ activities, ones that this class has not otherwise defined an _on event_ method for.
-      */
-     protected async onTurnActivity(context: TurnContext): Promise<void> {
-         switch (context.activity.type) {
-             case ActivityTypes.Message:
-                 await this.onMessageActivity(context);
-                 break;
-             case ActivityTypes.ConversationUpdate:
-                 await this.onConversationUpdateActivity(context);
-                 break;
-             case ActivityTypes.MessageReaction:
-                 await this.onMessageReactionActivity(context);
-                 break;
-             case ActivityTypes.Event:
-                 await this.onEventActivity(context);
-                 break;
-             case ActivityTypes.Invoke: {
-                 const invokeResponse = await this.onInvokeActivity(context);
-                 // If onInvokeActivity has already sent an InvokeResponse, do not send another one.
-                 if (invokeResponse && !context.turnState.get(INVOKE_RESPONSE_KEY)) {
-                     await context.sendActivity({ value: invokeResponse, type: 'invokeResponse' });
-                 }
-                 break;
-             }
-             case ActivityTypes.EndOfConversation:
-                 await this.onEndOfConversationActivity(context);
-                 break;
-             case ActivityTypes.Typing:
-                 await this.onTypingActivity(context);
-                 break;
-             case ActivityTypes.InstallationUpdate:
-                 await this.onInstallationUpdateActivity(context);
-                 break;
-             case ActivityTypes.Command:
-                 await this.onCommandActivity(context);
-                 break;
-             case ActivityTypes.CommandResult:
-                 await this.onCommandResultActivity(context);
-                 break;
-             default:
-                 // handler for unknown or unhandled types
-                 await this.onUnrecognizedActivity(context);
-                 break;
-         }
-     }
- 
-     /**
-      * Provides a hook for emitting the _message_ event.
-      *
-      * @param _context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _message_ handlers and then continue the event
-      * emission process.
-      */
-     protected async onMessageActivity(_context: TurnContext): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Provides a hook for emitting the _conversation update_ event.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _conversation update_ handlers and then continue the event
-      * emission process.
-      *
-      * The default logic is:
-      * - If members other than the bot were added to the conversation,
-      *   call [onMembersAddedActivity](xref:botbuilder-core.ActivityHandlerBase.onMembersAddedActivity).
-      * - If members other than the bot were removed from the conversation,
-      *   call [onMembersRemovedActivity](xref:botbuilder-core.ActivityHandlerBase.onMembersRemovedActivity).
-      */
-     protected async onConversationUpdateActivity(context: TurnContext): Promise<void> {
-         if (context.activity.membersAdded && context.activity.membersAdded.length > 0) {
-             if (
-                 context.activity.membersAdded.filter(
-                     (m) => context.activity.recipient && context.activity.recipient.id !== m.id
-                 ).length
-             ) {
-                 await this.onMembersAddedActivity(context.activity.membersAdded, context);
-             }
-         } else if (context.activity.membersRemoved && context.activity.membersRemoved.length > 0) {
-             if (
-                 context.activity.membersRemoved.filter(
-                     (m) => context.activity.recipient && context.activity.recipient.id !== m.id
-                 ).length
-             ) {
-                 await this.onMembersRemovedActivity(context.activity.membersRemoved, context);
-             }
-         }
-     }
- 
-     /**
-      * Provides a hook for emitting the _message reaction_ event.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _message reaction_ handlers and then continue the event
-      * emission process.
-      *
-      * The default logic is:
-      * - If reactions were added to a message,
-      *   call [onReactionsAddedActivity](xref:botbuilder-core.ActivityHandlerBase.onReactionsAddedActivity).
-      * - If reactions were removed from a message,
-      *   call [onReactionsRemovedActivity](xref:botbuilder-core.ActivityHandlerBase.onReactionsRemovedActivity).
-      */
-     protected async onMessageReactionActivity(context: TurnContext): Promise<void> {
-         if (context.activity.reactionsAdded?.length) {
-             await this.onReactionsAddedActivity(context.activity.reactionsAdded, context);
-         }
- 
-         if (context.activity.reactionsRemoved?.length) {
-             await this.onReactionsRemovedActivity(context.activity.reactionsRemoved, context);
-         }
-     }
- 
-     /**
-      * Provides a hook for emitting the _event_ event.
-      *
-      * @param _context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _event_ handlers and then continue the event
-      * emission process.
-      */
-     protected async onEventActivity(_context: TurnContext): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Provides a hook for invoke calls.
-      *
-      * @param _context The context object for the current turn.
-      * @returns {Promise<InvokeResponse>} An Invoke Response for the activity.
-      * @remarks
-      * Override this method to handle particular invoke calls.
-      */
-     protected async onInvokeActivity(_context: TurnContext): Promise<InvokeResponse> {
-         return { status: StatusCodes.NOT_IMPLEMENTED };
-     }
- 
-     /**
-      * Provides a hook for emitting the _end of conversation_ event.
-      *
-      * @param _context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _end of conversation_ handlers and then continue the event
-      * emission process.
-      */
-     protected async onEndOfConversationActivity(_context: TurnContext): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Provides a hook for emitting the _typing_ event.
-      *
-      * @param _context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _typing_ handlers and then continue the event
-      * emission process.
-      */
-     protected async onTypingActivity(_context: TurnContext): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Provides a hook for emitting the _installationupdate_ event.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _installationupdate_ handlers and then continue the event
-      * emission process.
-      */
-     protected async onInstallationUpdateActivity(context: TurnContext): Promise<void> {
-         switch (context.activity.action) {
-             case 'add':
-             case 'add-upgrade':
-                 await this.onInstallationUpdateAddActivity(context);
-                 return;
-             case 'remove':
-             case 'remove-upgrade':
-                 await this.onInstallationUpdateRemoveActivity(context);
-                 return;
-         }
-     }
- 
-     /**
-      * Provides a hook for emitting the _installationupdateadd_ event.
-      *
-      * @param _context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _installationupdateadd_ handlers and then continue the event
-      * emission process.
-      */
-     protected async onInstallationUpdateAddActivity(_context: TurnContext): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Provides a hook for emitting the _installationupdateremove_ event.
-      *
-      * @param _context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _installationupdateremove_ handlers and then continue the event
-      * emission process.
-      */
-     protected async onInstallationUpdateRemoveActivity(_context: TurnContext): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Provides a hook for emitting the _unrecognized_ event.
-      *
-      * @param _context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _unrecognized_ handlers and then continue the event
-      * emission process.
-      */
-     protected async onUnrecognizedActivity(_context: TurnContext): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Provides a hook for emitting the _members added_ event,
-      * a sub-type of the _conversation update_ event.
-      *
-      * @param _membersAdded An array of the members added to the conversation.
-      * @param _context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _members added_ handlers and then continue the event
-      * emission process.
-      */
-     protected async onMembersAddedActivity(_membersAdded: ChannelAccount[], _context: TurnContext): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Provides a hook for emitting the _members removed_ event,
-      * a sub-type of the _conversation update_ event.
-      *
-      * @param _membersRemoved An array of the members removed from the conversation.
-      * @param _context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _members removed_ handlers and then continue the event
-      * emission process.
-      */
-     protected async onMembersRemovedActivity(_membersRemoved: ChannelAccount[], _context: TurnContext): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Provides a hook for emitting the _reactions added_ event,
-      * a sub-type of the _message reaction_ event.
-      *
-      * @param _reactionsAdded An array of the reactions added to a message.
-      * @param _context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _reactions added_ handlers and then continue the event
-      * emission process.
-      */
-     protected async onReactionsAddedActivity(_reactionsAdded: MessageReaction[], _context: TurnContext): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Provides a hook for emitting the _reactions removed_ event,
-      * a sub-type of the _message reaction_ event.
-      *
-      * @param _reactionsRemoved An array of the reactions removed from a message.
-      * @param _context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _reactions removed_ handlers and then continue the event
-      * emission process.
-      */
-     protected async onReactionsRemovedActivity(
-         _reactionsRemoved: MessageReaction[],
-         _context: TurnContext
-     ): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Invoked when a command activity is received when the base behavior of
-      * `onTurn()` is used.
-      * Commands are requests to perform an action and receivers typically respond with
-      * one or more commandResult activities. Receivers are also expected to explicitly
-      * reject unsupported command activities.
-      *
-      * @param _context A context object for this turn.
-      * @returns A promise that represents the work queued to execute.
-      */
-     protected async onCommandActivity(_context: TurnContext): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Invoked when a commandResult activity is received when the base behavior of
-      * `onTurn()` is used.
-      * CommandResult activity can be used to communicate the result of a command execution.
-      *
-      * @param _context A context object for this turn.
-      * @returns A promise that represents the work queued to execute.
-      */
-     protected async onCommandResultActivity(_context: TurnContext): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Called to initiate the event emission process.
-      *
-      * @param context The context object for the current turn.
-      *
-      * @remarks
-      * Typically, you would provide this method as the function handler that the adapter calls
-      * to perform the bot's logic after the received activity has been pre-processed by the adapter
-      * and routed through any middleware.
-      *
-      * For example:
-      * ```javascript
-      *  server.post('/api/messages', (req, res) => {
-      *      adapter.processActivity(req, res, async (context) => {
-      *          // Route to main dialog.
-      *          await bot.run(context);
-      *      });
-      * });
-      * ```
-      *
-      * **See also**
-      * - [BotFrameworkAdapter.processActivity](xref:botbuilder.BotFrameworkAdapter.processActivity)
-      */
-     async run(context: TurnContext): Promise<void> {
-         if (!context) {
-             throw new Error('Missing TurnContext parameter');
-         }
- 
-         if (!context.activity) {
-             throw new Error('TurnContext does not include an activity');
-         }
- 
-         if (!context.activity.type) {
-             throw new Error('Activity is missing its type');
-         }
- 
-         // List of all Activity Types:
-         // https://github.com/Microsoft/botbuilder-js/blob/main/libraries/botframework-schema/src/index.ts#L1627
-         await this.onTurnActivity(context);
-     }
- }
+import { ActivityTypes, ChannelAccount, MessageReaction, TurnContext } from '.';
+import { InvokeResponse } from './invokeResponse';
+import { StatusCodes } from 'botframework-schema';
+
+// This key is exported internally so that subclassed ActivityHandlers and BotAdapters will not override any already set InvokeResponses.
+export const INVOKE_RESPONSE_KEY = Symbol('invokeResponse');
+
+/**
+ * Defines the core behavior for event-emitting activity handlers for bots.
+ *
+ * @remarks
+ * This provides an extensible class for handling incoming activities in an event-driven way.
+ * You can register an arbitrary set of handlers for each event type.
+ *
+ * To register a handler for an event, use the corresponding _on event_ method. If multiple handlers are
+ * registered for an event, they are run in the order in which they were registered.
+ *
+ * This object emits a series of _events_ as it processes an incoming activity.
+ * A handler can stop the propagation of the event by not calling the continuation function.
+ *
+ * | Event type | Description |
+ * | :--- | :--- |
+ * | Type-specific | Emitted for the specific activity type, before emitting an event for any sub-type. |
+ * | Sub-type | Emitted for certain specialized events, based on activity content. |
+ *
+ * **See also**
+ * - The [Bot Framework Activity schema](https://aka.ms/botSpecs-activitySchema)
+ */
+export class ActivityHandlerBase {
+    /**
+     * Called at the start of the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to use custom logic for emitting events.
+     *
+     * The default logic is to call any type-specific and sub-type handlers registered via
+     * the various _on event_ methods. Type-specific events are defined for:
+     * - Message activities
+     * - Conversation update activities
+     * - Message reaction activities
+     * - Event activities
+     * - Invoke activities
+     * - _Unrecognized_ activities, ones that this class has not otherwise defined an _on event_ method for.
+     */
+    protected async onTurnActivity(context: TurnContext): Promise<void> {
+        switch (context.activity.type) {
+            case ActivityTypes.Message:
+                await this.onMessageActivity(context);
+                break;
+            case ActivityTypes.MessageUpdate:
+                await this.onMessageUpdateActivity(context);
+                break;
+            case ActivityTypes.MessageDelete:
+                await this.onMessageDeleteActivity(context);
+                break;
+            case ActivityTypes.ConversationUpdate:
+                await this.onConversationUpdateActivity(context);
+                break;
+            case ActivityTypes.MessageReaction:
+                await this.onMessageReactionActivity(context);
+                break;
+            case ActivityTypes.Event:
+                await this.onEventActivity(context);
+                break;
+            case ActivityTypes.Invoke: {
+                const invokeResponse = await this.onInvokeActivity(context);
+                // If onInvokeActivity has already sent an InvokeResponse, do not send another one.
+                if (invokeResponse && !context.turnState.get(INVOKE_RESPONSE_KEY)) {
+                    await context.sendActivity({ value: invokeResponse, type: 'invokeResponse' });
+                }
+                break;
+            }
+            case ActivityTypes.EndOfConversation:
+                await this.onEndOfConversationActivity(context);
+                break;
+            case ActivityTypes.Typing:
+                await this.onTypingActivity(context);
+                break;
+            case ActivityTypes.InstallationUpdate:
+                await this.onInstallationUpdateActivity(context);
+                break;
+            case ActivityTypes.Command:
+                await this.onCommandActivity(context);
+                break;
+            case ActivityTypes.CommandResult:
+                await this.onCommandResultActivity(context);
+                break;
+            default:
+                // handler for unknown or unhandled types
+                await this.onUnrecognizedActivity(context);
+                break;
+        }
+    }
+
+    /**
+     * Provides a hook for emitting the _message_ event.
+     *
+     * @param _context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _message_ handlers and then continue the event
+     * emission process.
+     */
+    protected async onMessageActivity(_context: TurnContext): Promise<void> {
+        return;
+    }
+
+    /**
+     * Provides a hook for emitting the _message update_ event.
+     *
+     * @param _context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _message update_ handlers and then continue the event
+     * emission process.
+     */
+    protected async onMessageUpdateActivity(_context: TurnContext): Promise<void> {
+        return;
+    }
+
+    /**
+     * Provides a hook for emitting the _message delete_ event.
+     *
+     * @param _context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _message delete_ handlers and then continue the event
+     * emission process.
+     */
+    protected async onMessageDeleteActivity(_context: TurnContext): Promise<void> {
+        return;
+    }
+
+    /**
+     * Provides a hook for emitting the _conversation update_ event.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _conversation update_ handlers and then continue the event
+     * emission process.
+     *
+     * The default logic is:
+     * - If members other than the bot were added to the conversation,
+     *   call [onMembersAddedActivity](xref:botbuilder-core.ActivityHandlerBase.onMembersAddedActivity).
+     * - If members other than the bot were removed from the conversation,
+     *   call [onMembersRemovedActivity](xref:botbuilder-core.ActivityHandlerBase.onMembersRemovedActivity).
+     */
+    protected async onConversationUpdateActivity(context: TurnContext): Promise<void> {
+        if (context.activity.membersAdded && context.activity.membersAdded.length > 0) {
+            if (
+                context.activity.membersAdded.filter(
+                    (m) => context.activity.recipient && context.activity.recipient.id !== m.id
+                ).length
+            ) {
+                await this.onMembersAddedActivity(context.activity.membersAdded, context);
+            }
+        } else if (context.activity.membersRemoved && context.activity.membersRemoved.length > 0) {
+            if (
+                context.activity.membersRemoved.filter(
+                    (m) => context.activity.recipient && context.activity.recipient.id !== m.id
+                ).length
+            ) {
+                await this.onMembersRemovedActivity(context.activity.membersRemoved, context);
+            }
+        }
+    }
+
+    /**
+     * Provides a hook for emitting the _message reaction_ event.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _message reaction_ handlers and then continue the event
+     * emission process.
+     *
+     * The default logic is:
+     * - If reactions were added to a message,
+     *   call [onReactionsAddedActivity](xref:botbuilder-core.ActivityHandlerBase.onReactionsAddedActivity).
+     * - If reactions were removed from a message,
+     *   call [onReactionsRemovedActivity](xref:botbuilder-core.ActivityHandlerBase.onReactionsRemovedActivity).
+     */
+    protected async onMessageReactionActivity(context: TurnContext): Promise<void> {
+        if (context.activity.reactionsAdded?.length) {
+            await this.onReactionsAddedActivity(context.activity.reactionsAdded, context);
+        }
+
+        if (context.activity.reactionsRemoved?.length) {
+            await this.onReactionsRemovedActivity(context.activity.reactionsRemoved, context);
+        }
+    }
+
+    /**
+     * Provides a hook for emitting the _event_ event.
+     *
+     * @param _context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _event_ handlers and then continue the event
+     * emission process.
+     */
+    protected async onEventActivity(_context: TurnContext): Promise<void> {
+        return;
+    }
+
+    /**
+     * Provides a hook for invoke calls.
+     *
+     * @param _context The context object for the current turn.
+     * @returns {Promise<InvokeResponse>} An Invoke Response for the activity.
+     * @remarks
+     * Override this method to handle particular invoke calls.
+     */
+    protected async onInvokeActivity(_context: TurnContext): Promise<InvokeResponse> {
+        return { status: StatusCodes.NOT_IMPLEMENTED };
+    }
+
+    /**
+     * Provides a hook for emitting the _end of conversation_ event.
+     *
+     * @param _context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _end of conversation_ handlers and then continue the event
+     * emission process.
+     */
+    protected async onEndOfConversationActivity(_context: TurnContext): Promise<void> {
+        return;
+    }
+
+    /**
+     * Provides a hook for emitting the _typing_ event.
+     *
+     * @param _context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _typing_ handlers and then continue the event
+     * emission process.
+     */
+    protected async onTypingActivity(_context: TurnContext): Promise<void> {
+        return;
+    }
+
+    /**
+     * Provides a hook for emitting the _installationupdate_ event.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _installationupdate_ handlers and then continue the event
+     * emission process.
+     */
+    protected async onInstallationUpdateActivity(context: TurnContext): Promise<void> {
+        switch (context.activity.action) {
+            case 'add':
+            case 'add-upgrade':
+                await this.onInstallationUpdateAddActivity(context);
+                return;
+            case 'remove':
+            case 'remove-upgrade':
+                await this.onInstallationUpdateRemoveActivity(context);
+                return;
+        }
+    }
+
+    /**
+     * Provides a hook for emitting the _installationupdateadd_ event.
+     *
+     * @param _context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _installationupdateadd_ handlers and then continue the event
+     * emission process.
+     */
+    protected async onInstallationUpdateAddActivity(_context: TurnContext): Promise<void> {
+        return;
+    }
+
+    /**
+     * Provides a hook for emitting the _installationupdateremove_ event.
+     *
+     * @param _context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _installationupdateremove_ handlers and then continue the event
+     * emission process.
+     */
+    protected async onInstallationUpdateRemoveActivity(_context: TurnContext): Promise<void> {
+        return;
+    }
+
+    /**
+     * Provides a hook for emitting the _unrecognized_ event.
+     *
+     * @param _context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _unrecognized_ handlers and then continue the event
+     * emission process.
+     */
+    protected async onUnrecognizedActivity(_context: TurnContext): Promise<void> {
+        return;
+    }
+
+    /**
+     * Provides a hook for emitting the _members added_ event,
+     * a sub-type of the _conversation update_ event.
+     *
+     * @param _membersAdded An array of the members added to the conversation.
+     * @param _context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _members added_ handlers and then continue the event
+     * emission process.
+     */
+    protected async onMembersAddedActivity(_membersAdded: ChannelAccount[], _context: TurnContext): Promise<void> {
+        return;
+    }
+
+    /**
+     * Provides a hook for emitting the _members removed_ event,
+     * a sub-type of the _conversation update_ event.
+     *
+     * @param _membersRemoved An array of the members removed from the conversation.
+     * @param _context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _members removed_ handlers and then continue the event
+     * emission process.
+     */
+    protected async onMembersRemovedActivity(_membersRemoved: ChannelAccount[], _context: TurnContext): Promise<void> {
+        return;
+    }
+
+    /**
+     * Provides a hook for emitting the _reactions added_ event,
+     * a sub-type of the _message reaction_ event.
+     *
+     * @param _reactionsAdded An array of the reactions added to a message.
+     * @param _context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _reactions added_ handlers and then continue the event
+     * emission process.
+     */
+    protected async onReactionsAddedActivity(_reactionsAdded: MessageReaction[], _context: TurnContext): Promise<void> {
+        return;
+    }
+
+    /**
+     * Provides a hook for emitting the _reactions removed_ event,
+     * a sub-type of the _message reaction_ event.
+     *
+     * @param _reactionsRemoved An array of the reactions removed from a message.
+     * @param _context The context object for the current turn.
+     *
+     * @remarks
+     * Override this method to run registered _reactions removed_ handlers and then continue the event
+     * emission process.
+     */
+    protected async onReactionsRemovedActivity(
+        _reactionsRemoved: MessageReaction[],
+        _context: TurnContext
+    ): Promise<void> {
+        return;
+    }
+
+    /**
+     * Invoked when a command activity is received when the base behavior of
+     * `onTurn()` is used.
+     * Commands are requests to perform an action and receivers typically respond with
+     * one or more commandResult activities. Receivers are also expected to explicitly
+     * reject unsupported command activities.
+     *
+     * @param _context A context object for this turn.
+     * @returns A promise that represents the work queued to execute.
+     */
+    protected async onCommandActivity(_context: TurnContext): Promise<void> {
+        return;
+    }
+
+    /**
+     * Invoked when a commandResult activity is received when the base behavior of
+     * `onTurn()` is used.
+     * CommandResult activity can be used to communicate the result of a command execution.
+     *
+     * @param _context A context object for this turn.
+     * @returns A promise that represents the work queued to execute.
+     */
+    protected async onCommandResultActivity(_context: TurnContext): Promise<void> {
+        return;
+    }
+
+    /**
+     * Called to initiate the event emission process.
+     *
+     * @param context The context object for the current turn.
+     *
+     * @remarks
+     * Typically, you would provide this method as the function handler that the adapter calls
+     * to perform the bot's logic after the received activity has been pre-processed by the adapter
+     * and routed through any middleware.
+     *
+     * For example:
+     * ```javascript
+     *  server.post('/api/messages', (req, res) => {
+     *      adapter.processActivity(req, res, async (context) => {
+     *          // Route to main dialog.
+     *          await bot.run(context);
+     *      });
+     * });
+     * ```
+     *
+     * **See also**
+     * - [BotFrameworkAdapter.processActivity](xref:botbuilder.BotFrameworkAdapter.processActivity)
+     */
+    async run(context: TurnContext): Promise<void> {
+        if (!context) {
+            throw new Error('Missing TurnContext parameter');
+        }
+
+        if (!context.activity) {
+            throw new Error('TurnContext does not include an activity');
+        }
+
+        if (!context.activity.type) {
+            throw new Error('Activity is missing its type');
+        }
+
+        // List of all Activity Types:
+        // https://github.com/Microsoft/botbuilder-js/blob/main/libraries/botframework-schema/src/index.ts#L1627
+        await this.onTurnActivity(context);
+    }
+}

--- a/libraries/botbuilder-core/src/activityHandlerBase.ts
+++ b/libraries/botbuilder-core/src/activityHandlerBase.ts
@@ -53,12 +53,6 @@
              case ActivityTypes.Message:
                  await this.onMessageActivity(context);
                  break;
-             case ActivityTypes.MessageUpdate:
-                 await this.onMessageUpdateActivity(context);
-                 break;
-             case ActivityTypes.MessageDelete:
-                 await this.onMessageDeleteActivity(context);
-                 break;
              case ActivityTypes.ConversationUpdate:
                  await this.onConversationUpdateActivity(context);
                  break;
@@ -108,32 +102,6 @@
       * emission process.
       */
      protected async onMessageActivity(_context: TurnContext): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Provides a hook for emitting the _message update_ event.
-      *
-      * @param _context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _message update_ handlers and then continue the event
-      * emission process.
-      */
-     protected async onMessageUpdateActivity(_context: TurnContext): Promise<void> {
-         return;
-     }
- 
-     /**
-      * Provides a hook for emitting the _message delete_ event.
-      *
-      * @param _context The context object for the current turn.
-      *
-      * @remarks
-      * Override this method to run registered _message delete_ handlers and then continue the event
-      * emission process.
-      */
-     protected async onMessageDeleteActivity(_context: TurnContext): Promise<void> {
          return;
      }
  

--- a/libraries/botbuilder-core/src/activityHandlerBase.ts
+++ b/libraries/botbuilder-core/src/activityHandlerBase.ts
@@ -2,408 +2,441 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { ActivityTypes, ChannelAccount, MessageReaction, TurnContext } from '.';
-import { InvokeResponse } from './invokeResponse';
-import { StatusCodes } from 'botframework-schema';
-
-// This key is exported internally so that subclassed ActivityHandlers and BotAdapters will not override any already set InvokeResponses.
-export const INVOKE_RESPONSE_KEY = Symbol('invokeResponse');
-
-/**
- * Defines the core behavior for event-emitting activity handlers for bots.
- *
- * @remarks
- * This provides an extensible class for handling incoming activities in an event-driven way.
- * You can register an arbitrary set of handlers for each event type.
- *
- * To register a handler for an event, use the corresponding _on event_ method. If multiple handlers are
- * registered for an event, they are run in the order in which they were registered.
- *
- * This object emits a series of _events_ as it processes an incoming activity.
- * A handler can stop the propagation of the event by not calling the continuation function.
- *
- * | Event type | Description |
- * | :--- | :--- |
- * | Type-specific | Emitted for the specific activity type, before emitting an event for any sub-type. |
- * | Sub-type | Emitted for certain specialized events, based on activity content. |
- *
- * **See also**
- * - The [Bot Framework Activity schema](https://aka.ms/botSpecs-activitySchema)
- */
-export class ActivityHandlerBase {
-    /**
-     * Called at the start of the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to use custom logic for emitting events.
-     *
-     * The default logic is to call any type-specific and sub-type handlers registered via
-     * the various _on event_ methods. Type-specific events are defined for:
-     * - Message activities
-     * - Conversation update activities
-     * - Message reaction activities
-     * - Event activities
-     * - Invoke activities
-     * - _Unrecognized_ activities, ones that this class has not otherwise defined an _on event_ method for.
-     */
-    protected async onTurnActivity(context: TurnContext): Promise<void> {
-        switch (context.activity.type) {
-            case ActivityTypes.Message:
-                await this.onMessageActivity(context);
-                break;
-            case ActivityTypes.ConversationUpdate:
-                await this.onConversationUpdateActivity(context);
-                break;
-            case ActivityTypes.MessageReaction:
-                await this.onMessageReactionActivity(context);
-                break;
-            case ActivityTypes.Event:
-                await this.onEventActivity(context);
-                break;
-            case ActivityTypes.Invoke: {
-                const invokeResponse = await this.onInvokeActivity(context);
-                // If onInvokeActivity has already sent an InvokeResponse, do not send another one.
-                if (invokeResponse && !context.turnState.get(INVOKE_RESPONSE_KEY)) {
-                    await context.sendActivity({ value: invokeResponse, type: 'invokeResponse' });
-                }
-                break;
-            }
-            case ActivityTypes.EndOfConversation:
-                await this.onEndOfConversationActivity(context);
-                break;
-            case ActivityTypes.Typing:
-                await this.onTypingActivity(context);
-                break;
-            case ActivityTypes.InstallationUpdate:
-                await this.onInstallationUpdateActivity(context);
-                break;
-            case ActivityTypes.Command:
-                await this.onCommandActivity(context);
-                break;
-            case ActivityTypes.CommandResult:
-                await this.onCommandResultActivity(context);
-                break;
-            default:
-                // handler for unknown or unhandled types
-                await this.onUnrecognizedActivity(context);
-                break;
-        }
-    }
-
-    /**
-     * Provides a hook for emitting the _message_ event.
-     *
-     * @param _context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to run registered _message_ handlers and then continue the event
-     * emission process.
-     */
-    protected async onMessageActivity(_context: TurnContext): Promise<void> {
-        return;
-    }
-
-    /**
-     * Provides a hook for emitting the _conversation update_ event.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to run registered _conversation update_ handlers and then continue the event
-     * emission process.
-     *
-     * The default logic is:
-     * - If members other than the bot were added to the conversation,
-     *   call [onMembersAddedActivity](xref:botbuilder-core.ActivityHandlerBase.onMembersAddedActivity).
-     * - If members other than the bot were removed from the conversation,
-     *   call [onMembersRemovedActivity](xref:botbuilder-core.ActivityHandlerBase.onMembersRemovedActivity).
-     */
-    protected async onConversationUpdateActivity(context: TurnContext): Promise<void> {
-        if (context.activity.membersAdded && context.activity.membersAdded.length > 0) {
-            if (
-                context.activity.membersAdded.filter(
-                    (m) => context.activity.recipient && context.activity.recipient.id !== m.id
-                ).length
-            ) {
-                await this.onMembersAddedActivity(context.activity.membersAdded, context);
-            }
-        } else if (context.activity.membersRemoved && context.activity.membersRemoved.length > 0) {
-            if (
-                context.activity.membersRemoved.filter(
-                    (m) => context.activity.recipient && context.activity.recipient.id !== m.id
-                ).length
-            ) {
-                await this.onMembersRemovedActivity(context.activity.membersRemoved, context);
-            }
-        }
-    }
-
-    /**
-     * Provides a hook for emitting the _message reaction_ event.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to run registered _message reaction_ handlers and then continue the event
-     * emission process.
-     *
-     * The default logic is:
-     * - If reactions were added to a message,
-     *   call [onReactionsAddedActivity](xref:botbuilder-core.ActivityHandlerBase.onReactionsAddedActivity).
-     * - If reactions were removed from a message,
-     *   call [onReactionsRemovedActivity](xref:botbuilder-core.ActivityHandlerBase.onReactionsRemovedActivity).
-     */
-    protected async onMessageReactionActivity(context: TurnContext): Promise<void> {
-        if (context.activity.reactionsAdded?.length) {
-            await this.onReactionsAddedActivity(context.activity.reactionsAdded, context);
-        }
-
-        if (context.activity.reactionsRemoved?.length) {
-            await this.onReactionsRemovedActivity(context.activity.reactionsRemoved, context);
-        }
-    }
-
-    /**
-     * Provides a hook for emitting the _event_ event.
-     *
-     * @param _context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to run registered _event_ handlers and then continue the event
-     * emission process.
-     */
-    protected async onEventActivity(_context: TurnContext): Promise<void> {
-        return;
-    }
-
-    /**
-     * Provides a hook for invoke calls.
-     *
-     * @param _context The context object for the current turn.
-     * @returns {Promise<InvokeResponse>} An Invoke Response for the activity.
-     * @remarks
-     * Override this method to handle particular invoke calls.
-     */
-    protected async onInvokeActivity(_context: TurnContext): Promise<InvokeResponse> {
-        return { status: StatusCodes.NOT_IMPLEMENTED };
-    }
-
-    /**
-     * Provides a hook for emitting the _end of conversation_ event.
-     *
-     * @param _context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to run registered _end of conversation_ handlers and then continue the event
-     * emission process.
-     */
-    protected async onEndOfConversationActivity(_context: TurnContext): Promise<void> {
-        return;
-    }
-
-    /**
-     * Provides a hook for emitting the _typing_ event.
-     *
-     * @param _context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to run registered _typing_ handlers and then continue the event
-     * emission process.
-     */
-    protected async onTypingActivity(_context: TurnContext): Promise<void> {
-        return;
-    }
-
-    /**
-     * Provides a hook for emitting the _installationupdate_ event.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to run registered _installationupdate_ handlers and then continue the event
-     * emission process.
-     */
-    protected async onInstallationUpdateActivity(context: TurnContext): Promise<void> {
-        switch (context.activity.action) {
-            case 'add':
-            case 'add-upgrade':
-                await this.onInstallationUpdateAddActivity(context);
-                return;
-            case 'remove':
-            case 'remove-upgrade':
-                await this.onInstallationUpdateRemoveActivity(context);
-                return;
-        }
-    }
-
-    /**
-     * Provides a hook for emitting the _installationupdateadd_ event.
-     *
-     * @param _context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to run registered _installationupdateadd_ handlers and then continue the event
-     * emission process.
-     */
-    protected async onInstallationUpdateAddActivity(_context: TurnContext): Promise<void> {
-        return;
-    }
-
-    /**
-     * Provides a hook for emitting the _installationupdateremove_ event.
-     *
-     * @param _context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to run registered _installationupdateremove_ handlers and then continue the event
-     * emission process.
-     */
-    protected async onInstallationUpdateRemoveActivity(_context: TurnContext): Promise<void> {
-        return;
-    }
-
-    /**
-     * Provides a hook for emitting the _unrecognized_ event.
-     *
-     * @param _context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to run registered _unrecognized_ handlers and then continue the event
-     * emission process.
-     */
-    protected async onUnrecognizedActivity(_context: TurnContext): Promise<void> {
-        return;
-    }
-
-    /**
-     * Provides a hook for emitting the _members added_ event,
-     * a sub-type of the _conversation update_ event.
-     *
-     * @param _membersAdded An array of the members added to the conversation.
-     * @param _context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to run registered _members added_ handlers and then continue the event
-     * emission process.
-     */
-    protected async onMembersAddedActivity(_membersAdded: ChannelAccount[], _context: TurnContext): Promise<void> {
-        return;
-    }
-
-    /**
-     * Provides a hook for emitting the _members removed_ event,
-     * a sub-type of the _conversation update_ event.
-     *
-     * @param _membersRemoved An array of the members removed from the conversation.
-     * @param _context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to run registered _members removed_ handlers and then continue the event
-     * emission process.
-     */
-    protected async onMembersRemovedActivity(_membersRemoved: ChannelAccount[], _context: TurnContext): Promise<void> {
-        return;
-    }
-
-    /**
-     * Provides a hook for emitting the _reactions added_ event,
-     * a sub-type of the _message reaction_ event.
-     *
-     * @param _reactionsAdded An array of the reactions added to a message.
-     * @param _context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to run registered _reactions added_ handlers and then continue the event
-     * emission process.
-     */
-    protected async onReactionsAddedActivity(_reactionsAdded: MessageReaction[], _context: TurnContext): Promise<void> {
-        return;
-    }
-
-    /**
-     * Provides a hook for emitting the _reactions removed_ event,
-     * a sub-type of the _message reaction_ event.
-     *
-     * @param _reactionsRemoved An array of the reactions removed from a message.
-     * @param _context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to run registered _reactions removed_ handlers and then continue the event
-     * emission process.
-     */
-    protected async onReactionsRemovedActivity(
-        _reactionsRemoved: MessageReaction[],
-        _context: TurnContext
-    ): Promise<void> {
-        return;
-    }
-
-    /**
-     * Invoked when a command activity is received when the base behavior of
-     * `onTurn()` is used.
-     * Commands are requests to perform an action and receivers typically respond with
-     * one or more commandResult activities. Receivers are also expected to explicitly
-     * reject unsupported command activities.
-     *
-     * @param _context A context object for this turn.
-     * @returns A promise that represents the work queued to execute.
-     */
-    protected async onCommandActivity(_context: TurnContext): Promise<void> {
-        return;
-    }
-
-    /**
-     * Invoked when a commandResult activity is received when the base behavior of
-     * `onTurn()` is used.
-     * CommandResult activity can be used to communicate the result of a command execution.
-     *
-     * @param _context A context object for this turn.
-     * @returns A promise that represents the work queued to execute.
-     */
-    protected async onCommandResultActivity(_context: TurnContext): Promise<void> {
-        return;
-    }
-
-    /**
-     * Called to initiate the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Typically, you would provide this method as the function handler that the adapter calls
-     * to perform the bot's logic after the received activity has been pre-processed by the adapter
-     * and routed through any middleware.
-     *
-     * For example:
-     * ```javascript
-     *  server.post('/api/messages', (req, res) => {
-     *      adapter.processActivity(req, res, async (context) => {
-     *          // Route to main dialog.
-     *          await bot.run(context);
-     *      });
-     * });
-     * ```
-     *
-     * **See also**
-     * - [BotFrameworkAdapter.processActivity](xref:botbuilder.BotFrameworkAdapter.processActivity)
-     */
-    async run(context: TurnContext): Promise<void> {
-        if (!context) {
-            throw new Error('Missing TurnContext parameter');
-        }
-
-        if (!context.activity) {
-            throw new Error('TurnContext does not include an activity');
-        }
-
-        if (!context.activity.type) {
-            throw new Error('Activity is missing its type');
-        }
-
-        // List of all Activity Types:
-        // https://github.com/Microsoft/botbuilder-js/blob/main/libraries/botframework-schema/src/index.ts#L1627
-        await this.onTurnActivity(context);
-    }
-}
+ import { ActivityTypes, ChannelAccount, MessageReaction, TurnContext } from '.';
+ import { InvokeResponse } from './invokeResponse';
+ import { StatusCodes } from 'botframework-schema';
+ 
+ // This key is exported internally so that subclassed ActivityHandlers and BotAdapters will not override any already set InvokeResponses.
+ export const INVOKE_RESPONSE_KEY = Symbol('invokeResponse');
+ 
+ /**
+  * Defines the core behavior for event-emitting activity handlers for bots.
+  *
+  * @remarks
+  * This provides an extensible class for handling incoming activities in an event-driven way.
+  * You can register an arbitrary set of handlers for each event type.
+  *
+  * To register a handler for an event, use the corresponding _on event_ method. If multiple handlers are
+  * registered for an event, they are run in the order in which they were registered.
+  *
+  * This object emits a series of _events_ as it processes an incoming activity.
+  * A handler can stop the propagation of the event by not calling the continuation function.
+  *
+  * | Event type | Description |
+  * | :--- | :--- |
+  * | Type-specific | Emitted for the specific activity type, before emitting an event for any sub-type. |
+  * | Sub-type | Emitted for certain specialized events, based on activity content. |
+  *
+  * **See also**
+  * - The [Bot Framework Activity schema](https://aka.ms/botSpecs-activitySchema)
+  */
+ export class ActivityHandlerBase {
+     /**
+      * Called at the start of the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to use custom logic for emitting events.
+      *
+      * The default logic is to call any type-specific and sub-type handlers registered via
+      * the various _on event_ methods. Type-specific events are defined for:
+      * - Message activities
+      * - Conversation update activities
+      * - Message reaction activities
+      * - Event activities
+      * - Invoke activities
+      * - _Unrecognized_ activities, ones that this class has not otherwise defined an _on event_ method for.
+      */
+     protected async onTurnActivity(context: TurnContext): Promise<void> {
+         switch (context.activity.type) {
+             case ActivityTypes.Message:
+                 await this.onMessageActivity(context);
+                 break;
+             case ActivityTypes.MessageUpdate:
+                 await this.onMessageUpdateActivity(context);
+                 break;
+             case ActivityTypes.MessageDelete:
+                 await this.onMessageDeleteActivity(context);
+                 break;
+             case ActivityTypes.ConversationUpdate:
+                 await this.onConversationUpdateActivity(context);
+                 break;
+             case ActivityTypes.MessageReaction:
+                 await this.onMessageReactionActivity(context);
+                 break;
+             case ActivityTypes.Event:
+                 await this.onEventActivity(context);
+                 break;
+             case ActivityTypes.Invoke: {
+                 const invokeResponse = await this.onInvokeActivity(context);
+                 // If onInvokeActivity has already sent an InvokeResponse, do not send another one.
+                 if (invokeResponse && !context.turnState.get(INVOKE_RESPONSE_KEY)) {
+                     await context.sendActivity({ value: invokeResponse, type: 'invokeResponse' });
+                 }
+                 break;
+             }
+             case ActivityTypes.EndOfConversation:
+                 await this.onEndOfConversationActivity(context);
+                 break;
+             case ActivityTypes.Typing:
+                 await this.onTypingActivity(context);
+                 break;
+             case ActivityTypes.InstallationUpdate:
+                 await this.onInstallationUpdateActivity(context);
+                 break;
+             case ActivityTypes.Command:
+                 await this.onCommandActivity(context);
+                 break;
+             case ActivityTypes.CommandResult:
+                 await this.onCommandResultActivity(context);
+                 break;
+             default:
+                 // handler for unknown or unhandled types
+                 await this.onUnrecognizedActivity(context);
+                 break;
+         }
+     }
+ 
+     /**
+      * Provides a hook for emitting the _message_ event.
+      *
+      * @param _context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _message_ handlers and then continue the event
+      * emission process.
+      */
+     protected async onMessageActivity(_context: TurnContext): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Provides a hook for emitting the _message update_ event.
+      *
+      * @param _context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _message update_ handlers and then continue the event
+      * emission process.
+      */
+     protected async onMessageUpdateActivity(_context: TurnContext): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Provides a hook for emitting the _message delete_ event.
+      *
+      * @param _context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _message delete_ handlers and then continue the event
+      * emission process.
+      */
+     protected async onMessageDeleteActivity(_context: TurnContext): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Provides a hook for emitting the _conversation update_ event.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _conversation update_ handlers and then continue the event
+      * emission process.
+      *
+      * The default logic is:
+      * - If members other than the bot were added to the conversation,
+      *   call [onMembersAddedActivity](xref:botbuilder-core.ActivityHandlerBase.onMembersAddedActivity).
+      * - If members other than the bot were removed from the conversation,
+      *   call [onMembersRemovedActivity](xref:botbuilder-core.ActivityHandlerBase.onMembersRemovedActivity).
+      */
+     protected async onConversationUpdateActivity(context: TurnContext): Promise<void> {
+         if (context.activity.membersAdded && context.activity.membersAdded.length > 0) {
+             if (
+                 context.activity.membersAdded.filter(
+                     (m) => context.activity.recipient && context.activity.recipient.id !== m.id
+                 ).length
+             ) {
+                 await this.onMembersAddedActivity(context.activity.membersAdded, context);
+             }
+         } else if (context.activity.membersRemoved && context.activity.membersRemoved.length > 0) {
+             if (
+                 context.activity.membersRemoved.filter(
+                     (m) => context.activity.recipient && context.activity.recipient.id !== m.id
+                 ).length
+             ) {
+                 await this.onMembersRemovedActivity(context.activity.membersRemoved, context);
+             }
+         }
+     }
+ 
+     /**
+      * Provides a hook for emitting the _message reaction_ event.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _message reaction_ handlers and then continue the event
+      * emission process.
+      *
+      * The default logic is:
+      * - If reactions were added to a message,
+      *   call [onReactionsAddedActivity](xref:botbuilder-core.ActivityHandlerBase.onReactionsAddedActivity).
+      * - If reactions were removed from a message,
+      *   call [onReactionsRemovedActivity](xref:botbuilder-core.ActivityHandlerBase.onReactionsRemovedActivity).
+      */
+     protected async onMessageReactionActivity(context: TurnContext): Promise<void> {
+         if (context.activity.reactionsAdded?.length) {
+             await this.onReactionsAddedActivity(context.activity.reactionsAdded, context);
+         }
+ 
+         if (context.activity.reactionsRemoved?.length) {
+             await this.onReactionsRemovedActivity(context.activity.reactionsRemoved, context);
+         }
+     }
+ 
+     /**
+      * Provides a hook for emitting the _event_ event.
+      *
+      * @param _context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _event_ handlers and then continue the event
+      * emission process.
+      */
+     protected async onEventActivity(_context: TurnContext): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Provides a hook for invoke calls.
+      *
+      * @param _context The context object for the current turn.
+      * @returns {Promise<InvokeResponse>} An Invoke Response for the activity.
+      * @remarks
+      * Override this method to handle particular invoke calls.
+      */
+     protected async onInvokeActivity(_context: TurnContext): Promise<InvokeResponse> {
+         return { status: StatusCodes.NOT_IMPLEMENTED };
+     }
+ 
+     /**
+      * Provides a hook for emitting the _end of conversation_ event.
+      *
+      * @param _context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _end of conversation_ handlers and then continue the event
+      * emission process.
+      */
+     protected async onEndOfConversationActivity(_context: TurnContext): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Provides a hook for emitting the _typing_ event.
+      *
+      * @param _context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _typing_ handlers and then continue the event
+      * emission process.
+      */
+     protected async onTypingActivity(_context: TurnContext): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Provides a hook for emitting the _installationupdate_ event.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _installationupdate_ handlers and then continue the event
+      * emission process.
+      */
+     protected async onInstallationUpdateActivity(context: TurnContext): Promise<void> {
+         switch (context.activity.action) {
+             case 'add':
+             case 'add-upgrade':
+                 await this.onInstallationUpdateAddActivity(context);
+                 return;
+             case 'remove':
+             case 'remove-upgrade':
+                 await this.onInstallationUpdateRemoveActivity(context);
+                 return;
+         }
+     }
+ 
+     /**
+      * Provides a hook for emitting the _installationupdateadd_ event.
+      *
+      * @param _context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _installationupdateadd_ handlers and then continue the event
+      * emission process.
+      */
+     protected async onInstallationUpdateAddActivity(_context: TurnContext): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Provides a hook for emitting the _installationupdateremove_ event.
+      *
+      * @param _context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _installationupdateremove_ handlers and then continue the event
+      * emission process.
+      */
+     protected async onInstallationUpdateRemoveActivity(_context: TurnContext): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Provides a hook for emitting the _unrecognized_ event.
+      *
+      * @param _context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _unrecognized_ handlers and then continue the event
+      * emission process.
+      */
+     protected async onUnrecognizedActivity(_context: TurnContext): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Provides a hook for emitting the _members added_ event,
+      * a sub-type of the _conversation update_ event.
+      *
+      * @param _membersAdded An array of the members added to the conversation.
+      * @param _context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _members added_ handlers and then continue the event
+      * emission process.
+      */
+     protected async onMembersAddedActivity(_membersAdded: ChannelAccount[], _context: TurnContext): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Provides a hook for emitting the _members removed_ event,
+      * a sub-type of the _conversation update_ event.
+      *
+      * @param _membersRemoved An array of the members removed from the conversation.
+      * @param _context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _members removed_ handlers and then continue the event
+      * emission process.
+      */
+     protected async onMembersRemovedActivity(_membersRemoved: ChannelAccount[], _context: TurnContext): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Provides a hook for emitting the _reactions added_ event,
+      * a sub-type of the _message reaction_ event.
+      *
+      * @param _reactionsAdded An array of the reactions added to a message.
+      * @param _context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _reactions added_ handlers and then continue the event
+      * emission process.
+      */
+     protected async onReactionsAddedActivity(_reactionsAdded: MessageReaction[], _context: TurnContext): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Provides a hook for emitting the _reactions removed_ event,
+      * a sub-type of the _message reaction_ event.
+      *
+      * @param _reactionsRemoved An array of the reactions removed from a message.
+      * @param _context The context object for the current turn.
+      *
+      * @remarks
+      * Override this method to run registered _reactions removed_ handlers and then continue the event
+      * emission process.
+      */
+     protected async onReactionsRemovedActivity(
+         _reactionsRemoved: MessageReaction[],
+         _context: TurnContext
+     ): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Invoked when a command activity is received when the base behavior of
+      * `onTurn()` is used.
+      * Commands are requests to perform an action and receivers typically respond with
+      * one or more commandResult activities. Receivers are also expected to explicitly
+      * reject unsupported command activities.
+      *
+      * @param _context A context object for this turn.
+      * @returns A promise that represents the work queued to execute.
+      */
+     protected async onCommandActivity(_context: TurnContext): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Invoked when a commandResult activity is received when the base behavior of
+      * `onTurn()` is used.
+      * CommandResult activity can be used to communicate the result of a command execution.
+      *
+      * @param _context A context object for this turn.
+      * @returns A promise that represents the work queued to execute.
+      */
+     protected async onCommandResultActivity(_context: TurnContext): Promise<void> {
+         return;
+     }
+ 
+     /**
+      * Called to initiate the event emission process.
+      *
+      * @param context The context object for the current turn.
+      *
+      * @remarks
+      * Typically, you would provide this method as the function handler that the adapter calls
+      * to perform the bot's logic after the received activity has been pre-processed by the adapter
+      * and routed through any middleware.
+      *
+      * For example:
+      * ```javascript
+      *  server.post('/api/messages', (req, res) => {
+      *      adapter.processActivity(req, res, async (context) => {
+      *          // Route to main dialog.
+      *          await bot.run(context);
+      *      });
+      * });
+      * ```
+      *
+      * **See also**
+      * - [BotFrameworkAdapter.processActivity](xref:botbuilder.BotFrameworkAdapter.processActivity)
+      */
+     async run(context: TurnContext): Promise<void> {
+         if (!context) {
+             throw new Error('Missing TurnContext parameter');
+         }
+ 
+         if (!context.activity) {
+             throw new Error('TurnContext does not include an activity');
+         }
+ 
+         if (!context.activity.type) {
+             throw new Error('Activity is missing its type');
+         }
+ 
+         // List of all Activity Types:
+         // https://github.com/Microsoft/botbuilder-js/blob/main/libraries/botframework-schema/src/index.ts#L1627
+         await this.onTurnActivity(context);
+     }
+ }
+ 

--- a/libraries/botbuilder-core/tests/ActivityHandler.test.js
+++ b/libraries/botbuilder-core/tests/ActivityHandler.test.js
@@ -629,15 +629,20 @@ describe('ActivityHandler', function () {
         });
 
         it('call "MessageUpdate" then dispatch the its respective subtypes', async function () {
-            dispatchMessageUpdateActivityCalled = false;
+            let dispatchMessageUpdateActivityCalled = false;
             class MessageUpdateActivityHandler extends ActivityHandler {
                 dispatchMessageUpdateActivity(context) {
+                    assert(context, 'context not found');
                     assertTrueFlag(onMessageUpdateCalled, 'onMessageUpdate');
-                    assertFalseFlag(dispatchMessageUpdateActivityCalled, 'dispatchMessageUpdateActivity', 'onMessageUpdate')
+                    assertFalseFlag(
+                        dispatchMessageUpdateActivityCalled,
+                        'dispatchMessageUpdateActivity',
+                        'onMessageUpdate'
+                    );
                     dispatchMessageUpdateActivityCalled = true;
                 }
             }
-            
+
             const bot = new MessageUpdateActivityHandler();
 
             bot.onMessageUpdate(async (context, next) => {
@@ -676,15 +681,20 @@ describe('ActivityHandler', function () {
         });
 
         it('call "MessageDelete" then dispatch the its respective subtypes', async function () {
-            dispatchMessageDeleteActivityCalled = false;
+            let dispatchMessageDeleteActivityCalled = false;
             class MessageDeleteActivityHandler extends ActivityHandler {
                 dispatchMessageDeleteActivity(context) {
+                    assert(context, 'context not found');
                     assertTrueFlag(onMessageDeleteCalled, 'onMessageDelete');
-                    assertFalseFlag(dispatchMessageDeleteActivityCalled, 'dispatchMessageDeleteActivity', 'onMessageDelete')
+                    assertFalseFlag(
+                        dispatchMessageDeleteActivityCalled,
+                        'dispatchMessageDeleteActivity',
+                        'onMessageDelete'
+                    );
                     dispatchMessageDeleteActivityCalled = true;
                 }
             }
-            
+
             const bot = new MessageDeleteActivityHandler();
 
             bot.onMessageDelete(async (context, next) => {

--- a/libraries/botbuilder-core/tests/activityHandlerBase.test.js
+++ b/libraries/botbuilder-core/tests/activityHandlerBase.test.js
@@ -136,7 +136,7 @@ describe('ActivityHandlerBase', function () {
         }
     }
 
-    it.only('should dispatch by ActivityType in onTurnActivity()', async function () {
+    it('should dispatch by ActivityType in onTurnActivity()', async function () {
         const bot = new UpdatedActivityHandler();
 
         await processActivity({ type: ActivityTypes.Message }, bot);

--- a/libraries/botbuilder-core/tests/activityHandlerBase.test.js
+++ b/libraries/botbuilder-core/tests/activityHandlerBase.test.js
@@ -19,6 +19,8 @@ describe('ActivityHandlerBase', function () {
 
     let onTurnActivityCalled = false;
     let onMessageCalled = false;
+    let onMessageUpdateActivityCalled = false;
+    let onMessageDeleteActivityCalled = false;
     let onConversationUpdateActivityCalled = false;
     let onMessageReactionCalled = false;
     let onEventCalled = false;
@@ -30,6 +32,8 @@ describe('ActivityHandlerBase', function () {
     afterEach(function () {
         onTurnActivityCalled = false;
         onMessageCalled = false;
+        onMessageUpdateActivityCalled = false;
+        onMessageDeleteActivityCalled = false;
         onConversationUpdateActivityCalled = false;
         onMessageReactionCalled = false;
         onEventCalled = false;
@@ -86,6 +90,16 @@ describe('ActivityHandlerBase', function () {
             onMessageCalled = true;
         }
 
+        async onMessageUpdateActivity(context) {
+            assert(context, 'context not found');
+            onMessageUpdateActivityCalled = true;
+        }
+
+        async onMessageDeleteActivity(context) {
+            assert(context, 'context not found');
+            onMessageDeleteActivityCalled = true;
+        }
+
         async onConversationUpdateActivity(context) {
             assert(context, 'context not found');
             onConversationUpdateActivityCalled = true;
@@ -122,10 +136,12 @@ describe('ActivityHandlerBase', function () {
         }
     }
 
-    it('should dispatch by ActivityType in onTurnActivity()', async function () {
+    it.only('should dispatch by ActivityType in onTurnActivity()', async function () {
         const bot = new UpdatedActivityHandler();
 
         await processActivity({ type: ActivityTypes.Message }, bot);
+        await processActivity({ type: ActivityTypes.MessageUpdate }, bot);
+        await processActivity({ type: ActivityTypes.MessageDelete }, bot);
         await processActivity({ type: ActivityTypes.ConversationUpdate }, bot);
         await processActivity({ type: ActivityTypes.MessageReaction }, bot);
         await processActivity({ type: ActivityTypes.Event }, bot);
@@ -136,6 +152,8 @@ describe('ActivityHandlerBase', function () {
 
         assert(onTurnActivityCalled, 'onTurnActivity was not called');
         assert(onMessageCalled, 'onMessageActivity was not called');
+        assert(onMessageUpdateActivityCalled, 'onMessageUpdateActivity was not called');
+        assert(onMessageDeleteActivityCalled, 'onMessageDeleteActivity was not called');
         assert(onConversationUpdateActivityCalled, 'onConversationUpdateActivity was not called');
         assert(onMessageReactionCalled, 'onMessageReactionActivity was not called');
         assert(onEventCalled, 'onEventActivity was not called');

--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -383,6 +383,8 @@ export class TeamsActivityHandler extends ActivityHandler {
     protected handleTeamsTaskModuleFetch(_context: TurnContext, _taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse>;
     protected handleTeamsTaskModuleSubmit(_context: TurnContext, _taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse>;
     protected onInvokeActivity(context: TurnContext): Promise<InvokeResponse>;
+    protected onMessageDeleteActivity(context: TurnContext): Promise<void>;
+    protected onMessageUpdateActivity(context: TurnContext): Promise<void>;
     protected onSignInInvoke(context: TurnContext): Promise<void>;
     protected onTeamsChannelCreated(context: any): Promise<void>;
     onTeamsChannelCreatedEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
@@ -392,6 +394,8 @@ export class TeamsActivityHandler extends ActivityHandler {
     onTeamsChannelRenamedEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsChannelRestored(context: any): Promise<void>;
     onTeamsChannelRestoredEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
+    protected onTeamsEditMessage(context: TurnContext): Promise<void>;
+    onTeamsEditMessageEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsMeetingEnd(context: TurnContext): Promise<void>;
     onTeamsMeetingEndEvent(handler: (meeting: MeetingEndEventDetails, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsMeetingStart(context: TurnContext): Promise<void>;
@@ -402,6 +406,8 @@ export class TeamsActivityHandler extends ActivityHandler {
     onTeamsMembersRemovedEvent(handler: (membersRemoved: TeamsChannelAccount[], teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsReadReceipt(context: TurnContext): Promise<void>;
     onTeamsReadReceiptEvent(handler: (receiptInfo: ReadReceiptInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
+    protected onTeamsSoftDeleteMessage(context: TurnContext): Promise<void>;
+    onTeamsSoftDeleteMessageEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsTeamArchived(context: any): Promise<void>;
     onTeamsTeamArchivedEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsTeamDeleted(context: any): Promise<void>;
@@ -414,6 +420,9 @@ export class TeamsActivityHandler extends ActivityHandler {
     onTeamsTeamRestoredEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsTeamUnarchived(context: any): Promise<void>;
     onTeamsTeamUnarchivedEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
+    protected onTeamsUndeleteMessage(context: TurnContext): Promise<void>;
+    onTeamsUndeleteMessageEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
+    protected onTurnActivity(context: TurnContext): Promise<void>;
 }
 
 // @public

--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -394,8 +394,6 @@ export class TeamsActivityHandler extends ActivityHandler {
     onTeamsChannelRenamedEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsChannelRestored(context: any): Promise<void>;
     onTeamsChannelRestoredEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
-    protected onTeamsEditMessage(context: TurnContext): Promise<void>;
-    onTeamsEditMessageEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsMeetingEnd(context: TurnContext): Promise<void>;
     onTeamsMeetingEndEvent(handler: (meeting: MeetingEndEventDetails, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsMeetingStart(context: TurnContext): Promise<void>;
@@ -404,10 +402,14 @@ export class TeamsActivityHandler extends ActivityHandler {
     onTeamsMembersAddedEvent(handler: (membersAdded: TeamsChannelAccount[], teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsMembersRemoved(context: TurnContext): Promise<void>;
     onTeamsMembersRemovedEvent(handler: (membersRemoved: TeamsChannelAccount[], teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
+    protected onTeamsMessageEdit(context: TurnContext): Promise<void>;
+    onTeamsMessageEditEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
+    protected onTeamsMessageSoftDelete(context: TurnContext): Promise<void>;
+    onTeamsMessageSoftDeleteEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
+    protected onTeamsMessageUndelete(context: TurnContext): Promise<void>;
+    onTeamsMessageUndeleteEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsReadReceipt(context: TurnContext): Promise<void>;
     onTeamsReadReceiptEvent(handler: (receiptInfo: ReadReceiptInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
-    protected onTeamsSoftDeleteMessage(context: TurnContext): Promise<void>;
-    onTeamsSoftDeleteMessageEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsTeamArchived(context: any): Promise<void>;
     onTeamsTeamArchivedEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsTeamDeleted(context: any): Promise<void>;
@@ -420,8 +422,6 @@ export class TeamsActivityHandler extends ActivityHandler {
     onTeamsTeamRestoredEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsTeamUnarchived(context: any): Promise<void>;
     onTeamsTeamUnarchivedEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
-    protected onTeamsUndeleteMessage(context: TurnContext): Promise<void>;
-    onTeamsUndeleteMessageEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
 }
 
 // @public

--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -359,6 +359,8 @@ export class StreamingHttpClient implements HttpClient {
 export class TeamsActivityHandler extends ActivityHandler {
     protected dispatchConversationUpdateActivity(context: TurnContext): Promise<void>;
     protected dispatchEventActivity(context: TurnContext): Promise<void>;
+    protected dispatchMessageDeleteActivity(context: TurnContext): Promise<void>;
+    protected dispatchMessageUpdateActivity(context: TurnContext): Promise<void>;
     protected handleTeamsAnonymousAppBasedLinkQuery(_context: TurnContext, _query: AppBasedLinkQuery): Promise<MessagingExtensionResponse>;
     protected handleTeamsAppBasedLinkQuery(_context: TurnContext, _query: AppBasedLinkQuery): Promise<MessagingExtensionResponse>;
     protected handleTeamsCardActionInvoke(_context: TurnContext): Promise<InvokeResponse>;
@@ -383,8 +385,6 @@ export class TeamsActivityHandler extends ActivityHandler {
     protected handleTeamsTaskModuleFetch(_context: TurnContext, _taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse>;
     protected handleTeamsTaskModuleSubmit(_context: TurnContext, _taskModuleRequest: TaskModuleRequest): Promise<TaskModuleResponse>;
     protected onInvokeActivity(context: TurnContext): Promise<InvokeResponse>;
-    protected onMessageDeleteActivity(context: TurnContext): Promise<void>;
-    protected onMessageUpdateActivity(context: TurnContext): Promise<void>;
     protected onSignInInvoke(context: TurnContext): Promise<void>;
     protected onTeamsChannelCreated(context: any): Promise<void>;
     onTeamsChannelCreatedEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
@@ -422,7 +422,6 @@ export class TeamsActivityHandler extends ActivityHandler {
     onTeamsTeamUnarchivedEvent(handler: (teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsUndeleteMessage(context: TurnContext): Promise<void>;
     onTeamsUndeleteMessageEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
-    protected onTurnActivity(context: TurnContext): Promise<void>;
 }
 
 // @public

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
- import {
+import {
     ActivityHandler,
     AppBasedLinkQuery,
     ChannelInfo,
@@ -32,7 +32,6 @@
     TurnContext,
     tokenExchangeOperationName,
     verifyStateOperationName,
-    ActivityTypes,
 } from 'botbuilder-core';
 import { ReadReceiptInfo } from 'botframework-connector';
 import { TeamsInfo } from './teamsInfo';
@@ -613,7 +612,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context A context object for this turn.
      * @returns A promise that represents the work queued.
      */
-     protected async dispatchMessageUpdateActivity(context: TurnContext): Promise<void> {
+    protected async dispatchMessageUpdateActivity(context: TurnContext): Promise<void> {
         if (context.activity.channelId == 'msteams') {
             const channelData = context.activity.channelData as TeamsChannelData;
 
@@ -638,7 +637,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context A context object for this turn.
      * @returns A promise that represents the work queued.
      */
-     protected async dispatchMessageDeleteActivity(context: TurnContext): Promise<void> {
+    protected async dispatchMessageDeleteActivity(context: TurnContext): Promise<void> {
         if (context.activity.channelId == 'msteams') {
             const channelData = context.activity.channelData as TeamsChannelData;
 
@@ -662,7 +661,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context A context object for this turn.
      * @returns A promise that represents the work queued.
      */
-     protected async onTeamsUndeleteMessage(context: TurnContext): Promise<void> {
+    protected async onTeamsUndeleteMessage(context: TurnContext): Promise<void> {
         await this.handle(context, 'TeamsUndeleteMessage', this.defaultNextEvent(context));
     }
 
@@ -681,7 +680,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * Called in `onMessageDeleteActivity()` to trigger the `'TeamsEditMessage'` handlers.
      * Override this in a derived class to provide logic for when a message in a conversation is soft deleted.
      * This means that the message as the option of being undeleted.
-     * 
+     *
      * @param context A context object for this turn.
      * @returns A promise that represents the work queued.
      */
@@ -880,7 +879,7 @@ export class TeamsActivityHandler extends ActivityHandler {
     protected async onTeamsTeamUnarchived(context): Promise<void> {
         await this.handle(context, 'TeamsTeamUnarchived', this.defaultNextEvent(context));
     }
-    
+
     /**
      * Registers a handler for TeamsUndeleteMessage events, such as for when a message in a conversation that is
      * observed by the bot goes from a soft delete state to the normal state.
@@ -888,12 +887,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param handler A callback to handle the teams undelete message event.
      * @returns A promise that represents the work queued.
      */
-     onTeamsUndeleteMessageEvent(
-        handler: (
-            context: TurnContext,
-            next: () => Promise<void>
-        ) => Promise<void>
-    ): this {
+    onTeamsUndeleteMessageEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
         return this.on('TeamsUndeleteMessage', async (context, next) => {
             await handler(context, next);
         });
@@ -906,36 +900,26 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param handler A callback to handle the teams edit message event.
      * @returns A promise that represents the work queued.
      */
-    onTeamsEditMessageEvent(
-        handler: (
-            context: TurnContext,
-            next: () => Promise<void>
-        ) => Promise<void>
-    ): this {
+    onTeamsEditMessageEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
         return this.on('TeamsEditMessage', async (context, next) => {
             await handler(context, next);
         });
     }
-    
+
     /**
      * Registers a handler for TeamsSoftDeleteMessage events, such as for when a message in a conversation that is
-     * observed by the bot is soft deleted. This means that the deleted message, up to a certain time period, 
+     * observed by the bot is soft deleted. This means that the deleted message, up to a certain time period,
      * can be undoed.
      *
      * @param handler A callback to handle the teams edit message event.
      * @returns A promise that represents the work queued.
      */
-    onTeamsSoftDeleteMessageEvent(
-        handler: (
-            context: TurnContext,
-            next: () => Promise<void>
-        ) => Promise<void>
-    ): this {
+    onTeamsSoftDeleteMessageEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
         return this.on('onTeamsSoftDeleteMessage', async (context, next) => {
             await handler(context, next);
         });
     }
-    
+
     /**
      * Registers a handler for TeamsMembersAdded events, such as for when members other than the bot
      * join the channel, such as your bot's welcome logic.

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -654,7 +654,7 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * Called in `onMessageUpdateActivity()` to trigger the `'TeamsUndeleteMessage'` handlers.
+     * Called in `dispatchMessageUpdateActivity()` to trigger the `'TeamsUndeleteMessage'` handlers.
      * Override this in a derived class to provide logic for when a deleted message in a conversation is undeleted.
      * For example, when the user decides to "undo" a deleted message.
      *
@@ -666,7 +666,7 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * Called in `onMessageUpdateActivity()` to trigger the `'TeamsEditMessage'` handlers.
+     * Called in `dispatchMessageUpdateActivity()` to trigger the `'TeamsEditMessage'` handlers.
      * Override this in a derived class to provide logic for when a message in a conversation is edited.
      *
      * @param context A context object for this turn.
@@ -677,7 +677,7 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * Called in `onMessageDeleteActivity()` to trigger the `'TeamsEditMessage'` handlers.
+     * Called in `dispatchMessageDeleteActivity()` to trigger the `'TeamsEditMessage'` handlers.
      * Override this in a derived class to provide logic for when a message in a conversation is soft deleted.
      * This means that the message as the option of being undeleted.
      *

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -624,10 +624,10 @@ export class TeamsActivityHandler extends ActivityHandler {
                     return await this.onTeamsEditMessage(context);
 
                 default:
-                    return this.dispatchMessageUpdateActivity(context);
+                    return super.dispatchMessageUpdateActivity(context);
             }
         } else {
-            return await this.dispatchMessageUpdateActivity(context);
+            return await super.dispatchMessageUpdateActivity(context);
         }
     }
 
@@ -646,10 +646,10 @@ export class TeamsActivityHandler extends ActivityHandler {
                     return await this.onTeamsSoftDeleteMessage(context);
 
                 default:
-                    return this.dispatchMessageDeleteActivity(context);
+                    return super.dispatchMessageDeleteActivity(context);
             }
         } else {
-            return await this.dispatchMessageDeleteActivity(context);
+            return await super.dispatchMessageDeleteActivity(context);
         }
     }
 

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -618,10 +618,10 @@ export class TeamsActivityHandler extends ActivityHandler {
 
             switch (channelData.eventType) {
                 case 'undeleteMessage':
-                    return await this.onTeamsUndeleteMessage(context);
+                    return await this.onTeamsMessageUndelete(context);
 
                 case 'editMessage':
-                    return await this.onTeamsEditMessage(context);
+                    return await this.onTeamsMessageEdit(context);
 
                 default:
                     return super.dispatchMessageUpdateActivity(context);
@@ -643,7 +643,7 @@ export class TeamsActivityHandler extends ActivityHandler {
 
             switch (channelData.eventType) {
                 case 'softDeleteMessage':
-                    return await this.onTeamsSoftDeleteMessage(context);
+                    return await this.onTeamsMessageSoftDelete(context);
 
                 default:
                     return super.dispatchMessageDeleteActivity(context);
@@ -654,38 +654,38 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * Called in `dispatchMessageUpdateActivity()` to trigger the `'TeamsUndeleteMessage'` handlers.
+     * Called in `dispatchMessageUpdateActivity()` to trigger the `'TeamsMessageUndelete'` handlers.
      * Override this in a derived class to provide logic for when a deleted message in a conversation is undeleted.
      * For example, when the user decides to "undo" a deleted message.
      *
      * @param context A context object for this turn.
      * @returns A promise that represents the work queued.
      */
-    protected async onTeamsUndeleteMessage(context: TurnContext): Promise<void> {
-        await this.handle(context, 'TeamsUndeleteMessage', this.defaultNextEvent(context));
+    protected async onTeamsMessageUndelete(context: TurnContext): Promise<void> {
+        await this.handle(context, 'TeamsMessageUndelete', this.defaultNextEvent(context));
     }
 
     /**
-     * Called in `dispatchMessageUpdateActivity()` to trigger the `'TeamsEditMessage'` handlers.
+     * Called in `dispatchMessageUpdateActivity()` to trigger the `'TeamsMessageEdit'` handlers.
      * Override this in a derived class to provide logic for when a message in a conversation is edited.
      *
      * @param context A context object for this turn.
      * @returns A promise that represents the work queued.
      */
-    protected async onTeamsEditMessage(context: TurnContext): Promise<void> {
-        await this.handle(context, 'TeamsEditMessage', this.defaultNextEvent(context));
+    protected async onTeamsMessageEdit(context: TurnContext): Promise<void> {
+        await this.handle(context, 'TeamsMessageEdit', this.defaultNextEvent(context));
     }
 
     /**
-     * Called in `dispatchMessageDeleteActivity()` to trigger the `'TeamsEditMessage'` handlers.
+     * Called in `dispatchMessageDeleteActivity()` to trigger the `'TeamsMessageEdit'` handlers.
      * Override this in a derived class to provide logic for when a message in a conversation is soft deleted.
      * This means that the message as the option of being undeleted.
      *
      * @param context A context object for this turn.
      * @returns A promise that represents the work queued.
      */
-    protected async onTeamsSoftDeleteMessage(context: TurnContext): Promise<void> {
-        await this.handle(context, 'onTeamsSoftDeleteMessage', this.defaultNextEvent(context));
+    protected async onTeamsMessageSoftDelete(context: TurnContext): Promise<void> {
+        await this.handle(context, 'onTeamsMessageSoftDelete', this.defaultNextEvent(context));
     }
 
     /**
@@ -881,41 +881,41 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * Registers a handler for TeamsUndeleteMessage events, such as for when a message in a conversation that is
+     * Registers a handler for TeamsMessageUndelete events, such as for when a message in a conversation that is
      * observed by the bot goes from a soft delete state to the normal state.
      *
      * @param handler A callback to handle the teams undelete message event.
      * @returns A promise that represents the work queued.
      */
-    onTeamsUndeleteMessageEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
-        return this.on('TeamsUndeleteMessage', async (context, next) => {
+    onTeamsMessageUndeleteEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
+        return this.on('TeamsMessageUndelete', async (context, next) => {
             await handler(context, next);
         });
     }
 
     /**
-     * Registers a handler for TeamsEditMessage events, such as for when a message in a conversation that is
+     * Registers a handler for TeamsMessageEdit events, such as for when a message in a conversation that is
      * observed by the bot is edited.
      *
      * @param handler A callback to handle the teams edit message event.
      * @returns A promise that represents the work queued.
      */
-    onTeamsEditMessageEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
-        return this.on('TeamsEditMessage', async (context, next) => {
+    onTeamsMessageEditEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
+        return this.on('TeamsMessageEdit', async (context, next) => {
             await handler(context, next);
         });
     }
 
     /**
-     * Registers a handler for TeamsSoftDeleteMessage events, such as for when a message in a conversation that is
+     * Registers a handler for TeamsMessageSoftDelete events, such as for when a message in a conversation that is
      * observed by the bot is soft deleted. This means that the deleted message, up to a certain time period,
      * can be undoed.
      *
      * @param handler A callback to handle the teams edit message event.
      * @returns A promise that represents the work queued.
      */
-    onTeamsSoftDeleteMessageEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
-        return this.on('onTeamsSoftDeleteMessage', async (context, next) => {
+    onTeamsMessageSoftDeleteEvent(handler: (context: TurnContext, next: () => Promise<void>) => Promise<void>): this {
+        return this.on('onTeamsMessageSoftDelete', async (context, next) => {
             await handler(context, next);
         });
     }

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -73,39 +73,6 @@ const TeamsMeetingEndT = z
  * Developers wanting to handle Invoke activities *must* override methods starting with `handle...()` (e.g. `handleTeamsTaskModuleFetch()`).
  */
 export class TeamsActivityHandler extends ActivityHandler {
-    
-    /**
-     * Called at the start of the event emission process.
-     *
-     * @param context The context object for the current turn.
-     *
-     * @remarks
-     * Override this method to use custom logic for emitting events.
-     *
-     * The default logic is to call any type-specific and sub-type handlers registered via
-     * the various _on event_ methods. Type-specific events are defined for:
-     * - Message activities
-     * - Message update activities
-     * - Message delete activities
-     * - Conversation update activities
-     * - Message reaction activities
-     * - Event activities
-     * - Invoke activities
-     * - _Unrecognized_ activities, ones that this class has not otherwise defined an _on event_ method for.
-     */
-    protected async onTurnActivity(context: TurnContext): Promise<void> {
-        switch (context.activity.type) {
-            case ActivityTypes.MessageUpdate:
-                await this.onMessageUpdateActivity(context);
-                break;
-            case ActivityTypes.MessageDelete:
-                await this.onMessageDeleteActivity(context);
-                break;
-        }
-
-        await super.onTurnActivity(context);
-    }
-
     /**
      * Invoked when an invoke activity is received from the connector.
      * Invoke activities can be used to communicate many different things.
@@ -646,7 +613,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context A context object for this turn.
      * @returns A promise that represents the work queued.
      */
-     protected async onMessageUpdateActivity(context: TurnContext): Promise<void> {
+     protected async dispatchMessageUpdateActivity(context: TurnContext): Promise<void> {
         if (context.activity.channelId == 'msteams') {
             const channelData = context.activity.channelData as TeamsChannelData;
 
@@ -658,10 +625,10 @@ export class TeamsActivityHandler extends ActivityHandler {
                     return await this.onTeamsEditMessage(context);
 
                 default:
-                    return this.defaultNextEvent(context)();
+                    return this.dispatchMessageUpdateActivity(context);
             }
         } else {
-            return await this.defaultNextEvent(context)();
+            return await this.dispatchMessageUpdateActivity(context);
         }
     }
 
@@ -671,7 +638,7 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context A context object for this turn.
      * @returns A promise that represents the work queued.
      */
-     protected async onMessageDeleteActivity(context: TurnContext): Promise<void> {
+     protected async dispatchMessageDeleteActivity(context: TurnContext): Promise<void> {
         if (context.activity.channelId == 'msteams') {
             const channelData = context.activity.channelData as TeamsChannelData;
 
@@ -680,10 +647,10 @@ export class TeamsActivityHandler extends ActivityHandler {
                     return await this.onTeamsSoftDeleteMessage(context);
 
                 default:
-                    return this.defaultNextEvent(context)();
+                    return this.dispatchMessageDeleteActivity(context);
             }
         } else {
-            return await this.defaultNextEvent(context)();
+            return await this.dispatchMessageDeleteActivity(context);
         }
     }
 

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -688,9 +688,9 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * Called in `dispatchMessageUpdateActivity()` to trigger the `'TeamsUndeleteMessage'` handlers.
-     * Override this in a derived class to provide logic for when a message in a conversation that is
-     * observed by the bot goes from a soft delete state to the normal state.
+     * Called in `onMessageUpdateActivity()` to trigger the `'TeamsUndeleteMessage'` handlers.
+     * Override this in a derived class to provide logic for when a deleted message in a conversation is undeleted.
+     * For example, when the user decides to "undo" a deleted message.
      *
      * @param context A context object for this turn.
      * @returns A promise that represents the work queued.
@@ -700,9 +700,8 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * Called in `dispatchMessageUpdateActivity()` to trigger the `'TeamsEditMessage'` handlers.
-     * Override this in a derived class to provide logic for when a message in a conversation that is
-     * observed by the bot is edited.
+     * Called in `onMessageUpdateActivity()` to trigger the `'TeamsEditMessage'` handlers.
+     * Override this in a derived class to provide logic for when a message in a conversation is edited.
      *
      * @param context A context object for this turn.
      * @returns A promise that represents the work queued.
@@ -712,13 +711,13 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-         * Called in `dispatchMessageUpdateActivity()` to trigger the `'TeamsEditMessage'` handlers.
-         * Override this in a derived class to provide logic for when a message in a conversation that is
-         * observed by the bot is edited.
-         *
-         * @param context A context object for this turn.
-         * @returns A promise that represents the work queued.
-         */
+     * Called in `onMessageDeleteActivity()` to trigger the `'TeamsEditMessage'` handlers.
+     * Override this in a derived class to provide logic for when a message in a conversation is soft deleted.
+     * This means that the message as the option of being undeleted.
+     * 
+     * @param context A context object for this turn.
+     * @returns A promise that represents the work queued.
+     */
     protected async onTeamsSoftDeleteMessage(context: TurnContext): Promise<void> {
         await this.handle(context, 'onTeamsSoftDeleteMessage', this.defaultNextEvent(context));
     }

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -257,6 +257,34 @@ describe('TeamsActivityHandler', function () {
                 })
                 .startTest();
         });
+
+        it('should route to defaultNextEvent when channelid is not msteams', async function () {
+            let defaultNextEventCalled = false;
+            class TestActivityHandler extends TeamsActivityHandler {
+                defaultNextEvent(context) {
+                    assert(context, 'context not found');
+                    return () => {
+                        defaultNextEventCalled = true;
+                    };
+                }
+            }
+
+            const bot = new TestActivityHandler();
+
+            const adapter = new TestAdapter(async (context) => {
+                await bot.run(context);
+            });
+
+            await adapter
+                .send({
+                    type: ActivityTypes.MessageUpdate,
+                    channelId: 'not msteams',
+                })
+                .then(() => {
+                    assert(defaultNextEventCalled, 'defaultNextEvent not called');
+                })
+                .startTest();
+        });
     });
 
     describe('dispatchMessageDeleteActivity', function () {
@@ -345,6 +373,34 @@ describe('TeamsActivityHandler', function () {
 
             await adapter
                 .send(createMessageDeleteActivity('invalid subtype'))
+                .then(() => {
+                    assert(defaultNextEventCalled, 'defaultNextEvent not called');
+                })
+                .startTest();
+        });
+
+        it('should route to defaultNextEvent when channelid is not msteams', async function () {
+            let defaultNextEventCalled = false;
+            class TestActivityHandler extends TeamsActivityHandler {
+                defaultNextEvent(context) {
+                    assert(context, 'context not found');
+                    return () => {
+                        defaultNextEventCalled = true;
+                    };
+                }
+            }
+
+            const bot = new TestActivityHandler();
+
+            const adapter = new TestAdapter(async (context) => {
+                await bot.run(context);
+            });
+
+            await adapter
+                .send({
+                    type: ActivityTypes.MessageDelete,
+                    channelId: 'not msteams',
+                })
                 .then(() => {
                     assert(defaultNextEventCalled, 'defaultNextEvent not called');
                 })

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -127,7 +127,7 @@ describe('TeamsActivityHandler', function () {
 
                 class TestActivityHandler extends TeamsActivityHandler {
                     async onTeamsEditMessage(context) {
-                        assert(context, "context not found")
+                        assert(context, 'context not found');
                         onTeamsEditMessageCalled = true;
                     }
                 }
@@ -154,7 +154,7 @@ describe('TeamsActivityHandler', function () {
                         super();
 
                         this.onTeamsEditMessageEvent((context, next) => {
-                            assert(context, "context not found")
+                            assert(context, 'context not found');
                             onTeamsEditMessageEventCalled = true;
 
                             next();
@@ -183,7 +183,7 @@ describe('TeamsActivityHandler', function () {
 
                 class TestActivityHandler extends TeamsActivityHandler {
                     async onTeamsUndeleteMessage(context) {
-                        assert(context, "context not found")
+                        assert(context, 'context not found');
                         onTeamsUndeleteMessageCalled = true;
                     }
                 }
@@ -210,7 +210,7 @@ describe('TeamsActivityHandler', function () {
                         super();
 
                         this.onTeamsUndeleteMessageEvent((context, next) => {
-                            assert(context, "context not found")
+                            assert(context, 'context not found');
                             onTeamsUndeleteMessageEventCalled = true;
 
                             next();
@@ -236,9 +236,11 @@ describe('TeamsActivityHandler', function () {
         it('should route to defaultNextEvent when unrecognized subtype encountered', async function () {
             let defaultNextEventCalled = false;
             class TestActivityHandler extends TeamsActivityHandler {
-                defaultNextEvent(context){
-                    assert(context, "context not found")
-                    return () => { defaultNextEventCalled = true };
+                defaultNextEvent(context) {
+                    assert(context, 'context not found');
+                    return () => {
+                        defaultNextEventCalled = true;
+                    };
                 }
             }
 
@@ -275,7 +277,7 @@ describe('TeamsActivityHandler', function () {
 
                 class TestActivityHandler extends TeamsActivityHandler {
                     async onTeamsSoftDeleteMessage(context) {
-                        assert(context, "context not found")
+                        assert(context, 'context not found');
                         onTeamsSoftDeleteMessageCalled = true;
                     }
                 }
@@ -301,7 +303,7 @@ describe('TeamsActivityHandler', function () {
                         super();
 
                         this.onTeamsSoftDeleteMessageEvent((context, next) => {
-                            assert(context, "context not found")
+                            assert(context, 'context not found');
                             onTeamsSoftDeleteMessageEventCalled = true;
 
                             next();
@@ -327,9 +329,11 @@ describe('TeamsActivityHandler', function () {
         it('should route to defaultNextEvent when unrecognized subtype encountered', async function () {
             let defaultNextEventCalled = false;
             class TestActivityHandler extends TeamsActivityHandler {
-                defaultNextEvent(context){
-                    assert(context, "context not found")
-                    return () => { defaultNextEventCalled = true };
+                defaultNextEvent(context) {
+                    assert(context, 'context not found');
+                    return () => {
+                        defaultNextEventCalled = true;
+                    };
                 }
             }
 

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -121,14 +121,14 @@ describe('TeamsActivityHandler', function () {
             return activity;
         }
 
-        describe('routing to onTeamsEditMessage', function () {
-            it('should route to onTeamsEditMessage method', async function () {
-                let onTeamsEditMessageCalled = false;
+        describe('routing to onTeamsMessageEdit', function () {
+            it('should route to onTeamsMessageEdit method', async function () {
+                let onTeamsMessageEditCalled = false;
 
                 class TestActivityHandler extends TeamsActivityHandler {
-                    async onTeamsEditMessage(context) {
+                    async onTeamsMessageEdit(context) {
                         assert(context, 'context not found');
-                        onTeamsEditMessageCalled = true;
+                        onTeamsMessageEditCalled = true;
                     }
                 }
 
@@ -141,21 +141,21 @@ describe('TeamsActivityHandler', function () {
                 await adapter
                     .send(createMessageUpdateActivity('editMessage'))
                     .then(() => {
-                        assert(onTeamsEditMessageCalled, 'onTeamsEditMessage handler not called');
+                        assert(onTeamsMessageEditCalled, 'onTeamsMessageEdit handler not called');
                     })
                     .startTest();
             });
 
-            it('should route to onTeamsEditMessageEvent registered handlers', async function () {
-                let onTeamsEditMessageEventCalled = false;
+            it('should route to onTeamsMessageEditEvent registered handlers', async function () {
+                let onTeamsMessageEditEventCalled = false;
 
                 class TestActivityHandler extends TeamsActivityHandler {
                     constructor() {
                         super();
 
-                        this.onTeamsEditMessageEvent((context, next) => {
+                        this.onTeamsMessageEditEvent((context, next) => {
                             assert(context, 'context not found');
-                            onTeamsEditMessageEventCalled = true;
+                            onTeamsMessageEditEventCalled = true;
 
                             next();
                         });
@@ -171,20 +171,20 @@ describe('TeamsActivityHandler', function () {
                 await adapter
                     .send(createMessageUpdateActivity('editMessage'))
                     .then(() => {
-                        assert(onTeamsEditMessageEventCalled, 'onTeamsEditMessageEvent handler not called');
+                        assert(onTeamsMessageEditEventCalled, 'onTeamsMessageEditEvent handler not called');
                     })
                     .startTest();
             });
         });
 
-        describe('routing to onTeamsUndeleteMessage', function () {
-            it('should route to onTeamsUndeleteMessage', async function () {
-                let onTeamsUndeleteMessageCalled = false;
+        describe('routing to onTeamsMessageUndelete', function () {
+            it('should route to onTeamsMessageUndelete', async function () {
+                let onTeamsMessageUndeleteCalled = false;
 
                 class TestActivityHandler extends TeamsActivityHandler {
-                    async onTeamsUndeleteMessage(context) {
+                    async onTeamsMessageUndelete(context) {
                         assert(context, 'context not found');
-                        onTeamsUndeleteMessageCalled = true;
+                        onTeamsMessageUndeleteCalled = true;
                     }
                 }
 
@@ -197,21 +197,21 @@ describe('TeamsActivityHandler', function () {
                 await adapter
                     .send(createMessageUpdateActivity('undeleteMessage'))
                     .then(() => {
-                        assert(onTeamsUndeleteMessageCalled, 'onTeamsUndeleteMessage handler not called');
+                        assert(onTeamsMessageUndeleteCalled, 'onTeamsMessageUndelete handler not called');
                     })
                     .startTest();
             });
 
-            it('should route to onTeamsUndeleteMessageEvent registered handlers', async function () {
-                let onTeamsUndeleteMessageEventCalled = false;
+            it('should route to onTeamsMessageUndeleteEvent registered handlers', async function () {
+                let onTeamsMessageUndeleteEventCalled = false;
 
                 class TestActivityHandler extends TeamsActivityHandler {
                     constructor() {
                         super();
 
-                        this.onTeamsUndeleteMessageEvent((context, next) => {
+                        this.onTeamsMessageUndeleteEvent((context, next) => {
                             assert(context, 'context not found');
-                            onTeamsUndeleteMessageEventCalled = true;
+                            onTeamsMessageUndeleteEventCalled = true;
 
                             next();
                         });
@@ -227,7 +227,7 @@ describe('TeamsActivityHandler', function () {
                 await adapter
                     .send(createMessageUpdateActivity('undeleteMessage'))
                     .then(() => {
-                        assert(onTeamsUndeleteMessageEventCalled, 'onTeamsUndeleteMessageEvent handler not called');
+                        assert(onTeamsMessageUndeleteEventCalled, 'onTeamsMessageUndeleteEvent handler not called');
                     })
                     .startTest();
             });
@@ -299,14 +299,14 @@ describe('TeamsActivityHandler', function () {
             return activity;
         }
 
-        describe('routing to onTeamsSoftDeleteMessage', function () {
-            it('should route to onTeamsSoftDeleteMessage', async function () {
-                let onTeamsSoftDeleteMessageCalled = false;
+        describe('routing to onTeamsMessageSoftDelete', function () {
+            it('should route to onTeamsMessageSoftDelete', async function () {
+                let onTeamsMessageSoftDeleteCalled = false;
 
                 class TestActivityHandler extends TeamsActivityHandler {
-                    async onTeamsSoftDeleteMessage(context) {
+                    async onTeamsMessageSoftDelete(context) {
                         assert(context, 'context not found');
-                        onTeamsSoftDeleteMessageCalled = true;
+                        onTeamsMessageSoftDeleteCalled = true;
                     }
                 }
 
@@ -319,20 +319,20 @@ describe('TeamsActivityHandler', function () {
                 await adapter
                     .send(createMessageDeleteActivity('softDeleteMessage'))
                     .then(() => {
-                        assert(onTeamsSoftDeleteMessageCalled, 'onTeamsSoftDeleteMessage handler not called');
+                        assert(onTeamsMessageSoftDeleteCalled, 'onTeamsMessageSoftDelete handler not called');
                     })
                     .startTest();
             });
 
-            it('should route to onTeamsSoftDeleteMessageEvent registered handlers', async function () {
-                let onTeamsSoftDeleteMessageEventCalled = false;
+            it('should route to onTeamsMessageSoftDeleteEvent registered handlers', async function () {
+                let onTeamsMessageSoftDeleteEventCalled = false;
                 class TestActivityHandler extends TeamsActivityHandler {
                     constructor() {
                         super();
 
-                        this.onTeamsSoftDeleteMessageEvent((context, next) => {
+                        this.onTeamsMessageSoftDeleteEvent((context, next) => {
                             assert(context, 'context not found');
-                            onTeamsSoftDeleteMessageEventCalled = true;
+                            onTeamsMessageSoftDeleteEventCalled = true;
 
                             next();
                         });
@@ -348,7 +348,7 @@ describe('TeamsActivityHandler', function () {
                 await adapter
                     .send(createMessageDeleteActivity('softDeleteMessage'))
                     .then(() => {
-                        assert(onTeamsSoftDeleteMessageEventCalled, 'onTeamsSoftDeleteMessageEvent handler not called');
+                        assert(onTeamsMessageSoftDeleteEventCalled, 'onTeamsMessageSoftDeleteEvent handler not called');
                     })
                     .startTest();
             });

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -62,7 +62,7 @@ describe('TeamsActivityHandler', function () {
                 .startTest();
         });
 
-        it.only('should call onMessageUpdateActivity when the activity type is messageUpdate', async function (){
+        it('should call onMessageUpdateActivity when the activity type is messageUpdate', async function (){
             const msg = "hi";
             class TestActivityHandler extends TeamsActivityHandler {
                 async onMessageUpdateActivity(context) {
@@ -85,7 +85,7 @@ describe('TeamsActivityHandler', function () {
                 .startTest();
         });
 
-        it.only('should call onMessageDeleteActivity when the activity type is messageDelete', async function (){
+        it('should call onMessageDeleteActivity when the activity type is messageDelete', async function (){
             const msg = "hi";
             class TestActivityHandler extends TeamsActivityHandler {
                 async onMessageDeleteActivity(context) {
@@ -109,7 +109,7 @@ describe('TeamsActivityHandler', function () {
         });
     });
 
-    describe.only('dispatchMessageUpdateActivity', function () {
+    describe('dispatchMessageUpdateActivity', function () {
         function createMessageUpdateActivity(channelDataEventType) {
             const activity = {
                 type: ActivityTypes.MessageUpdate,
@@ -230,7 +230,7 @@ describe('TeamsActivityHandler', function () {
         })
     })
 
-    describe.only('dispatchMessageDeleteActivity', function () {
+    describe('dispatchMessageDeleteActivity', function () {
         function createMessageDeleteActivity(channelDataEventType) {
             const activity = {
                 type: ActivityTypes.MessageDelete,

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -62,48 +62,48 @@ describe('TeamsActivityHandler', function () {
                 .startTest();
         });
 
-        it('should call onMessageUpdateActivity when the activity type is messageUpdate', async function (){
-            const msg = "hi";
+        it('should call onMessageUpdateActivity when the activity type is messageUpdate', async function () {
+            const msg = 'hi';
             class TestActivityHandler extends TeamsActivityHandler {
                 async onMessageUpdateActivity(context) {
-                    await context.sendActivity({type: context.activity.type, text: msg});
+                    await context.sendActivity({ type: context.activity.type, text: msg });
                 }
             }
-            
+
             const bot = new TestActivityHandler();
 
             const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
-            })
+            });
 
             await adapter
-                .send({ type: ActivityTypes.MessageUpdate})
+                .send({ type: ActivityTypes.MessageUpdate })
                 .assertReply((activity) => {
                     assert.strictEqual(activity.type, ActivityTypes.MessageUpdate);
-                    assert.strictEqual(activity.text, msg)
+                    assert.strictEqual(activity.text, msg);
                 })
                 .startTest();
         });
 
-        it('should call onMessageDeleteActivity when the activity type is messageDelete', async function (){
-            const msg = "hi";
+        it('should call onMessageDeleteActivity when the activity type is messageDelete', async function () {
+            const msg = 'hi';
             class TestActivityHandler extends TeamsActivityHandler {
                 async onMessageDeleteActivity(context) {
-                    await context.sendActivity({type: context.activity.type, text: msg});
+                    await context.sendActivity({ type: context.activity.type, text: msg });
                 }
             }
-            
+
             const bot = new TestActivityHandler();
 
             const adapter = new TestAdapter(async (context) => {
                 await bot.run(context);
-            })
+            });
 
             await adapter
-                .send({ type: ActivityTypes.MessageDelete})
+                .send({ type: ActivityTypes.MessageDelete })
                 .assertReply((activity) => {
                     assert.strictEqual(activity.type, ActivityTypes.MessageDelete);
-                    assert.strictEqual(activity.text, msg)
+                    assert.strictEqual(activity.text, msg);
                 })
                 .startTest();
         });
@@ -114,188 +114,187 @@ describe('TeamsActivityHandler', function () {
             const activity = {
                 type: ActivityTypes.MessageUpdate,
                 channelData: {
-                    eventType: channelDataEventType
+                    eventType: channelDataEventType,
                 },
                 channelId: 'msteams',
             };
             return activity;
         }
 
-        describe('routing to onTeamsEditMessage', () => {
+        describe('routing to onTeamsEditMessage', function () {
             it('should route to onTeamsEditMessage method', async function () {
-                var onTeamsEditMessageCalled = false;
-    
+                let onTeamsEditMessageCalled = false;
+
                 class TestActivityHandler extends TeamsActivityHandler {
-                    async onTeamsEditMessage(context) {
+                    async onTeamsEditMessage() {
                         onTeamsEditMessageCalled = true;
                     }
                 }
-                
+
                 const bot = new TestActivityHandler();
-    
+
                 const adapter = new TestAdapter(async (context) => {
                     await bot.run(context);
-                })
-    
+                });
+
                 await adapter
-                    .send(createMessageUpdateActivity("editMessage"))
+                    .send(createMessageUpdateActivity('editMessage'))
                     .then(() => {
-                        assert(onTeamsEditMessageCalled, "onTeamsEditMessage handler not called");
+                        assert(onTeamsEditMessageCalled, 'onTeamsEditMessage handler not called');
                     })
                     .startTest();
-            })
+            });
 
             it('should route to onTeamsEditMessageEvent registered handlers', async function () {
-                var onTeamsEditMessageEventCalled = false;
-    
+                let onTeamsEditMessageEventCalled = false;
+
                 class TestActivityHandler extends TeamsActivityHandler {
-                    constructor () {
-                        super()
+                    constructor() {
+                        super();
 
                         this.onTeamsEditMessageEvent((context, next) => {
                             onTeamsEditMessageEventCalled = true;
 
                             next();
-                        })
+                        });
                     }
                 }
-                
+
                 const bot = new TestActivityHandler();
-    
+
                 const adapter = new TestAdapter(async (context) => {
                     await bot.run(context);
-                })
-    
+                });
+
                 await adapter
-                    .send(createMessageUpdateActivity("editMessage"))
+                    .send(createMessageUpdateActivity('editMessage'))
                     .then(() => {
-                        assert(onTeamsEditMessageEventCalled, "onTeamsEditMessageEvent handler not called");
+                        assert(onTeamsEditMessageEventCalled, 'onTeamsEditMessageEvent handler not called');
                     })
                     .startTest();
-            })
-        })
+            });
+        });
 
-        describe('routing to onTeamsUndeleteMessage', () => {
+        describe('routing to onTeamsUndeleteMessage', function () {
             it('should route to onTeamsUndeleteMessage', async function () {
-                var onTeamsUndeleteMessageCalled = false;
-    
+                let onTeamsUndeleteMessageCalled = false;
+
                 class TestActivityHandler extends TeamsActivityHandler {
-                    async onTeamsUndeleteMessage(context) {
+                    async onTeamsUndeleteMessage() {
                         onTeamsUndeleteMessageCalled = true;
                     }
                 }
-                
+
                 const bot = new TestActivityHandler();
-    
+
                 const adapter = new TestAdapter(async (context) => {
                     await bot.run(context);
-                })
-    
+                });
+
                 await adapter
-                    .send(createMessageUpdateActivity("undeleteMessage"))
+                    .send(createMessageUpdateActivity('undeleteMessage'))
                     .then(() => {
-                        assert(onTeamsUndeleteMessageCalled, "onTeamsUndeleteMessage handler not called");
+                        assert(onTeamsUndeleteMessageCalled, 'onTeamsUndeleteMessage handler not called');
                     })
                     .startTest();
-            })
-    
+            });
+
             it('should route to onTeamsUndeleteMessageEvent registered handlers', async function () {
-                var onTeamsUndeleteMessageEventCalled = false;
-    
+                let onTeamsUndeleteMessageEventCalled = false;
+
                 class TestActivityHandler extends TeamsActivityHandler {
-                    constructor () {
-                        super()
-                        
+                    constructor() {
+                        super();
+
                         this.onTeamsUndeleteMessageEvent((context, next) => {
                             onTeamsUndeleteMessageEventCalled = true;
-    
+
                             next();
-                        })
+                        });
                     }
                 }
-                
+
                 const bot = new TestActivityHandler();
-    
+
                 const adapter = new TestAdapter(async (context) => {
                     await bot.run(context);
-                })
-    
+                });
+
                 await adapter
-                    .send(createMessageUpdateActivity("undeleteMessage"))
+                    .send(createMessageUpdateActivity('undeleteMessage'))
                     .then(() => {
-                        assert(onTeamsUndeleteMessageEventCalled, "onTeamsUndeleteMessageEvent handler not called");
+                        assert(onTeamsUndeleteMessageEventCalled, 'onTeamsUndeleteMessageEvent handler not called');
                     })
                     .startTest();
-            })    
-        })
-    })
+            });
+        });
+    });
 
     describe('dispatchMessageDeleteActivity', function () {
         function createMessageDeleteActivity(channelDataEventType) {
             const activity = {
                 type: ActivityTypes.MessageDelete,
                 channelData: {
-                    eventType: channelDataEventType
+                    eventType: channelDataEventType,
                 },
                 channelId: 'msteams',
             };
             return activity;
         }
 
-        describe('routing to onTeamsSoftDeleteMessage', () => {
+        describe('routing to onTeamsSoftDeleteMessage', function () {
             it('should route to onTeamsSoftDeleteMessage', async function () {
-                var onTeamsSoftDeleteMessageCalled = false;
-    
+                let onTeamsSoftDeleteMessageCalled = false;
+
                 class TestActivityHandler extends TeamsActivityHandler {
-                    async onTeamsSoftDeleteMessage(context) {
+                    async onTeamsSoftDeleteMessage() {
                         onTeamsSoftDeleteMessageCalled = true;
                     }
                 }
-                
+
                 const bot = new TestActivityHandler();
-    
+
                 const adapter = new TestAdapter(async (context) => {
                     await bot.run(context);
-                })
-    
+                });
+
                 await adapter
-                    .send(createMessageDeleteActivity("softDeleteMessage"))
+                    .send(createMessageDeleteActivity('softDeleteMessage'))
                     .then(() => {
-                        assert(onTeamsSoftDeleteMessageCalled, "onTeamsSoftDeleteMessage handler not called");
+                        assert(onTeamsSoftDeleteMessageCalled, 'onTeamsSoftDeleteMessage handler not called');
                     })
                     .startTest();
-            })
+            });
 
             it('should route to onTeamsSoftDeleteMessageEvent registered handlers', async function () {
-                var onTeamsSoftDeleteMessageEventCalled = false;
+                let onTeamsSoftDeleteMessageEventCalled = false;
                 class TestActivityHandler extends TeamsActivityHandler {
-                    constructor () {
-                        super()
-                        
+                    constructor() {
+                        super();
+
                         this.onTeamsSoftDeleteMessageEvent((context, next) => {
                             onTeamsSoftDeleteMessageEventCalled = true;
-    
+
                             next();
-                        })
+                        });
                     }
                 }
-                
+
                 const bot = new TestActivityHandler();
-    
+
                 const adapter = new TestAdapter(async (context) => {
                     await bot.run(context);
-                })
-    
+                });
+
                 await adapter
-                    .send(createMessageDeleteActivity("softDeleteMessage"))
+                    .send(createMessageDeleteActivity('softDeleteMessage'))
                     .then(() => {
-                        assert(onTeamsSoftDeleteMessageEventCalled, "onTeamsSoftDeleteMessageEvent handler not called");
+                        assert(onTeamsSoftDeleteMessageEventCalled, 'onTeamsSoftDeleteMessageEvent handler not called');
                     })
                     .startTest();
-            })    
-
-        })
-    })
+            });
+        });
+    });
 
     describe('onInvokeActivity()', function () {
         class InvokeActivityEmptyHandlers extends TeamsActivityHandler {

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -109,7 +109,7 @@ describe('TeamsActivityHandler', function () {
         });
     });
 
-    describe.only('onMessageUpdateActivity', function () {
+    describe.only('dispatchMessageUpdateActivity', function () {
         function createMessageUpdateActivity(channelDataEventType) {
             const activity = {
                 type: ActivityTypes.MessageUpdate,
@@ -228,32 +228,9 @@ describe('TeamsActivityHandler', function () {
                     .startTest();
             })    
         })
-
-        it('should route to defaultNextEvent if it is a non-existent subtype', async function () {
-            var routedToDefaultNextEvent = false;
-
-            class TestActivityHandler extends TeamsActivityHandler {
-                defaultNextEvent(context){
-                    return () => { routedToDefaultNextEvent = true };
-                }
-            }
-            
-            const bot = new TestActivityHandler();
-
-            const adapter = new TestAdapter(async (context) => {
-                await bot.run(context);
-            })
-
-            await adapter
-                .send(createMessageUpdateActivity("nonexistent-subtype"))
-                .then(() => {
-                    assert(routedToDefaultNextEvent, "did not route to the default next event not called");
-                })
-                .startTest();
-        })
     })
 
-    describe.only('onMessageDeleteActivity', function () {
+    describe.only('dispatchMessageDeleteActivity', function () {
         function createMessageDeleteActivity(channelDataEventType) {
             const activity = {
                 type: ActivityTypes.MessageDelete,
@@ -317,28 +294,6 @@ describe('TeamsActivityHandler', function () {
                     .startTest();
             })    
 
-        })
-
-        it('should route to defaultNextEvent if it is a non-existent subtype', async function () {
-            var routedToDefaultNextEvent = false;
-            class TestActivityHandler extends TeamsActivityHandler {
-                defaultNextEvent(context){
-                    return () => { routedToDefaultNextEvent = true };
-                }
-            }
-            
-            const bot = new TestActivityHandler();
-
-            const adapter = new TestAdapter(async (context) => {
-                await bot.run(context);
-            })
-
-            await adapter
-                .send(createMessageDeleteActivity("nonexistent-subtype"))
-                .then(() => {
-                    assert(routedToDefaultNextEvent, "did not route to the default next event not called");
-                })
-                .startTest();
         })
     })
 

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -126,7 +126,8 @@ describe('TeamsActivityHandler', function () {
                 let onTeamsEditMessageCalled = false;
 
                 class TestActivityHandler extends TeamsActivityHandler {
-                    async onTeamsEditMessage() {
+                    async onTeamsEditMessage(context) {
+                        assert(context, "context not found")
                         onTeamsEditMessageCalled = true;
                     }
                 }
@@ -153,6 +154,7 @@ describe('TeamsActivityHandler', function () {
                         super();
 
                         this.onTeamsEditMessageEvent((context, next) => {
+                            assert(context, "context not found")
                             onTeamsEditMessageEventCalled = true;
 
                             next();
@@ -180,7 +182,8 @@ describe('TeamsActivityHandler', function () {
                 let onTeamsUndeleteMessageCalled = false;
 
                 class TestActivityHandler extends TeamsActivityHandler {
-                    async onTeamsUndeleteMessage() {
+                    async onTeamsUndeleteMessage(context) {
+                        assert(context, "context not found")
                         onTeamsUndeleteMessageCalled = true;
                     }
                 }
@@ -207,6 +210,7 @@ describe('TeamsActivityHandler', function () {
                         super();
 
                         this.onTeamsUndeleteMessageEvent((context, next) => {
+                            assert(context, "context not found")
                             onTeamsUndeleteMessageEventCalled = true;
 
                             next();
@@ -228,6 +232,29 @@ describe('TeamsActivityHandler', function () {
                     .startTest();
             });
         });
+
+        it('should route to defaultNextEvent when unrecognized subtype encountered', async function () {
+            let defaultNextEventCalled = false;
+            class TestActivityHandler extends TeamsActivityHandler {
+                defaultNextEvent(context){
+                    assert(context, "context not found")
+                    return () => { defaultNextEventCalled = true };
+                }
+            }
+
+            const bot = new TestActivityHandler();
+
+            const adapter = new TestAdapter(async (context) => {
+                await bot.run(context);
+            });
+
+            await adapter
+                .send(createMessageUpdateActivity('invalid subtype'))
+                .then(() => {
+                    assert(defaultNextEventCalled, 'defaultNextEvent not called');
+                })
+                .startTest();
+        });
     });
 
     describe('dispatchMessageDeleteActivity', function () {
@@ -247,7 +274,8 @@ describe('TeamsActivityHandler', function () {
                 let onTeamsSoftDeleteMessageCalled = false;
 
                 class TestActivityHandler extends TeamsActivityHandler {
-                    async onTeamsSoftDeleteMessage() {
+                    async onTeamsSoftDeleteMessage(context) {
+                        assert(context, "context not found")
                         onTeamsSoftDeleteMessageCalled = true;
                     }
                 }
@@ -273,6 +301,7 @@ describe('TeamsActivityHandler', function () {
                         super();
 
                         this.onTeamsSoftDeleteMessageEvent((context, next) => {
+                            assert(context, "context not found")
                             onTeamsSoftDeleteMessageEventCalled = true;
 
                             next();
@@ -293,6 +322,29 @@ describe('TeamsActivityHandler', function () {
                     })
                     .startTest();
             });
+        });
+
+        it('should route to defaultNextEvent when unrecognized subtype encountered', async function () {
+            let defaultNextEventCalled = false;
+            class TestActivityHandler extends TeamsActivityHandler {
+                defaultNextEvent(context){
+                    assert(context, "context not found")
+                    return () => { defaultNextEventCalled = true };
+                }
+            }
+
+            const bot = new TestActivityHandler();
+
+            const adapter = new TestAdapter(async (context) => {
+                await bot.run(context);
+            });
+
+            await adapter
+                .send(createMessageDeleteActivity('invalid subtype'))
+                .then(() => {
+                    assert(defaultNextEventCalled, 'defaultNextEvent not called');
+                })
+                .startTest();
         });
     });
 


### PR DESCRIPTION
This PR aims to extend the Bot SDK so that developers can consume newly added events that Teams will emit to the bot. They are:

`TeamsMessageEdit` - a user editing a message in Teams.
`TeamsMessageUndelete` - a user undo-ing a deleted message in Teams.
`TeamsMessageSoftDelete` - a user deleting a message in Teams.

Closes #4375

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
* Extended `ActivityHandlerBase` to handle `MessageUpdate` and `MessageDelete` activity types
* Extended `ActivityHandler` to handle `MessageUpdate` and `MessageDelete` activity types and dispatch functions for subtypes.
* Extended `TeamsActivityHandler` to handle `MessageUpdate` (with subtypes `TeamsMessageEdit` and `TeamsMessageUndelete`) and `MessageDelete` (with subtype `TeamsMessageSoftDelete`) teams events.


## Specific Changes
<!-- Please list the changes in a concise manner. -->
* Ran `yarn build:rollup` on both the `botbuilder` and `botbuilder-core` libraries to generate public api doc.


### ActivityHandlerBase class
  - Updated switch statement to handle `MessageUpdate` and `MessageDelete` 
  - Defined `onMessageUpdateActivity` and `onMessageDeleteActivity` methods
  - the changes conform to existing convention and are synonymous to the `Message` activity event.

### ActivityHandler class
  - Implemented event handler registration methods `onMessageUpdate` and `onMessageDelete` 
  - Implemented hooks `onMessageUpdateActivity` and `onMessageDeleteActivity` to mirror `onConversationUpdateActivity`
  - Implemented subtype dispatch functions `dispatchMessageUpdateAcitivty` and `dispatchMessageDeleteActivity`. They conform to existing convention (ex. `onConversationUpdateActivity`).

### TeamsActivityHandler class
  - Extended `dispatchMessageUpdateActivity` to handle subtypes `onTeamsMessageEdit` & `onTeamsMessageUndelete`.
  - Extended `dispatchMessageDeleteActivity` to handle subtypes `onTeamsSoftDelete`.
  - Implemented event handler registration methods `onTeamsMessageEditEvent`, `onTeamsMessageUndeleteEvent` and `onTeamsMessageSoftDeleteEvent`.
  - Implemented methods `onTeamsMessageEdit`, `onTeamsMessageUndelete` and `onTeamsMessageSoftDelete` that are dispatched by the respective dispatch methods.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
  - Added unit tests for changes in all the three classes.