### PR TITLE
port: [#4351] Throwing for invalid runtimeSettings.storage values or missing storage config (#6533)

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-runtime/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/src/index.ts
@@ -215,7 +215,14 @@ function addStorage(services: ServiceCollection, configuration: Configuration): 
                 });
             }
 
+            case 'Memory': {
+                return new MemoryStorage();
+            }
+
             default:
+                if (storage) {
+                    throw new TypeError('Invalid runtime.storage value');
+                }
                 return new MemoryStorage();
         }
     });

--- a/libraries/botbuilder-dialogs-adaptive-runtime/test/index.test.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime/test/index.test.ts
@@ -86,8 +86,31 @@ describe('getRuntimeServices', function () {
     });
 
     describe('storage', function () {
+        it('throws error for wrong storage settings', async function () {
+            const configuration = new Configuration().argv().env();
+
+            configuration.set(['runtimeSettings', 'storage'], 'WrongStorage');
+
+            await rejects(async () => {
+                const [services] = await getRuntimeServices(__dirname, configuration);
+                const _ = services.mustMakeInstance('storage');
+            }, new TypeError('Invalid runtime.storage value'));
+        });
+
         it('defaults to memory storage', async function () {
             const [services] = await getRuntimeServices(__dirname, __dirname);
+            ok(services);
+
+            const storage = services.mustMakeInstance('storage');
+            ok(storage instanceof MemoryStorage);
+        });
+
+        it('supports memory storage', async function () {
+            const configuration = new Configuration().argv().env();
+
+            configuration.set(['runtimeSettings', 'storage'], 'Memory');
+
+            const [services] = await getRuntimeServices(__dirname, configuration);
             ok(services);
 
             const storage = services.mustMakeInstance('storage');


### PR DESCRIPTION
Fixes #4351

## Description
This PR ports the changes from .NET [PR#6533](https://github.com/microsoft/botbuilder-dotnet/pull/6533) to throw an error if the storage value of the _runtimeSettings_ does not match any of the possible values. Only defaults to _MemoryStorage_ for an empty/missing storage value.

## Specific Changes
- Updated default case in **_addStorage_** function of `botbuilder-dialogs-adaptive-runtime/index.ts`.
- Updated a unit test and added two new ones to cover the new scenario in `botbuilder-dialogs-adaptive-runtime/test/index.test.ts`.

## Testing
This image shows the new unit tests passing.
![image](https://user-images.githubusercontent.com/44245136/205369726-463f1bbe-9688-4756-aa86-54d85abca771.png)
