### PR TITLE
feat: send targeted meeting notification in Teams meetings

### DIFF
--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -70,6 +70,8 @@ import { TeamDetails } from 'botbuilder-core';
 import { TeamInfo } from 'botbuilder-core';
 import { TeamsChannelAccount } from 'botbuilder-core';
 import { TeamsMeetingInfo } from 'botbuilder-core';
+import { TeamsMeetingNotification } from 'botbuilder-core';
+import { TeamsMeetingNotificationRecipientFailureInfos } from 'botbuilder-core';
 import { TeamsMeetingParticipant } from 'botbuilder-core';
 import { TeamsPagedMembersResult } from 'botbuilder-core';
 import { TenantInfo } from 'botbuilder-core';
@@ -448,6 +450,8 @@ export class TeamsInfo {
     static getTeamMember(context: TurnContext, teamId?: string, userId?: string): Promise<TeamsChannelAccount>;
     // @deprecated
     static getTeamMembers(context: TurnContext, teamId?: string): Promise<TeamsChannelAccount[]>;
+    // (undocumented)
+    static sendMeetingNotification(context: TurnContext, notification: TeamsMeetingNotification, meetingId?: string): Promise<TeamsMeetingNotificationRecipientFailureInfos | {}>;
     static sendMessageToTeamsChannel(context: TurnContext, activity: Activity, teamsChannelId: string, botAppId?: string): Promise<[ConversationReference, string]>;
 }
 

--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -450,7 +450,6 @@ export class TeamsInfo {
     static getTeamMember(context: TurnContext, teamId?: string, userId?: string): Promise<TeamsChannelAccount>;
     // @deprecated
     static getTeamMembers(context: TurnContext, teamId?: string): Promise<TeamsChannelAccount[]>;
-    // (undocumented)
     static sendMeetingNotification(context: TurnContext, notification: TeamsMeetingNotification, meetingId?: string): Promise<TeamsMeetingNotificationRecipientFailureInfos | {}>;
     static sendMessageToTeamsChannel(context: TurnContext, activity: Activity, teamsChannelId: string, botAppId?: string): Promise<[ConversationReference, string]>;
 }

--- a/libraries/botbuilder/src/teamsInfo.ts
+++ b/libraries/botbuilder/src/teamsInfo.ts
@@ -333,6 +333,22 @@ export class TeamsInfo {
         return await this.getMemberInternal(this.getConnectorClient(context), t, userId);
     }
 
+    // TODO: Update types
+    static async sendMeetingNotification(context: TurnContext, notification: any, meetingId?: string): Promise<any> {
+        const activity = context.activity;
+
+        if (meetingId == null) {
+            const meeting = teamsGetTeamMeetingInfo(activity);
+            meetingId = meeting?.id;
+        }
+
+        if (!meetingId) {
+            throw new Error('meetingId is required.');
+        }
+
+        return await this.getTeamsConnectorClient(context).teams.sendMeetingNotification(meetingId, notification);
+    }
+
     /**
      * @private
      */

--- a/libraries/botbuilder/src/teamsInfo.ts
+++ b/libraries/botbuilder/src/teamsInfo.ts
@@ -22,6 +22,8 @@ import {
     TeamsMeetingParticipant,
     TeamsMeetingInfo,
     Channels,
+    TeamsMeetingNotification,
+    TeamsMeetingNotificationRecipientFailureInfos,
 } from 'botbuilder-core';
 import { ConnectorClient, TeamsConnectorClient, TeamsConnectorModels } from 'botframework-connector';
 
@@ -333,8 +335,7 @@ export class TeamsInfo {
         return await this.getMemberInternal(this.getConnectorClient(context), t, userId);
     }
 
-    // TODO: Update types
-    static async sendMeetingNotification(context: TurnContext, notification: any, meetingId?: string): Promise<any> {
+    static async sendMeetingNotification(context: TurnContext, notification: TeamsMeetingNotification, meetingId?: string): Promise<TeamsMeetingNotificationRecipientFailureInfos | {}> {
         const activity = context.activity;
 
         if (meetingId == null) {

--- a/libraries/botbuilder/src/teamsInfo.ts
+++ b/libraries/botbuilder/src/teamsInfo.ts
@@ -335,7 +335,21 @@ export class TeamsInfo {
         return await this.getMemberInternal(this.getConnectorClient(context), t, userId);
     }
 
-    static async sendMeetingNotification(context: TurnContext, notification: TeamsMeetingNotification, meetingId?: string): Promise<TeamsMeetingNotificationRecipientFailureInfos | {}> {
+    /**
+     * Sends a meeting notification to specific users in a Teams meeting.
+     *
+     * @param context The [TurnContext](xref:botbuilder-core.TurnContext) for this turn.
+     * @param notification The meeting notification payload.
+     * @param meetingId Id of the Teams meeting.
+     * @returns Promise with either an empty object if notifications were successfully sent to all recipients or
+     * [TeamsMeetingNotificationRecipientFailureInfos](xref:botframework-schema.TeamsMeetingNotificationRecipientFailureInfos) if notifications
+     * were sent to some but not all recipients.
+     */
+    static async sendMeetingNotification(
+        context: TurnContext,
+        notification: TeamsMeetingNotification,
+        meetingId?: string
+    ): Promise<TeamsMeetingNotificationRecipientFailureInfos | {}> {
         const activity = context.activity;
 
         if (meetingId == null) {

--- a/libraries/botbuilder/tests/teamsInfo.test.js
+++ b/libraries/botbuilder/tests/teamsInfo.test.js
@@ -954,128 +954,131 @@ describe('TeamsInfo', function () {
     });
 
     describe('sendTeamsMeetingNotification()', function () {
-        it("should correctly map notification object as the request body of the POST request", async () => {
+        it('should correctly map notification object as the request body of the POST request', async function () {
             const notification = {
-                type: "targetedMeetingNotification",
+                type: 'targetedMeetingNotification',
                 value: {
-                    recipients: [
-                        "8:orgid:3c493705-8971-4e22-9830-967ad65cc74a",
-                        ],
+                    recipients: ['random recipient id'],
                     surfaces: [
                         {
-                        surface: "meetingStage",
-                        contentType: "task",
-                        content: {
-                            value: {
-                            height: "3",
-                            width: "4",
-                            title: "this is Yunny's test",
-                            url: "https://www.bing.com"
-                            }
-                        }
-                        }
-                    ]
+                            surface: 'meetingStage',
+                            contentType: 'task',
+                            content: {
+                                value: {
+                                    height: '3',
+                                    width: '4',
+                                    title: "this is Johnny's test",
+                                    url: 'https://www.bing.com',
+                                },
+                            },
+                        },
+                    ],
                 },
                 channelData: {
-                  onBehalfOf: [ // support for user attributions
-                    {
-                      itemid: 0,
-                      mentionType: "person",
-                      mri: "8:orgid:cf41f188-30ee-4698-9a65-8af95b9eb9c3",
-                      displayName: "MOD Administrator"
-                    }
-                  ]
-                }
-              };
-            const meetingId = "randomGUID";
+                    onBehalfOf: [
+                        // support for user attributions
+                        {
+                            itemid: 0,
+                            mentionType: 'person',
+                            mri: 'random admin',
+                            displayName: 'admin',
+                        },
+                    ],
+                },
+            };
+            const meetingId = 'randomGUID';
             const { expectedAuthHeader, expectation: fetchOauthToken } = nockOauth();
 
             const sendTeamsMeetingNotificationExpectation = nock('https://smba.trafficmanager.net/amer')
-            .post(`/v1/meetings/${meetingId}/notification`, notification)
-            .matchHeader('Authorization', expectedAuthHeader)
-            .reply(202, {});
+                .post(`/v1/meetings/${meetingId}/notification`, notification)
+                .matchHeader('Authorization', expectedAuthHeader)
+                .reply(202, {});
 
-            
             const context = new TestContext(teamActivity);
             context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
             // if notification object wasn't passed as request body, test would fail
-            const sendTeamsMeetingNotification = await TeamsInfo.sendMeetingNotification(context, notification, meetingId);
+            await TeamsInfo.sendMeetingNotification(context, notification, meetingId);
 
             assert(fetchOauthToken.isDone());
             assert(sendTeamsMeetingNotificationExpectation.isDone());
-        })
+        });
 
-        it("should return an empty object if a 202 status code was returned", async function () {
+        it('should return an empty object if a 202 status code was returned', async function () {
             const notification = {};
-            const meetingId = "randomGUID";
+            const meetingId = 'randomGUID';
             const { expectedAuthHeader, expectation: fetchOauthToken } = nockOauth();
 
             const sendTeamsMeetingNotificationExpectation = nock('https://smba.trafficmanager.net/amer')
-            .post(`/v1/meetings/${meetingId}/notification`, notification)
-            .matchHeader('Authorization', expectedAuthHeader)
-            .reply(202, {});
+                .post(`/v1/meetings/${meetingId}/notification`, notification)
+                .matchHeader('Authorization', expectedAuthHeader)
+                .reply(202, {});
 
-            
             const context = new TestContext(teamActivity);
             context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
-            const sendTeamsMeetingNotification = await TeamsInfo.sendMeetingNotification(context, notification, meetingId);
+            const sendTeamsMeetingNotification = await TeamsInfo.sendMeetingNotification(
+                context,
+                notification,
+                meetingId
+            );
 
             assert(fetchOauthToken.isDone());
             assert(sendTeamsMeetingNotificationExpectation.isDone());
 
-            const isEmptyObject = obj => Object.keys(obj).length == 0;
+            const isEmptyObject = (obj) => Object.keys(obj).length == 0;
             assert(isEmptyObject(sendTeamsMeetingNotification));
-        })
+        });
 
-        it("should return a TeamsMeetingNotificationRecipientFailureInfos if a 207 status code was returned", async function () {
+        it('should return a TeamsMeetingNotificationRecipientFailureInfos if a 207 status code was returned', async function () {
             const notification = {};
-            const meetingId = "randomGUID";
+            const meetingId = 'randomGUID';
             const { expectedAuthHeader, expectation: fetchOauthToken } = nockOauth();
 
             const recipientsFailureInfo = {
                 recipientsFailureInfo: [
                     {
-                    recipientMri: '8:orgid:4e8a10c0-4687-4f0a-9ed6-95f28d67c102',
-                    failureReason: 'Invalid recipient. Recipient not in roster',
-                    errorCode: 'MemberNotFoundInConversation'
+                        recipientMri: '8:orgid:4e8a10c0-4687-4f0a-9ed6-95f28d67c102',
+                        failureReason: 'Invalid recipient. Recipient not in roster',
+                        errorCode: 'MemberNotFoundInConversation',
                     },
                     {
-                    recipientMri: '8:orgid:4e8a10c0-4687-4f0a-9ed6-95f28d67c103',
-                    failureReason: 'Invalid recipient. Recipient not in roster',
-                    errorCode: 'MemberNotFoundInConversation'
-                    }
-                ]
-            }
+                        recipientMri: '8:orgid:4e8a10c0-4687-4f0a-9ed6-95f28d67c103',
+                        failureReason: 'Invalid recipient. Recipient not in roster',
+                        errorCode: 'MemberNotFoundInConversation',
+                    },
+                ],
+            };
 
             const sendTeamsMeetingNotificationExpectation = nock('https://smba.trafficmanager.net/amer')
-            .post(`/v1/meetings/${meetingId}/notification`, notification)
-            .matchHeader('Authorization', expectedAuthHeader)
-            .reply(207, recipientsFailureInfo);
+                .post(`/v1/meetings/${meetingId}/notification`, notification)
+                .matchHeader('Authorization', expectedAuthHeader)
+                .reply(207, recipientsFailureInfo);
 
-            
             const context = new TestContext(teamActivity);
             context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
-            const sendTeamsMeetingNotification = await TeamsInfo.sendMeetingNotification(context, notification, meetingId);
+            const sendTeamsMeetingNotification = await TeamsInfo.sendMeetingNotification(
+                context,
+                notification,
+                meetingId
+            );
 
             assert(fetchOauthToken.isDone());
             assert(sendTeamsMeetingNotificationExpectation.isDone());
 
             assert.deepEqual(sendTeamsMeetingNotification, recipientsFailureInfo);
-        })
+        });
 
-        it("should return standard error response if a 4xx status code was returned", async function () {
+        it('should return standard error response if a 4xx status code was returned', async function () {
             const notification = {};
-            const meetingId = "randomGUID";
+            const meetingId = 'randomGUID';
             const { expectedAuthHeader, expectation: fetchOauthToken } = nockOauth();
 
             const errorResponse = { error: { code: 'BadSyntax', message: 'Payload is incorrect' } };
 
             const sendTeamsMeetingNotificationExpectation = nock('https://smba.trafficmanager.net/amer')
-            .post(`/v1/meetings/${meetingId}/notification`, notification)
-            .matchHeader('Authorization', expectedAuthHeader)
-            .reply(400, errorResponse)
+                .post(`/v1/meetings/${meetingId}/notification`, notification)
+                .matchHeader('Authorization', expectedAuthHeader)
+                .reply(400, errorResponse);
 
-            
             const context = new TestContext(teamActivity);
             context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
 
@@ -1091,8 +1094,8 @@ describe('TeamsInfo', function () {
 
             assert(fetchOauthToken.isDone());
             assert(sendTeamsMeetingNotificationExpectation.isDone());
-        })
-    })
+        });
+    });
 
     describe('private methods', function () {
         describe('getConnectorClient()', function () {

--- a/libraries/botbuilder/tests/teamsInfo.test.js
+++ b/libraries/botbuilder/tests/teamsInfo.test.js
@@ -1098,7 +1098,7 @@ describe('TeamsInfo', function () {
 
         it('should throw an error if an empty meeting id is provided', async function () {
             const notification = {};
-            const emptyMeetingId = "";
+            const emptyMeetingId = '';
             const { expectedAuthHeader, expectation: fetchOauthToken } = nockOauth();
 
             const sendTeamsMeetingNotificationExpectation = nock('https://smba.trafficmanager.net/amer')
@@ -1117,7 +1117,7 @@ describe('TeamsInfo', function () {
                 assert(e.message, 'meetingId is required.');
                 isErrorThrown = true;
             }
-            
+
             assert(isErrorThrown);
             assert(fetchOauthToken.isDone() === false);
             assert(sendTeamsMeetingNotificationExpectation.isDone() === false);
@@ -1130,14 +1130,17 @@ describe('TeamsInfo', function () {
             const context = new TestContext(teamActivity);
 
             const sendTeamsMeetingNotificationExpectation = nock('https://smba.trafficmanager.net/amer')
-                .post(`/v1/meetings/${encodeURIComponent(teamActivity.channelData.meeting.id)}/notification`, notification)
+                .post(
+                    `/v1/meetings/${encodeURIComponent(teamActivity.channelData.meeting.id)}/notification`,
+                    notification
+                )
                 .matchHeader('Authorization', expectedAuthHeader)
                 .reply(202, {});
 
             context.turnState.set(context.adapter.ConnectorClientKey, connectorClient);
 
             await TeamsInfo.sendMeetingNotification(context, notification);
-            
+
             assert(fetchOauthToken.isDone());
             assert(sendTeamsMeetingNotificationExpectation.isDone());
         });

--- a/libraries/botframework-connector/src/teams/models/index.ts
+++ b/libraries/botframework-connector/src/teams/models/index.ts
@@ -4,7 +4,13 @@
  */
 
 import { HttpResponse, ServiceClientOptions, RequestOptionsBase } from '@azure/ms-rest-js';
-import { ConversationList, TeamDetails, TeamsMeetingInfo, TeamsMeetingNotificationRecipientFailureInfos, TeamsMeetingParticipant } from 'botframework-schema';
+import {
+    ConversationList,
+    TeamDetails,
+    TeamsMeetingInfo,
+    TeamsMeetingNotificationRecipientFailureInfos,
+    TeamsMeetingParticipant,
+} from 'botframework-schema';
 
 /**
  * @interface
@@ -122,7 +128,7 @@ export type TeamsMeetingInfoResponse = TeamsMeetingInfo & {
 /**
  * Contains response data for the sendMeetingNotification operation.
  */
- export type TeamsSendMeetingNotificationResponse = TeamsMeetingNotificationRecipientFailureInfos & {
+export type TeamsSendMeetingNotificationResponse = TeamsMeetingNotificationRecipientFailureInfos & {
     /**
      * The underlying HTTP response.
      */

--- a/libraries/botframework-connector/src/teams/models/index.ts
+++ b/libraries/botframework-connector/src/teams/models/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { HttpResponse, ServiceClientOptions, RequestOptionsBase } from '@azure/ms-rest-js';
-import { ConversationList, TeamDetails, TeamsMeetingInfo, TeamsMeetingParticipant } from 'botframework-schema';
+import { ConversationList, TeamDetails, TeamsMeetingInfo, TeamsMeetingNotificationRecipientFailureInfos, TeamsMeetingParticipant } from 'botframework-schema';
 
 /**
  * @interface
@@ -116,5 +116,24 @@ export type TeamsMeetingInfoResponse = TeamsMeetingInfo & {
          * The response body as parsed JSON or XML
          */
         parsedBody: TeamsMeetingParticipant;
+    };
+};
+
+/**
+ * Contains response data for the sendMeetingNotification operation.
+ */
+ export type TeamsSendMeetingNotificationResponse = TeamsMeetingNotificationRecipientFailureInfos & {
+    /**
+     * The underlying HTTP response.
+     */
+    _response: HttpResponse & {
+        /**
+         * The response body as text (string format)
+         */
+        bodyAsText: string;
+        /**
+         * The response body as parsed JSON or XML
+         */
+        parsedBody: TeamsMeetingNotificationRecipientFailureInfos | {};
     };
 };

--- a/libraries/botframework-connector/src/teams/models/mappers.ts
+++ b/libraries/botframework-connector/src/teams/models/mappers.ts
@@ -435,203 +435,202 @@ export const TeamsMeetingDetails: msRest.CompositeMapper = {
 };
 
 export const TeamsMeetingNotificationInfo: msRest.CompositeMapper = {
-    serializedName: "TeamsMeetingNotificationInfo",
+    serializedName: 'TeamsMeetingNotificationInfo',
     type: {
-        name: "Composite",
-        className: "TeamsMeetingNotificationInfo",
+        name: 'Composite',
+        className: 'TeamsMeetingNotificationInfo',
         modelProperties: {
             recipients: {
-                serializedName: "recipients",
+                serializedName: 'recipients',
                 type: {
-                    name: "Sequence",
+                    name: 'Sequence',
                     element: {
                         type: {
-                            name: "String",
-                        }
-                    }
-                }
+                            name: 'String',
+                        },
+                    },
+                },
             },
             surfaces: {
-                serializedName: "surfaces",
+                serializedName: 'surfaces',
                 type: {
-                    name: "Sequence",
+                    name: 'Sequence',
                     element: {
                         type: {
-                            name: "Composite",
-                            className: "TeamsMeetingNotificationSurface"
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
+                            name: 'Composite',
+                            className: 'TeamsMeetingNotificationSurface',
+                        },
+                    },
+                },
+            },
+        },
+    },
+};
 
 export const TeamsMeetingNotification: msRest.CompositeMapper = {
-    serializedName: "TeamsMeetingNotification",
+    serializedName: 'TeamsMeetingNotification',
     type: {
-        name: "Composite",
-        className: "TeamsMeetingNotification",
+        name: 'Composite',
+        className: 'TeamsMeetingNotification',
         modelProperties: {
             type: {
-                serializedName: "type",
+                serializedName: 'type',
                 type: {
-                    name: "String"
-                }
+                    name: 'String',
+                },
             },
             value: {
-                serializedName: "value",
+                serializedName: 'value',
                 type: {
-                    name: "Composite",
-                    className: "TeamsMeetingNotificationInfo"
-                }
+                    name: 'Composite',
+                    className: 'TeamsMeetingNotificationInfo',
+                },
             },
             channelData: {
-                serializedName: "channelData",
+                serializedName: 'channelData',
                 type: {
-                    name: "Composite",
-                    className: "TeamsMeetingNotificationChannelData"
-                }
-            }
-
-        }
-    }
-}
+                    name: 'Composite',
+                    className: 'TeamsMeetingNotificationChannelData',
+                },
+            },
+        },
+    },
+};
 
 export const TeamsMeetingNotificationSurface: msRest.CompositeMapper = {
-    serializedName: "TeamsMeetingNotificationSurface",
+    serializedName: 'TeamsMeetingNotificationSurface',
     type: {
-        name: "Composite",
-        className: "TeamsMeetingNotificationSurface",
+        name: 'Composite',
+        className: 'TeamsMeetingNotificationSurface',
         modelProperties: {
             surface: {
-                serializedName: "surface",
+                serializedName: 'surface',
                 type: {
-                    name: "String"
-                }
+                    name: 'String',
+                },
             },
             contentType: {
-                serializedName: "contentType",
+                serializedName: 'contentType',
                 type: {
-                    name: "String",
-                }
+                    name: 'String',
+                },
             },
             content: {
-                serializedName: "content",
+                serializedName: 'content',
                 type: {
-                    name: "Composite",
-                    className: "TaskModuleContinueResponse"
-                }
-            }
-        }
-    }
-}
+                    name: 'Composite',
+                    className: 'TaskModuleContinueResponse',
+                },
+            },
+        },
+    },
+};
 
 export const TeamsMeetingNotificationChannelData = {
-    serializedName: "TeamsMeetingNotificationChannelData",
+    serializedName: 'TeamsMeetingNotificationChannelData',
     type: {
-        name: "Composite",
-        className: "TeamsMeetingNotificationChannelData",
+        name: 'Composite',
+        className: 'TeamsMeetingNotificationChannelData',
         modelProperties: {
             onBehalfOf: {
-                serializedName: "onBehalfOf",
+                serializedName: 'onBehalfOf',
                 type: {
-                    name: "Sequence",
-                    element: {
-                        type: { 
-                            name: "Composite",
-                            className: "TeamsMeetingOnBehalfOf"
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-export const TeamsMeetingOnBehalfOf: msRest.CompositeMapper = {
-    serializedName: "TeamsMeetingOnBehalfOf",
-    type: {
-        name: "Composite",
-        className: "TeamsMeetingOnBehalfOf",
-        modelProperties: {
-            itemid: {
-                serializedName: "itemid",
-                type: {
-                    name: "Number"
-                }
-            },
-            mentionType: {
-                serializedName: "mentionType",
-                type: {
-                    name: "String"
-                }
-            },
-            mri: {
-                serializedName: "mri",
-                type: {
-                    name: "String"
-                }
-            },
-            displayName: {
-                serializedName: "displayName",
-                type: {
-                    name: "String"
-                }
-            }
-        }
-    }
-}
-
-export const TeamsMeetingNotificationRecipientFailureInfo: msRest.CompositeMapper = {
-    serializedName: "TeamsMeetingNotificationRecipientFailureInfo",
-    type: {
-        name: "Composite",
-        className: "TeamsMeetingNotificationRecipientFailureInfo",
-        modelProperties: {
-            recipientMri: {
-                serializedName: "recipientMri",
-                type: {
-                    name: "String"
-                }
-            },
-            failureReason: {
-                serializedName: "failureReason",
-                type: {
-                    name: "String"
-                }
-            },
-            errorCode: {
-                serializedName: "errorCode",
-                type: {
-                    name: "String"
-                }
-            },
-        }
-    }
-}
-
-export const TeamsMeetingNotificationRecipientFailureInfos: msRest.CompositeMapper = {
-    serializedName: "TeamsMeetingNotificationRecipientFailureInfos",
-    type: {
-        name: "Composite",
-        className: "TeamsMeetingNotificationRecipientFailureInfos",
-        modelProperties: {
-            recipientsFailureInfo: {
-                serializedName: "recipientsFailureInfo",
-                type: {
-                    name: "Sequence",
+                    name: 'Sequence',
                     element: {
                         type: {
-                            name: "Composite",
-                            className: "TeamsMeetingNotificationRecipientFailureInfo"
-                        }
-                    }
-                }
+                            name: 'Composite',
+                            className: 'TeamsMeetingOnBehalfOf',
+                        },
+                    },
+                },
             },
-        }
-    }
-}
+        },
+    },
+};
+
+export const TeamsMeetingOnBehalfOf: msRest.CompositeMapper = {
+    serializedName: 'TeamsMeetingOnBehalfOf',
+    type: {
+        name: 'Composite',
+        className: 'TeamsMeetingOnBehalfOf',
+        modelProperties: {
+            itemid: {
+                serializedName: 'itemid',
+                type: {
+                    name: 'Number',
+                },
+            },
+            mentionType: {
+                serializedName: 'mentionType',
+                type: {
+                    name: 'String',
+                },
+            },
+            mri: {
+                serializedName: 'mri',
+                type: {
+                    name: 'String',
+                },
+            },
+            displayName: {
+                serializedName: 'displayName',
+                type: {
+                    name: 'String',
+                },
+            },
+        },
+    },
+};
+
+export const TeamsMeetingNotificationRecipientFailureInfo: msRest.CompositeMapper = {
+    serializedName: 'TeamsMeetingNotificationRecipientFailureInfo',
+    type: {
+        name: 'Composite',
+        className: 'TeamsMeetingNotificationRecipientFailureInfo',
+        modelProperties: {
+            recipientMri: {
+                serializedName: 'recipientMri',
+                type: {
+                    name: 'String',
+                },
+            },
+            failureReason: {
+                serializedName: 'failureReason',
+                type: {
+                    name: 'String',
+                },
+            },
+            errorCode: {
+                serializedName: 'errorCode',
+                type: {
+                    name: 'String',
+                },
+            },
+        },
+    },
+};
+
+export const TeamsMeetingNotificationRecipientFailureInfos: msRest.CompositeMapper = {
+    serializedName: 'TeamsMeetingNotificationRecipientFailureInfos',
+    type: {
+        name: 'Composite',
+        className: 'TeamsMeetingNotificationRecipientFailureInfos',
+        modelProperties: {
+            recipientsFailureInfo: {
+                serializedName: 'recipientsFailureInfo',
+                type: {
+                    name: 'Sequence',
+                    element: {
+                        type: {
+                            name: 'Composite',
+                            className: 'TeamsMeetingNotificationRecipientFailureInfo',
+                        },
+                    },
+                },
+            },
+        },
+    },
+};
 
 export const CardAction: msRest.CompositeMapper = {
     serializedName: 'CardAction',

--- a/libraries/botframework-connector/src/teams/models/mappers.ts
+++ b/libraries/botframework-connector/src/teams/models/mappers.ts
@@ -434,6 +434,155 @@ export const TeamsMeetingDetails: msRest.CompositeMapper = {
     },
 };
 
+export const TeamsMeetingNotificationInfo: msRest.CompositeMapper = {
+    serializedName: "TeamsMeetingNotificationInfo",
+    type: {
+        name: "Composite",
+        className: "TeamsMeetingNotificationInfo",
+        modelProperties: {
+            recipients: {
+                serializedName: "recipients",
+                type: {
+                    name: "Sequence",
+                    element: {
+                        type: {
+                            name: "String",
+                        }
+                    }
+                }
+            },
+            surfaces: {
+                serializedName: "surfaces",
+                type: {
+                    name: "Sequence",
+                    element: {
+                        type: {
+                            name: "Composite",
+                            className: "TeamsMeetingNotificationSurface"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+export const TeamsMeetingNotification: msRest.CompositeMapper = {
+    serializedName: "TeamsMeetingNotification",
+    type: {
+        name: "Composite",
+        className: "TeamsMeetingNotification",
+        modelProperties: {
+            type: {
+                serializedName: "type",
+                type: {
+                    name: "String"
+                }
+            },
+            value: {
+                serializedName: "value",
+                type: {
+                    name: "Composite",
+                    className: "TeamsMeetingNotificationInfo"
+                }
+            },
+            channelData: {
+                serializedName: "channelData",
+                type: {
+                    name: "Composite",
+                    className: "TeamsMeetingNotificationChannelData"
+                }
+            }
+
+        }
+    }
+}
+
+export const TeamsMeetingNotificationSurface: msRest.CompositeMapper = {
+    serializedName: "TeamsMeetingNotificationSurface",
+    type: {
+        name: "Composite",
+        className: "TeamsMeetingNotificationSurface",
+        modelProperties: {
+            surface: {
+                serializedName: "surface",
+                type: {
+                    name: "String"
+                }
+            },
+            contentType: {
+                serializedName: "contentType",
+                type: {
+                    name: "String",
+                }
+            },
+            content: {
+                serializedName: "content",
+                type: {
+                    name: "Composite",
+                    className: "TaskModuleContinueResponse"
+                }
+            }
+        }
+    }
+}
+
+export const TeamsMeetingNotificationChannelData = {
+    serializedName: "TeamsMeetingNotificationChannelData",
+    type: {
+        name: "Composite",
+        className: "TeamsMeetingNotificationChannelData",
+        modelProperties: {
+            onBehalfOf: {
+                serializedName: "onBehalfOf",
+                type: {
+                    name: "Sequence",
+                    element: {
+                        type: { 
+                            name: "Composite",
+                            className: "TeamsMeetingOnBehalfOf"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+export const TeamsMeetingOnBehalfOf: msRest.CompositeMapper = {
+    serializedName: "TeamsMeetingOnBehalfOf",
+    type: {
+        name: "Composite",
+        className: "TeamsMeetingOnBehalfOf",
+        modelProperties: {
+            itemid: {
+                serializedName: "itemid",
+                type: {
+                    name: "Number"
+                }
+            },
+            mentionType: {
+                serializedName: "mentionType",
+                type: {
+                    name: "String"
+                }
+            },
+            mri: {
+                serializedName: "mri",
+                type: {
+                    name: "String"
+                }
+            },
+            displayName: {
+                serializedName: "displayName",
+                type: {
+                    name: "String"
+                }
+            }
+        }
+    }
+}
+
 export const CardAction: msRest.CompositeMapper = {
     serializedName: 'CardAction',
     type: {

--- a/libraries/botframework-connector/src/teams/models/mappers.ts
+++ b/libraries/botframework-connector/src/teams/models/mappers.ts
@@ -583,6 +583,56 @@ export const TeamsMeetingOnBehalfOf: msRest.CompositeMapper = {
     }
 }
 
+export const TeamsMeetingNotificationRecipientFailureInfo: msRest.CompositeMapper = {
+    serializedName: "TeamsMeetingNotificationRecipientFailureInfo",
+    type: {
+        name: "Composite",
+        className: "TeamsMeetingNotificationRecipientFailureInfo",
+        modelProperties: {
+            recipientMri: {
+                serializedName: "recipientMri",
+                type: {
+                    name: "String"
+                }
+            },
+            failureReason: {
+                serializedName: "failureReason",
+                type: {
+                    name: "String"
+                }
+            },
+            errorCode: {
+                serializedName: "errorCode",
+                type: {
+                    name: "String"
+                }
+            },
+        }
+    }
+}
+
+export const TeamsMeetingNotificationRecipientFailureInfos: msRest.CompositeMapper = {
+    serializedName: "TeamsMeetingNotificationRecipientFailureInfos",
+    type: {
+        name: "Composite",
+        className: "TeamsMeetingNotificationRecipientFailureInfos",
+        modelProperties: {
+            recipientsFailureInfo: {
+                serializedName: "recipientsFailureInfo",
+                type: {
+                    name: "Sequence",
+                    element: {
+                        type: {
+                            name: "Composite",
+                            className: "TeamsMeetingNotificationRecipientFailureInfo"
+                        }
+                    }
+                }
+            },
+        }
+    }
+}
+
 export const CardAction: msRest.CompositeMapper = {
     serializedName: 'CardAction',
     type: {

--- a/libraries/botframework-connector/src/teams/models/teamsMappers.ts
+++ b/libraries/botframework-connector/src/teams/models/teamsMappers.ts
@@ -4,6 +4,12 @@
  */
 
 export {
+    ErrorResponse,
+    ErrorModel,
+    InnerHttpError  
+} from '../../connectorApi/models/mappers';
+
+export {
     ConversationList,
     ChannelInfo,
     MessageActionsPayloadConversation,
@@ -18,6 +24,8 @@ export {
     TeamsMeetingNotificationSurface,
     TeamsMeetingNotificationChannelData,
     TeamsMeetingOnBehalfOf,
+    TeamsMeetingNotificationRecipientFailureInfo,
+    TeamsMeetingNotificationRecipientFailureInfos,
     TaskModuleContinueResponse,
     TaskModuleTaskInfo,
     Attachment,

--- a/libraries/botframework-connector/src/teams/models/teamsMappers.ts
+++ b/libraries/botframework-connector/src/teams/models/teamsMappers.ts
@@ -3,11 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export {
-    ErrorResponse,
-    ErrorModel,
-    InnerHttpError  
-} from '../../connectorApi/models/mappers';
+export { ErrorResponse, ErrorModel, InnerHttpError } from '../../connectorApi/models/mappers';
 
 export {
     ConversationList,

--- a/libraries/botframework-connector/src/teams/models/teamsMappers.ts
+++ b/libraries/botframework-connector/src/teams/models/teamsMappers.ts
@@ -13,4 +13,12 @@ export {
     TeamsMeetingDetails,
     TeamsMeetingInfo,
     TeamsMeetingParticipant,
+    TeamsMeetingNotification,
+    TeamsMeetingNotificationInfo,
+    TeamsMeetingNotificationSurface,
+    TeamsMeetingNotificationChannelData,
+    TeamsMeetingOnBehalfOf,
+    TaskModuleContinueResponse,
+    TaskModuleTaskInfo,
+    Attachment,
 } from './mappers';

--- a/libraries/botframework-connector/src/teams/operations/teams.ts
+++ b/libraries/botframework-connector/src/teams/operations/teams.ts
@@ -9,7 +9,7 @@ import * as Models from '../models';
 import * as Mappers from '../models/teamsMappers';
 import * as Parameters from '../models/parameters';
 import { TeamsConnectorClientContext } from '../';
-import { ConversationList, TeamDetails, TeamsMeetingInfo, TeamsMeetingParticipant } from 'botframework-schema';
+import { ConversationList, TeamDetails, TeamsMeetingInfo, TeamsMeetingParticipant, TeamsMeetingNotificationRecipientFailureInfos, TeamsMeetingNotification } from 'botframework-schema';
 
 /** Class representing a Teams. */
 export class Teams {
@@ -241,13 +241,54 @@ export class Teams {
         ) as Promise<Models.TeamsMeetingInfoResponse>;
     }
 
-    // TODO: Add multiple method definitions
+    /**
+     * Send meeting notification.
+     * 
+     * @param meetingId Meeting Id.
+     * @param notification The content and configuration for the notification to send.
+     * @param options The optional parameters.
+     * @param options 
+     */
     sendMeetingNotification(
         meetingId: string,
-        notification: any,
+        notification: TeamsMeetingNotification,
         options?: msRest.RequestOptionsBase,
-        callback?: msRest.ServiceCallback<any>
-    ): Promise<any> {
+    ): Promise<Models.TeamsSendMeetingNotificationResponse>
+    /**
+     * @param meetingId Meeting Id.
+     * @param notification The content and configuration for the notification to send.
+     * @param callback The callback.
+     */
+    sendMeetingNotification(
+        meetingId: string,
+        notification: TeamsMeetingNotification,
+        callback: msRest.ServiceCallback<TeamsMeetingNotificationRecipientFailureInfos | {}>
+    ): void;
+    /**
+     * @param meetingId Meeting Id.
+     * @param notification The content and configuration for the notification to send.
+     * @param options The optional parameters.
+     * @param callback The callback.
+     */
+    sendMeetingNotification(
+        meetingId: string,
+        notification: TeamsMeetingNotification,
+        options: msRest.RequestOptionsBase,
+        callback: msRest.ServiceCallback<TeamsMeetingNotificationRecipientFailureInfos | {}>
+    ): void;
+    /**
+     * @param meetingId Meeting Id.
+     * @param notification The content and configuration for the notification to send.
+     * @param options The optional parameters.
+     * @param callback The callback.
+     * @returns Promise with either TeamsMeetingNotificationRecipientFailureInfos or an empty object.
+     */
+    sendMeetingNotification(
+        meetingId: string,
+        notification: TeamsMeetingNotification,
+        options?: msRest.RequestOptionsBase,
+        callback?: msRest.ServiceCallback<TeamsMeetingNotificationRecipientFailureInfos | {}>
+    ): Promise<Models.TeamsSendMeetingNotificationResponse> {
         return this.client.sendOperationRequest(
             {
                 meetingId,
@@ -256,7 +297,7 @@ export class Teams {
             },
             sendMeetingNotificationOperationSpec,
             callback
-        ) as Promise<any>;
+        ) as Promise<Models.TeamsSendMeetingNotificationResponse>;
     }
 }
 
@@ -327,7 +368,15 @@ const sendMeetingNotificationOperationSpec: msRest.OperationSpec = {
         }
     },
     responses: {
-        default: {} // TODO: ADD response mappers
+        202: {
+            bodyMapper: Mappers.TeamsMeetingNotificationRecipientFailureInfos
+        },
+        207: {
+            bodyMapper: Mappers.TeamsMeetingNotificationRecipientFailureInfos
+        },
+        default: {
+            bodyMapper: Mappers.ErrorResponse
+        }
     },
     serializer
 }

--- a/libraries/botframework-connector/src/teams/operations/teams.ts
+++ b/libraries/botframework-connector/src/teams/operations/teams.ts
@@ -240,6 +240,24 @@ export class Teams {
             callback
         ) as Promise<Models.TeamsMeetingInfoResponse>;
     }
+
+    // TODO: Add multiple method definitions
+    sendMeetingNotification(
+        meetingId: string,
+        notification: any,
+        options?: msRest.RequestOptionsBase,
+        callback?: msRest.ServiceCallback<any>
+    ): Promise<any> {
+        return this.client.sendOperationRequest(
+            {
+                meetingId,
+                notification,
+                options
+            },
+            sendMeetingNotificationOperationSpec,
+            callback
+        ) as Promise<any>;
+    }
 }
 
 // Operation Specifications
@@ -296,3 +314,20 @@ const fetchMeetingInfoOperationSpec: msRest.OperationSpec = {
     },
     serializer,
 };
+
+const sendMeetingNotificationOperationSpec: msRest.OperationSpec = {
+    httpMethod: 'POST',
+    path: 'v1/meetings/{meetingId}/notification',
+    urlParameters: [Parameters.meetingId],
+    requestBody: {
+        parameterPath: "notification",
+        mapper: {
+            ...Mappers.TeamsMeetingNotification,
+            required: true
+        }
+    },
+    responses: {
+        default: {} // TODO: ADD response mappers
+    },
+    serializer
+}

--- a/libraries/botframework-connector/src/teams/operations/teams.ts
+++ b/libraries/botframework-connector/src/teams/operations/teams.ts
@@ -247,7 +247,6 @@ export class Teams {
      * @param meetingId Meeting Id.
      * @param notification The content and configuration for the notification to send.
      * @param options The optional parameters.
-     * @param options 
      */
     sendMeetingNotification(
         meetingId: string,
@@ -361,7 +360,7 @@ const sendMeetingNotificationOperationSpec: msRest.OperationSpec = {
     path: 'v1/meetings/{meetingId}/notification',
     urlParameters: [Parameters.meetingId],
     requestBody: {
-        parameterPath: "notification",
+        parameterPath: 'notification',
         mapper: {
             ...Mappers.TeamsMeetingNotification,
             required: true

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -1718,11 +1718,8 @@ export interface TeamsMeetingInfo {
 
 // @public
 export interface TeamsMeetingNotification {
-    // (undocumented)
     channelData: TeamsMeetingNotificationChannelData;
-    // (undocumented)
     type: 'targetedMeetingNotification' | string;
-    // (undocumented)
     value: TeamsMeetingNotificationInfo;
 }
 

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -1721,60 +1721,46 @@ export interface TeamsMeetingNotification {
     // (undocumented)
     channelData: TeamsMeetingNotificationChannelData;
     // (undocumented)
-    type: string;
+    type: 'targetedMeetingNotification' | string;
     // (undocumented)
     value: TeamsMeetingNotificationInfo;
 }
 
 // @public
 export interface TeamsMeetingNotificationChannelData {
-    // (undocumented)
-    onBehalfOf: TeamsMeetingOnBehalfOf;
+    onBehalfOf?: TeamsMeetingOnBehalfOf;
 }
 
 // @public
 export interface TeamsMeetingNotificationInfo {
-    // (undocumented)
     recipients: string[];
-    // (undocumented)
     surfaces: TeamsMeetingNotificationSurface[];
 }
 
 // @public
 export interface TeamsMeetingNotificationRecipientFailureInfo {
-    // (undocumented)
     errorCode: string;
-    // (undocumented)
     failureReason: string;
-    // (undocumented)
     recipientMri: string;
 }
 
 // @public
 export interface TeamsMeetingNotificationRecipientFailureInfos {
-    // (undocumented)
     recipientsFailureInfo: TeamsMeetingNotificationRecipientFailureInfo[];
 }
 
 // @public
 export interface TeamsMeetingNotificationSurface {
-    // (undocumented)
     content: TaskModuleContinueResponse;
-    // (undocumented)
-    contentType: string;
-    // (undocumented)
-    surface: string;
+    contentType: 'task' | string;
+    surface: 'meetingStage' | string;
 }
 
 // @public
 export interface TeamsMeetingOnBehalfOf {
-    // (undocumented)
-    displayName: string;
-    // (undocumented)
-    itemid: number;
-    // (undocumented)
-    mentionType: string;
-    // (undocumented)
+    displayName?: string;
+    itemid: 0 | number;
+    mentionType: 'person' | string;
     mri: string;
 }
 

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -1717,6 +1717,68 @@ export interface TeamsMeetingInfo {
 }
 
 // @public
+export interface TeamsMeetingNotification {
+    // (undocumented)
+    channelData: TeamsMeetingNotificationChannelData;
+    // (undocumented)
+    type: string;
+    // (undocumented)
+    value: TeamsMeetingNotificationInfo;
+}
+
+// @public
+export interface TeamsMeetingNotificationChannelData {
+    // (undocumented)
+    onBehalfOf: TeamsMeetingOnBehalfOf;
+}
+
+// @public
+export interface TeamsMeetingNotificationInfo {
+    // (undocumented)
+    recipients: string[];
+    // (undocumented)
+    surfaces: TeamsMeetingNotificationSurface[];
+}
+
+// @public
+export interface TeamsMeetingNotificationRecipientFailureInfo {
+    // (undocumented)
+    errorCode: string;
+    // (undocumented)
+    failureReason: string;
+    // (undocumented)
+    recipientMri: string;
+}
+
+// @public
+export interface TeamsMeetingNotificationRecipientFailureInfos {
+    // (undocumented)
+    recipientsFailureInfo: TeamsMeetingNotificationRecipientFailureInfo[];
+}
+
+// @public
+export interface TeamsMeetingNotificationSurface {
+    // (undocumented)
+    content: TaskModuleContinueResponse;
+    // (undocumented)
+    contentType: string;
+    // (undocumented)
+    surface: string;
+}
+
+// @public
+export interface TeamsMeetingOnBehalfOf {
+    // (undocumented)
+    displayName: string;
+    // (undocumented)
+    itemid: number;
+    // (undocumented)
+    mentionType: string;
+    // (undocumented)
+    mri: string;
+}
+
+// @public
 export interface TeamsMeetingParticipant {
     conversation?: ConversationAccount;
     meeting?: Meeting;

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -1860,7 +1860,7 @@ export interface TeamsMeetingNotificationChannelData {
  * Specifies the Teams user that triggered the Teams meeting notification.
  */
 export interface TeamsMeetingOnBehalfOf {
-    itemid: number; // Supposed to be an integer BUT Typescript does not have an integer type. Should we be explicit here? i.e itemid: 0 | 1 | ..etc  
+    itemid: number;
     mentionType: string;
     mri: string;
     displayName: string;

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -1823,7 +1823,7 @@ export interface MeetingEndEventDetails extends MeetingEventDetails {
  * Specifies details of a Teams meeting send notification payload.
  */
 export interface TeamsMeetingNotification {
-    type: string;
+    type: 'targetedMeetingNotification' | string;
     value: TeamsMeetingNotificationInfo;
     channelData: TeamsMeetingNotificationChannelData;
 }
@@ -1833,17 +1833,32 @@ export interface TeamsMeetingNotification {
  * Specifies recipients and surfaces to target in a Teams meeting notification.
  */
 export interface TeamsMeetingNotificationInfo {
+    /**
+     * @member {string[]} [recipients] The list of recipient meeting MRIs.
+     */
     recipients: string[];
+    /**
+     * @member {TeamsMeetingNotificationSurface[]} [surfaces] The List of notification surface configuration.
+     */
     surfaces: TeamsMeetingNotificationSurface[];
 }
 
 /**
  * @interface
- * Specifies the surface and content for a Teams meeting notification. 
+ * Specifies the surface and content for a Teams meeting notification.
  */
 export interface TeamsMeetingNotificationSurface {
-    surface: string;
-    contentType: string;
+    /**
+     * @member {string} [surface] The surface type.
+     */
+    surface: 'meetingStage' | string;
+    /**
+     * @member {string} [contentType] The content type.
+     */
+    contentType: 'task' | string;
+    /**
+     * @member {TaskModuleContinueResponse} [content] The content to display in the meeting notification.
+     */
     content: TaskModuleContinueResponse;
 }
 
@@ -1852,7 +1867,10 @@ export interface TeamsMeetingNotificationSurface {
  * Specifies channel data associated with the Teams meeting notification.
  */
 export interface TeamsMeetingNotificationChannelData {
-    onBehalfOf: TeamsMeetingOnBehalfOf;
+    /**
+     * @member {TeamsMeetingOnBehalfOf} [onBehalfOf] The user that the bot is sending the notification on behalfOf, if any.
+     */
+    onBehalfOf?: TeamsMeetingOnBehalfOf;
 }
 
 /**
@@ -1860,19 +1878,40 @@ export interface TeamsMeetingNotificationChannelData {
  * Specifies the Teams user that triggered the Teams meeting notification.
  */
 export interface TeamsMeetingOnBehalfOf {
-    itemid: number;
-    mentionType: string;
+    /**
+     * @member {number} [itemid] The id of the item.
+     */
+    itemid: 0 | number;
+    /**
+     * @member {string} [mentionType] The mention type of a "person".
+     */
+    mentionType: 'person' | string;
+    /**
+     * @member {string} [mri] Ther user MRI of the sender.
+     */
     mri: string;
-    displayName: string;
+    /**
+     * @member {string} [displayName] The  of the person.
+     */
+    displayName?: string;
 }
 
 /**
  * @interface
- * Specifies the recipients for which the Teams meeting notification was not sent. 
+ * Specifies the recipients for which the Teams meeting notification was not sent.
  */
 export interface TeamsMeetingNotificationRecipientFailureInfo {
+    /**
+     * @member {string} [recipientMri] The targeted recipient's MRI.
+     */
     recipientMri: string;
+    /**
+     * @member {string} [failureReason] The reason for which the meetings notification could not be sent to the recipient.
+     */
     failureReason: string;
+    /**
+     * @member {string} [errorCode] The error code.
+     */
     errorCode: string;
 }
 
@@ -1881,5 +1920,8 @@ export interface TeamsMeetingNotificationRecipientFailureInfo {
  * Specifies the list of recipients for which the Teams meeting notification was not sent.
  */
 export interface TeamsMeetingNotificationRecipientFailureInfos {
+    /**
+     * @member {string} [errorCode] The list of recipients that failed to recieve the sent meetings notification.
+     */
     recipientsFailureInfo: TeamsMeetingNotificationRecipientFailureInfo[];
 }

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -1818,27 +1818,47 @@ export interface MeetingEndEventDetails extends MeetingEventDetails {
     endTime: Date;
 }
 
+/**
+ * @interface
+ * Specifies details of a Teams meeting send notification payload.
+ */
 export interface TeamsMeetingNotification {
     type: string;
     value: TeamsMeetingNotificationInfo;
     channelData: TeamsMeetingNotificationChannelData;
 }
 
+/**
+ * @interface
+ * Specifies recipients and surfaces to target in a Teams meeting notification.
+ */
 export interface TeamsMeetingNotificationInfo {
     recipients: string[];
     surfaces: TeamsMeetingNotificationSurface[];
 }
 
+/**
+ * @interface
+ * Specifies the surface and content for a Teams meeting notification. 
+ */
 export interface TeamsMeetingNotificationSurface {
     surface: string;
     contentType: string;
     content: TaskModuleContinueResponse;
 }
 
+/**
+ * @interface
+ * Specifies channel data associated with the Teams meeting notification.
+ */
 export interface TeamsMeetingNotificationChannelData {
     onBehalfOf: TeamsMeetingOnBehalfOf;
 }
 
+/**
+ * @interface
+ * Specifies the Teams user that triggered the Teams meeting notification.
+ */
 export interface TeamsMeetingOnBehalfOf {
     itemid: number; // Supposed to be an integer BUT Typescript does not have an integer type. Should we be explicit here? i.e itemid: 0 | 1 | ..etc  
     mentionType: string;
@@ -1846,12 +1866,20 @@ export interface TeamsMeetingOnBehalfOf {
     displayName: string;
 }
 
+/**
+ * @interface
+ * Specifies the recipients for which the Teams meeting notification was not sent. 
+ */
 export interface TeamsMeetingNotificationRecipientFailureInfo {
     recipientMri: string;
     failureReason: string;
     errorCode: string;
 }
 
+/**
+ * @interface
+ * Specifies the list of recipients for which the Teams meeting notification was not sent.
+ */
 export interface TeamsMeetingNotificationRecipientFailureInfos {
     recipientsFailureInfo: TeamsMeetingNotificationRecipientFailureInfo[];
 }

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -1823,8 +1823,17 @@ export interface MeetingEndEventDetails extends MeetingEventDetails {
  * Specifies details of a Teams meeting send notification payload.
  */
 export interface TeamsMeetingNotification {
+    /**
+     * @member {string} [type] The type of meeting notification.
+     */
     type: 'targetedMeetingNotification' | string;
+    /**
+     * @member {TeamsMeetingNotificationInfo} [type] The specific details of the meeting notification.
+     */
     value: TeamsMeetingNotificationInfo;
+    /**
+     * @member {TeamsMeetingNotificationChannelData} [type] The channel data of the meeting notification.
+     */
     channelData: TeamsMeetingNotificationChannelData;
 }
 

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -1817,3 +1817,41 @@ export interface MeetingEndEventDetails extends MeetingEventDetails {
      */
     endTime: Date;
 }
+
+export interface TeamsMeetingNotification {
+    type: string;
+    value: TeamsMeetingNotificationInfo;
+    channelData: TeamsMeetingNotificationChannelData;
+}
+
+export interface TeamsMeetingNotificationInfo {
+    recipients: string[];
+    surfaces: TeamsMeetingNotificationSurface[];
+}
+
+export interface TeamsMeetingNotificationSurface {
+    surface: string;
+    contentType: string;
+    content: TaskModuleContinueResponse;
+}
+
+export interface TeamsMeetingNotificationChannelData {
+    onBehalfOf: TeamsMeetingOnBehalfOf;
+}
+
+export interface TeamsMeetingOnBehalfOf {
+    itemid: number; // Supposed to be an integer BUT Typescript does not have an integer type. Should we be explicit here? i.e itemid: 0 | 1 | ..etc  
+    mentionType: string;
+    mri: string;
+    displayName: string;
+}
+
+export interface TeamsMeetingNotificationRecipientFailureInfo {
+    recipientMri: string;
+    failureReason: string;
+    errorCode: string;
+}
+
+export interface TeamsMeetingNotificationRecipientFailureInfos {
+    recipientsFailureInfo: TeamsMeetingNotificationRecipientFailureInfo[];
+}


### PR DESCRIPTION
## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
This feature aims to extend the JS Bot SDK so that developers can send targeted meeting notifications in Microsoft Teams meetings.

Closes #4384

## Specific Changes
<!-- Please list the changes in a concise manner. -->
Ran yarn build:rollup on both the botbuilder, botframework-connector & botframework-schema libraries to generate public api doc.
 
#### botbuilder
  - Added `sendMeetingNotification` method to `TeamsInfo` class.

#### botframework-schema
- Added multiple interfaces to the `index.ts` monolith of interfaces & types related to Teams meeting notifications. `TeamsMeetingNotification` interface defines the `notification` payload to the API call. All other interfaces are used to build this interface.

#### botframework-connector
- Added a type to teams related model.
- Added multiple ms-rest objects used in the ms-rest set up for the REST API call.
- Implemented `sendMeetingNotification` REST API call using the existing ms-rest template.

## Testing
- Unit tests only done for changes in `teamsInfo.ts` from the `botbuilder` library.
- `botframework-schema` changes are adding new types & interfaces so it doesn't make sense to have a unit test.
- `botframework-connector` unit tests are done indirectly through testing `teamsInfo.ts` method. This follows existing precedent of a PR with a similar feature addition: https://github.com/microsoft/botbuilder-js/pull/2884 