### PR TITLE
port: [#4369] Prompt validation of confirm prompt in chatbot is not working for newly added language (#6554)

### DIFF
--- a/libraries/botbuilder-dialogs/etc/botbuilder-dialogs.api.md
+++ b/libraries/botbuilder-dialogs/etc/botbuilder-dialogs.api.md
@@ -661,6 +661,7 @@ export class PromptCultureModels {
 export interface PromptOptions {
     choices?: (string | Choice)[];
     prompt?: string | Partial<Activity>;
+    recognizeLanguage?: string;
     retryPrompt?: string | Partial<Activity>;
     style?: ListStyle;
     validations?: object;

--- a/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
@@ -147,7 +147,7 @@ export class ConfirmPrompt extends Prompt<boolean> {
             return result;
         }
         const culture = this.determineCulture(context.activity);
-        const results = Recognizers.recognizeBoolean(utterance, culture);
+        const results = Recognizers.recognizeBoolean(utterance, _options.recognizeLanguage ?? culture);
         if (results.length > 0 && results[0].resolution) {
             result.succeeded = true;
             result.value = results[0].resolution.value;

--- a/libraries/botbuilder-dialogs/src/prompts/prompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/prompt.ts
@@ -75,6 +75,11 @@ export interface PromptOptions {
      * (Optional) Additional validation rules to pass the prompts validator routine.
      */
     validations?: object;
+
+    /**
+     * The locale to be use for recognizing the utterance.
+     */
+    recognizeLanguage?: string;
 }
 
 /**


### PR DESCRIPTION
Fixes #4369

## Description
This PR adds the **_recognizeLanguage_** property in the **_PromptOptions_** interface.
It also updates the _onRecognize_ method of the _**ConfirmPrompt**_ class to use this property solving the issue when a ConfirmPrompt is used along with a TranslationMiddleware.

## Specific Changes
  - Updated **_PromptOptions_** interface adding the **_recognizeLanguage_** property.
  - Updated the **_onRecognize_** method of the **_ConfirmPrompt_** class using the new property.
  - Added a unit test in **_confirmPrompt.tests_** to cover the new test case.

## Testing
These images show how the sample bot recognizes the option in French.
![image](https://user-images.githubusercontent.com/64815358/205923815-0b0c3e61-fb31-4bfe-95c2-05030cd7e35d.png)
