### PR TITLE
Upgrade adal-node to v 0.2.4 

### DIFF
--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@azure/identity": "^2.0.4",
     "@azure/ms-rest-js": "^2.6.1",
-    "adal-node": "0.2.3",
+    "adal-node": "0.2.4",
     "axios": "^0.25.0",
     "base64url": "^3.0.0",
     "botbuilder-stdlib": "4.1.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "update-versions": "yarn workspace botbuilder-repo-utils update-versions"
   },
   "resolutions": {
-    "adal-node": "0.2.3",
     "async": "3.2.3",
     "minimist": "^1.2.6",
     "mixme": "0.5.2",
@@ -48,7 +47,6 @@
     "node-fetch": "2.6.7",
     "underscore": "1.13.1",
     "json-schema": "0.4.0",
-    "@xmldom/xmldom": "0.8.6",
     "**/botbuilder-ai/@azure/cognitiveservices-luis-runtime/@azure/ms-rest-js": "^2.6.1"
   },
   "devDependencies": {

--- a/tools/package.json
+++ b/tools/package.json
@@ -40,7 +40,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "adal-node": "^0.1.28",
+    "adal-node": "^0.2.4",
     "async": "^2.6.1",
     "colors": "1.1.2",
     "fs-extra": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2373,7 +2373,7 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@xmldom/xmldom@0.8.6", "@xmldom/xmldom@^0.7.0", "@xmldom/xmldom@^0.8.6":
+"@xmldom/xmldom@0.8.6", "@xmldom/xmldom@^0.8.3", "@xmldom/xmldom@^0.8.6":
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.6.tgz#8a1524eb5bd5e965c1e3735476f0262469f71440"
   integrity sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==
@@ -2469,12 +2469,12 @@ acorn@^8.7.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
-adal-node@0.2.3, adal-node@^0.1.28, adal-node@^0.2.2:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/adal-node/-/adal-node-0.2.3.tgz#87ed3dbed344f6e114e36bf18fe1c4e7d3cc6069"
-  integrity sha512-gMKr8RuYEYvsj7jyfCv/4BfKToQThz20SP71N3AtFn3ia3yAR8Qt2T3aVQhuJzunWs2b38ZsQV0qsZPdwZr7VQ==
+adal-node@0.2.4, adal-node@^0.2.2, adal-node@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/adal-node/-/adal-node-0.2.4.tgz#881beed9d493b76a86706ad5c8dc6f60eff04520"
+  integrity sha512-zIcvbwQFKMUtKxxj8YMHeTT1o/TPXfVNsTXVgXD8sxwV6h4AFQgK77dRciGhuEF9/Sdm3UQPJVPc/6XxrccSeA==
   dependencies:
-    "@xmldom/xmldom" "^0.7.0"
+    "@xmldom/xmldom" "^0.8.3"
     async "^2.6.3"
     axios "^0.21.1"
     date-utils "*"
@@ -13116,7 +13116,7 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-tough-cookie@^2.3.3, tough-cookie@^2.4.3, tough-cookie@~2.5.0:
+tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==


### PR DESCRIPTION
Fixes #minor

## Description
adal-node v 0.2.3 depends on @xmldom/xmldom@0.7.5 which has the critical severity alert: ** DISPUTED ** A prototype pollution vulnerability exists in the function copy in dom.js in @xmldom/xmldom before 0.8.3.

adal-node v 0.2.4 depends on the safer @xmldom/xmldom version 0.8.6. 

## Specific Changes
Upgrade to "adal-node": "0.2.4"

For more information on the vulnerability, see [https://github.com/microsoft/botframework-components/pull/1436](https://github.com/microsoft/botframework-components/pull/1436)
