### PR TITLE
port: [#4315] Support passing sas token url's for token service (#6449)

### DIFF
--- a/libraries/botbuilder-core/etc/botbuilder-core.api.md
+++ b/libraries/botbuilder-core/etc/botbuilder-core.api.md
@@ -43,6 +43,7 @@ import { StatusCodes } from 'botframework-schema';
 import { ThumbnailCard } from 'botframework-schema';
 import { TokenExchangeRequest } from 'botframework-schema';
 import { TokenExchangeResource } from 'botframework-schema';
+import { TokenPostResource } from 'botframework-schema';
 import { TokenResponse } from 'botframework-schema';
 import { UserTokenClient } from 'botframework-connector';
 import { VideoCard } from 'botframework-schema';
@@ -302,7 +303,7 @@ export class CardFactory {
     static images(images: (CardImage | string)[] | undefined): CardImage[];
     static media(links: (MediaUrl | string)[] | undefined): MediaUrl[];
     static o365ConnectorCard(card: O365ConnectorCard): Attachment;
-    static oauthCard(connectionName: string, title: string, text?: string, link?: string, tokenExchangeResource?: TokenExchangeResource): Attachment;
+    static oauthCard(connectionName: string, title: string, text?: string, link?: string, tokenExchangeResource?: TokenExchangeResource, tokenPostResource?: TokenPostResource): Attachment;
     static receiptCard(card: ReceiptCard): Attachment;
     static signinCard(title: string, url: string, text?: string): Attachment;
     static thumbnailCard(title: string, images?: (CardImage | string)[], buttons?: (CardAction | string)[], other?: Partial<ThumbnailCard>): Attachment;

--- a/libraries/botbuilder-core/src/cardFactory.ts
+++ b/libraries/botbuilder-core/src/cardFactory.ts
@@ -17,6 +17,7 @@ import {
     SigninCard,
     ThumbnailCard,
     TokenExchangeResource,
+    TokenPostResource,
     VideoCard,
 } from 'botframework-schema';
 
@@ -237,6 +238,7 @@ export class CardFactory {
      * @param text Optional. Additional text to include on the card.
      * @param link Optional. The sign-in link to use.
      * @param tokenExchangeResource optional. The resource to try to perform token exchange with.
+     * @param tokenPostResource optional. The resource for directly post a token to token service.
      * @returns An [Attachment](xref:botframework-schema.Attachment).
      * @remarks OAuth cards support the Bot Framework's single sign on (SSO) service.
      */
@@ -245,12 +247,14 @@ export class CardFactory {
         title: string,
         text?: string,
         link?: string,
-        tokenExchangeResource?: TokenExchangeResource
+        tokenExchangeResource?: TokenExchangeResource,
+        tokenPostResource?: TokenPostResource
     ): Attachment {
         const card: Partial<OAuthCard> = {
             buttons: [{ type: ActionTypes.Signin, title: title, value: link, channelData: undefined }],
             connectionName,
             tokenExchangeResource,
+            tokenPostResource,
         };
         if (text) {
             card.text = text;

--- a/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/oauthPrompt.ts
@@ -376,7 +376,8 @@ export class OAuthPrompt extends Dialog {
                 settings.title,
                 settings.text,
                 link,
-                signInResource.tokenExchangeResource
+                signInResource.tokenExchangeResource,
+                signInResource.tokenPostResource
             );
 
             // Set the appropriate ActionType for the button.

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -1265,6 +1265,7 @@ export interface OAuthCard {
     connectionName: string;
     text: string;
     tokenExchangeResource: TokenExchangeResource;
+    tokenPostResource: TokenPostResource;
 }
 
 // @public
@@ -1808,6 +1809,11 @@ export type TokenExchangeState = {
     relatesTo: ConversationReference;
     msAppId: string;
 };
+
+// @public
+export interface TokenPostResource {
+    sasUrl?: string;
+}
 
 // @public
 export interface TokenRequest {

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -1509,6 +1509,7 @@ export interface SigninStateVerificationQuery {
 export interface SignInUrlResponse {
     signInLink?: string;
     tokenExchangeResource?: TokenExchangeResource;
+    tokenPostResource?: TokenPostResource;
 }
 
 // @public

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -1367,6 +1367,10 @@ export interface OAuthCard {
      */
     tokenExchangeResource: TokenExchangeResource;
     /**
+     * The token for directly post a token to token service
+     */
+    tokenPostResource: TokenPostResource;
+    /**
      * Action to use to perform signin
      */
     buttons: CardAction[];
@@ -1989,6 +1993,7 @@ export interface SignInUrlResponse {
      * @member {TokenExchangeResource} [tokenExchangeResource]
      */
     tokenExchangeResource?: TokenExchangeResource;
+    tokenPostResource?: TokenPostResource;
 }
 
 /**
@@ -2008,6 +2013,17 @@ export interface TokenExchangeResource {
      * @member {string} [providerId]
      */
     providerId?: string;
+}
+
+/**
+ * @interface
+ * An interface representing TokenPostResource.
+ */
+export interface TokenPostResource {
+    /**
+     * @member {string} [sasUrl]
+     */
+    sasUrl?: string;
 }
 
 /**

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -1993,6 +1993,9 @@ export interface SignInUrlResponse {
      * @member {TokenExchangeResource} [tokenExchangeResource]
      */
     tokenExchangeResource?: TokenExchangeResource;
+    /**
+     * @member {TokenPostResource} [tokenPostResource]
+     */
     tokenPostResource?: TokenPostResource;
 }
 


### PR DESCRIPTION
Fixes #4315

## Description
This PR introduces support for passing through a token post resource via botbuilder. The token post resource contains a sas url for directly posting a token from a client to the bot framework token service. Botbuilder gets this url from token service and passes it onto the client.
These changes were ported from .NET repository.

## Specific Changes
- Add support for token post resource
- Support optional token post resource inside oauthcard

## Testing
- Added unit tests 
![image](https://user-images.githubusercontent.com/94375175/208159765-75c2e01b-b900-43b9-ac39-5cd3a768d0ce.png)

- Working sample
![image](https://user-images.githubusercontent.com/94375175/208159996-7ea49ea3-9dad-4675-84fe-f891ed0c880c.png)
