### PR TITLE
fix: Teams activity handler documentation fix

### DIFF
--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -61,12 +61,12 @@ const TeamsMeetingEndT = z
  * Adds support for Microsoft Teams specific events and interactions.
  *
  * @remarks
- * Developers may handle Conversation Update activities sent from Microsoft Teams via two methods:
+ * Developers may handle Message Update, Message Delete, and Conversation Update activities sent from Microsoft Teams via two methods:
  *  1. Overriding methods starting with `on..` and *not* ending in `..Event()` (e.g. `onTeamsMembersAdded()`), or instead
  *  2. Passing callbacks to methods starting with `on..` *and* ending in `...Event()` (e.g. `onTeamsMembersAddedEvent()`),
  *      to stay in line with older {@see ActivityHandler} implementation.
  *
- * Developers should use either #1 or #2, above for all Conversation Update activities and not *both* #2 and #3 for the same activity. Meaning,
+ * Developers should use either #1 or #2, above for all Message Update, Message Delete, and Conversation Update activities and not *both* #1 and #2 for the same activity. Meaning,
  *   developers should override `onTeamsMembersAdded()` and not use both `onTeamsMembersAdded()` and `onTeamsMembersAddedEvent()`.
  *
  * Developers wanting to handle Invoke activities *must* override methods starting with `handle...()` (e.g. `handleTeamsTaskModuleFetch()`).


### PR DESCRIPTION
Added remarks for usage of `Message Update` and `Message Delete` events

Fixes #4406 <!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

## Specific Changes
Documentation changes to include remarks on the Teams-related message update and message delete activities. 