### PR TITLE
type structure changes, tested

### DIFF
--- a/libraries/botframework-connector/src/teams/models/mappers.ts
+++ b/libraries/botframework-connector/src/teams/models/mappers.ts
@@ -434,40 +434,7 @@ export const TeamsMeetingDetails: msRest.CompositeMapper = {
     },
 };
 
-export const TeamsMeetingNotificationInfo: msRest.CompositeMapper = {
-    serializedName: 'TeamsMeetingNotificationInfo',
-    type: {
-        name: 'Composite',
-        className: 'TeamsMeetingNotificationInfo',
-        modelProperties: {
-            recipients: {
-                serializedName: 'recipients',
-                type: {
-                    name: 'Sequence',
-                    element: {
-                        type: {
-                            name: 'String',
-                        },
-                    },
-                },
-            },
-            surfaces: {
-                serializedName: 'surfaces',
-                type: {
-                    name: 'Sequence',
-                    element: {
-                        type: {
-                            name: 'Composite',
-                            className: 'TeamsMeetingNotificationSurface',
-                        },
-                    },
-                },
-            },
-        },
-    },
-};
-
-export const TeamsMeetingNotification: msRest.CompositeMapper = {
+export const TeamsMeetingNotification: msRest.CompositeMapper =  {
     serializedName: 'TeamsMeetingNotification',
     type: {
         name: 'Composite',
@@ -482,8 +449,7 @@ export const TeamsMeetingNotification: msRest.CompositeMapper = {
             value: {
                 serializedName: 'value',
                 type: {
-                    name: 'Composite',
-                    className: 'TeamsMeetingNotificationInfo',
+                    name: 'any',
                 },
             },
             channelData: {
@@ -497,34 +463,6 @@ export const TeamsMeetingNotification: msRest.CompositeMapper = {
     },
 };
 
-export const TeamsMeetingNotificationSurface: msRest.CompositeMapper = {
-    serializedName: 'TeamsMeetingNotificationSurface',
-    type: {
-        name: 'Composite',
-        className: 'TeamsMeetingNotificationSurface',
-        modelProperties: {
-            surface: {
-                serializedName: 'surface',
-                type: {
-                    name: 'String',
-                },
-            },
-            contentType: {
-                serializedName: 'contentType',
-                type: {
-                    name: 'String',
-                },
-            },
-            content: {
-                serializedName: 'content',
-                type: {
-                    name: 'Composite',
-                    className: 'TaskModuleContinueResponse',
-                },
-            },
-        },
-    },
-};
 
 export const TeamsMeetingNotificationChannelData = {
     serializedName: 'TeamsMeetingNotificationChannelData',

--- a/libraries/botframework-connector/src/teams/models/teamsMappers.ts
+++ b/libraries/botframework-connector/src/teams/models/teamsMappers.ts
@@ -16,8 +16,6 @@ export {
     TeamsMeetingInfo,
     TeamsMeetingParticipant,
     TeamsMeetingNotification,
-    TeamsMeetingNotificationInfo,
-    TeamsMeetingNotificationSurface,
     TeamsMeetingNotificationChannelData,
     TeamsMeetingOnBehalfOf,
     TeamsMeetingNotificationRecipientFailureInfo,

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -1820,28 +1820,50 @@ export interface MeetingEndEventDetails extends MeetingEventDetails {
 
 /**
  * @interface
- * Specifies details of a Teams meeting send notification payload.
+ * Specifies base details of a Teams meeting send notification payload.
  */
-export interface TeamsMeetingNotification {
+export interface TeamsMeetingNotificationBase<T> {
     /**
      * @member {string} [type] The type of meeting notification.
      */
-    type: 'targetedMeetingNotification' | string;
+    type: string;
+
     /**
-     * @member {TeamsMeetingNotificationInfo} [type] The specific details of the meeting notification.
+     * @member {T} [value] The specific details of the meeting notification.
      */
-    value: TeamsMeetingNotificationInfo;
+    value: T;
+} 
+
+
+/**
+ * @interface
+ * Specifies details of a targeted Teams meeting send notification payload.
+ */
+export interface TargetedMeetingNotification extends TeamsMeetingNotificationBase<TargetedMeetingNotificationInfo> {
     /**
-     * @member {TeamsMeetingNotificationChannelData} [type] The channel data of the meeting notification.
+     * @member {string} [type] The type of meeting notification.
      */
-    channelData: TeamsMeetingNotificationChannelData;
-}
+    type: 'targetedMeetingNotification';
+
+    /**
+     * @member {TeamsMeetingNotificationChannelData} [channelData] The channel data of the meeting notification.
+     */
+    channelData?: TeamsMeetingNotificationChannelData;
+} 
+
+
+/**
+ * @type
+ * Defines the base Teams meeting notification type
+ */
+export type TeamsMeetingNotification = TargetedMeetingNotification;
+
 
 /**
  * @interface
  * Specifies recipients and surfaces to target in a Teams meeting notification.
  */
-export interface TeamsMeetingNotificationInfo {
+export interface TargetedMeetingNotificationInfo {
     /**
      * @member {string[]} [recipients] The list of recipient meeting MRIs.
      */
@@ -1849,26 +1871,26 @@ export interface TeamsMeetingNotificationInfo {
     /**
      * @member {TeamsMeetingNotificationSurface[]} [surfaces] The List of notification surface configuration.
      */
-    surfaces: TeamsMeetingNotificationSurface[];
+    surfaces: TeamsMeetingSurface[];
 }
 
-/**
- * @interface
- * Specifies the surface and content for a Teams meeting notification.
- */
-export interface TeamsMeetingNotificationSurface {
+
+export type TeamsMeetingSurface = TeamsMeetingStageSurface<any>;
+
+
+export interface TeamsMeetingStageSurface<T> {
     /**
      * @member {string} [surface] The surface type.
-     */
-    surface: 'meetingStage' | string;
+    */
+    surface: 'meetingStage';
     /**
      * @member {string} [contentType] The content type.
-     */
+    */
     contentType: 'task' | string;
     /**
-     * @member {TaskModuleContinueResponse} [content] The content to display in the meeting notification.
+     * @member {T} [content] The content to display in the meeting notification.
      */
-    content: TaskModuleContinueResponse;
+    content: T;
 }
 
 /**
@@ -1879,7 +1901,7 @@ export interface TeamsMeetingNotificationChannelData {
     /**
      * @member {TeamsMeetingOnBehalfOf} [onBehalfOf] The user that the bot is sending the notification on behalfOf, if any.
      */
-    onBehalfOf?: TeamsMeetingOnBehalfOf;
+    onBehalfOf?: TeamsMeetingOnBehalfOf[];
 }
 
 /**


### PR DESCRIPTION
Fixes #4415 <!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

* Refactored types and interfaces associated with `sendMeetingNotification` api call, so that it can be extended without any breaking changes. And by 'extend`, I mean adding new types, making-optional existing properties and adding properties to existing interfaces.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

* Made `channelData` an optional property
* Updated the type of `onBehalfOf` property to be a list of `TeamsOnBehalfOf` objects.
* Notification payload type expected the `notification` parameter in `sendMeetingNotification` API function is  `TeamsMeetingNotification`. Currently it is equal to `TargetedMeetingNotification`. However it can made be a union of any arbitrary type. This makes the payload type extensible without any breaking changes.
* The request body mappers were simplified so that any value passed to the `value` property would be serialized without any hard coded constraints. 
* `surfaces` now is a list of `TeamsMeetingSurface` type. Just like `TeamsMeetingNotification` it can be a union of any arbitrary type. Making it possible to have more than one type of surface object in the list of surfaces.


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->

* Performed end-to-end test
* Unit tests remain the same