### PR TITLE
fix: use connectorClientOptions to create ConnectorFactory (#4420)

### DIFF
--- a/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
@@ -123,7 +123,8 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             this.toChannelFromBotOAuthScope,
             this.toChannelFromBotLoginUrl,
             this.validateAuthority,
-            this.credentialsFactory
+            this.credentialsFactory,
+            this.connectorClientOptions
         );
 
         return {
@@ -188,7 +189,8 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             this.toChannelFromBotOAuthScope,
             this.toChannelFromBotLoginUrl,
             this.validateAuthority,
-            this.credentialsFactory
+            this.credentialsFactory,
+            this.connectorClientOptions
         );
     }
 


### PR DESCRIPTION
Fixes #4420

## Description

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - `ParameterizedBotFrameworkAuthentication` uses `connectorClientOptions` to create `ConnectorFactory`.
