### PR TITLE
fix: Update channelServiceRoutes to add next() parameter to support restify 10.0.0+ 

### DIFF
--- a/libraries/botbuilder/src/channelServiceRoutes.ts
+++ b/libraries/botbuilder/src/channelServiceRoutes.ts
@@ -92,6 +92,7 @@ export class ChannelServiceRoutes {
                             res.send(resourceResponse);
                         }
                         res.end();
+                        return next();
                     })
                     .catch((err) => {
                         ChannelServiceRoutes.handleError(err, res);
@@ -117,6 +118,7 @@ export class ChannelServiceRoutes {
                             res.send(resourceResponse);
                         }
                         res.end();
+                        return next();
                     })
                     .catch((err) => {
                         ChannelServiceRoutes.handleError(err, res);
@@ -142,6 +144,7 @@ export class ChannelServiceRoutes {
                             res.send(resourceResponse);
                         }
                         res.end();
+                        return next();
                     })
                     .catch((err) => {
                         ChannelServiceRoutes.handleError(err, res);
@@ -162,6 +165,7 @@ export class ChannelServiceRoutes {
             .then(() => {
                 res.status(200);
                 res.end();
+                return next();
             })
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
@@ -181,6 +185,7 @@ export class ChannelServiceRoutes {
                 }
                 res.status(200);
                 res.end();
+                return next();
             })
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
@@ -201,6 +206,7 @@ export class ChannelServiceRoutes {
                     }
                     res.status(201);
                     res.end();
+                    return next();
                 })
                 .catch((err) => {
                     ChannelServiceRoutes.handleError(err, res);
@@ -221,6 +227,7 @@ export class ChannelServiceRoutes {
                 }
                 res.status(200);
                 res.end();
+                return next();
             })
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
@@ -240,6 +247,7 @@ export class ChannelServiceRoutes {
                     res.send(channelAccounts);
                 }
                 res.end();
+                return next();
             })
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
@@ -259,6 +267,7 @@ export class ChannelServiceRoutes {
                     res.send(channelAccount);
                 }
                 res.end();
+                return next();
             })
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
@@ -287,6 +296,7 @@ export class ChannelServiceRoutes {
                     res.send(pagedMembersResult);
                 }
                 res.end();
+                return next();
             })
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
@@ -303,6 +313,7 @@ export class ChannelServiceRoutes {
             .then(() => {
                 res.status(200);
                 res.end();
+                return next();
             })
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
@@ -324,6 +335,7 @@ export class ChannelServiceRoutes {
                         }
                         res.status(200);
                         res.end();
+                        return next();
                     })
                     .catch((err) => {
                         ChannelServiceRoutes.handleError(err, res);
@@ -349,6 +361,7 @@ export class ChannelServiceRoutes {
                         }
                         res.status(200);
                         res.end();
+                        return next();
                     })
                     .catch((err) => {
                         ChannelServiceRoutes.handleError(err, res);

--- a/libraries/botbuilder/src/channelServiceRoutes.ts
+++ b/libraries/botbuilder/src/channelServiceRoutes.ts
@@ -100,7 +100,6 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
-        return next();
     }
 
     /**
@@ -126,7 +125,6 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
-        return next();
     }
 
     /**
@@ -152,7 +150,6 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
-        return next();
     }
 
     /**
@@ -169,7 +166,6 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
-        return next();
     }
 
     /**
@@ -189,7 +185,6 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
-        return next();
     }
 
     /**
@@ -211,7 +206,6 @@ export class ChannelServiceRoutes {
                     ChannelServiceRoutes.handleError(err, res);
                 });
         });
-        return next();
     }
 
     /**
@@ -231,7 +225,6 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
-        return next();
     }
 
     /**
@@ -251,7 +244,6 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
-        return next();
     }
 
     /**
@@ -271,7 +263,6 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
-        return next();
     }
 
     /**
@@ -300,7 +291,6 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
-        return next();
     }
 
     /**
@@ -317,7 +307,6 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
-        return next();
     }
 
     /**
@@ -343,7 +332,6 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
-        return next();
     }
 
     /**
@@ -369,7 +357,6 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
-        return next();
     }
 
     /**

--- a/libraries/botbuilder/src/channelServiceRoutes.ts
+++ b/libraries/botbuilder/src/channelServiceRoutes.ts
@@ -80,7 +80,7 @@ export class ChannelServiceRoutes {
     /**
      * @private
      */
-    private processSendToConversation(req: WebRequest, res: WebResponse): void {
+    private processSendToConversation(req: WebRequest, res: WebResponse, next): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readActivity(req)
             .then((activity) => {
@@ -100,12 +100,13 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
+        return next();
     }
 
     /**
      * @private
      */
-    private processReplyToActivity(req: WebRequest, res: WebResponse): void {
+    private processReplyToActivity(req: WebRequest, res: WebResponse, next): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readActivity(req)
             .then((activity) => {
@@ -125,12 +126,13 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
+        return next();
     }
 
     /**
      * @private
      */
-    private processUpdateActivity(req: WebRequest, res: WebResponse): void {
+    private processUpdateActivity(req: WebRequest, res: WebResponse, next): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readActivity(req)
             .then((activity) => {
@@ -150,12 +152,13 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
+        return next();
     }
 
     /**
      * @private
      */
-    private processDeleteActivity(req: WebRequest, res: WebResponse): void {
+    private processDeleteActivity(req: WebRequest, res: WebResponse, next): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler
             .handleDeleteActivity(authHeader, req.params.conversationId, req.params.activityId)
@@ -166,12 +169,13 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
+        return next();
     }
 
     /**
      * @private
      */
-    private processGetActivityMembers(req: WebRequest, res: WebResponse): void {
+    private processGetActivityMembers(req: WebRequest, res: WebResponse, next): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler
             .handleGetActivityMembers(authHeader, req.params.conversationId, req.params.activityId)
@@ -185,12 +189,13 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
+        return next();
     }
 
     /**
      * @private
      */
-    private processCreateConversation(req: WebRequest, res: WebResponse): void {
+    private processCreateConversation(req: WebRequest, res: WebResponse, next): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readBody<ConversationParameters>(req).then((conversationParameters) => {
             this.channelServiceHandler
@@ -206,12 +211,13 @@ export class ChannelServiceRoutes {
                     ChannelServiceRoutes.handleError(err, res);
                 });
         });
+        return next();
     }
 
     /**
      * @private
      */
-    private processGetConversations(req: WebRequest, res: WebResponse): void {
+    private processGetConversations(req: WebRequest, res: WebResponse, next): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler
             .handleGetConversations(authHeader, req.params.conversationId, req.query.continuationToken)
@@ -225,12 +231,13 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
+        return next();
     }
 
     /**
      * @private
      */
-    private processGetConversationMembers(req: WebRequest, res: WebResponse): void {
+    private processGetConversationMembers(req: WebRequest, res: WebResponse, next): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler
             .handleGetConversationMembers(authHeader, req.params.conversationId)
@@ -244,12 +251,13 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
+        return next();
     }
 
     /**
      * @private
      */
-    private processGetConversationMember(req: WebRequest, res: WebResponse): void {
+    private processGetConversationMember(req: WebRequest, res: WebResponse, next): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler
             .handleGetConversationMember(authHeader, req.params.memberId, req.params.conversationId)
@@ -263,12 +271,13 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
+        return next();
     }
 
     /**
      * @private
      */
-    private processGetConversationPagedMembers(req: WebRequest, res: WebResponse): void {
+    private processGetConversationPagedMembers(req: WebRequest, res: WebResponse, next): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         let pageSize = parseInt(req.query.pageSize);
         if (isNaN(pageSize)) {
@@ -291,12 +300,13 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
+        return next();
     }
 
     /**
      * @private
      */
-    private processDeleteConversationMember(req: WebRequest, res: WebResponse): void {
+    private processDeleteConversationMember(req: WebRequest, res: WebResponse, next): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler
             .handleDeleteConversationMember(authHeader, req.params.conversationId, req.params.memberId)
@@ -307,12 +317,13 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
+        return next();
     }
 
     /**
      * @private
      */
-    private processSendConversationHistory(req: WebRequest, res: WebResponse): void {
+    private processSendConversationHistory(req: WebRequest, res: WebResponse, next): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readBody<Transcript>(req)
             .then((transcript) => {
@@ -332,12 +343,13 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
+        return next();
     }
 
     /**
      * @private
      */
-    private processUploadAttachment(req: WebRequest, res: WebResponse): void {
+    private processUploadAttachment(req: WebRequest, res: WebResponse, next): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readBody<AttachmentData>(req)
             .then((attachmentData) => {
@@ -357,6 +369,7 @@ export class ChannelServiceRoutes {
             .catch((err) => {
                 ChannelServiceRoutes.handleError(err, res);
             });
+        return next();
     }
 
     /**

--- a/libraries/botbuilder/src/channelServiceRoutes.ts
+++ b/libraries/botbuilder/src/channelServiceRoutes.ts
@@ -80,7 +80,7 @@ export class ChannelServiceRoutes {
     /**
      * @private
      */
-    private processSendToConversation(req: WebRequest, res: WebResponse, next): void {
+    private processSendToConversation(req: WebRequest, res: WebResponse, next: Function): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readActivity(req)
             .then((activity) => {
@@ -106,7 +106,7 @@ export class ChannelServiceRoutes {
     /**
      * @private
      */
-    private processReplyToActivity(req: WebRequest, res: WebResponse, next): void {
+    private processReplyToActivity(req: WebRequest, res: WebResponse, next: Function): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readActivity(req)
             .then((activity) => {
@@ -132,7 +132,7 @@ export class ChannelServiceRoutes {
     /**
      * @private
      */
-    private processUpdateActivity(req: WebRequest, res: WebResponse, next): void {
+    private processUpdateActivity(req: WebRequest, res: WebResponse, next: Function): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readActivity(req)
             .then((activity) => {
@@ -158,7 +158,7 @@ export class ChannelServiceRoutes {
     /**
      * @private
      */
-    private processDeleteActivity(req: WebRequest, res: WebResponse, next): void {
+    private processDeleteActivity(req: WebRequest, res: WebResponse, next: Function): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler
             .handleDeleteActivity(authHeader, req.params.conversationId, req.params.activityId)
@@ -175,7 +175,7 @@ export class ChannelServiceRoutes {
     /**
      * @private
      */
-    private processGetActivityMembers(req: WebRequest, res: WebResponse, next): void {
+    private processGetActivityMembers(req: WebRequest, res: WebResponse, next: Function): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler
             .handleGetActivityMembers(authHeader, req.params.conversationId, req.params.activityId)
@@ -195,7 +195,7 @@ export class ChannelServiceRoutes {
     /**
      * @private
      */
-    private processCreateConversation(req: WebRequest, res: WebResponse, next): void {
+    private processCreateConversation(req: WebRequest, res: WebResponse, next: Function): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readBody<ConversationParameters>(req).then((conversationParameters) => {
             this.channelServiceHandler
@@ -217,7 +217,7 @@ export class ChannelServiceRoutes {
     /**
      * @private
      */
-    private processGetConversations(req: WebRequest, res: WebResponse, next): void {
+    private processGetConversations(req: WebRequest, res: WebResponse, next: Function): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler
             .handleGetConversations(authHeader, req.params.conversationId, req.query.continuationToken)
@@ -237,7 +237,7 @@ export class ChannelServiceRoutes {
     /**
      * @private
      */
-    private processGetConversationMembers(req: WebRequest, res: WebResponse, next): void {
+    private processGetConversationMembers(req: WebRequest, res: WebResponse, next: Function): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler
             .handleGetConversationMembers(authHeader, req.params.conversationId)
@@ -257,7 +257,7 @@ export class ChannelServiceRoutes {
     /**
      * @private
      */
-    private processGetConversationMember(req: WebRequest, res: WebResponse, next): void {
+    private processGetConversationMember(req: WebRequest, res: WebResponse, next: Function): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler
             .handleGetConversationMember(authHeader, req.params.memberId, req.params.conversationId)
@@ -277,7 +277,7 @@ export class ChannelServiceRoutes {
     /**
      * @private
      */
-    private processGetConversationPagedMembers(req: WebRequest, res: WebResponse, next): void {
+    private processGetConversationPagedMembers(req: WebRequest, res: WebResponse, next: Function): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         let pageSize = parseInt(req.query.pageSize);
         if (isNaN(pageSize)) {
@@ -306,7 +306,7 @@ export class ChannelServiceRoutes {
     /**
      * @private
      */
-    private processDeleteConversationMember(req: WebRequest, res: WebResponse, next): void {
+    private processDeleteConversationMember(req: WebRequest, res: WebResponse, next: Function): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         this.channelServiceHandler
             .handleDeleteConversationMember(authHeader, req.params.conversationId, req.params.memberId)
@@ -323,7 +323,7 @@ export class ChannelServiceRoutes {
     /**
      * @private
      */
-    private processSendConversationHistory(req: WebRequest, res: WebResponse, next): void {
+    private processSendConversationHistory(req: WebRequest, res: WebResponse, next: Function): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readBody<Transcript>(req)
             .then((transcript) => {
@@ -349,7 +349,7 @@ export class ChannelServiceRoutes {
     /**
      * @private
      */
-    private processUploadAttachment(req: WebRequest, res: WebResponse, next): void {
+    private processUploadAttachment(req: WebRequest, res: WebResponse, next: Function): void {
         const authHeader = req.headers.authorization || req.headers.Authorization || '';
         ChannelServiceRoutes.readBody<AttachmentData>(req)
             .then((attachmentData) => {

--- a/libraries/botbuilder/tests/channelServiceRoutes.test.js
+++ b/libraries/botbuilder/tests/channelServiceRoutes.test.js
@@ -127,7 +127,7 @@ describe('channelServiceRoutes', function () {
                     service.handleSendToConversation = sandbox.stub().resolves(testResource);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processSendToConversation(req, res);
+                    channel.processSendToConversation(req, res, Function);
                 } catch (err) {
                     done(err);
                 }
@@ -156,7 +156,7 @@ describe('channelServiceRoutes', function () {
                     service.handleSendToConversation = sandbox.stub().rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processSendToConversation(req, res);
+                    channel.processSendToConversation(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -188,7 +188,7 @@ describe('channelServiceRoutes', function () {
                     readActivityStub.rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processSendToConversation(req, res);
+                    channel.processSendToConversation(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -210,7 +210,7 @@ describe('channelServiceRoutes', function () {
                     service.handleReplyToActivity = sandbox.stub().resolves(testResource);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processReplyToActivity(req, res);
+                    channel.processReplyToActivity(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -240,7 +240,7 @@ describe('channelServiceRoutes', function () {
                     service.handleReplyToActivity = sandbox.stub().rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processReplyToActivity(req, res);
+                    channel.processReplyToActivity(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -272,7 +272,7 @@ describe('channelServiceRoutes', function () {
                     readActivityStub.rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processReplyToActivity(req, res);
+                    channel.processReplyToActivity(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -294,7 +294,7 @@ describe('channelServiceRoutes', function () {
                     service.handleUpdateActivity = sandbox.stub().resolves(testResource);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processUpdateActivity(req, res);
+                    channel.processUpdateActivity(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -324,7 +324,7 @@ describe('channelServiceRoutes', function () {
                     service.handleUpdateActivity = sandbox.stub().rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processUpdateActivity(req, res);
+                    channel.processUpdateActivity(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -356,7 +356,7 @@ describe('channelServiceRoutes', function () {
                     readActivityStub.rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processUpdateActivity(req, res);
+                    channel.processUpdateActivity(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -378,7 +378,7 @@ describe('channelServiceRoutes', function () {
                     service.handleDeleteActivity = sandbox.stub().resolves();
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processDeleteActivity(req, res);
+                    channel.processDeleteActivity(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -408,7 +408,7 @@ describe('channelServiceRoutes', function () {
                     service.handleDeleteActivity = sandbox.stub().rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processDeleteActivity(req, res);
+                    channel.processDeleteActivity(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -430,7 +430,7 @@ describe('channelServiceRoutes', function () {
                     service.handleGetActivityMembers = sandbox.stub().resolves(testResource);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processGetActivityMembers(req, res);
+                    channel.processGetActivityMembers(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -460,7 +460,7 @@ describe('channelServiceRoutes', function () {
                     service.handleGetActivityMembers = sandbox.stub().rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processGetActivityMembers(req, res);
+                    channel.processGetActivityMembers(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -482,7 +482,7 @@ describe('channelServiceRoutes', function () {
                     service.handleCreateConversation = sandbox.stub().resolves(testResource);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processCreateConversation(req, res);
+                    channel.processCreateConversation(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -512,7 +512,7 @@ describe('channelServiceRoutes', function () {
                     service.handleCreateConversation = sandbox.stub().rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processCreateConversation(req, res);
+                    channel.processCreateConversation(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -534,7 +534,7 @@ describe('channelServiceRoutes', function () {
                     service.handleGetConversations = sandbox.stub().resolves(testResource);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processGetConversations(req, res);
+                    channel.processGetConversations(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -564,7 +564,7 @@ describe('channelServiceRoutes', function () {
                     service.handleGetConversations = sandbox.stub().rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processGetConversations(req, res);
+                    channel.processGetConversations(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -586,7 +586,7 @@ describe('channelServiceRoutes', function () {
                     service.handleGetConversationMembers = sandbox.stub().resolves(testResource);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processGetConversationMembers(req, res);
+                    channel.processGetConversationMembers(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -616,7 +616,7 @@ describe('channelServiceRoutes', function () {
                     service.handleGetConversationMembers = sandbox.stub().rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processGetConversationMembers(req, res);
+                    channel.processGetConversationMembers(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -638,7 +638,7 @@ describe('channelServiceRoutes', function () {
                     service.handleGetConversationPagedMembers = sandbox.stub().resolves(testResource);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processGetConversationPagedMembers(req, res);
+                    channel.processGetConversationPagedMembers(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -668,7 +668,7 @@ describe('channelServiceRoutes', function () {
                     service.handleGetConversationPagedMembers = sandbox.stub().rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processGetConversationPagedMembers(req, res);
+                    channel.processGetConversationPagedMembers(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -690,7 +690,7 @@ describe('channelServiceRoutes', function () {
                     service.handleDeleteConversationMember = sandbox.stub().resolves(testResource);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processDeleteConversationMember(req, res);
+                    channel.processDeleteConversationMember(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -720,7 +720,7 @@ describe('channelServiceRoutes', function () {
                     service.handleDeleteConversationMember = sandbox.stub().rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processDeleteConversationMember(req, res);
+                    channel.processDeleteConversationMember(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -742,7 +742,7 @@ describe('channelServiceRoutes', function () {
                     service.handleSendConversationHistory = sandbox.stub().resolves(testResource);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processSendConversationHistory(req, res);
+                    channel.processSendConversationHistory(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -772,7 +772,7 @@ describe('channelServiceRoutes', function () {
                     service.handleSendConversationHistory = sandbox.stub().rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processSendConversationHistory(req, res);
+                    channel.processSendConversationHistory(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -804,7 +804,7 @@ describe('channelServiceRoutes', function () {
                     readBodyStub.rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processSendConversationHistory(req, res);
+                    channel.processSendConversationHistory(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -826,7 +826,7 @@ describe('channelServiceRoutes', function () {
                     service.handleUploadAttachment = sandbox.stub().resolves(testResource);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processUploadAttachment(req, res);
+                    channel.processUploadAttachment(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -856,7 +856,7 @@ describe('channelServiceRoutes', function () {
                     service.handleUploadAttachment = sandbox.stub().rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processUploadAttachment(req, res);
+                    channel.processUploadAttachment(req, res, Function);
                 } catch (error) {
                     done(error);
                 }
@@ -888,7 +888,7 @@ describe('channelServiceRoutes', function () {
                     readBodyStub.rejects(resourceResponse);
 
                     const channel = new ChannelServiceRoutes(service);
-                    channel.processUploadAttachment(req, res);
+                    channel.processUploadAttachment(req, res, Function);
                 } catch (error) {
                     done(error);
                 }


### PR DESCRIPTION
#minor
Fixes **Internal**: https://portal.microsofticm.com/imp/v3/incidents/details/365652257/home

## Description
restify 10.0.0 and greater enforces the need for a `next()` callback that passes execution to the next function in the handler chain. `channelServiceRoutes.ts` does not currently address this requirement. Since this class is required to interact with skills, this means that root bots that import this class will fail to start.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Add the `next: Function` parameter to the handlers in `channelServiceRoutes.ts`
  - Add a `return next()` statement to the aforementioned handlers
  - Update the tests in `channelServiceRoutes.test.js` to pass in an empty `Function` as `next` in each test

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
Ran the updated unit tests successfully.