### PR TITLE
feat: Add MeetingTabIconSurface to MeetingSurface capabilities

### DIFF
--- a/libraries/botbuilder/tests/teamsInfo.test.js
+++ b/libraries/botbuilder/tests/teamsInfo.test.js
@@ -972,6 +972,10 @@ describe('TeamsInfo', function () {
                                 },
                             },
                         },
+                        {
+                            surface: 'meetingTabIcon',
+                            tabEntityId: 'some-tab-id',
+                        },
                     ],
                 },
                 channelData: {

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -1876,7 +1876,7 @@ export interface TargetedMeetingNotificationValue {
  * @type {MeetingSurface}
  * Defines the generic Teams meeting surface type.
  */
-export type MeetingSurface = MeetingStageSurface<any>;
+export type MeetingSurface = MeetingStageSurface<any> | MeetingTabIconSurface;
 
 /**
  * @interface
@@ -1896,6 +1896,22 @@ export interface MeetingStageSurface<T> {
      * @member {T} [content] The content to display in the meeting notification.
      */
     content: T;
+}
+
+/**
+ * @interface
+ * Specifies the meeting tab icon surface in a Teams meeting notification.
+ */
+export interface MeetingTabIconSurface {
+    /**
+     * @member {string} [surface] The surface type.
+     */
+    surface: 'meetingTabIcon';
+
+    /**
+     * @member {string} [tabEntityId] The tab entity ID.
+     */
+    tabEntityId?: string;
 }
 
 /**


### PR DESCRIPTION
Resolves #4458

## Description
Add-on to Meeting Notifications feature, where tab icons can push a notification to alert specified users in the UBar

## Specific Changes
  -  Add new interface `MeetingTabIconSurface` to `teams`
  - Turn `MeetingSurface` into union type: `MeetingStageSurface<any> | MeetingTabIconSurface`
  - Add to tests that using `MeetingTabIcon` payload 

## Testing
- Unit tests updated
- Manual testing was successful. Different scenarios below: 
    - 200: Sending TabIcon to hardcoded sender's user id: returns 200 with empty payload
![image](https://user-images.githubusercontent.com/14900841/233718238-790d95c2-91b2-4de4-8f78-b1b5c73d1aff.png)
![image](https://user-images.githubusercontent.com/14900841/233718855-e1052132-42b2-4275-a958-2ac9a1f9f6cc.png)
   - Success when recipient is just a hardcoded member string: (same as above)
   - 207: Partial success where one of two member id's are invalid: Payload indicates the failure and reason.
    ![image](https://user-images.githubusercontent.com/14900841/233719540-bc19cf0b-018c-4e5d-86e7-3dbd8fefda0b.png)
![image](https://user-images.githubusercontent.com/14900841/233718582-7b2c6053-b906-41ce-9cd2-91c96b3deace.png)
 - When recipient array is empty: 
 ![image](https://user-images.githubusercontent.com/14900841/233721451-c72f9a78-0efb-4f8c-8bad-3bd724686bf4.png)

FE screencaps TBD