### PR TITLE
fix: [#4452][#4456][#4460][botframework-streaming] Should reject pending requests on disconnection

### DIFF
--- a/libraries/botframework-streaming/src/payloads/requestManager.ts
+++ b/libraries/botframework-streaming/src/payloads/requestManager.ts
@@ -21,7 +21,7 @@ class PendingRequest {
  * Orchestrates and manages pending streaming requests.
  */
 export class RequestManager {
-    private readonly _pendingRequests = {};
+    private readonly _pendingRequests: Record<string, PendingRequest> = {};
 
     /**
      * Gets the count of the pending requests.
@@ -76,5 +76,18 @@ export class RequestManager {
         this._pendingRequests[requestId] = pendingRequest;
 
         return promise;
+    }
+
+    /**
+     * Rejects all requests pending a response.
+     *
+     * @param reason The reason for rejection.
+     */
+    rejectAllResponses(reason?: Error): void {
+        Object.entries(this._pendingRequests).forEach(([requestId, { reject }]) => {
+            reject(reason);
+
+            delete this._pendingRequests[requestId];
+        });
     }
 }

--- a/libraries/botframework-streaming/src/protocolAdapter.ts
+++ b/libraries/botframework-streaming/src/protocolAdapter.ts
@@ -71,9 +71,14 @@ export class ProtocolAdapter {
      */
     async sendRequest(request: StreamingRequest): Promise<IReceiveResponse> {
         const requestId: string = generateGuid();
+
+        // Register the request in the request manager before sending it to the server.
+        // Otherwise, if the server respond quickly, it may miss the request.
+        const getResponsePromise = this.requestManager.getResponse(requestId);
+
         await this.sendOperations.sendRequest(requestId, request);
 
-        return this.requestManager.getResponse(requestId);
+        return getResponsePromise;
     }
 
     /**

--- a/libraries/botframework-streaming/src/webSocket/browserWebSocketClient.ts
+++ b/libraries/botframework-streaming/src/webSocket/browserWebSocketClient.ts
@@ -96,6 +96,9 @@ export class WebSocketClient implements IStreamingTransportClient {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private onConnectionDisconnected(sender: Record<string, unknown>, args: any): void {
+        // Rejects all pending requests on disconnect.
+        this._requestManager.rejectAllResponses(new Error('Disconnect was called.'));
+
         if (this._disconnectionHandler != null) {
             this._disconnectionHandler('Disconnected');
             return;

--- a/libraries/botframework-streaming/src/webSocket/nodeWebSocketClient.ts
+++ b/libraries/botframework-streaming/src/webSocket/nodeWebSocketClient.ts
@@ -100,6 +100,9 @@ export class WebSocketClient implements IStreamingTransportClient {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private onConnectionDisconnected(sender: Record<string, unknown>, args: any): void {
+        // Rejects all pending requests on disconnect.
+        this._requestManager.rejectAllResponses(new Error('Disconnect was called.'));
+
         if (this._disconnectionHandler != null) {
             this._disconnectionHandler('Disconnected');
             return;

--- a/libraries/botframework-streaming/src/webSocket/webSocketTransport.ts
+++ b/libraries/botframework-streaming/src/webSocket/webSocketTransport.ts
@@ -59,7 +59,7 @@ export class WebSocketTransport implements ITransportSender, ITransportReceiver 
      * @returns `true` if the the transport is connected and ready to send data, `false` otherwise.
      */
     get isConnected(): boolean {
-        return this.ws?.isConnected;
+        return !!this.ws?.isConnected;
     }
 
     /**

--- a/libraries/botframework-streaming/tests/Assembler.test.js
+++ b/libraries/botframework-streaming/tests/Assembler.test.js
@@ -30,7 +30,7 @@ describe('PayloadAssembler', function () {
 
         expect(() => {
             rra.close();
-        }).to.not.throw;
+        }).to.not.throw();
     });
 
     it('returns a new stream.', function () {
@@ -121,7 +121,7 @@ describe('PayloadAssembler', function () {
         const csa = new PayloadAssembler(streamManager, { header, onCompleted: () => {} });
 
         expect(csa.createPayloadStream()).instanceOf(SubscribableStream);
-        expect(csa.close()).to.not.throw;
+        expect(() => csa.close()).to.not.throw();
     });
 });
 
@@ -175,7 +175,7 @@ describe('PayloadAssemblerManager', function () {
         };
         const s = p.getPayloadStream(head);
         expect(s).to.be.instanceOf(SubscribableStream);
-        expect(p.onReceive(head, s, 0)).to.not.throw;
+        expect(() => p.onReceive(head, s, 0)).to.not.throw();
         done();
     });
 
@@ -195,7 +195,7 @@ describe('PayloadAssemblerManager', function () {
         const s = p.getPayloadStream(head);
 
         expect(s).to.be.instanceOf(SubscribableStream);
-        expect(p.onReceive(head, s, 0)).to.not.throw;
+        expect(() => p.onReceive(head, s, 0)).to.not.throw();
         done();
     });
 
@@ -215,7 +215,7 @@ describe('PayloadAssemblerManager', function () {
         const s = p.getPayloadStream(head);
 
         expect(s).to.be.instanceOf(SubscribableStream);
-        expect(p.onReceive(head, s, 0)).to.not.throw;
+        expect(() => p.onReceive(head, s, 0)).to.not.throw();
         done();
     });
 

--- a/libraries/botframework-streaming/tests/ContentStream.test.js
+++ b/libraries/botframework-streaming/tests/ContentStream.test.js
@@ -134,6 +134,6 @@ describe('Streaming Extensions ContentStream Tests ', function () {
         const cs = new ContentStream('cs1', new TestPayloadAssembler());
         cs.readAsString();
 
-        expect(cs.cancel()).to.not.throw;
+        expect(() => cs.cancel()).to.not.throw();
     });
 });

--- a/libraries/botframework-streaming/tests/Disassembler.test.js
+++ b/libraries/botframework-streaming/tests/Disassembler.test.js
@@ -41,6 +41,6 @@ describe('CancelDisassembler', function () {
         expect(cd.payloadType).to.equal(PayloadTypes.cancelStream);
         expect(cd.sender).to.equal(sender);
 
-        expect(cd.disassemble()).to.not.throw;
+        expect(() => cd.disassemble()).to.not.throw();
     });
 });

--- a/libraries/botframework-streaming/tests/NamedPipe.test.js
+++ b/libraries/botframework-streaming/tests/NamedPipe.test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const { expect } = require('chai');
 const { NamedPipeClient, NamedPipeServer, StreamingRequest } = require('../lib');
 const { NamedPipeTransport } = require('../lib/namedPipe');
+const { platform } = require('os');
 const { RequestHandler } = require('../lib');
 const { createNodeServer, getServerFactory } = require('../lib/utilities/createNodeServer');
 
@@ -78,7 +79,9 @@ class TestClient {
     }
 }
 
-describe('Streaming Extensions NamedPipe Library Tests', function () {
+describe.windowsOnly = platform() === 'linux' ? describe.skip : describe;
+
+describe.windowsOnly('Streaming Extensions NamedPipe Library Tests', function () {
     describe('NamedPipe Transport Tests', function () {
         it('Client connect', function () {
             const c = new TestClient('pipeName');

--- a/libraries/botframework-streaming/tests/NamedPipe.test.js
+++ b/libraries/botframework-streaming/tests/NamedPipe.test.js
@@ -108,7 +108,7 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
             sock.writable = true;
             const transport = new NamedPipeTransport(sock, 'fakeSocket1');
             expect(transport).to.be.instanceOf(NamedPipeTransport);
-            expect(() => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw();
         });
 
         it('creates a new transport and connects', function () {
@@ -119,7 +119,7 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
             const transport = new NamedPipeTransport(sock, 'fakeSocket2');
             expect(transport).to.be.instanceOf(NamedPipeTransport);
             expect(transport.isConnected).to.be.true;
-            expect(() => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw();
         });
 
         it('closes the transport without throwing', function () {
@@ -129,7 +129,7 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
             sock.writable = true;
             const transport = new NamedPipeTransport(sock, 'fakeSocket3');
             expect(transport).to.be.instanceOf(NamedPipeTransport);
-            expect(transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw();
             expect(transport.isConnected).to.be.false;
         });
 
@@ -144,7 +144,7 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
             const buff = Buffer.from('hello', 'utf8');
             const sent = transport.send(buff);
             expect(sent).to.equal(5);
-            expect(() => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw();
         });
 
         it('returns 0 when attempting to write to a closed socket', function () {
@@ -159,7 +159,7 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
             const buff = Buffer.from('hello', 'utf8');
             const sent = transport.send(buff);
             expect(sent).to.equal(0);
-            expect(() => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw();
         });
 
         it('throws when reading from a dead socket', function () {
@@ -170,8 +170,8 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
             const transport = new NamedPipeTransport(sock, 'fakeSocket5');
             expect(transport).to.be.instanceOf(NamedPipeTransport);
             expect(transport.isConnected).to.be.true;
-            expect(transport.receive(5)).to.throw;
-            expect(() => transport.close()).to.not.throw;
+            expect(transport.receive(5)).to.throw();
+            expect(() => transport.close()).to.not.throw();
         });
 
         it('can read from the socket', function () {
@@ -185,7 +185,7 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
             transport.receive(12).catch();
             transport.socketReceive(Buffer.from('Hello World!', 'utf8'));
 
-            expect(() => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw();
         });
 
         it('cleans up when onClose is fired', function () {
@@ -231,7 +231,7 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
             expect(transport).to.be.instanceOf(NamedPipeTransport);
             expect(transport.isConnected).to.be.true;
             const buff = Buffer.from('hello', 'utf8');
-            expect(transport.socketReceive(buff)).to.not.throw;
+            expect(transport.socketReceive(buff)).to.not.throw();
         });
     });
 
@@ -240,16 +240,16 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
 
         it('creates a new client', function () {
             expect(client).to.be.instanceOf(NamedPipeClient);
-            expect(client.disconnect()).to.not.throw;
+            expect(() => client.disconnect()).to.not.throw();
         });
 
         it('connects without throwing', function () {
-            expect(client.connect()).to.not.throw;
-            expect(client.disconnect()).to.not.throw;
+            expect(() => client.connect()).to.not.throw();
+            expect(() => client.disconnect()).to.not.throw();
         });
 
         it('disconnects without throwing', function () {
-            expect(client.disconnect()).to.not.throw;
+            expect(() => client.disconnect()).to.not.throw();
         });
 
         it('sends without throwing', function (done) {
@@ -262,7 +262,7 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
                 .catch((err) => {
                     expect(err).to.be.undefined;
                 })
-                .then(done());
+                .then(done);
         });
     });
 
@@ -270,7 +270,7 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
         it('creates a new server', function () {
             const server = new NamedPipeServer('pipeA', new RequestHandler());
             expect(server).to.be.instanceOf(NamedPipeServer);
-            expect(server.disconnect()).to.not.throw;
+            expect(() => server.disconnect()).to.not.throw();
         });
 
         it('throws a TypeError during construction if missing the "baseName" parameter', function () {
@@ -281,15 +281,15 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
             const server = new NamedPipeServer('pipeA', new RequestHandler());
             expect(server).to.be.instanceOf(NamedPipeServer);
 
-            expect(server.start()).to.not.throw;
-            expect(server.disconnect()).to.not.throw;
+            expect(() => server.start()).to.not.throw();
+            expect(() => server.disconnect()).to.not.throw();
         });
 
         it('disconnects without throwing', function () {
             const server = new NamedPipeServer('pipeA', new RequestHandler());
             expect(server).to.be.instanceOf(NamedPipeServer);
-            expect(server.start()).to.not.throw;
-            expect(server.disconnect()).to.not.throw;
+            expect(() => server.start()).to.not.throw();
+            expect(() => server.disconnect()).to.not.throw();
         });
 
         it('returns true if isConnected === true on _receiver & _sender', function () {
@@ -304,22 +304,22 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
         it('sends without throwing', function (done) {
             const server = new NamedPipeServer('pipeA', new RequestHandler());
             expect(server).to.be.instanceOf(NamedPipeServer);
-            expect(server.start()).to.not.throw;
+            expect(() => server.start()).to.not.throw();
             const req = { verb: 'POST', path: '/api/messages', streams: [] };
             server
                 .send(req)
                 .catch((err) => {
                     expect(err).to.be.undefined;
                 })
-                .then(expect(server.disconnect()).to.not.throw)
-                .then(done());
+                .then(expect(() => server.disconnect()).to.not.throw)
+                .then(done);
         });
 
         it('handles being disconnected', function () {
             const server = new NamedPipeServer('pipeA', new RequestHandler());
             expect(server).to.be.instanceOf(NamedPipeServer);
             server.start();
-            expect(server.disconnect()).to.not.throw;
+            expect(() => server.disconnect()).to.not.throw();
         });
 
         it('ensures that two servers cannot get into a split brain scenario', async function () {
@@ -369,12 +369,12 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
         });
 
         it('should not throw when choosing not to pass in a callback at all into createNodeServer()', function () {
-            expect(() => createNodeServer()).to.not.throw;
+            expect(() => createNodeServer()).to.not.throw();
         });
 
         it('should return a Server when calling createNodeServer()', function () {
             const server = createNodeServer();
-            expect(server).to.not.throw;
+            expect(server).to.not.throw();
             expect(server).to.not.be.null;
             expect(server).to.be.instanceOf(Object);
             expect(typeof server.listen).to.equal('function');
@@ -382,7 +382,7 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
         });
 
         it('should return the factory when calling getServerFactory()', function () {
-            expect(getServerFactory()).to.not.throw;
+            expect(() => getServerFactory()).to.not.throw();
             const serverFactoryFunction = getServerFactory();
             expect(serverFactoryFunction).to.not.be.null;
             expect(typeof serverFactoryFunction).to.equal('function');
@@ -391,7 +391,7 @@ describe('Streaming Extensions NamedPipe Library Tests', function () {
         it("should throw if the callback isn't a valid connection listener callback", function () {
             const callback = () => {};
             const serverFactory = getServerFactory();
-            expect(serverFactory(callback)).to.throw;
+            expect(serverFactory(callback)).to.throw();
         });
     });
 });

--- a/libraries/botframework-streaming/tests/NodeWebSocket.test.js
+++ b/libraries/botframework-streaming/tests/NodeWebSocket.test.js
@@ -10,7 +10,7 @@ describe('NodeWebSocket', function () {
     it('creates a new NodeWebSocket', function () {
         const socket = new NodeWebSocket(new FauxSock());
         expect(socket).to.be.instanceOf(NodeWebSocket);
-        expect(socket.close()).to.not.throw;
+        expect(() => socket.close()).to.not.throw();
     });
 
     it('starts out connected', function () {
@@ -21,14 +21,17 @@ describe('NodeWebSocket', function () {
     it('writes to the socket', function () {
         const socket = new NodeWebSocket(new FauxSock());
         const buff = Buffer.from('hello');
-        expect(socket.write(buff)).to.not.throw;
+        expect(() => socket.write(buff)).to.not.throw();
     });
 
     it('attempts to open a connection', function () {
         const socket = new NodeWebSocket(new FauxSock());
         expect(
             socket.connect().catch((error) => {
-                expect(error.message).to.equal('connect ECONNREFUSED 127.0.0.1:8082');
+                expect(
+                    error.message === 'connect ECONNREFUSED 127.0.0.1:8082' ||
+                        error.message === 'connect ECONNREFUSED ::1:8082'
+                ).to.be.true;
             })
         );
     });
@@ -37,7 +40,7 @@ describe('NodeWebSocket', function () {
         const sock = new FauxSock();
         const socket = new NodeWebSocket(sock);
         expect(sock.messageHandler).to.be.undefined;
-        expect(socket.setOnMessageHandler(() => {})).to.not.throw;
+        expect(() => socket.setOnMessageHandler(() => {})).to.not.throw();
         expect(sock.messageHandler).to.not.be.undefined;
     });
 
@@ -45,7 +48,7 @@ describe('NodeWebSocket', function () {
         const sock = new FauxSock();
         const socket = new NodeWebSocket(sock);
         expect(sock.errorHandler).to.be.undefined;
-        expect(socket.setOnErrorHandler(() => {})).to.not.throw;
+        expect(() => socket.setOnErrorHandler(() => {})).to.not.throw();
         expect(sock.errorHandler).to.not.be.undefined;
     });
 
@@ -53,7 +56,7 @@ describe('NodeWebSocket', function () {
         const sock = new FauxSock();
         const socket = new NodeWebSocket(sock);
         expect(sock.closeHandler).to.be.undefined;
-        expect(socket.setOnCloseHandler(() => {})).to.not.throw;
+        expect(() => socket.setOnCloseHandler(() => {})).to.not.throw();
         expect(sock.closeHandler).to.not.be.undefined;
     });
 

--- a/libraries/botframework-streaming/tests/PayloadSender.test.js
+++ b/libraries/botframework-streaming/tests/PayloadSender.test.js
@@ -135,13 +135,11 @@ describe('PayloadTransport', function () {
             expect(ps.isConnected).to.equal(false);
         });
 
-        it('gracefully fails when trying to write before connecting.', function (done) {
+        it('gracefully fails when trying to write before connecting.', function () {
+            // When not connected, PayloadSender should not throw.
+            // It should drop the packet silently.
             const ps = new PayloadSender();
-            ps.disconnected = () => done();
             expect(ps.isConnected).to.equal(false);
-            ps.connect(new FauxSock());
-            expect(ps.isConnected).to.equal(true);
-            expect(ps.disconnected).to.not.be.undefined;
 
             const stream = new SubscribableStream();
             stream.write('This is a test stream.');
@@ -152,7 +150,7 @@ describe('PayloadTransport', function () {
                 end: true,
             };
 
-            ps.sendPayload(header, stream, () => done());
+            ps.sendPayload(header, stream);
         });
     });
 
@@ -191,7 +189,7 @@ describe('PayloadTransport', function () {
                     assemblerManager.onReceive(header, contentStream, contentLength)
             );
 
-            expect(pr.connect(sock)).to.not.throw;
+            expect(() => pr.connect(sock)).to.not.throw();
 
             pr.disconnected = () => done();
             expect(pr.isConnected).to.be.true;

--- a/libraries/botframework-streaming/tests/ProtocolAdapter.test.js
+++ b/libraries/botframework-streaming/tests/ProtocolAdapter.test.js
@@ -127,7 +127,7 @@ describe('Streaming Extensions ProtocolAdapter', function () {
             onCompleted: function () {},
         });
 
-        expect(protocolAdapter.onCancelStream(assembler)).to.not.throw;
+        expect(() => protocolAdapter.onCancelStream(assembler)).to.not.throw();
     });
 
     it('sends requests.', async function (done) {
@@ -142,7 +142,7 @@ describe('Streaming Extensions ProtocolAdapter', function () {
             payloadReceiver
         );
 
-        expect(protocolAdapter.sendRequest(new Request.StreamingRequest())).to.not.throw;
+        expect(() => protocolAdapter.sendRequest(new Request.StreamingRequest())).to.not.throw();
         done();
     });
 

--- a/libraries/botframework-streaming/tests/StreamManager.test.js
+++ b/libraries/botframework-streaming/tests/StreamManager.test.js
@@ -55,7 +55,7 @@ describe('StreamManager', function () {
         };
         const stream = new SubscribableStream();
         stream.write('hello');
-        expect(sm.onReceive(head, stream, 5)).to.not.throw;
+        expect(() => sm.onReceive(head, stream, 5)).to.not.throw();
     });
 
     it('attempts to receive from an existing stream', function () {
@@ -70,7 +70,7 @@ describe('StreamManager', function () {
         expect(pa.id).to.equal('bob');
         const stream = new SubscribableStream();
         stream.write('hello');
-        expect(sm.onReceive(head, stream, 5)).to.not.throw;
+        expect(() => sm.onReceive(head, stream, 5)).to.not.throw();
     });
 
     it('can close a stream', function (done) {
@@ -80,7 +80,7 @@ describe('StreamManager', function () {
         expect(pa.id).to.equal('bob');
         const stream = new SubscribableStream();
         stream.write('hello');
-        expect(sm.closeStream(pa.id)).to.not.throw;
+        expect(() => sm.closeStream(pa.id)).to.not.throw();
     });
 
     it('does not throw when asked to close a stream that does not exist', function (done) {
@@ -91,6 +91,6 @@ describe('StreamManager', function () {
             id: 'bob',
             end: true,
         };
-        expect(sm.closeStream(head.id)).to.not.throw;
+        expect(() => sm.closeStream(head.id)).to.not.throw();
     });
 });

--- a/libraries/botframework-streaming/tests/WebSocket.test.js
+++ b/libraries/botframework-streaming/tests/WebSocket.test.js
@@ -1,11 +1,10 @@
 const { expect } = require('chai');
 const { spy } = require('sinon');
 
-const { RequestHandler, StreamingRequest, WebSocketClient, WebSocketServer } = require('../');
 const { BrowserWebSocket } = require('../lib/index-browser');
 const { WebSocketTransport } = require('../lib/webSocket/webSocketTransport');
 
-const { FauxSock } = require('./helpers');
+const { expectEventually, FauxSock } = require('./helpers');
 
 describe('Streaming Extensions WebSocket Library Tests', function () {
     describe('WebSocket Transport Tests', function () {
@@ -13,7 +12,7 @@ describe('Streaming Extensions WebSocket Library Tests', function () {
             const sock = new FauxSock();
             const transport = new WebSocketTransport(sock);
             expect(transport).to.be.instanceOf(WebSocketTransport);
-            expect(() => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw();
         });
 
         it('creates a new transport with modified state', function () {
@@ -23,7 +22,7 @@ describe('Streaming Extensions WebSocket Library Tests', function () {
             sock.writable = true;
             const transport = new WebSocketTransport(sock);
             expect(transport).to.be.instanceOf(WebSocketTransport);
-            expect(() => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw();
         });
 
         it('creates a new transport and connects', function () {
@@ -34,7 +33,7 @@ describe('Streaming Extensions WebSocket Library Tests', function () {
             const transport = new WebSocketTransport(sock);
             expect(transport).to.be.instanceOf(WebSocketTransport);
             expect(transport.isConnected).to.be.true;
-            expect(() => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw();
         });
 
         it('closes the transport without throwing', function () {
@@ -43,7 +42,7 @@ describe('Streaming Extensions WebSocket Library Tests', function () {
             sock.connecting = false;
             sock.writable = true;
             const transport = new WebSocketTransport(sock);
-            expect(transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw();
             expect(transport.isConnected).to.be.false;
         });
 
@@ -57,7 +56,7 @@ describe('Streaming Extensions WebSocket Library Tests', function () {
             const buff = Buffer.from('hello', 'utf8');
             const sent = transport.send(buff);
             expect(sent).to.equal(5);
-            expect(() => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw();
         });
 
         it('returns 0 when attempting to write to a closed socket', function () {
@@ -72,18 +71,19 @@ describe('Streaming Extensions WebSocket Library Tests', function () {
             const buff = Buffer.from('hello', 'utf8');
             const sent = transport.send(buff);
             expect(sent).to.equal(0);
-            expect(() => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw();
         });
 
-        it('throws when reading from a dead socket', function () {
+        it('throws when reading from a dead socket', async function () {
             const sock = new FauxSock();
             sock.destroyed = false;
             sock.connecting = false;
             sock.writable = true;
             const transport = new WebSocketTransport(sock);
             expect(transport.isConnected).to.be.true;
-            expect(transport.receive(5)).to.throw;
-            expect(() => transport.close()).to.not.throw;
+            const promise = transport.receive(5);
+            expect(() => transport.close()).to.not.throw();
+            (await expectEventually(promise)).to.throw('Socket was closed.');
         });
 
         it('can read from the socket', function () {
@@ -96,7 +96,7 @@ describe('Streaming Extensions WebSocket Library Tests', function () {
             transport.receive(12).catch();
             transport.onReceive(Buffer.from('{"VERB":"POST", "PATH":"somewhere/something"}', 'utf8'));
 
-            expect(() => transport.close()).to.not.throw;
+            expect(() => transport.close()).to.not.throw();
         });
 
         it('cleans up when onClose is fired', function () {
@@ -139,83 +139,7 @@ describe('Streaming Extensions WebSocket Library Tests', function () {
             const transport = new WebSocketTransport(sock);
             expect(transport.isConnected).to.be.true;
             const buff = Buffer.from('hello', 'utf8');
-            expect(transport.onReceive(buff)).to.not.throw;
-        });
-    });
-
-    describe('WebSocket Client Tests', function () {
-        it('creates a new client', function () {
-            const client = new WebSocketClient('fakeURL', new RequestHandler());
-            expect(client).to.be.instanceOf(WebSocketClient);
-            expect(client.disconnect()).to.not.throw;
-        });
-
-        it('selects the right websocket and attempts to connect to the transport layer', function (done) {
-            const client = new WebSocketClient('fakeURL', new RequestHandler());
-            client
-                .connect()
-                .catch((err) => {
-                    expect(err.message).to.equal('Unable to connect client to Node transport.');
-                }) //We don't want to really open a connection.
-                .then(done());
-        });
-
-        it('sends', function (done) {
-            const client = new WebSocketClient('fakeURL', new RequestHandler());
-            const req = new StreamingRequest();
-            req.Verb = 'POST';
-            req.Path = 'some/path';
-            req.setBody('Hello World!');
-            client
-                .send(req)
-                .catch((err) => {
-                    expect(err).to.be.undefined;
-                })
-                .then(done());
-        });
-
-        it('disconnects', function (done) {
-            const client = new WebSocketClient('fakeURL', new RequestHandler());
-            expect(client.disconnect()).to.not.throw;
-            done();
-        });
-    });
-
-    describe('WebSocket Server Tests', function () {
-        it('creates a new server', function () {
-            const server = new WebSocketServer(new FauxSock(), new RequestHandler());
-            expect(server).to.be.instanceOf(WebSocketServer);
-            expect(server.disconnect()).to.not.throw;
-        });
-
-        it('throws a TypeError during construction if missing the "socket" parameter', function () {
-            expect(() => new WebSocketServer()).to.throw('WebSocketServer: Missing socket parameter');
-        });
-
-        it('connects', function (done) {
-            const server = new WebSocketServer(new FauxSock(), new RequestHandler());
-            expect(server.start()).to.not.throw;
-            done();
-        });
-
-        it('sends', function (done) {
-            const server = new WebSocketServer(new FauxSock(), new RequestHandler());
-            const req = new StreamingRequest();
-            req.Verb = 'POST';
-            req.Path = 'some/path';
-            req.setBody('Hello World!');
-            server
-                .send(req)
-                .catch((err) => {
-                    expect(err).to.be.undefined;
-                })
-                .then(done());
-        });
-
-        it('disconnects', function (done) {
-            const server = new WebSocketServer(new FauxSock(), new RequestHandler());
-            expect(server.disconnect()).to.not.throw;
-            done();
+            expect(() => transport.onReceive(buff)).to.not.throw();
         });
     });
 
@@ -223,7 +147,7 @@ describe('Streaming Extensions WebSocket Library Tests', function () {
         it('creates a new BrowserSocket', function () {
             const bs = new BrowserWebSocket(new FauxSock());
             expect(bs).to.be.instanceOf(BrowserWebSocket);
-            expect(() => bs.close()).to.not.throw;
+            expect(() => bs.close()).to.not.throw();
         });
 
         it('knows its connected', function () {
@@ -235,19 +159,19 @@ describe('Streaming Extensions WebSocket Library Tests', function () {
         it('writes to the socket', function () {
             const bs = new BrowserWebSocket(new FauxSock());
             const buff = Buffer.from('hello');
-            expect(bs.write(buff)).to.not.throw;
+            expect(() => bs.write(buff)).to.not.throw();
         });
 
         it('always thinks it connects', function () {
             const bs = new BrowserWebSocket(new FauxSock());
-            expect(bs.connect()).to.not.throw;
+            expect(() => bs.connect()).to.not.throw();
         });
 
         it('can set error handler on the socket', function () {
             const sock = new FauxSock();
             const bs = new BrowserWebSocket(sock);
             expect(sock.onerror).to.be.undefined;
-            expect(bs.setOnErrorHandler(() => {})).to.not.throw;
+            expect(() => bs.setOnErrorHandler(() => {})).to.not.throw();
             expect(sock.onerror).to.not.be.undefined;
         });
 
@@ -255,7 +179,7 @@ describe('Streaming Extensions WebSocket Library Tests', function () {
             const sock = new FauxSock();
             const bs = new BrowserWebSocket(sock);
             expect(sock.onclose).to.be.undefined;
-            expect(bs.setOnCloseHandler(() => {})).to.not.throw;
+            expect(() => bs.setOnCloseHandler(() => {})).to.not.throw();
             expect(sock.onclose).to.not.be.undefined;
         });
 

--- a/libraries/botframework-streaming/tests/WebSocketClientServer.test.js
+++ b/libraries/botframework-streaming/tests/WebSocketClientServer.test.js
@@ -1,0 +1,245 @@
+const { expect } = require('chai');
+const { Server } = require('ws');
+const { spy, stub } = require('sinon');
+
+const {
+    NodeWebSocket,
+    RequestHandler,
+    StreamingRequest,
+    StreamingResponse,
+    WebSocketClient,
+    WebSocketServer,
+} = require('../');
+
+const { createDeferred, expectEventually } = require('./helpers');
+
+class EchoRequestHandler extends RequestHandler {
+    // RequestHandler.processRequest is marked as abstract.
+    // When stubbing it, we need a member declaration, even if it is empty.
+    async processRequest() {}
+}
+
+async function echoRequest(request) {
+    const response = StreamingResponse.create(200);
+
+    response.setBody(await request.streams[0].readAsString());
+
+    return response;
+}
+
+describe('WebSocket Client/Server Tests', function () {
+    let activeConnections;
+    let clientProcessRequest;
+    let firstConnectionDeferred;
+    let firstDisconnectionDeferred;
+    let httpServer;
+    let server;
+    let serverProcessRequest;
+    let serverStartPromise;
+
+    this.beforeEach(() => {
+        const serverRequestHandler = new EchoRequestHandler();
+
+        activeConnections = [];
+        firstConnectionDeferred = createDeferred();
+        firstDisconnectionDeferred = createDeferred();
+        serverProcessRequest = stub(serverRequestHandler, 'processRequest').callsFake(echoRequest);
+
+        httpServer = new Server({ port: 0 }).on('connection', (webSocket) => {
+            activeConnections.push(webSocket);
+            firstConnectionDeferred.resolve(webSocket);
+
+            server = new WebSocketServer(new NodeWebSocket(webSocket), serverRequestHandler);
+            serverStartPromise = server.start();
+
+            webSocket.on('close', () => {
+                activeConnections = activeConnections.filter((s) => s !== webSocket);
+
+                firstDisconnectionDeferred.resolve(webSocket);
+            });
+        });
+    });
+
+    this.afterEach(() => {
+        activeConnections.map((connection) => connection.close());
+        httpServer.close();
+    });
+
+    describe('connected', function () {
+        let client;
+        const disconnectionHandler = spy();
+
+        this.beforeEach(function () {
+            const address = httpServer.address();
+            const requestHandler = new EchoRequestHandler();
+            const url = `ws://${typeof address === 'string' ? address : `localhost:${address.port}`}`;
+
+            clientProcessRequest = stub(requestHandler, 'processRequest').callsFake(echoRequest);
+
+            client = new WebSocketClient({ disconnectionHandler, requestHandler, url });
+
+            expect(client).to.be.instanceOf(WebSocketClient);
+
+            return client.connect();
+        });
+
+        it('should connect to server', async function () {
+            await firstConnectionDeferred.promise;
+            expect(activeConnections.length).to.equal(1);
+        });
+
+        describe('client', function () {
+            describe('sends', function () {
+                let sendPromise;
+
+                this.beforeEach(function () {
+                    const req = new StreamingRequest();
+                    req.Verb = 'POST';
+                    req.Path = 'some/path';
+                    req.setBody('Hello World!');
+                    sendPromise = client.send(req);
+                    return sendPromise;
+                });
+
+                it('server should process the request', function () {
+                    expect(serverProcessRequest.callCount).to.equal(1);
+                });
+
+                it('should receive response', async function () {
+                    const response = await sendPromise;
+                    await expect(response.streams.length).to.equal(1);
+                    (await expectEventually(response.streams[0].readAsString())).to.equal('"Hello World!"');
+                });
+            });
+
+            describe('disconnects', function () {
+                this.beforeEach(async function () {
+                    client.disconnect();
+                    await firstDisconnectionDeferred.promise;
+                });
+
+                it('should call disconnectHandler', function () {
+                    expect(disconnectionHandler.called).to.be.true;
+                });
+
+                it('should disconnect', function () {
+                    expect(activeConnections.length).to.equal(0);
+                });
+            });
+
+            describe('sends and waiting for server to process', function () {
+                let sendPromise;
+                let serverProcessRequestDeferred;
+
+                this.beforeEach(async function () {
+                    serverProcessRequestDeferred = createDeferred();
+                    // Will not resolve the processRequest promise and never respond.
+                    serverProcessRequest.returns(new Promise(serverProcessRequestDeferred.resolve));
+                    const req = new StreamingRequest();
+                    req.Verb = 'POST';
+                    req.Path = 'some/path';
+                    req.setBody('Hello World!');
+                    sendPromise = client.send(req);
+                    await serverProcessRequestDeferred.promise;
+                });
+
+                it('when client disconnect should throw', async function () {
+                    client.disconnect();
+                    (await expectEventually(sendPromise)).to.throw('Disconnect was called.');
+                });
+
+                it('when server disconnect should throw', async function () {
+                    server.disconnect();
+                    (await expectEventually(sendPromise)).to.throw('Disconnect was called.');
+                });
+            });
+        });
+
+        describe('server', function () {
+            describe('sends', function () {
+                let sendPromise;
+
+                this.beforeEach(function () {
+                    const req = new StreamingRequest();
+                    req.Verb = 'POST';
+                    req.Path = 'some/path';
+                    req.setBody('Hello World!');
+                    sendPromise = server.send(req);
+                    return sendPromise;
+                });
+
+                it('client should process the request', function () {
+                    expect(clientProcessRequest.callCount).to.equal(1);
+                });
+
+                it('should receive response', async function () {
+                    const response = await sendPromise;
+                    await expect(response.streams.length).to.equal(1);
+                    (await expectEventually(response.streams[0].readAsString())).to.equal('"Hello World!"');
+                });
+            });
+
+            describe('disconnects', function () {
+                this.beforeEach(async function () {
+                    server.disconnect();
+                    await firstDisconnectionDeferred.promise;
+                });
+
+                it('should call disconnectHandler', function () {
+                    expect(disconnectionHandler.called).to.be.true;
+                });
+
+                it('should disconnect', function () {
+                    expect(activeConnections.length).to.equal(0);
+                });
+
+                it('should resolve connect()', function () {
+                    return serverStartPromise;
+                });
+            });
+
+            describe('sends and waiting for client to process', function () {
+                let sendPromise;
+                let clientProcessRequestDeferred;
+
+                this.beforeEach(async function () {
+                    clientProcessRequestDeferred = createDeferred();
+                    // Will not resolve the processRequest promise and never respond.
+                    clientProcessRequest.returns(new Promise(clientProcessRequestDeferred.resolve));
+                    const req = new StreamingRequest();
+                    req.Verb = 'POST';
+                    req.Path = 'some/path';
+                    req.setBody('Hello World!');
+                    sendPromise = client.send(req);
+                    await clientProcessRequestDeferred.promise;
+                });
+
+                it('when client disconnect should throw', async function () {
+                    client.disconnect();
+                    (await expectEventually(sendPromise)).to.throw('Disconnect was called.');
+                });
+
+                it('when server disconnect should throw', async function () {
+                    server.disconnect();
+                    (await expectEventually(sendPromise)).to.throw('Disconnect was called.');
+                });
+            });
+        });
+    });
+
+    describe('client connects to bad URL', function () {
+        let client;
+
+        this.beforeEach(function () {
+            client = new WebSocketClient({ url: 'fakeURL.localhost' });
+        });
+
+        it('should throw', async function () {
+            (await expectEventually(client.connect())).to.throw('Unable to connect client to Node transport.');
+        });
+    });
+
+    describe('server throws a TypeError during construction if missing the "socket" parameter', function () {
+        expect(() => new WebSocketServer()).to.throw('WebSocketServer: Missing socket parameter');
+    });
+});

--- a/libraries/botframework-streaming/tests/helpers/createDeferred.js
+++ b/libraries/botframework-streaming/tests/helpers/createDeferred.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+module.exports.createDeferred = function createDeferred() {
+    const deferred = {};
+
+    deferred.promise = new Promise((resolve, reject) => {
+        deferred.reject = reject;
+        deferred.resolve = resolve;
+    });
+
+    return deferred;
+};

--- a/libraries/botframework-streaming/tests/helpers/expectEventually.js
+++ b/libraries/botframework-streaming/tests/helpers/expectEventually.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const { expect } = require('chai');
+
+// chai-as-promised is not actively maintained, we need to build something simple.
+
+module.exports.expectEventually = async function (promise) {
+    let error, result;
+
+    try {
+        result = await promise;
+    } catch (e) {
+        error = e;
+    }
+
+    if (error) {
+        return expect(() => {
+            throw error;
+        });
+    } else {
+        return expect(result);
+    }
+};

--- a/libraries/botframework-streaming/tests/helpers/fauxSock.js
+++ b/libraries/botframework-streaming/tests/helpers/fauxSock.js
@@ -64,7 +64,10 @@ class FauxSock {
         if (this.receiver.isConnected) this.receiver.disconnect();
     }
     close() {
-        this.connected = false;
+        if (this.connected) {
+            this.connected = false;
+            this.closeHandler?.();
+        }
     }
     end() {
         this.exists = false;

--- a/libraries/botframework-streaming/tests/helpers/fauxSock.js
+++ b/libraries/botframework-streaming/tests/helpers/fauxSock.js
@@ -66,7 +66,7 @@ class FauxSock {
     close() {
         if (this.connected) {
             this.connected = false;
-            this.closeHandler?.();
+            this.closeHandler && this.closeHandler();
         }
     }
     end() {

--- a/libraries/botframework-streaming/tests/helpers/index.js
+++ b/libraries/botframework-streaming/tests/helpers/index.js
@@ -3,12 +3,16 @@
  * Licensed under the MIT License.
  */
 
+const { createDeferred } = require('./createDeferred');
+const { expectEventually } = require('./expectEventually');
 const { FauxSock } = require('./fauxSock');
 const { FauxSocket } = require('./fauxSocket');
 const { sleep } = require('./sleep');
 const { TestRequest } = require('./testRequest');
 const { waitFor } = require('./waitFor');
 
+module.exports.createDeferred = createDeferred;
+module.exports.expectEventually = expectEventually;
 module.exports.FauxSock = FauxSock;
 module.exports.FauxSocket = FauxSocket;
 module.exports.sleep = sleep;


### PR DESCRIPTION
Fixes #4452. Fixes #4456. Fixes #4460.

# APPROVERS: This fix may need to port to C#. Please check C# source code and port accordingly.

## Description

When Web Socket disconnected, all pending requests should be rejected.

## Specific Changes

- Added `RequestManager.rejectAllResponses()` to reject all pending responses
- Updated `browserWebSocketClient` and `nodeWebSocketClient` to call `RequestManager.rejectAllResponses()` on disconnection
- Fixed inconclusive tests related to `.to.throw`
- Fixed a racing condition in `ProtocolAdapter`
   - If server respond quickly, some responses may be dropped
   - This is because their respective requests are registered in `RequestManager` only after the request is send, the response may already get through

## Testing

Added tests to make sure `NodeWebSocketClient` and `WebSocketServer` can communicate with each other by using real Web Socket. This should make our test more stable.

Note: because there is no infrastructure for testing `BrowserWebSocketClient`, there are no tests added for it.

## Additional context

This fix is related to an issue in `botframework-directlinejs`. When `postActivity()` is called after disconnection, it is not failing.

`botframework-directlinejs` did not fail the call because `botframework-streaming` does not reject any pending requests.