### PR TITLE
fix: [#4455] [botframework-streaming] Tests are not conclusive

### DIFF
--- a/libraries/botbuilder/tests/channelServiceRoutes.test.js
+++ b/libraries/botbuilder/tests/channelServiceRoutes.test.js
@@ -136,13 +136,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a handleSendToConversation error', function (done) {
                 try {
                     const resourceResponse = { error: 'handleSendToConversation error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -165,13 +162,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a readActivity error', function (done) {
                 try {
                     const resourceResponse = { error: 'readActivity error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -219,13 +213,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a handleReplyToActivity error', function (done) {
                 try {
                     const resourceResponse = { error: 'handleReplyToActivity error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -249,13 +240,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a readActivity error', function (done) {
                 try {
                     const resourceResponse = { error: 'readActivity error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -303,13 +291,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a handleUpdateActivity error', function (done) {
                 try {
                     const resourceResponse = { error: 'handleUpdateActivity error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -333,13 +318,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a readActivity error', function (done) {
                 try {
                     const resourceResponse = { error: 'readActivity error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -387,13 +369,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a handleDeleteActivity error', function (done) {
                 try {
                     const resourceResponse = { error: 'handleDeleteActivity error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -439,13 +418,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a handleGetActivityMembers error', function (done) {
                 try {
                     const resourceResponse = { error: 'handleGetActivityMembers error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -491,13 +467,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a handleCreateConversation error', function (done) {
                 try {
                     const resourceResponse = { error: 'handleCreateConversation error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -543,13 +516,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a handleGetConversations error', function (done) {
                 try {
                     const resourceResponse = { error: 'handleGetConversations error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -595,13 +565,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a handleGetConversationMembers error', function (done) {
                 try {
                     const resourceResponse = { error: 'handleGetConversationMembers error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -647,13 +614,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a handleGetConversationPagedMembers error', function (done) {
                 try {
                     const resourceResponse = { error: 'handleGetConversationPagedMembers error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -699,13 +663,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a handleDeleteConversationMember error', function (done) {
                 try {
                     const resourceResponse = { error: 'handleDeleteConversationMember error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -751,13 +712,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a handleSendConversationHistory error', function (done) {
                 try {
                     const resourceResponse = { error: 'handleSendConversationHistory error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -781,13 +739,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a readBody error', function (done) {
                 try {
                     const resourceResponse = { error: 'readBody error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -835,13 +790,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a handleUploadAttachment error', function (done) {
                 try {
                     const resourceResponse = { error: 'handleUploadAttachment error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(
@@ -865,13 +817,10 @@ describe('channelServiceRoutes', function () {
             it('should throw a readBody error', function (done) {
                 try {
                     const resourceResponse = { error: 'readBody error' };
-                    const res = new MockResponse(
-                        {
-                            statusCode: 200,
-                            body: resourceResponse,
-                        },
-                        done
-                    );
+                    const res = new MockResponse({
+                        statusCode: 200,
+                        body: resourceResponse,
+                    });
 
                     ChannelServiceRoutes.handleError = (err) => {
                         assert.deepStrictEqual(

--- a/libraries/botframework-connector/tests/connector.test.js
+++ b/libraries/botframework-connector/tests/connector.test.js
@@ -96,14 +96,13 @@ const readStreamToBuffer = function (stream, callback) {
 };
 
 describe('Bot Framework Connector SDK', function () {
-    before(function (done) {
+    before(function () {
         suite = new SuiteBase(this, testPrefix, requiredEnvironment, libraryPath);
         suite.setupSuite(function () {
             credentials = new BotConnector.MicrosoftAppCredentials(clientId, clientSecret);
             client = new ConnectorClient(credentials, { baseUri: hostURL });
             tokenApiClient = new TokenApiClient(credentials, { baseUri: 'https://token.botframework.com' });
         });
-        done();
     });
 
     after(function (done) {

--- a/libraries/botframework-streaming/tests/Assembler.test.js
+++ b/libraries/botframework-streaming/tests/Assembler.test.js
@@ -126,12 +126,8 @@ describe('PayloadAssembler', function () {
 });
 
 describe('PayloadAssemblerManager', function () {
-    it('creates a response stream', function (done) {
-        const p = new PayloadAssemblerManager(
-            streamManager,
-            () => done(),
-            () => done()
-        );
+    it('creates a response stream', function () {
+        const p = new PayloadAssemblerManager(streamManager);
         const head = {
             payloadType: PayloadTypes.response,
             payloadLength: '42',
@@ -140,15 +136,10 @@ describe('PayloadAssemblerManager', function () {
         };
 
         expect(p.getPayloadStream(head)).to.be.instanceOf(SubscribableStream);
-        done();
     });
 
-    it('creates a request stream', function (done) {
-        const p = new PayloadAssemblerManager(
-            streamManager,
-            () => done(),
-            () => done()
-        );
+    it('creates a request stream', function () {
+        const p = new PayloadAssemblerManager(streamManager);
         const head = {
             payloadType: PayloadTypes.request,
             payloadLength: '42',
@@ -157,16 +148,10 @@ describe('PayloadAssemblerManager', function () {
         };
 
         expect(p.getPayloadStream(head)).to.be.instanceOf(SubscribableStream);
-        done();
     });
 
-    it('does not throw when receiving a request', function (done) {
-        const p = new PayloadAssemblerManager(
-            streamManager,
-            () => done(),
-            () => done()
-        );
-
+    it('does not throw when receiving a request', function () {
+        const p = new PayloadAssemblerManager(streamManager);
         const head = {
             payloadType: PayloadTypes.request,
             payloadLength: '42',
@@ -176,16 +161,10 @@ describe('PayloadAssemblerManager', function () {
         const s = p.getPayloadStream(head);
         expect(s).to.be.instanceOf(SubscribableStream);
         expect(() => p.onReceive(head, s, 0)).to.not.throw();
-        done();
     });
 
-    it('does not throw when receiving a stream', function (done) {
-        const p = new PayloadAssemblerManager(
-            streamManager,
-            () => done(),
-            () => done()
-        );
-
+    it('does not throw when receiving a stream', function () {
+        const p = new PayloadAssemblerManager(streamManager);
         const head = {
             payloadType: PayloadTypes.stream,
             payloadLength: '42',
@@ -196,16 +175,10 @@ describe('PayloadAssemblerManager', function () {
 
         expect(s).to.be.instanceOf(SubscribableStream);
         expect(() => p.onReceive(head, s, 0)).to.not.throw();
-        done();
     });
 
-    it('does not throw when receiving a response', function (done) {
-        const p = new PayloadAssemblerManager(
-            streamManager,
-            () => done(),
-            () => done()
-        );
-
+    it('does not throw when receiving a response', function () {
+        const p = new PayloadAssemblerManager(streamManager);
         const head = {
             payloadType: PayloadTypes.response,
             payloadLength: '42',
@@ -216,16 +189,10 @@ describe('PayloadAssemblerManager', function () {
 
         expect(s).to.be.instanceOf(SubscribableStream);
         expect(() => p.onReceive(head, s, 0)).to.not.throw();
-        done();
     });
 
-    it('returns undefined when asked to create an existing stream', function (done) {
-        const p = new PayloadAssemblerManager(
-            streamManager,
-            () => done(),
-            () => done()
-        );
-
+    it('returns undefined when asked to create an existing stream', function () {
+        const p = new PayloadAssemblerManager(streamManager);
         const head = {
             payloadType: PayloadTypes.request,
             payloadLength: '42',
@@ -236,24 +203,18 @@ describe('PayloadAssemblerManager', function () {
 
         expect(s).to.be.instanceOf(SubscribableStream);
         expect(p.getPayloadStream(head)).to.be.undefined;
-        done();
     });
 
-    it('throws if not given an ID', function (done) {
+    it('throws if not given an ID', function () {
         const header = {
             payloadType: PayloadTypes.request,
             payloadLength: '5',
             id: undefined,
             end: true,
         };
-        expect(
-            () =>
-                new PayloadAssembler(streamManager, {
-                    header,
-                    onCompleted: () => done(),
-                })
-        ).to.throw('An ID must be supplied when creating an assembler.');
-        done();
+        expect(() => new PayloadAssembler(streamManager, { header })).to.throw(
+            'An ID must be supplied when creating an assembler.'
+        );
     });
 
     it('processes a response with streams without throwing.', function (done) {

--- a/libraries/botframework-streaming/tests/NamedPipe.test.js
+++ b/libraries/botframework-streaming/tests/NamedPipe.test.js
@@ -92,7 +92,7 @@ describe.windowsOnly('Streaming Extensions NamedPipe Library Tests', function ()
             c.disconnect();
         });
 
-        it('Client cannot send while connecting', async function (done) {
+        it('Client cannot send while connecting', async function () {
             const c = new TestClient('pipeName');
             c.connect();
 
@@ -103,7 +103,6 @@ describe.windowsOnly('Streaming Extensions NamedPipe Library Tests', function ()
             expect(count).to.equal(0);
 
             c.disconnect();
-            done();
         });
 
         it('creates a new transport', function () {

--- a/libraries/botframework-streaming/tests/PayloadSender.test.js
+++ b/libraries/botframework-streaming/tests/PayloadSender.test.js
@@ -177,11 +177,7 @@ describe('PayloadTransport', function () {
             sock.setReceiver(pr);
 
             this.streamManager = new StreamManager(undefined);
-            const assemblerManager = new PayloadAssemblerManager(
-                this.streamManager,
-                () => done(),
-                () => done()
-            );
+            const assemblerManager = new PayloadAssemblerManager(this.streamManager);
 
             pr.subscribe(
                 (header) => assemblerManager.getPayloadStream(header),

--- a/libraries/botframework-streaming/tests/ProtocolAdapter.test.js
+++ b/libraries/botframework-streaming/tests/ProtocolAdapter.test.js
@@ -130,7 +130,7 @@ describe('Streaming Extensions ProtocolAdapter', function () {
         expect(() => protocolAdapter.onCancelStream(assembler)).to.not.throw();
     });
 
-    it('sends requests.', async function (done) {
+    it('sends requests.', async function () {
         const requestHandler = new TestRequestHandler();
         const requestManager = new TestRequestManager();
         const payloadSender = new TestPayloadSender();
@@ -143,7 +143,6 @@ describe('Streaming Extensions ProtocolAdapter', function () {
         );
 
         expect(() => protocolAdapter.sendRequest(new Request.StreamingRequest())).to.not.throw();
-        done();
     });
 
     it('payloadreceiver ignores duplicate connections', function () {

--- a/libraries/botframework-streaming/tests/StreamManager.test.js
+++ b/libraries/botframework-streaming/tests/StreamManager.test.js
@@ -73,18 +73,21 @@ describe('StreamManager', function () {
         expect(() => sm.onReceive(head, stream, 5)).to.not.throw();
     });
 
-    it('can close a stream', function (done) {
-        const sm = new StreamManager(done());
+    it('can close a stream', function () {
+        let called = false;
+        const sm = new StreamManager(() => (called = true));
         const pa = sm.getPayloadAssembler('bob');
 
         expect(pa.id).to.equal('bob');
         const stream = new SubscribableStream();
         stream.write('hello');
         expect(() => sm.closeStream(pa.id)).to.not.throw();
+        expect(called).to.be.true;
     });
 
-    it('does not throw when asked to close a stream that does not exist', function (done) {
-        const sm = new StreamManager(done());
+    it('does not throw when asked to close a stream that does not exist', function () {
+        let called = false;
+        const sm = new StreamManager(() => (called = true));
         const head = {
             payloadType: PayloadTypes.request,
             payloadLength: '0',
@@ -92,5 +95,6 @@ describe('StreamManager', function () {
             end: true,
         };
         expect(() => sm.closeStream(head.id)).to.not.throw();
+        expect(called).to.be.false;
     });
 });


### PR DESCRIPTION
Fixes #4455

## Description
This PR modifies and removes unnecessary `done` function calls from all unit tests.

## Specific Changes
  - Redundant `done` function calls have been removed to use only one.
  - Removed `done` function calls where wasn't necessary.