### PR TITLE
port: [#4464] USER scope variable values do not transfer to skill when SSO is configured

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/src/actions/setProperties.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/setProperties.ts
@@ -109,6 +109,9 @@ export class SetProperties<O extends object = {}> extends Dialog<O> implements S
             dc.state.setValue(property, value);
         }
 
+        // save all state scopes to their respective botState locations.
+        await dc.state.saveAllChanges();
+
         return await dc.endDialog();
     }
 

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/setProperty.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/setProperty.ts
@@ -120,6 +120,9 @@ export class SetProperty<O extends object = {}> extends Dialog<O> implements Set
 
         dc.state.setValue(property, value);
 
+        // save all state scopes to their respective botState locations.
+        await dc.state.saveAllChanges();
+
         return await dc.endDialog();
     }
 


### PR DESCRIPTION
Fixes #4464

## Description
This PR ports the changes from [PR#6612](https://github.com/microsoft/botbuilder-dotnet/pull/6612) to save the state after setting the properties avoiding user scope properties to lose their value.

## Specific Changes
- Added a call to [DialogStateManager's saveAllChanges](https://github.com/Microsoft/botbuilder-js/blob/main/libraries/botbuilder-dialogs/src/memory/dialogStateManager.ts) method after setting the property value in **_SetProperty_** and **_SetProperties_** adaptive actions.

## Testing
These images show the user scope variable before and after the fix.
![image](https://user-images.githubusercontent.com/44245136/235962890-0831e44a-e459-449d-848c-2f83d5cf5f92.png)
