### PR TITLE
fix: Upgrading restify to fix error on Node version 18+

### DIFF
--- a/generators/generator-botbuilder/generators/app/templates/echo/package.json.js
+++ b/generators/generator-botbuilder/generators/app/templates/echo/package.json.js
@@ -18,7 +18,7 @@
     "dependencies": {
         "botbuilder": "~4.15.0",
         "dotenv": "~8.2.0",
-        "restify": "~10.0.0"
+        "restify": "~11.1.0"
     },
     "devDependencies": {
         "eslint": "^7.0.0",


### PR DESCRIPTION
#minor

## Description
Current version of restify leads to the following error on Node 18+:
```
➜  my-echo-bot npm start

> my-echo-bot@1.0.0 start
> node ./index.js

/home/gregborrelly/development/myJsBots/my-echo-bot/node_modules/restify/lib/request.js:848
    Request.prototype.closed = function closed() {
                             ^

TypeError: Cannot set property closed of #<Readable> which has only a getter
    at patch (/home/gregborrelly/development/myJsBots/my-echo-bot/node_modules/restify/lib/request.js:848:30)
    at Object.<anonymous> (/home/gregborrelly/development/myJsBots/my-echo-bot/node_modules/restify/lib/server.js:33:1)
```
## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - Upgraded restify version in Package.json

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->
Create a echo bot dot following the SDK docs, if you are on Node 18 or above you will run into the following error. 

## Related PR 
 https://github.com/restify/node-restify/pull/1906