### PR TITLE
port: [#4530] Add support for meeting participants added/removed events

### DIFF
--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -45,6 +45,7 @@ import { IStreamingTransportServer } from 'botframework-streaming';
 import { MeetingEndEventDetails } from 'botbuilder-core';
 import { MeetingNotification } from 'botbuilder-core';
 import { MeetingNotificationResponse } from 'botbuilder-core';
+import { MeetingParticipantsEventDetails } from 'botbuilder-core';
 import { MeetingStartEventDetails } from 'botbuilder-core';
 import { MessagingExtensionAction } from 'botbuilder-core';
 import { MessagingExtensionActionResponse } from 'botbuilder-core';
@@ -404,6 +405,10 @@ export class TeamsActivityHandler extends ActivityHandler {
     onTeamsChannelRestoredEvent(handler: (channelInfo: ChannelInfo, teamInfo: TeamInfo, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsMeetingEnd(context: TurnContext): Promise<void>;
     onTeamsMeetingEndEvent(handler: (meeting: MeetingEndEventDetails, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
+    protected onTeamsMeetingParticipantsJoin(context: TurnContext): Promise<void>;
+    onTeamsMeetingParticipantsJoinEvent(handler: (meeting: MeetingParticipantsEventDetails, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
+    protected onTeamsMeetingParticipantsLeave(context: TurnContext): Promise<void>;
+    onTeamsMeetingParticipantsLeaveEvent(handler: (meeting: MeetingParticipantsEventDetails, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsMeetingStart(context: TurnContext): Promise<void>;
     onTeamsMeetingStartEvent(handler: (meeting: MeetingStartEventDetails, context: TurnContext, next: () => Promise<void>) => Promise<void>): this;
     protected onTeamsMembersAdded(context: TurnContext): Promise<void>;

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -1249,7 +1249,7 @@ export class TeamsActivityHandler extends ActivityHandler {
     }
 
     /**
-     * Invoked when a Meeting Participant Join event activity is received from the connector.
+     * Invoked when a Meeting Participant Leave event activity is received from the connector.
      * Override this in a derived class to provide logic for when a meeting participant is left.
      *
      * @param context The context for this turn.

--- a/libraries/botbuilder/src/teamsActivityHandler.ts
+++ b/libraries/botbuilder/src/teamsActivityHandler.ts
@@ -35,7 +35,7 @@ import {
     tokenExchangeOperationName,
     TurnContext,
     verifyStateOperationName,
-    MeetingParticipantsEventDetails
+    MeetingParticipantsEventDetails,
 } from 'botbuilder-core';
 import { ReadReceiptInfo } from 'botframework-connector';
 import { TeamsInfo } from './teamsInfo';
@@ -1194,10 +1194,10 @@ export class TeamsActivityHandler extends ActivityHandler {
                     return this.onTeamsMeetingStart(context);
                 case 'application/vnd.microsoft.meetingEnd':
                     return this.onTeamsMeetingEnd(context);
-                case "application/vnd.microsoft.meetingParticipantJoin":
-                    return this.onTeamsMeetingParticipantJoin(context);
-                case "application/vnd.microsoft.meetingParticipantLeave":
-                    return this.onTeamsMeetingParticipantLeave(context);
+                case 'application/vnd.microsoft.meetingParticipantJoin':
+                    return this.onTeamsMeetingParticipantsJoin(context);
+                case 'application/vnd.microsoft.meetingParticipantLeave':
+                    return this.onTeamsMeetingParticipantsLeave(context);
             }
         }
 
@@ -1244,8 +1244,8 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context The context for this turn.
      * @returns A promise that represents the work queued.
      */
-    protected async onTeamsMeetingParticipantJoin(context: TurnContext): Promise<void> {
-        await this.handle(context, 'TeamsMeetingParticipantJoin', this.defaultNextEvent(context));
+    protected async onTeamsMeetingParticipantsJoin(context: TurnContext): Promise<void> {
+        await this.handle(context, 'TeamsMeetingParticipantsJoin', this.defaultNextEvent(context));
     }
 
     /**
@@ -1255,8 +1255,8 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @param context The context for this turn.
      * @returns A promise that represents the work queued.
      */
-    protected async onTeamsMeetingParticipantLeave(context: TurnContext): Promise<void> {
-        await this.handle(context, 'TeamsMeetingParticipantLeave', this.defaultNextEvent(context));
+    protected async onTeamsMeetingParticipantsLeave(context: TurnContext): Promise<void> {
+        await this.handle(context, 'TeamsMeetingParticipantsLeave', this.defaultNextEvent(context));
     }
 
     /**
@@ -1331,13 +1331,17 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @returns A promise that represents the work queued.
      */
     onTeamsMeetingParticipantsJoinEvent(
-        handler: (meeting: MeetingParticipantsEventDetails, context: TurnContext, next: () => Promise<void>) => Promise<void>
+        handler: (
+            meeting: MeetingParticipantsEventDetails,
+            context: TurnContext,
+            next: () => Promise<void>
+        ) => Promise<void>
     ): this {
         return this.on('TeamsMeetingParticipantsJoin', async (context, next) => {
             const meeting = context.activity.value;
             await handler(
                 {
-                    members: meeting?.members
+                    members: meeting?.members,
                 },
                 context,
                 next
@@ -1352,13 +1356,17 @@ export class TeamsActivityHandler extends ActivityHandler {
      * @returns A promise that represents the work queued.
      */
     onTeamsMeetingParticipantsLeaveEvent(
-        handler: (meeting: MeetingParticipantsEventDetails, context: TurnContext, next: () => Promise<void>) => Promise<void>
+        handler: (
+            meeting: MeetingParticipantsEventDetails,
+            context: TurnContext,
+            next: () => Promise<void>
+        ) => Promise<void>
     ): this {
         return this.on('TeamsMeetingParticipantsLeave', async (context, next) => {
             const meeting = context.activity.value;
             await handler(
                 {
-                    members: meeting?.members
+                    members: meeting?.members,
                 },
                 context,
                 next

--- a/libraries/botbuilder/tests/teamsActivityHandler.test.js
+++ b/libraries/botbuilder/tests/teamsActivityHandler.test.js
@@ -414,23 +414,23 @@ describe('TeamsActivityHandler', function () {
                 super();
             }
 
-            handleTeamsO365ConnectorCardAction() { }
+            handleTeamsO365ConnectorCardAction() {}
 
-            handleTeamsAppBasedLinkQuery() { }
+            handleTeamsAppBasedLinkQuery() {}
 
-            handleTeamsAnonymousAppBasedLinkQuery() { }
+            handleTeamsAnonymousAppBasedLinkQuery() {}
 
-            handleTeamsMessagingExtensionQuery() { }
+            handleTeamsMessagingExtensionQuery() {}
 
-            handleTeamsMessagingExtensionSelectItem() { }
+            handleTeamsMessagingExtensionSelectItem() {}
 
-            handleTeamsMessagingExtensionFetchTask() { }
+            handleTeamsMessagingExtensionFetchTask() {}
 
-            handleTeamsMessagingExtensionConfigurationQuerySettingUrl() { }
+            handleTeamsMessagingExtensionConfigurationQuerySettingUrl() {}
 
-            handleTeamsMessagingExtensionConfigurationSetting() { }
+            handleTeamsMessagingExtensionConfigurationSetting() {}
 
-            handleTeamsMessagingExtensionCardButtonClicked() { }
+            handleTeamsMessagingExtensionCardButtonClicked() {}
         }
 
         it('activity.name is not defined. should return status code [501].', async function () {
@@ -2607,25 +2607,25 @@ describe('TeamsActivityHandler', function () {
             const value = {
                 members: [
                     {
-                        user:
-                        {
+                        user: {
                             id: 'id',
-                            name: 'name'
+                            name: 'name',
                         },
-                        meeting:
-                        {
+                        meeting: {
                             role: 'role',
-                            inMeeting: join
-                        }
-                    }
-                ]
-            }
+                            inMeeting: join,
+                        },
+                    },
+                ],
+            };
 
             const activity = {
                 channelId: Channels.Msteams,
                 type: 'event',
                 value: value,
-                name: join ? "application/vnd.microsoft.meetingParticipantJoin" : "application/vnd.microsoft.meetingParticipantLeave"
+                name: join
+                    ? 'application/vnd.microsoft.meetingParticipantJoin'
+                    : 'application/vnd.microsoft.meetingParticipantLeave',
             };
 
             return activity;
@@ -2779,14 +2779,14 @@ describe('TeamsActivityHandler', function () {
                 .startTest();
         });
 
-        it.only('onTeamsReadReceipt routed activity', async function () {
+        it('onTeamsReadReceipt routed activity', async function () {
             let onTeamsReadReceiptCalled = false;
             const bot = new TeamsActivityHandler();
             const activity = {
                 channelId: Channels.Msteams,
                 type: 'event',
                 name: 'application/vnd.microsoft.readReceipt',
-                value: JSON.parse('{ "lastReadMessageI": 10101010}'),
+                value: JSON.parse('{ "lastReadMessageId": 10101010}'),
             };
 
             bot.onEvent(async (context, next) => {
@@ -2826,8 +2826,8 @@ describe('TeamsActivityHandler', function () {
                 .startTest();
         });
 
-        it.only('onTeamsMeetingParticipantJoin routed activity', async function () {
-            let onTeamsMeetingParticipantJoinCalled = false;
+        it('onTeamsMeetingParticipantsJoin routed activity', async function () {
+            let onTeamsMeetingParticipantsJoinCalled = false;
             const bot = new TeamsActivityHandler();
             const activity = createMeetingParticipantEventActivity();
 
@@ -2842,8 +2842,8 @@ describe('TeamsActivityHandler', function () {
                 assert(meeting, 'meeting not found');
                 assert(context, 'context not found');
                 assert(next, 'next not found');
-                assert.strictEqual(meeting, activity.value);
-                onTeamsMeetingParticipantJoinCalled = true;
+                assert.deepStrictEqual(meeting, activity.value);
+                onTeamsMeetingParticipantsJoinCalled = true;
                 await next();
             });
 
@@ -2861,7 +2861,49 @@ describe('TeamsActivityHandler', function () {
             await adapter
                 .send(activity)
                 .then(() => {
-                    assert(onTeamsMeetingParticipantJoinCalled);
+                    assert(onTeamsMeetingParticipantsJoinCalled);
+                    assert(onEventCalled, 'onConversationUpdate handler not called');
+                    assert(onDialogCalled, 'onDialog handler not called');
+                })
+                .startTest();
+        });
+
+        it('onTeamsMeetingParticipantsLeave routed activity', async function () {
+            let onTeamsMeetingParticipantsLeaveCalled = false;
+            const bot = new TeamsActivityHandler();
+            const activity = createMeetingParticipantEventActivity(false);
+
+            bot.onEvent(async (context, next) => {
+                assert(context, 'context not found');
+                assert(next, 'next not found');
+                onEventCalled = true;
+                await next();
+            });
+
+            bot.onTeamsMeetingParticipantsLeaveEvent(async (meeting, context, next) => {
+                assert(meeting, 'meeting not found');
+                assert(context, 'context not found');
+                assert(next, 'next not found');
+                assert.deepStrictEqual(meeting, activity.value);
+                onTeamsMeetingParticipantsLeaveCalled = true;
+                await next();
+            });
+
+            bot.onDialog(async (context, next) => {
+                assert(context, 'context not found');
+                assert(next, 'next not found');
+                onDialogCalled = true;
+                await next();
+            });
+
+            const adapter = new TestAdapter(async (context) => {
+                await bot.run(context);
+            });
+
+            await adapter
+                .send(activity)
+                .then(() => {
+                    assert(onTeamsMeetingParticipantsLeaveCalled);
                     assert(onEventCalled, 'onConversationUpdate handler not called');
                     assert(onDialogCalled, 'onDialog handler not called');
                 })

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -1004,6 +1004,11 @@ export interface MeetingNotificationResponse {
 }
 
 // @public
+export interface MeetingParticipantsEventDetails {
+    members: TeamsMeetingMember[];
+}
+
+// @public
 export interface MeetingStageSurface<T> {
     content: T;
     contentType: 'task';
@@ -1806,6 +1811,12 @@ export interface TeamsMeetingInfo {
 }
 
 // @public
+export interface TeamsMeetingMember {
+    meeting: UserMeetingDetails;
+    user: TeamsChannelAccount;
+}
+
+// @public
 export interface TeamsMeetingParticipant {
     conversation?: ConversationAccount;
     meeting?: Meeting;
@@ -1948,6 +1959,12 @@ export type Type3 = MessagingExtensionResultType;
 
 // @public
 export type UserIdentityType = 'aadUser' | 'onPremiseAadUser' | 'anonymousGuest' | 'federatedUser';
+
+// @public
+export interface UserMeetingDetails {
+    inMeeting: boolean;
+    role: string;
+}
 
 // @public
 export interface VideoCard {

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -25,10 +25,10 @@ export interface BotConfigAuth {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ConfigAuthResponse extends ConfigResponse<BotConfigAuth> {}
+export interface ConfigAuthResponse extends ConfigResponse<BotConfigAuth> { }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ConfigTaskResponse extends ConfigResponse<TaskModuleResponse> {}
+export interface ConfigTaskResponse extends ConfigResponse<TaskModuleResponse> { }
 /**
  * @interface
  * An interface representing ChannelInfo.
@@ -2028,4 +2028,45 @@ export interface MeetingNotificationResponse {
      * @member {string} [recipientsFailureInfo] The list of recipients that failed to recieve the sent meetings notification.
      */
     recipientsFailureInfo?: MeetingNotificationRecipientFailureInfo[];
+}
+
+/**
+ * @interface
+ * Specific details about the meeting participants.
+ */
+export interface MeetingParticipantsEventDetails {
+    /**
+     * @member {TeamsMeetingMember[]} [members] The participants info.
+     */
+    members: TeamsMeetingMember[];
+}
+
+/**
+ * @interface
+ * Specific details about the meeting participants.
+ */
+export interface TeamsMeetingMember {
+    /**
+     * @member {TeamsChannelAccount} [user] The participant account.
+     */
+    user: TeamsChannelAccount;
+    /**
+     * @member {UserMeetingDetails} [meeting] The participants info.
+     */
+    meeting: UserMeetingDetails;
+}
+
+/**
+ * @interface
+ * Specific details of a user in a Teams meeting.
+ */
+export interface UserMeetingDetails {
+    /**
+     * @member {boolean} [inMeeting] The user in meeting indicator.
+     */
+    inMeeting: boolean;
+    /**
+     * @member {string} [role] The user's role.
+     */
+    role: string;
 }

--- a/libraries/botframework-schema/src/teams/index.ts
+++ b/libraries/botframework-schema/src/teams/index.ts
@@ -25,10 +25,10 @@ export interface BotConfigAuth {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ConfigAuthResponse extends ConfigResponse<BotConfigAuth> { }
+export interface ConfigAuthResponse extends ConfigResponse<BotConfigAuth> {}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ConfigTaskResponse extends ConfigResponse<TaskModuleResponse> { }
+export interface ConfigTaskResponse extends ConfigResponse<TaskModuleResponse> {}
 /**
  * @interface
  * An interface representing ChannelInfo.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev:link": "wsrun --if is-not-private --bin=yarn link",
     "dev:unlink": "wsrun --if is-not-private --bin=yarn unlink",
     "functional-test": "yarn build && yarn workspace functional-tests test",
-    "lint": "wsrun -m -l lint --max-warnings=0 --fix",
+    "lint": "wsrun -m -l lint --max-warnings=0",
     "package": "wsrun -e -t -l --if is-not-private --bin yarn pack",
     "test": "npm-run-all build test:mocha test:runtime test:runtime test:nyc:report",
     "test:compat": "wsrun -e -m -t test:compat",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev:link": "wsrun --if is-not-private --bin=yarn link",
     "dev:unlink": "wsrun --if is-not-private --bin=yarn unlink",
     "functional-test": "yarn build && yarn workspace functional-tests test",
-    "lint": "wsrun -m -l lint --max-warnings=0",
+    "lint": "wsrun -m -l lint --max-warnings=0 --fix",
     "package": "wsrun -e -t -l --if is-not-private --bin yarn pack",
     "test": "npm-run-all build test:mocha test:runtime test:runtime test:nyc:report",
     "test:compat": "wsrun -e -m -t test:compat",


### PR DESCRIPTION
Fixes #4530 

## Description
This PR ports the changes in [PR#6677](https://github.com/microsoft/botbuilder-dotnet/pull/6677) to add support for the new meeting participants join/leave events.

## Specific Changes
- Added support for 2 new activity types - `application/vnd.microsoft.meetingParticipantJoin` and `application/vnd.microsoft.meetingParticipantLeave`.
- Added functions to register handlers for when teams meeting participants are joined/left.
- Added unit tests for every case.

## Testing
This image shows the implementation tested with a sample.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/6d0e59cb-b997-42ea-8870-a27c1d27b9b8)