### PR TITLE
fix: [SharePointActivityHandler] Rename type to responseType in handleActionResponse

### DIFF
--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -393,7 +393,7 @@ export interface BaseCardViewParameters {
 // @public
 export interface BaseHandleActionResponse {
     renderArguments?: CardViewResponse | QuickViewResponse;
-    type: ViewResponseType;
+    responseType: ViewResponseType;
 }
 
 // @public
@@ -558,7 +558,7 @@ export type CardViewFooterParameters = CardViewActionsFooterParameters | [CardTe
 // @public
 export interface CardViewHandleActionResponse extends BaseHandleActionResponse {
     renderArguments: CardViewResponse;
-    type: 'Card';
+    responseType: 'Card';
 }
 
 // @public
@@ -1480,7 +1480,7 @@ export interface MicrosoftPayMethodData {
 // @public
 export interface NoOpHandleActionResponse extends BaseHandleActionResponse {
     renderArguments?: undefined;
-    type: 'NoOp';
+    responseType: 'NoOp';
 }
 
 // @public
@@ -1963,7 +1963,7 @@ export interface QuickViewData {
 // @public
 export interface QuickViewHandleActionResponse extends BaseHandleActionResponse {
     renderArguments: QuickViewResponse;
-    type: 'QuickView';
+    responseType: 'QuickView';
 }
 
 // @public

--- a/libraries/botframework-schema/src/sharepoint/handleActionResponse.ts
+++ b/libraries/botframework-schema/src/sharepoint/handleActionResponse.ts
@@ -16,7 +16,7 @@ export interface BaseHandleActionResponse {
     /**
      * The type of the view in the handle action response.
      */
-    type: ViewResponseType;
+    responseType: ViewResponseType;
     /**
      * The render arguments.
      */
@@ -30,7 +30,7 @@ export interface CardViewHandleActionResponse extends BaseHandleActionResponse {
     /**
      * Card view.
      */
-    type: 'Card';
+    responseType: 'Card';
     /**
      * Card view render arguments.
      */
@@ -44,7 +44,7 @@ export interface QuickViewHandleActionResponse extends BaseHandleActionResponse 
     /**
      * Quick view.
      */
-    type: 'QuickView';
+    responseType: 'QuickView';
     /**
      * Quick view render arguments.
      */
@@ -58,7 +58,7 @@ export interface NoOpHandleActionResponse extends BaseHandleActionResponse {
     /**
      * No op.
      */
-    type: 'NoOp';
+    responseType: 'NoOp';
     /**
      * No op doesn't have render arguments.
      */


### PR DESCRIPTION
Fixes #4557 

## Description
The PR fixes issue with incorrectly named property for SharePoint `HandleActionResponse`.

## Specific Changes
- rename `type` to `responseType` in `BaseHandleActionResponse`, `CardViewHandleActionResponse`, `QuickViewHandleActionResponse` and `NoOpeHandleActionResponse`

## Testing
Full flow tests using locally served bot and SharePoint Online.

![image](https://github.com/microsoft/botbuilder-js/assets/17036219/b67745fd-54ce-4bd8-8417-38c1bd40f35d)
