### PR TITLE
chore: corrected typo in README.md

### DIFF
--- a/libraries/botbuilder-dialogs/README.md
+++ b/libraries/botbuilder-dialogs/README.md
@@ -132,7 +132,7 @@ See this module in action in these example apps:
 
 [DialogSet](https://docs.microsoft.com/en-us/javascript/api/botbuilder-dialogs/dialogset) DialogSet is a container for multiple dialogs. Once added to a DialogSet, dialogs can be called and interlinked.
 
-[WaterfallDialog](https://docs.microsoft.com/en-us/javascript/api/botbuilder-dialogs/waterfalldialog) WaterfallDialogs execute a series of step functions in order, passing the resulting user input from each steo into the next step's function.
+[WaterfallDialog](https://docs.microsoft.com/en-us/javascript/api/botbuilder-dialogs/waterfalldialog) WaterfallDialogs execute a series of step functions in order, passing the resulting user input from each step into the next step's function.
 
 [Track Waterfall Dialogs with Application Insights](https://github.com/Microsoft/botbuilder-js/tree/main/libraries/botbuilder-applicationinsights#use-with-waterfall-dialogs).
 


### PR DESCRIPTION
Corrected typo, `steo` should be `step` within README documentation.

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Description
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->

Corrected a typo in the readme

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - "steo" should be "step"

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->