### PR TITLE
feat: Extraction of thumbprint value through the certificate

### DIFF
--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -37,7 +37,8 @@
     "cross-fetch": "^3.0.5",
     "jsonwebtoken": "^9.0.0",
     "rsa-pem-from-mod-exp": "^0.8.4",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "openssl-wrapper": "^0.3.4"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "8.3.5",

--- a/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
@@ -71,16 +71,12 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
             'CertificateServiceClientCredentialsFactory.constructor(): missing certificatePrivateKey.'
         );
 
-        if (certificateThumbprintOrx5c.includes('-----BEGIN CERTIFICATE-----')) {
+        if (certificateThumbprintOrx5c?.includes('-----BEGIN CERTIFICATE-----')) {
             this.x5c = certificateThumbprintOrx5c;
-            ok(
-                certificateThumbprintOrx5c.trim(),
-                'CertificateServiceClientCredentialsFactory.constructor(): missing x5c.'
-            );
         } else {
             ok(
                 certificateThumbprintOrx5c.trim(),
-                'CertificateServiceClientCredentialsFactory.constructor(): missing certificateThumbprint.'
+                'CertificateServiceClientCredentialsFactory.constructor(): missing certificateThumbprint or x5c value.'
             );
             this.certificateThumbprint = certificateThumbprintOrx5c;
             this.x5c = x5c;

--- a/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
@@ -10,6 +10,9 @@ import type { ServiceClientCredentials } from '@azure/ms-rest-js';
 import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
 import { ok } from 'assert';
 import { CertificateAppCredentials } from './certificateAppCredentials';
+import { promisify } from 'util';
+import * as opensslWrapper from 'openssl-wrapper';
+const openssl = promisify(opensslWrapper.default);
 
 /**
  * A Certificate implementation of the [ServiceClientCredentialsFactory](xref:botframework-connector.ServiceClientCredentialsFactory) abstract class.
@@ -28,21 +31,31 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
      * @param certificateThumbprint A hex encoded thumbprint of the certificate.
      * @param certificatePrivateKey A PEM encoded certificate private key.
      * @param tenantId Optional. The oauth token tenant.
-     * @param x5c Optional. Enables application developers to achieve easy certificates roll-over in Azure AD:
      * set this parameter to send the public certificate (BEGIN CERTIFICATE) to Azure AD, so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
      */
-    constructor(
-        appId: string,
-        certificateThumbprint: string,
-        certificatePrivateKey: string,
-        tenantId?: string,
-        x5c?: string
-    ) {
+    constructor(appId: string, certificateThumbprintOrx5c?: string, certificatePrivateKey?: string, tenantId?: string);
+
+    /**
+     * Initializes a new instance of the CertificateServiceClientCredentialsFactory class.
+     *
+     * @param appId Microsoft application Id related to the certificate.
+     * @param x5c Value that enables application developers to achieve easy certificates roll-over in Azure AD
+     * @param certificatePrivateKey A PEM encoded certificate private key.
+     * @param tenantId Optional. The oauth token tenant.
+     * set this parameter to send the public certificate (BEGIN CERTIFICATE) to Azure AD, so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
+     */
+    constructor(appId: string, certificateThumbprintOrx5c?: string, certificatePrivateKey?: string, tenantId?: string);
+
+    /**
+     * @internal
+     */
+    constructor(appId: string, certificateThumbprintOrx5c?: string, certificatePrivateKey?: string, tenantId?: string) {
         super();
+
         ok(appId?.trim(), 'CertificateServiceClientCredentialsFactory.constructor(): missing appId.');
         ok(
-            certificateThumbprint?.trim(),
-            'CertificateServiceClientCredentialsFactory.constructor(): missing certificateThumbprint.'
+            certificateThumbprintOrx5c?.trim(),
+            'CertificateServiceClientCredentialsFactory.constructor(): missing certificateThumbprint or x5c value.'
         );
         ok(
             certificatePrivateKey?.trim(),
@@ -50,10 +63,10 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
         );
 
         this.appId = appId;
-        this.certificateThumbprint = certificateThumbprint;
+        this.certificateThumbprint = certificateThumbprintOrx5c?.length <= 40 ? certificateThumbprintOrx5c : undefined;
         this.certificatePrivateKey = certificatePrivateKey;
         this.tenantId = tenantId;
-        this.x5c = x5c;
+        this.x5c = certificateThumbprintOrx5c?.length > 40 ? certificateThumbprintOrx5c : undefined;
     }
 
     /**
@@ -63,6 +76,23 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
         return appId === this.appId;
     }
 
+    /**
+     * @param cert Value with the certificate content.
+     * @returns the thumbprint value calculated from the cert content.
+     */
+    async getThumbprint(cert) {
+        const certString = Buffer.from(cert).toString();
+        const begin = certString.lastIndexOf('-----BEGIN CERTIFICATE-----');
+        const end = certString.lastIndexOf('-----END CERTIFICATE-----') + '-----END CERTIFICATE-----'.length;
+        const certificate = certString.slice(begin, end);
+
+        const fingerprintResponse = await openssl('x509', Buffer.from(certificate), { fingerprint: true, noout: true });
+        return Buffer.from(fingerprintResponse)
+            .toString()
+            .replace(/^.*Fingerprint=/, '')
+            .replace(/:/g, '')
+            .trim();
+    }
     /**
      * @inheritdoc
      */
@@ -82,7 +112,7 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
 
         return new CertificateAppCredentials(
             this.appId,
-            this.certificateThumbprint,
+            this.certificateThumbprint ?? (await this.getThumbprint(this.x5c)),
             this.certificatePrivateKey,
             this.tenantId,
             audience,

--- a/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
@@ -75,7 +75,7 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
             this.x5c = certificateThumbprintOrx5c;
         } else {
             ok(
-                certificateThumbprintOrx5c.trim(),
+                certificateThumbprintOrx5c?.trim(),
                 'CertificateServiceClientCredentialsFactory.constructor(): missing certificateThumbprint or x5c value.'
             );
             this.certificateThumbprint = certificateThumbprintOrx5c;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10254,6 +10254,11 @@ open@8.4.0, open@^8.0.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
+openssl-wrapper@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/openssl-wrapper/-/openssl-wrapper-0.3.4.tgz#c01ec98e4dcd2b5dfe0b693f31827200e3b81b07"
+  integrity sha512-iITsrx6Ho8V3/2OVtmZzzX8wQaKAaFXEJQdzoPUZDtyf5jWFlqo+h+OhGT4TATQ47f9ACKHua8nw7Qoy85aeKQ==
+
 optionator@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"


### PR DESCRIPTION
#minor

## Description
This PR allows the creation of an object of the _CertificateServiceClientCredentialsFactory_ class using only the values:

- _App Id_
- _x5c_ 
- _Certificate key_

In addition to being able to get the thumbprint value through the certificate when creating the credentials.

## Specific Changes
  - Added the possibility of two possible parameters (thumbprint of x5c) for the constructor of the _CertificateServiceClientCredentialsFactory_ class.
  - Added the method _**getThumbprint**_ to obtain the thumbprint value of the certificate when the x5c value is provided.

## Testing
The following image shows the bot running with SNI authentication.
![image](https://github.com/microsoft/botbuilder-js/assets/122501764/60515cc0-8f98-47aa-8bef-04580f0cdeae)

This is the configuration required to use the SNI authentication.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/c5895d13-c15a-4ad4-b8fa-87622160b752)