### PR TITLE
fix: add `/.default` to oAuthScope default value for appCredentials

### DIFF
--- a/libraries/botframework-connector/src/auth/appCredentials.ts
+++ b/libraries/botframework-connector/src/auth/appCredentials.ts
@@ -48,7 +48,7 @@ export abstract class AppCredentials implements ServiceClientCredentials {
     constructor(
         appId: string,
         channelAuthTenant?: string,
-        oAuthScope: string = AuthenticationConstants.ToBotFromChannelTokenIssuer
+        oAuthScope: string = AuthenticationConstants.ToBotFromChannelTokenIssuer + "/.default"
     ) {
         this.appId = appId;
         this.tenant = channelAuthTenant;

--- a/libraries/botframework-connector/src/auth/appCredentials.ts
+++ b/libraries/botframework-connector/src/auth/appCredentials.ts
@@ -48,7 +48,7 @@ export abstract class AppCredentials implements ServiceClientCredentials {
     constructor(
         appId: string,
         channelAuthTenant?: string,
-        oAuthScope: string = AuthenticationConstants.ToBotFromChannelTokenIssuer + "/.default"
+        oAuthScope: string = AuthenticationConstants.ToBotFromChannelTokenIssuer + '/.default'
     ) {
         this.appId = appId;
         this.tenant = channelAuthTenant;


### PR DESCRIPTION
Fixes #4582


## Description
The default constant has the issuer url. The oAuthScope requires to end with `/.default`.

## Specific Changes
<!-- Please list the changes in a concise manner. -->

  - added  `/.default` to the default oAuthScope value
  
## Testing
we are using this change in our application (patched via `patch-package` library)