### PR TITLE
fix: USGovSingleTenant OAuthEndpoint

### DIFF
--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -261,8 +261,7 @@ export class BotFrameworkAdapter
                     this.settings.appPassword || '',
                     this.settings.channelAuthTenant
                 );
-            }
-            else{
+            } else {
                 this.credentials = new MicrosoftAppCredentials(
                     this.settings.appId,
                     this.settings.appPassword || '',
@@ -1634,10 +1633,19 @@ export class BotFrameworkAdapter
             );
         } else {
             if (JwtTokenValidation.isGovernment(this.settings.channelService)) {
-                credentials = new MicrosoftGovernmentAppCredentials(appId, appPassword, this.settings.channelAuthTenant, oAuthScope);
-            }
-            else{
-                credentials = new MicrosoftAppCredentials(appId, appPassword, this.settings.channelAuthTenant, oAuthScope);
+                credentials = new MicrosoftGovernmentAppCredentials(
+                    appId,
+                    appPassword,
+                    this.settings.channelAuthTenant,
+                    oAuthScope
+                );
+            } else {
+                credentials = new MicrosoftAppCredentials(
+                    appId,
+                    appPassword,
+                    this.settings.channelAuthTenant,
+                    oAuthScope
+                );
             }
         }
 

--- a/libraries/botbuilder/src/botFrameworkAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkAdapter.ts
@@ -56,6 +56,7 @@ import {
     GovernmentConstants,
     JwtTokenValidation,
     MicrosoftAppCredentials,
+    MicrosoftGovernmentAppCredentials,
     SignInUrlResponse,
     SimpleCredentialProvider,
     SkillValidation,
@@ -254,11 +255,20 @@ export class BotFrameworkAdapter
             );
             this.credentialsProvider = new SimpleCredentialProvider(this.credentials.appId, '');
         } else {
-            this.credentials = new MicrosoftAppCredentials(
-                this.settings.appId,
-                this.settings.appPassword || '',
-                this.settings.channelAuthTenant
-            );
+            if (JwtTokenValidation.isGovernment(this.settings.channelService)) {
+                this.credentials = new MicrosoftGovernmentAppCredentials(
+                    this.settings.appId,
+                    this.settings.appPassword || '',
+                    this.settings.channelAuthTenant
+                );
+            }
+            else{
+                this.credentials = new MicrosoftAppCredentials(
+                    this.settings.appId,
+                    this.settings.appPassword || '',
+                    this.settings.channelAuthTenant
+                );
+            }
             this.credentialsProvider = new SimpleCredentialProvider(
                 this.credentials.appId,
                 this.settings.appPassword || ''
@@ -279,10 +289,6 @@ export class BotFrameworkAdapter
         if (this.settings.openIdMetadata) {
             ChannelValidation.OpenIdMetadataEndpoint = this.settings.openIdMetadata;
             GovernmentChannelValidation.OpenIdMetadataEndpoint = this.settings.openIdMetadata;
-        }
-        if (JwtTokenValidation.isGovernment(this.settings.channelService)) {
-            this.credentials.oAuthEndpoint = GovernmentConstants.ToChannelFromBotLoginUrl;
-            this.credentials.oAuthScope = GovernmentConstants.ToChannelFromBotOAuthScope;
         }
 
         // If a NodeWebSocketFactoryBase was passed in, set it on the BotFrameworkAdapter.
@@ -1627,12 +1633,12 @@ export class BotFrameworkAdapter
                 this.settings.channelAuthTenant
             );
         } else {
-            credentials = new MicrosoftAppCredentials(appId, appPassword, this.settings.channelAuthTenant, oAuthScope);
-        }
-
-        if (JwtTokenValidation.isGovernment(this.settings.channelService)) {
-            credentials.oAuthEndpoint = GovernmentConstants.ToChannelFromBotLoginUrl;
-            credentials.oAuthScope = oAuthScope || GovernmentConstants.ToChannelFromBotOAuthScope;
+            if (JwtTokenValidation.isGovernment(this.settings.channelService)) {
+                credentials = new MicrosoftGovernmentAppCredentials(appId, appPassword, this.settings.channelAuthTenant, oAuthScope);
+            }
+            else{
+                credentials = new MicrosoftAppCredentials(appId, appPassword, this.settings.channelAuthTenant, oAuthScope);
+            }
         }
 
         return credentials;

--- a/libraries/botbuilder/src/botFrameworkHttpClient.ts
+++ b/libraries/botbuilder/src/botFrameworkHttpClient.ts
@@ -16,7 +16,7 @@ import {
     ICredentialProvider,
     JwtTokenValidation,
     MicrosoftAppCredentials,
-    MicrosoftGovernmentAppCredentials
+    MicrosoftGovernmentAppCredentials,
 } from 'botframework-connector';
 
 import { USER_AGENT } from './botFrameworkAdapter';

--- a/libraries/botbuilder/src/botFrameworkHttpClient.ts
+++ b/libraries/botbuilder/src/botFrameworkHttpClient.ts
@@ -13,10 +13,10 @@ import {
     AppCredentials,
     AuthenticationConstants,
     ConversationConstants,
-    GovernmentConstants,
     ICredentialProvider,
     JwtTokenValidation,
     MicrosoftAppCredentials,
+    MicrosoftGovernmentAppCredentials
 } from 'botframework-connector';
 
 import { USER_AGENT } from './botFrameworkAdapter';
@@ -158,9 +158,7 @@ export class BotFrameworkHttpClient implements BotFrameworkClient {
     protected async buildCredentials(appId: string, oAuthScope?: string): Promise<AppCredentials> {
         const appPassword = await this.credentialProvider.getAppPassword(appId);
         if (JwtTokenValidation.isGovernment(this.channelService)) {
-            const appCredentials = new MicrosoftAppCredentials(appId, appPassword, undefined, oAuthScope);
-            appCredentials.oAuthEndpoint = GovernmentConstants.ToChannelFromBotLoginUrl;
-            return appCredentials;
+            return new MicrosoftGovernmentAppCredentials(appId, appPassword, undefined, oAuthScope);
         } else {
             return new MicrosoftAppCredentials(appId, appPassword, undefined, oAuthScope);
         }

--- a/libraries/botframework-connector/src/auth/appCredentials.ts
+++ b/libraries/botframework-connector/src/auth/appCredentials.ts
@@ -45,17 +45,11 @@ export abstract class AppCredentials implements ServiceClientCredentials {
      * @param channelAuthTenant Optional. The oauth token tenant.
      * @param oAuthScope The scope for the token.
      */
-    constructor(
-        appId: string,
-        channelAuthTenant?: string,
-        oAuthScope: string = null
-    ) {
+    constructor(appId: string, channelAuthTenant?: string, oAuthScope: string = null) {
         this.appId = appId;
         this.tenant = channelAuthTenant;
         this.oAuthEndpoint = this.GetToChannelFromBotLoginUrlPrefix() + this.tenant;
-        this.oAuthScope = (oAuthScope && oAuthScope.length > 0)
-            ? oAuthScope
-            : this.GetToChannelFromBotOAuthScope();
+        this.oAuthScope = oAuthScope && oAuthScope.length > 0 ? oAuthScope : this.GetToChannelFromBotOAuthScope();
     }
 
     /**

--- a/libraries/botframework-connector/src/auth/appCredentials.ts
+++ b/libraries/botframework-connector/src/auth/appCredentials.ts
@@ -48,12 +48,14 @@ export abstract class AppCredentials implements ServiceClientCredentials {
     constructor(
         appId: string,
         channelAuthTenant?: string,
-        oAuthScope: string = AuthenticationConstants.ToBotFromChannelTokenIssuer
+        oAuthScope: string = null
     ) {
         this.appId = appId;
         this.tenant = channelAuthTenant;
-        this.oAuthEndpoint = AuthenticationConstants.ToChannelFromBotLoginUrlPrefix + this.tenant;
-        this.oAuthScope = oAuthScope;
+        this.oAuthEndpoint = this.GetToChannelFromBotLoginUrlPrefix() + this.tenant;
+        this.oAuthScope = (oAuthScope && oAuthScope.length > 0)
+            ? oAuthScope
+            : this.GetToChannelFromBotOAuthScope();
     }
 
     /**
@@ -69,7 +71,7 @@ export abstract class AppCredentials implements ServiceClientCredentials {
      * Sets tenant to be used for channel authentication.
      */
     private set tenant(value: string) {
-        this._tenant = value && value.length > 0 ? value : AuthenticationConstants.DefaultChannelAuthTenant;
+        this._tenant = value && value.length > 0 ? value : this.GetDefaultChannelAuthTenant();
     }
 
     /**
@@ -189,6 +191,18 @@ export abstract class AppCredentials implements ServiceClientCredentials {
         } else {
             throw new Error('Authentication: No response or error received from MSAL.');
         }
+    }
+
+    protected GetToChannelFromBotOAuthScope(): string {
+        return AuthenticationConstants.ToChannelFromBotOAuthScope;
+    }
+
+    protected GetToChannelFromBotLoginUrlPrefix(): string {
+        return AuthenticationConstants.ToChannelFromBotLoginUrlPrefix;
+    }
+
+    protected GetDefaultChannelAuthTenant(): string {
+        return AuthenticationConstants.DefaultChannelAuthTenant;
     }
 
     protected abstract refreshToken(): Promise<AuthenticatorResult>;

--- a/libraries/botframework-connector/src/auth/governmentConstants.ts
+++ b/libraries/botframework-connector/src/auth/governmentConstants.ts
@@ -15,8 +15,20 @@ export namespace GovernmentConstants {
 
     /**
      * TO CHANNEL FROM BOT: Login URL
+     *
+     * DEPRECATED: DO NOT USE
      */
     export const ToChannelFromBotLoginUrl = 'https://login.microsoftonline.us/MicrosoftServices.onmicrosoft.us';
+
+    /**
+     * TO CHANNEL FROM BOT: Login URL prefix
+     */
+    export const ToChannelFromBotLoginUrlPrefix = 'https://login.microsoftonline.us/';
+
+    /**
+     * TO CHANNEL FROM BOT: Default tenant from which to obtain a token for bot to channel communication
+     */
+    export const DefaultChannelAuthTenant = 'MicrosoftServices.onmicrosoft.us';
 
     /**
      * TO CHANNEL FROM BOT: OAuth scope to request

--- a/libraries/botframework-connector/src/auth/index.ts
+++ b/libraries/botframework-connector/src/auth/index.ts
@@ -32,6 +32,7 @@ export * from './managedIdentityAppCredentials';
 export * from './managedIdentityAuthenticator';
 export * from './managedIdentityServiceClientCredentialsFactory';
 export * from './microsoftAppCredentials';
+export * from './microsoftGovernmentAppCredentials';
 export * from './passwordServiceClientCredentialFactory';
 export * from './serviceClientCredentialsFactory';
 export * from './skillValidation';

--- a/libraries/botframework-connector/src/auth/microsoftGovernmentAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/microsoftGovernmentAppCredentials.ts
@@ -13,8 +13,7 @@ import { MicrosoftAppCredentials } from './microsoftAppCredentials';
  * MicrosoftGovermentAppCredentials auth implementation
  */
 export class MicrosoftGovernmentAppCredentials extends MicrosoftAppCredentials {
-
-      /**
+    /**
      * Initializes a new instance of the [MicrosoftGovernmentAppCredentials](xref:botframework-connector.MicrosoftGovernmentAppCredentials) class.
      *
      * @param {string} appId The Microsoft app ID.

--- a/libraries/botframework-connector/src/auth/microsoftGovernmentAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/microsoftGovernmentAppCredentials.ts
@@ -1,0 +1,40 @@
+/**
+ * @module botframework-connector
+ */
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { GovernmentConstants } from './governmentConstants';
+import { MicrosoftAppCredentials } from './microsoftAppCredentials';
+
+/**
+ * MicrosoftGovermentAppCredentials auth implementation
+ */
+export class MicrosoftGovernmentAppCredentials extends MicrosoftAppCredentials {
+
+      /**
+     * Initializes a new instance of the [MicrosoftGovernmentAppCredentials](xref:botframework-connector.MicrosoftGovernmentAppCredentials) class.
+     *
+     * @param {string} appId The Microsoft app ID.
+     * @param {string} appPassword The Microsoft app password.
+     * @param {string} channelAuthTenant Optional. The oauth token tenant.
+     * @param {string} oAuthScope Optional. The scope for the token.
+     */
+    constructor(appId: string, public appPassword: string, channelAuthTenant?: string, oAuthScope?: string) {
+        super(appId, appPassword, channelAuthTenant, oAuthScope);
+    }
+
+    protected GetToChannelFromBotOAuthScope(): string {
+        return GovernmentConstants.ToChannelFromBotOAuthScope;
+    }
+
+    protected GetToChannelFromBotLoginUrlPrefix(): string {
+        return GovernmentConstants.ToChannelFromBotLoginUrlPrefix;
+    }
+
+    protected GetDefaultChannelAuthTenant(): string {
+        return GovernmentConstants.DefaultChannelAuthTenant;
+    }
+}

--- a/libraries/botframework-connector/src/auth/msalServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/msalServiceClientCredentialsFactory.ts
@@ -70,11 +70,11 @@ export class MsalServiceClientCredentialsFactory implements ServiceClientCredent
             );
         }
 
-        if (normalizedEndpoint === GovernmentConstants.ToChannelFromBotLoginUrl.toLowerCase()) {
+        if (normalizedEndpoint.startsWith(GovernmentConstants.ToChannelFromBotLoginUrlPrefix)) {
             return new MsalAppCredentials(
                 this.clientApplication,
                 appId,
-                GovernmentConstants.ToChannelFromBotLoginUrl,
+                undefined,
                 audience || GovernmentConstants.ToChannelFromBotOAuthScope
             );
         }

--- a/libraries/botframework-connector/src/auth/passwordServiceClientCredentialFactory.ts
+++ b/libraries/botframework-connector/src/auth/passwordServiceClientCredentialFactory.ts
@@ -8,6 +8,7 @@ import type { ServiceClientCredentials } from '@azure/core-http';
 import { AuthenticationConstants } from './authenticationConstants';
 import { GovernmentConstants } from './governmentConstants';
 import { MicrosoftAppCredentials } from './microsoftAppCredentials';
+import { MicrosoftGovernmentAppCredentials } from './microsoftGovernmentAppCredentials';
 import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFactory';
 import { stringExt } from 'botbuilder-stdlib';
 
@@ -111,9 +112,8 @@ export class PasswordServiceClientCredentialFactory implements ServiceClientCred
 
         if (normalizedEndpoint?.startsWith(AuthenticationConstants.ToChannelFromBotLoginUrlPrefix)) {
             credentials = new MicrosoftAppCredentials(appId, this.password, this.tenantId, audience);
-        } else if (normalizedEndpoint === GovernmentConstants.ToChannelFromBotLoginUrl.toLowerCase()) {
-            credentials = new MicrosoftAppCredentials(appId, this.password, this.tenantId, audience);
-            credentials.oAuthEndpoint = loginEndpoint;
+        } else if (normalizedEndpoint?.startsWith(GovernmentConstants.ToChannelFromBotLoginUrlPrefix)) {
+            credentials = new MicrosoftGovernmentAppCredentials(appId, this.password, this.tenantId, audience);
         } else {
             credentials = new PrivateCloudAppCredentials(
                 appId,

--- a/libraries/botframework-connector/tests/auth/microsoftAppCredentials.test.js
+++ b/libraries/botframework-connector/tests/auth/microsoftAppCredentials.test.js
@@ -1,0 +1,17 @@
+const { MicrosoftAppCredentials, AuthenticationConstants } = require('../..');
+const assert = require('assert');
+
+describe('MicrosoftAppCredentialsTestSuite', function () {
+    describe('MicrosoftAppCredentialsTestCase', function () {
+        it('AssertOAuthEndpointAndOAuthScope', function() {
+            var credentials = new MicrosoftAppCredentials("appId", "password", "tenantId", "audience");
+            assert.strictEqual(AuthenticationConstants.ToChannelFromBotLoginUrlPrefix + "tenantId", credentials.oAuthEndpoint);
+            assert.strictEqual("audience", credentials.oAuthScope);
+
+            var credentials = new MicrosoftAppCredentials("appId", "password");
+            assert.strictEqual(AuthenticationConstants.ToChannelFromBotLoginUrlPrefix + AuthenticationConstants.DefaultChannelAuthTenant, credentials.oAuthEndpoint);
+            assert.strictEqual(AuthenticationConstants.ToChannelFromBotOAuthScope, credentials.oAuthScope);
+          });
+
+    });
+});

--- a/libraries/botframework-connector/tests/auth/microsoftAppCredentials.test.js
+++ b/libraries/botframework-connector/tests/auth/microsoftAppCredentials.test.js
@@ -3,15 +3,21 @@ const assert = require('assert');
 
 describe('MicrosoftAppCredentialsTestSuite', function () {
     describe('MicrosoftAppCredentialsTestCase', function () {
-        it('AssertOAuthEndpointAndOAuthScope', function() {
-            var credentials = new MicrosoftAppCredentials("appId", "password", "tenantId", "audience");
-            assert.strictEqual(AuthenticationConstants.ToChannelFromBotLoginUrlPrefix + "tenantId", credentials.oAuthEndpoint);
-            assert.strictEqual("audience", credentials.oAuthScope);
+        it('AssertOAuthEndpointAndOAuthScope', function () {
+            const credentials1 = new MicrosoftAppCredentials('appId', 'password', 'tenantId', 'audience');
+            assert.strictEqual(
+                AuthenticationConstants.ToChannelFromBotLoginUrlPrefix + 'tenantId',
+                credentials1.oAuthEndpoint
+            );
+            assert.strictEqual('audience', credentials1.oAuthScope);
 
-            var credentials = new MicrosoftAppCredentials("appId", "password");
-            assert.strictEqual(AuthenticationConstants.ToChannelFromBotLoginUrlPrefix + AuthenticationConstants.DefaultChannelAuthTenant, credentials.oAuthEndpoint);
-            assert.strictEqual(AuthenticationConstants.ToChannelFromBotOAuthScope, credentials.oAuthScope);
-          });
-
+            const credentials2 = new MicrosoftAppCredentials('appId', 'password');
+            assert.strictEqual(
+                AuthenticationConstants.ToChannelFromBotLoginUrlPrefix +
+                    AuthenticationConstants.DefaultChannelAuthTenant,
+                credentials2.oAuthEndpoint
+            );
+            assert.strictEqual(AuthenticationConstants.ToChannelFromBotOAuthScope, credentials2.oAuthScope);
+        });
     });
 });

--- a/libraries/botframework-connector/tests/auth/microsoftGovernmentAppCredentials.test.js
+++ b/libraries/botframework-connector/tests/auth/microsoftGovernmentAppCredentials.test.js
@@ -1,0 +1,17 @@
+const { MicrosoftGovernmentAppCredentials, GovernmentConstants } = require('../..');
+const assert = require('assert');
+
+describe('MicrosoftGovernmentAppCredentialsTestSuite', function () {
+    describe('MicrosoftGovernmentAppCredentialsTestCase', function () {
+        it('AssertOAuthEndpointAndOAuthScope', function() {
+            var credentials = new MicrosoftGovernmentAppCredentials("appId", "password", "tenantId", "audience");
+            assert.strictEqual(GovernmentConstants.ToChannelFromBotLoginUrlPrefix + "tenantId", credentials.oAuthEndpoint);
+            assert.strictEqual("audience", credentials.oAuthScope);
+
+            var credentials = new MicrosoftGovernmentAppCredentials("appId", "password");
+            assert.strictEqual(GovernmentConstants.ToChannelFromBotLoginUrlPrefix + GovernmentConstants.DefaultChannelAuthTenant, credentials.oAuthEndpoint);
+            assert.strictEqual(GovernmentConstants.ToChannelFromBotOAuthScope, credentials.oAuthScope);
+          });
+
+    });
+});

--- a/libraries/botframework-connector/tests/auth/microsoftGovernmentAppCredentials.test.js
+++ b/libraries/botframework-connector/tests/auth/microsoftGovernmentAppCredentials.test.js
@@ -3,15 +3,20 @@ const assert = require('assert');
 
 describe('MicrosoftGovernmentAppCredentialsTestSuite', function () {
     describe('MicrosoftGovernmentAppCredentialsTestCase', function () {
-        it('AssertOAuthEndpointAndOAuthScope', function() {
-            var credentials = new MicrosoftGovernmentAppCredentials("appId", "password", "tenantId", "audience");
-            assert.strictEqual(GovernmentConstants.ToChannelFromBotLoginUrlPrefix + "tenantId", credentials.oAuthEndpoint);
-            assert.strictEqual("audience", credentials.oAuthScope);
+        it('AssertOAuthEndpointAndOAuthScope', function () {
+            const credentials1 = new MicrosoftGovernmentAppCredentials('appId', 'password', 'tenantId', 'audience');
+            assert.strictEqual(
+                GovernmentConstants.ToChannelFromBotLoginUrlPrefix + 'tenantId',
+                credentials1.oAuthEndpoint
+            );
+            assert.strictEqual('audience', credentials1.oAuthScope);
 
-            var credentials = new MicrosoftGovernmentAppCredentials("appId", "password");
-            assert.strictEqual(GovernmentConstants.ToChannelFromBotLoginUrlPrefix + GovernmentConstants.DefaultChannelAuthTenant, credentials.oAuthEndpoint);
-            assert.strictEqual(GovernmentConstants.ToChannelFromBotOAuthScope, credentials.oAuthScope);
-          });
-
+            const credentials2 = new MicrosoftGovernmentAppCredentials('appId', 'password');
+            assert.strictEqual(
+                GovernmentConstants.ToChannelFromBotLoginUrlPrefix + GovernmentConstants.DefaultChannelAuthTenant,
+                credentials2.oAuthEndpoint
+            );
+            assert.strictEqual(GovernmentConstants.ToChannelFromBotOAuthScope, credentials2.oAuthScope);
+        });
     });
 });


### PR DESCRIPTION
Fixes #6717 
C# PR #6714

## Description
Fix a potential bug with USGov OAuthEndpoint while using SingleTenant.
Single tenant can't get token within <MicrosoftServices.onmicrosoft.us>.

## Specific Changes
Update MicrosoftGovernmentAppCredentials.OAuthEndpoint.


## Testing
Test locally, hard to add usgov single appid/password to the TestEnvironment.
MicrosoftGovernmentAppCredentialsTests.ConstructorTests