### PR TITLE
fix: Remove old babel/traverse version with a postinstall script

### DIFF
--- a/libraries/botbuilder-ai-orchestrator/package.json
+++ b/libraries/botbuilder-ai-orchestrator/package.json
@@ -47,7 +47,8 @@
     "lint": "eslint . --ext .js,.ts",
     "postbuild": "downlevel-dts lib _ts3.4/lib --checksum",
     "test": "yarn build && nyc mocha tests/",
-    "test:compat": "api-extractor run --verbose"
+    "test:compat": "api-extractor run --verbose",
+    "postinstall": "npx rimraf node_modules/@microsoft/orchestrator-core/node_modules/@babel/traverse"
   },
   "files": [
     "_ts3.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "test:runtime": "wsrun -m -p \"botbuilder-dialogs-adaptive-runtime*\" -t test",
     "test:runtime:min": "wsrun -m -p \"botbuilder-dialogs-adaptive-runtime*\" -t test:min",
     "test:schemas": "mocha libraries/botbuilder-dialogs-declarative/tests/schemaMergeTest.js --exit --bail",
-    "update-versions": "yarn workspace botbuilder-repo-utils update-versions"
+    "update-versions": "yarn workspace botbuilder-repo-utils update-versions",
+    "postinstall": "npx rimraf node_modules/@microsoft/orchestrator-core/node_modules/@babel/traverse"
   },
   "resolutions": {
     "async": "3.2.3",


### PR DESCRIPTION
#minor

## Description
This PR removes the old version of `@babel/traverse` (7.19.4) that is installed by the `@microsoft/orchestrator-core` package. This version of babel/traverse is vulnerable and _botbuilder_ is also installing a later and secure version of this package (7.23.2).

## Specific Changes
- Added a **_postinstall_** script in the _root_ and _botbuilder-orchestrator-ai_ package.json files to remove the old version of babel.

## Testing
These images show the dependencies tree before and after running the _postinstall_ script.
![image](https://github.com/southworks/botbuilder-js/assets/44245136/1f7e4252-50cc-47d5-a160-571d42b652e8)
