### PR TITLE
fix: Update axios and fix issue in botframework-connector

### DIFF
--- a/libraries/botbuilder-core/package.json
+++ b/libraries/botbuilder-core/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@microsoft/bf-chatdown": "^4.15.0",
-    "axios": "^0.25.0",
+    "axios": "^1.6.0",
     "unzipper": "^0.10.9"
   },
   "scripts": {

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@azure/core-http": "^3.0.2",
     "@azure/msal-node": "^1.2.0",
-    "axios": "^0.25.0",
+    "axios": "^1.6.0",
     "botbuilder-core": "4.1.6",
     "botbuilder-stdlib": "4.1.6",
     "botframework-connector": "4.1.6",

--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -30,8 +30,6 @@
     "@azure/core-http": "^3.0.2",
     "@azure/identity": "^2.0.4",
     "@azure/msal-node": "^1.2.0",
-    "@azure/core-http": "^3.0.2",
-    "axios": "^0.25.0",
     "base64url": "^3.0.0",
     "botbuilder-stdlib": "4.1.6",
     "botframework-schema": "4.1.6",

--- a/libraries/botframework-connector/src/auth/botFrameworkClientImpl.ts
+++ b/libraries/botframework-connector/src/auth/botFrameworkClientImpl.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import * as z from 'zod';
-import axios from 'axios';
 import { Activity, ChannelAccount, InvokeResponse, RoleTypes } from 'botframework-schema';
 import { BotFrameworkClient } from '../skills';
 import { ConversationIdHttpHeaderName } from '../conversationConstants';
@@ -15,14 +14,14 @@ const botFrameworkClientFetchImpl: typeof fetch = async (input, init) => {
     const url = z.string().parse(input);
     const { body, headers } = z.object({ body: z.string(), headers: z.record(z.string()).optional() }).parse(init);
 
-    const response = await axios.post(url, JSON.parse(body), {
+    const response = await fetch(url, {
+        body: JSON.parse(body),
         headers,
-        validateStatus: () => true,
     });
 
     return {
         status: response.status,
-        json: async () => response.data,
+        json: async () => response.body,
     } as Response;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3275,12 +3275,14 @@ axios@^0.24.0:
   dependencies:
     follow-redirects "^1.14.4"
 
-axios@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
-  integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
+axios@^1.6.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
+  integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
   dependencies:
-    follow-redirects "^1.14.7"
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-loader@^8.0.6:
   version "8.1.0"
@@ -6426,10 +6428,15 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.7:
+follow-redirects@^1.14.0, follow-redirects@^1.14.4:
   version "1.14.7"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
   integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+
+follow-redirects@^1.15.0:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
#minor

## Description
This PR updates the _axios_ package and replaces it  with _fetch_ in _botframework-connector_ due to a [breaking change](https://stackoverflow.com/questions/73958968/cannot-use-import-statement-outside-a-module-with-axios) in version 1.x.x of _axios_.

## Specific Changes
  - Updated _axios_ version to _**^1.6.0**_ in botbuilder and botbuilder-core.
  - Replaced _axios_ with _fetch_ in the _**botFrameworkClientImpl**_ class.

## Testing
The following image shows a bot working using _CloudAdapter_ with the _botframework-connector_ fix.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/771c492f-7fd1-45e0-aac9-98b4c6172f1c)
