### PR TITLE
fix: Add HTTP method in fetch request

### DIFF
--- a/libraries/botframework-connector/src/auth/botFrameworkClientImpl.ts
+++ b/libraries/botframework-connector/src/auth/botFrameworkClientImpl.ts
@@ -9,13 +9,15 @@ import { ServiceClientCredentialsFactory } from './serviceClientCredentialsFacto
 import { USER_AGENT } from './connectorFactoryImpl';
 import { WebResource } from '@azure/core-http';
 import { ok } from 'assert';
+import fetch from 'cross-fetch';
 
 const botFrameworkClientFetchImpl: typeof fetch = async (input, init) => {
     const url = z.string().parse(input);
     const { body, headers } = z.object({ body: z.string(), headers: z.record(z.string()).optional() }).parse(init);
 
     const response = await fetch(url, {
-        body: JSON.parse(body),
+        method: 'POST',
+        body,
         headers,
     });
 


### PR DESCRIPTION
#minor

## Description
This PR includes the HTTP method _**post**_ to the _fetch_ request.

## Specific Changes
  - Added _**post**_ method to the _fetch_ request in botFrameworkClientImpl.
  - Imported _fetch_ from **_cross-fetch_**.
  - Removed the _body_ parse.

## Testing
The following image shows a skill bot working using _CloudAdapter_ with the _botframework-connector_ fix.
![image](https://github.com/microsoft/botbuilder-js/assets/122501764/393e5862-48db-4c5c-9e0b-840353c004ca)