### PR TITLE
fix: BotState cache hash skipped properties

### DIFF
--- a/libraries/botbuilder-core/src/botState.ts
+++ b/libraries/botbuilder-core/src/botState.ts
@@ -202,6 +202,7 @@ export class BotState implements PropertyManager {
     /**
      * Skips properties from the cached state object.
      *
+     * @remarks Primarily used to skip properties before calculating the hash value in the calculateChangeHash function.
      * @param state Dictionary of state values.
      * @returns Dictionary of state values, without the skipped properties.
      */
@@ -217,7 +218,7 @@ export class BotState implements PropertyManager {
         };
 
         const inner = ([key, value], skip = []) => {
-            if (skip.includes(key)) {
+            if (value === null || value === undefined || skip.includes(key)) {
                 return;
             }
 
@@ -225,15 +226,15 @@ export class BotState implements PropertyManager {
                 return value.map((e) => inner([null, e], skip));
             }
 
-            if (value === null || typeof value !== 'object') {
-                return value;
+            if (typeof value !== 'object') {
+                return value.valueOf();
             }
 
             return Object.entries(value).reduce((acc, [k, v]) => {
                 const skipResult = skipHandler(k) ?? [];
                 acc[k] = inner([k, v], [...skip, ...skipResult]);
                 return acc;
-            }, value);
+            }, {});
         };
 
         return inner([null, state]);

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
@@ -201,8 +201,8 @@ describe('ActionTests', function () {
         const [, { state: beginSkillState }] = actionScope.dialogStack;
         const options = beginSkillState['BeginSkill.dialogOptionsData'];
 
-        assert.equal(options.conversationIdFactory, null);
-        assert.equal(options.conversationState, null);
+        assert.notEqual(options.conversationIdFactory, null);
+        assert.notEqual(options.conversationState, null);
         assert.notEqual(beginSkillDialog.dialogOptions.conversationIdFactory, null);
         assert.notEqual(beginSkillDialog.dialogOptions.conversationState, null);
     });

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
@@ -208,8 +208,9 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
 
         // Store the initialized dialogOptions in state so we can restore these values when the dialog is resumed.
         dc.activeDialog.state[this._dialogOptionsStateKey] = this.dialogOptions;
+        // Skip properties from the bot's state cache hash due to unwanted conversationState behavior.
         const skipProperties = dc.context.turnState.get(CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY);
-        const props: (keyof SkillDialogOptions)[] = ['conversationIdFactory', 'conversationState'];
+        const props: (keyof SkillDialogOptions)[] = ['conversationIdFactory', 'conversationState', 'skillClient'];
         skipProperties(this._dialogOptionsStateKey, props);
 
         // Get the activity to send to the skill.


### PR DESCRIPTION
#minor

## Description
This PR fixes an issue where the predefined skipped properties were removed from the bot's state cache object, instead of removing them only from the cache hash calculation because of the original issue (https://github.com/microsoft/botbuilder-js/issues/4325).

## Specific Changes
  - Updated skipProperties method to not modify the parameter value, and instead generate a copy, so later the hash calculation can use.
  - Updated the unit tests for BeginSkill, showing the properties are no longer deleted from the cache.
  - Added `skillClient` to the skipped properties.

## Testing
The following image shows the current error, and the bot working from the original issue.
![image](https://github.com/southworks/botbuilder-js/assets/62260472/da9a799e-bf98-470e-b237-9f1b7d0f97e0)
![image](https://github.com/southworks/botbuilder-js/assets/62260472/c44afa7b-da40-4480-90c0-60e1d7871778)
