### PR TITLE
feat: Add isVisible property to AceData

### DIFF
--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -17,6 +17,7 @@ export interface AceData {
     description: string;
     iconProperty: string;
     id: string;
+    isVisible?: boolean;
     properties: any;
     title: string;
 }

--- a/libraries/botframework-schema/src/sharepoint/aceData.ts
+++ b/libraries/botframework-schema/src/sharepoint/aceData.ts
@@ -33,6 +33,10 @@ export interface AceData {
      */
     description: string;
     /**
+     * The visibility of the Adaptive Card Extension.
+     */
+    isVisible?: boolean;
+    /**
      * The properties of the ACE.
      */
     properties: any;

--- a/libraries/botframework-schema/src/sharepoint/aceData.ts
+++ b/libraries/botframework-schema/src/sharepoint/aceData.ts
@@ -34,6 +34,7 @@ export interface AceData {
     description: string;
     /**
      * The visibility of the Adaptive Card Extension.
+     * true if not specified.
      */
     isVisible?: boolean;
     /**


### PR DESCRIPTION
Fixes #4605

## Description
The PR adds `isVisible` property to the `AceData` interface to implement the #4605 feature request.

## Specific Changes
```ts
interface AceData {
  // ...
  isVisible?: boolean;
  // ...
}
```

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->