### PR TITLE
fix: Remove old @microsoft/recognizers-text-number version with postinstall scripts

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/package.json
+++ b/libraries/botbuilder-dialogs-adaptive/package.json
@@ -47,8 +47,7 @@
     "node-fetch": "^2.6.7"
   },
   "devDependencies": {
-    "@types/node-fetch": "^2.5.3",
-    "rimraf": "^3.0.2"
+    "@types/node-fetch": "^2.5.3"
   },
   "scripts": {
     "build": "npm-run-all build:src build:tests",

--- a/libraries/botbuilder-dialogs-adaptive/package.json
+++ b/libraries/botbuilder-dialogs-adaptive/package.json
@@ -47,10 +47,8 @@
     "node-fetch": "^2.6.7"
   },
   "devDependencies": {
-    "@types/node-fetch": "^2.5.3"
-  },
-  "resolutions": {
-    "@microsoft/recognizers-text-number": "1.3.1"
+    "@types/node-fetch": "^2.5.3",
+    "rimraf": "^3.0.2"
   },
   "scripts": {
     "build": "npm-run-all build:src build:tests",
@@ -62,7 +60,11 @@
     "lint": "eslint . --ext .js,.ts",
     "postbuild": "downlevel-dts lib _ts3.4/lib --checksum",
     "test": "yarn build && nyc mocha tests/",
-    "test:compat": "api-extractor run --verbose"
+    "test:compat": "api-extractor run --verbose",
+    "postinstall": "yarn text-suite && yarn date-time && yarn number-with-unit",
+    "text-suite": "npx rimraf ../@microsoft/recognizers-text-suite/node_modules/@microsoft/recognizers-text-number",
+    "date-time": "npx rimraf ../@microsoft/recognizers-text-date-time/node_modules/@microsoft/recognizers-text-number",
+    "number-with-unit": "npx rimraf ../@microsoft/recognizers-text-number-with-unit/node_modules/@microsoft/recognizers-text-number"
   },
   "files": [
     "_ts3.4",

--- a/libraries/botbuilder-dialogs-adaptive/package.json
+++ b/libraries/botbuilder-dialogs-adaptive/package.json
@@ -49,6 +49,9 @@
   "devDependencies": {
     "@types/node-fetch": "^2.5.3"
   },
+  "resolutions": {
+    "@microsoft/recognizers-text-number": "1.3.1"
+  },
   "scripts": {
     "build": "npm-run-all build:src build:tests",
     "build-docs": "typedoc --theme markdown --entryPoint botbuilder-dialogs-adaptive --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\botbuilder-dialogs .\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK - Dialogs\" --readme none",

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -41,8 +41,7 @@
   },
   "devDependencies": {
     "@types/globalize": "^1.5.0",
-    "line-reader": "^0.4.0",
-    "rimraf": "^3.0.2"
+    "line-reader": "^0.4.0"
   },
   "scripts": {
     "build": "tsc -b",

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -43,6 +43,9 @@
     "@types/globalize": "^1.5.0",
     "line-reader": "^0.4.0"
   },
+  "resolutions": {
+    "@microsoft/recognizers-text-number": "1.3.1"
+  },
   "scripts": {
     "build": "tsc -b",
     "build-docs": "typedoc --theme markdown --entryPoint botbuilder-dialogs --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\botbuilder-dialogs .\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK - Dialogs\" --readme none",

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -41,10 +41,8 @@
   },
   "devDependencies": {
     "@types/globalize": "^1.5.0",
-    "line-reader": "^0.4.0"
-  },
-  "resolutions": {
-    "@microsoft/recognizers-text-number": "1.3.1"
+    "line-reader": "^0.4.0",
+    "rimraf": "^3.0.2"
   },
   "scripts": {
     "build": "tsc -b",
@@ -56,7 +54,11 @@
     "postbuild": "downlevel-dts lib _ts3.4/lib --checksum",
     "test": "npm-run-all build test:mocha",
     "test:mocha": "nyc mocha --recursive --require source-map-support/register tests",
-    "test:compat": "api-extractor run --verbose"
+    "test:compat": "api-extractor run --verbose",
+    "postinstall": "yarn text-suite && yarn date-time && yarn number-with-unit",
+    "text-suite": "npx rimraf ../@microsoft/recognizers-text-suite/node_modules/@microsoft/recognizers-text-number",
+    "date-time": "npx rimraf ../@microsoft/recognizers-text-date-time/node_modules/@microsoft/recognizers-text-number",
+    "number-with-unit": "npx rimraf ../@microsoft/recognizers-text-number-with-unit/node_modules/@microsoft/recognizers-text-number"
   },
   "files": [
     "_ts3.4",


### PR DESCRIPTION
#minor

## Description
This PR removes the old version or **_@microsoft/recognizers-text-number_** from the other recognizers packages that require it.

## Specific Changes
  - Added postinstall scripts in botbuilder-dialogs and botbuilder-dialogs-adaptive package.json files to remove the old version of  **_@microsoft/recognizers-text-number_**.

## Testing
These images show the dependencies tree before and after running the postinstall scripts.
![image](https://github.com/southworks/botbuilder-js/assets/122501764/02c94d78-e795-42a5-8593-4afc9438e1f8)