### PR TITLE
fix: skip properties to be set in the Conversation State

### DIFF
--- a/libraries/botbuilder-core/src/botState.ts
+++ b/libraries/botbuilder-core/src/botState.ts
@@ -78,8 +78,10 @@ export class BotState implements PropertyManager {
     public load(context: TurnContext, force = false): Promise<any> {
         const cached: CachedBotState = context.turnState.get(this.stateKey);
         if (!context.turnState.get(CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY)) {
-            context.turnState.set(CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY, (key, properties) =>
-                this.skippedProperties.set(key, properties)
+            context.turnState.set(
+                CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY,
+                (state: BotState, key: string, properties: string[] = null) =>
+                    state.skippedProperties.set(key, properties)
             );
         }
         if (force || !cached || !cached.state) {

--- a/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/actions/beginSkill.ts
@@ -204,7 +204,7 @@ export class BeginSkill extends SkillDialog implements BeginSkillConfiguration {
         // Skip properties from the bot's state cache hash due to unwanted conversationState behavior.
         const skipProperties = dc.context.turnState.get(CACHED_BOT_STATE_SKIP_PROPERTIES_HANDLER_KEY);
         const props: (keyof SkillDialogOptions)[] = ['conversationIdFactory', 'conversationState', 'skillClient'];
-        skipProperties(this._dialogOptionsStateKey, props);
+        skipProperties(this.dialogOptions.conversationState, this._dialogOptionsStateKey, props);
 
         // Get the activity to send to the skill.
         options = {} as BeginSkillDialogOptions;


### PR DESCRIPTION
#minor

## Description
This PR fixes an issue where the skip properties were not set properly in the correct bot state. It was changed to be set directly in the Conversation State instance.

## Specific Changes
- Updated the custom internal handler to receive the state to skip the properties from.

## Testing
The following image shows the change working.
![image](https://github.com/southworks/botbuilder-js/assets/62260472/217f6e26-82df-4577-b135-dec46f136a13)