### PR TITLE
fix: Use npm to run postinstall scripts

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive/package.json
+++ b/libraries/botbuilder-dialogs-adaptive/package.json
@@ -60,7 +60,7 @@
     "postbuild": "downlevel-dts lib _ts3.4/lib --checksum",
     "test": "yarn build && nyc mocha tests/",
     "test:compat": "api-extractor run --verbose",
-    "postinstall": "yarn text-suite && yarn date-time && yarn number-with-unit",
+    "postinstall": "npm run text-suite && npm run date-time && npm run number-with-unit",
     "text-suite": "npx rimraf ../@microsoft/recognizers-text-suite/node_modules/@microsoft/recognizers-text-number",
     "date-time": "npx rimraf ../@microsoft/recognizers-text-date-time/node_modules/@microsoft/recognizers-text-number",
     "number-with-unit": "npx rimraf ../@microsoft/recognizers-text-number-with-unit/node_modules/@microsoft/recognizers-text-number"

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -54,7 +54,7 @@
     "test": "npm-run-all build test:mocha",
     "test:mocha": "nyc mocha --recursive --require source-map-support/register tests",
     "test:compat": "api-extractor run --verbose",
-    "postinstall": "yarn text-suite && yarn date-time && yarn number-with-unit",
+    "postinstall": "npm run text-suite && npm run date-time && npm run number-with-unit",
     "text-suite": "npx rimraf ../@microsoft/recognizers-text-suite/node_modules/@microsoft/recognizers-text-number",
     "date-time": "npx rimraf ../@microsoft/recognizers-text-date-time/node_modules/@microsoft/recognizers-text-number",
     "number-with-unit": "npx rimraf ../@microsoft/recognizers-text-number-with-unit/node_modules/@microsoft/recognizers-text-number"


### PR DESCRIPTION
#minor

## Description
This PR replaces yarn with npm to execute the postinstall scripts.

## Specific Changes
  - Replaced _**yarn**_ command with _**npm run**_ command in _botbuilder-dialogs_ and _botbuilder-dialogs-adaptive_

## Testing
The following image shows the postinstall script working with _**npm run**_.
![image](https://github.com/microsoft/botbuilder-js/assets/122501764/37ffbe28-36e7-454b-bc33-5f9b70b944e6)