### PR TITLE
bump: Update follow-redirects to ^1.15.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "**/request-promise-native/tough-cookie": "^4.1.3",
     "**/istanbul-lib-instrument/@babel/core": "^7.23.2",
     "**/@babel/plugin-proposal-class-properties/@babel/core": "^7.23.2",
-    "follow-redirects": "^1.14.8",
+    "follow-redirects": "^1.15.4",
     "@types/ramda": "0.26.0"
   },
   "devDependencies": {

--- a/testing/browser-functional/browser-echo-bot/package.json
+++ b/testing/browser-functional/browser-echo-bot/package.json
@@ -38,5 +38,8 @@
   },
   "resolutions": {
     "follow-redirects": "^1.15.4"
+  },
+  "overrides": {
+    "follow-redirects": "^1.15.4"
   }
 }

--- a/testing/browser-functional/browser-echo-bot/package.json
+++ b/testing/browser-functional/browser-echo-bot/package.json
@@ -35,5 +35,8 @@
     "webpack": "^4.35.3",
     "webpack-cli": "^3.3.6",
     "webpack-dev-server": "^3.7.2"
+  },
+  "resolutions": {
+    "follow-redirects": "^1.15.4"
   }
 }

--- a/testing/browser-functional/browser-echo-bot/yarn.lock
+++ b/testing/browser-functional/browser-echo-bot/yarn.lock
@@ -3321,10 +3321,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0:
-  version "1.14.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
-  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
+follow-redirects@^1.0.0, follow-redirects@^1.15.4:
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
+  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
 
 for-in@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6803,7 +6803,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.14.0, follow-redirects@^1.14.8, follow-redirects@^1.15.0, follow-redirects@^1.15.4:
+follow-redirects@^1.14.0, follow-redirects@^1.15.0, follow-redirects@^1.15.4:
   version "1.15.4"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
   integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==


### PR DESCRIPTION
#minor

## Description
This PR updates the _**follow-redirects**_ package version to ^1.15.4 to avoid [_improperly handles URLs_](https://github.com/microsoft/botbuilder-js/security/dependabot/319) vulnerability.

## Specific Changes
  - Updated  _**follow-redirects**_  to ^1.15.4 in _browser-echo bot_ and _botbuilder_.
  
## Testing
The following image shows the _browser-echo bot_  working after the changes.
![image](https://github.com/microsoft/botbuilder-js/assets/122501764/40ee073e-9a45-48cb-b32d-8544935b4e62)