### PR TITLE
fix: [#4584] ChannelAccount cannot accept extensible properties

### DIFF
--- a/libraries/botframework-connector/src/connectorApi/models/mappers.ts
+++ b/libraries/botframework-connector/src/connectorApi/models/mappers.ts
@@ -158,6 +158,17 @@ export const ChannelAccount: CompositeMapper = {
         type: {
           name: "String"
         }
+      },
+      properties: {
+        serializedName: "properties",
+        type: {
+          name: "Dictionary",
+          value: {
+            type: {
+              name: "any"
+            }
+          }
+        }
       }
     }
   }

--- a/libraries/botframework-connector/src/connectorApi/models/mappers.ts
+++ b/libraries/botframework-connector/src/connectorApi/models/mappers.ts
@@ -162,12 +162,7 @@ export const ChannelAccount: CompositeMapper = {
       properties: {
         serializedName: "properties",
         type: {
-          name: "Dictionary",
-          value: {
-            type: {
-              name: "any"
-            }
-          }
+          name: "Object"
         }
       }
     }

--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -579,6 +579,7 @@ export interface ChannelAccount {
     aadObjectId?: string;
     id: string;
     name: string;
+    properties?: any;
     role?: RoleTypes | string;
 }
 

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -155,6 +155,11 @@ export interface ChannelAccount {
      * 'user', 'bot', 'skill'
      */
     role?: RoleTypes | string;
+
+    /**
+     * Properties not represented in a defined type
+     */
+    properties: { [key: string]: any };
 }
 
 const channelAccount = z.object({
@@ -2456,7 +2461,7 @@ export interface SearchInvokeOptions {
  * Name of 'application/search'.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SearchInvokeResponse extends AdaptiveCardInvokeResponse {}
+export interface SearchInvokeResponse extends AdaptiveCardInvokeResponse { }
 
 /**
  * Represents a response returned by a bot when it receives an `invoke` activity.

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -157,9 +157,9 @@ export interface ChannelAccount {
     role?: RoleTypes | string;
 
     /**
-     * Properties not represented in a defined type
+     * Custom properties object (optional)
      */
-    properties: { [key: string]: any };
+    properties?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 const channelAccount = z.object({
@@ -2461,7 +2461,7 @@ export interface SearchInvokeOptions {
  * Name of 'application/search'.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SearchInvokeResponse extends AdaptiveCardInvokeResponse { }
+export interface SearchInvokeResponse extends AdaptiveCardInvokeResponse {}
 
 /**
  * Represents a response returned by a bot when it receives an `invoke` activity.


### PR DESCRIPTION
Fixes #4584

## Description
This PR includes the **_Properties_** property to the _ChannelAccount_ interface to allow using optional properties.

## Specific Changes
  - Added _**Properties**_ property to the _ChannelAccount_ interface.
  - Added _**properties**_ serialization in CompositeMapper.

## Testing
The following image shows the object Properties retrieved in the request body of the bot.
![image](https://github.com/microsoft/botbuilder-js/assets/122501764/ef9f8137-69e0-4f19-a73f-251491063bc2)