### PR TITLE
chore: [#4636] Add more information to Tenant parameters

### DIFF
--- a/libraries/botframework-connector/src/auth/appCredentials.ts
+++ b/libraries/botframework-connector/src/auth/appCredentials.ts
@@ -42,7 +42,11 @@ export abstract class AppCredentials implements ServiceClientCredentials {
      * Initializes a new instance of the [AppCredentials](xref:botframework-connector.AppCredentials) class.
      *
      * @param appId The App ID.
-     * @param channelAuthTenant Optional. The oauth token tenant.
+     * @param channelAuthTenant Tenant ID of the Azure AD tenant where the bot is created.
+     *   * Required for SingleTenant app types.
+     *   * Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *
+     * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
      * @param oAuthScope The scope for the token.
      */
     constructor(appId: string, channelAuthTenant?: string, oAuthScope: string = null) {

--- a/libraries/botframework-connector/src/auth/certificateAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/certificateAppCredentials.ts
@@ -27,7 +27,11 @@ export class CertificateAppCredentials extends AppCredentials {
      * @param appId Microsoft application Id related to the certificate.
      * @param certificateThumbprint A hex encoded thumbprint of the certificate.
      * @param certificatePrivateKey A PEM encoded certificate private key.
-     * @param channelAuthTenant Optional. The oauth token tenant.
+     * @param channelAuthTenant Tenant ID of the Azure AD tenant where the bot is created.
+     *   * Required for SingleTenant app types.
+     *   * Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *
+     * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
      * @param oAuthScope Optional. The scope for the token.
      * @param x5c Optional. Enables application developers to achieve easy certificates roll-over in Azure AD:
      * set this parameter to send the public certificate (BEGIN CERTIFICATE) to Azure AD, so that Azure AD can use it to validate the subject name based on a trusted issuer policy.

--- a/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
+++ b/libraries/botframework-connector/src/auth/certificateServiceClientCredentialsFactory.ts
@@ -30,7 +30,11 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
      * @param appId Microsoft application Id related to the certificate.
      * @param certificateThumbprint A hex encoded thumbprint of the certificate.
      * @param certificatePrivateKey A PEM encoded certificate private key.
-     * @param tenantId Optional. The oauth token tenant.
+     * @param tenantId Tenant ID of the Azure AD tenant where the bot is created.
+     *   * Required for SingleTenant app types.
+     *   * Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *
+     * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
      * @param x5c Optional. Enables application developers to achieve easy certificates roll-over in Azure AD:
      * set this parameter to send the public certificate (BEGIN CERTIFICATE) to Azure AD, so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
      */
@@ -49,7 +53,11 @@ export class CertificateServiceClientCredentialsFactory extends ServiceClientCre
      * @param x5c Value that enables application developers to achieve easy certificates roll-over in Azure AD
      * set this parameter to send the public certificate (BEGIN CERTIFICATE) to Azure AD, so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
      * @param certificatePrivateKey A PEM encoded certificate private key.
-     * @param tenantId Optional. The oauth token tenant.
+     * @param tenantId Tenant ID of the Azure AD tenant where the bot is created.
+     *   * Required for SingleTenant app types.
+     *   * Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *
+     * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
      */
     constructor(appId: string, x5c: string, certificatePrivateKey: string, tenantId?: string);
 

--- a/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
+++ b/libraries/botframework-connector/src/auth/microsoftAppCredentials.ts
@@ -26,7 +26,11 @@ export class MicrosoftAppCredentials extends AppCredentials {
      *
      * @param {string} appId The Microsoft app ID.
      * @param {string} appPassword The Microsoft app password.
-     * @param {string} channelAuthTenant Optional. The oauth token tenant.
+     * @param {string} channelAuthTenant Tenant ID of the Azure AD tenant where the bot is created.
+     *   * Required for SingleTenant app types.
+     *   * Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *
+     * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
      * @param {string} oAuthScope Optional. The scope for the token.
      */
     constructor(appId: string, public appPassword: string, channelAuthTenant?: string, oAuthScope?: string) {

--- a/libraries/botframework-connector/src/auth/passwordServiceClientCredentialFactory.ts
+++ b/libraries/botframework-connector/src/auth/passwordServiceClientCredentialFactory.ts
@@ -53,6 +53,10 @@ export class PasswordServiceClientCredentialFactory implements ServiceClientCred
      * @param appId The app ID.
      * @param password The app password.
      * @param tenantId Tenant ID of the Azure AD tenant where the bot is created.
+     *   * Required for SingleTenant app types.
+     *   * Optional for MultiTenant app types. **Note**: '_botframework.com_' is the default tenant when no value is provided.
+     *
+     * More information: https://learn.microsoft.com/en-us/security/zero-trust/develop/identity-supported-account-types.
      */
     constructor(appId: string, password: string, tenantId: string);
 


### PR DESCRIPTION
Fixes #4636

## Description
This PR adds more information to optional Tenant parameters used in authentication classes. Explaining when it's optional or required, and the default when no value is provided.

## Specific Changes
  - Add Tenant comment to authentication (AppCredentials, CertificateAppCredentials, MicrosoftAppCredentials, and auth factories) classes.
  - The new comment contains information when required, optional, and the default value. Additionally, a link to the supported Azure app types.

## Testing
The following image shows how the new comment looks.
![image](https://github.com/southworks/botbuilder-js/assets/62260472/5ee933c8-155f-4a24-a7ab-e06fd43a3a61)