### PR TITLE
refactor: Update Recognizers-Text references

### DIFF
--- a/libraries/adaptive-expressions-ie11/webpack.config.js
+++ b/libraries/adaptive-expressions-ie11/webpack.config.js
@@ -40,7 +40,7 @@ module.exports = () => {
                     query: { compact: false },
                     include: [
                         resolvePackageRoot('adaptive-expressions'),
-                        resolvePackageRoot('@microsoft/recognizers-text-data-types-timex-expression'),
+                        resolvePackageRoot('botbuilder-stdlib'),
                         resolvePackageRoot('antlr4ts'),
                         resolvePackageRoot('lru-cache'),
                         resolvePackageRoot('yallist'),

--- a/libraries/adaptive-expressions/package.json
+++ b/libraries/adaptive-expressions/package.json
@@ -20,7 +20,7 @@
   "browser": "./lib/browser.js",
   "typings": "./lib/index.d.ts",
   "dependencies": {
-    "@microsoft/recognizers-text-data-types-timex-expression": "1.3.0",
+    "botbuilder-stdlib": "4.1.6",
     "@types/atob-lite": "^2.0.0",
     "@types/btoa-lite": "^1.0.0",
     "@types/lodash.isequal": "^4.5.5",

--- a/libraries/adaptive-expressions/src/builtinFunctions/dateReadBack.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/dateReadBack.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { TimexProperty } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 import dayjs from 'dayjs';
 import { Expression } from '../expression';
 import { EvaluateExpressionDelegate, ExpressionEvaluator, ValueWithError } from '../expressionEvaluator';

--- a/libraries/adaptive-expressions/src/builtinFunctions/getNextViableDate.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getNextViableDate.ts
@@ -20,7 +20,7 @@ import utc from 'dayjs/plugin/utc';
 dayjs.extend(utc);
 import timezone from 'dayjs/plugin/timezone';
 dayjs.extend(timezone);
-import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { TimexProperty } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 
 /**
  * Return the next viable date of a timex expression based on the current date and user's timezone.

--- a/libraries/adaptive-expressions/src/builtinFunctions/getNextViableTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getNextViableTime.ts
@@ -20,7 +20,7 @@ import utc from 'dayjs/plugin/utc';
 dayjs.extend(utc);
 import timezone from 'dayjs/plugin/timezone';
 dayjs.extend(timezone);
-import { TimexProperty, Time } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { TimexProperty, Time } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 /**
  * Return the next viable time of a timex expression based on the current time and user's timezone.
  */

--- a/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableDate.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableDate.ts
@@ -20,7 +20,7 @@ import timezone from 'dayjs/plugin/timezone';
 dayjs.extend(timezone);
 import utc from 'dayjs/plugin/utc';
 dayjs.extend(utc);
-import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { TimexProperty } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 
 /**
  * Return the previous viable date of a timex expression based on the current date and user's timezone.

--- a/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/getPreviousViableTime.ts
@@ -18,7 +18,7 @@ import { TimeZoneConverter } from '../timeZoneConverter';
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 dayjs.extend(timezone);
-import { TimexProperty, Time } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { TimexProperty, Time } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 /**
  * Return the previous viable time of a timex expression based on the current time and user's timezone.
  */

--- a/libraries/adaptive-expressions/src/builtinFunctions/isDate.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isDate.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { TimexProperty } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 
 import { Expression } from '../expression';
 import { ExpressionEvaluator, ValueWithError } from '../expressionEvaluator';

--- a/libraries/adaptive-expressions/src/builtinFunctions/isDateRange.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isDateRange.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { TimexProperty } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 
 import { Expression } from '../expression';
 import { ExpressionEvaluator, ValueWithError } from '../expressionEvaluator';

--- a/libraries/adaptive-expressions/src/builtinFunctions/isDefinite.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isDefinite.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { TimexProperty } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 
 import { Expression } from '../expression';
 import { ExpressionEvaluator, ValueWithError } from '../expressionEvaluator';

--- a/libraries/adaptive-expressions/src/builtinFunctions/isDuration.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isDuration.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { TimexProperty } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 
 import { Expression } from '../expression';
 import { ExpressionEvaluator, ValueWithError } from '../expressionEvaluator';

--- a/libraries/adaptive-expressions/src/builtinFunctions/isPresent.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isPresent.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { TimexProperty } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 
 import { Expression } from '../expression';
 import { ExpressionEvaluator, ValueWithError } from '../expressionEvaluator';

--- a/libraries/adaptive-expressions/src/builtinFunctions/isTime.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isTime.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { TimexProperty } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 
 import { Expression } from '../expression';
 import { ExpressionEvaluator, ValueWithError } from '../expressionEvaluator';

--- a/libraries/adaptive-expressions/src/builtinFunctions/isTimeRange.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/isTimeRange.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { TimexProperty } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 
 import { Expression } from '../expression';
 import { ExpressionEvaluator, ValueWithError } from '../expressionEvaluator';

--- a/libraries/adaptive-expressions/src/builtinFunctions/timexResolve.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/timexResolve.ts
@@ -6,7 +6,10 @@
  * Licensed under the MIT License.
  */
 
-import { TimexProperty, valueResolver } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
+import {
+    TimexProperty,
+    valueResolver,
+} from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 import { Expression } from '../expression';
 import { ExpressionEvaluator, ValueWithError } from '../expressionEvaluator';
 import { ExpressionType } from '../expressionType';

--- a/libraries/adaptive-expressions/src/builtinFunctions/timexResolve.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/timexResolve.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { TimexProperty, valueResolver } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { TimexProperty, valueResolver } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 import { Expression } from '../expression';
 import { ExpressionEvaluator, ValueWithError } from '../expressionEvaluator';
 import { ExpressionType } from '../expressionType';

--- a/libraries/adaptive-expressions/src/functionUtils.internal.ts
+++ b/libraries/adaptive-expressions/src/functionUtils.internal.ts
@@ -15,7 +15,7 @@ import { ExpressionType } from './expressionType';
 import { Options } from './options';
 import { EvaluateExpressionDelegate, ValueWithError } from './expressionEvaluator';
 import { MemoryInterface, SimpleObjectMemory, StackedMemory } from './memory';
-import { TimexProperty } from '@microsoft/recognizers-text-data-types-timex-expression';
+import { TimexProperty } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression';
 import bigInt = require('big-integer');
 import util = require('util');
 

--- a/libraries/adaptive-expressions/tests/expressionParser.test.js
+++ b/libraries/adaptive-expressions/tests/expressionParser.test.js
@@ -2,7 +2,7 @@
 const assert = require('assert');
 const bigInt = require('big-integer');
 const { Expression, SimpleObjectMemory, FunctionUtils, Options, NumericEvaluator, StackedMemory } = require('../lib');
-const { TimexProperty } = require('@microsoft/recognizers-text-data-types-timex-expression');
+const { TimexProperty } = require('botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression');
 const { useFakeTimers } = require('sinon');
 const os = require('os');
 

--- a/libraries/botbuilder-dialogs-adaptive-testing/package.json
+++ b/libraries/botbuilder-dialogs-adaptive-testing/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "botbuilder": "4.1.6",
-    "@microsoft/recognizers-text-suite": "1.1.4",
+    "botbuilder-stdlib": "4.1.6",
     "@types/nock": "^11.1.0"
   },
   "author": "Microsoft",

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/activityUtils.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/activityUtils.js
@@ -1,4 +1,4 @@
-const { Culture } = require('@microsoft/recognizers-text-suite');
+const { Culture } = require('botbuilder-stdlib/vendors/@microsoft/recognizers-text-suite');
 const { ActivityTypes, TestAdapter, TurnContext } = require('botbuilder-core');
 const { DialogContext, DialogSet } = require('botbuilder-dialogs');
 const user = {

--- a/libraries/botbuilder-dialogs-adaptive/package.json
+++ b/libraries/botbuilder-dialogs-adaptive/package.json
@@ -28,13 +28,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/recognizers-text": "~1.1.4",
-    "@microsoft/recognizers-text-choice": "~1.1.4",
-    "@microsoft/recognizers-text-date-time": "~1.1.4",
-    "@microsoft/recognizers-text-number": "~1.3.1",
-    "@microsoft/recognizers-text-number-with-unit": "~1.1.4",
-    "@microsoft/recognizers-text-sequence": "~1.1.4",
-    "@microsoft/recognizers-text-suite": "1.1.4",
+    "botbuilder-stdlib": "4.1.6",
     "adaptive-expressions": "4.1.6",
     "botbuilder": "4.1.6",
     "botbuilder-core": "4.1.6",
@@ -59,11 +53,7 @@
     "lint": "eslint . --ext .js,.ts",
     "postbuild": "downlevel-dts lib _ts3.4/lib --checksum",
     "test": "yarn build && nyc mocha tests/",
-    "test:compat": "api-extractor run --verbose",
-    "postinstall": "npm run text-suite && npm run date-time && npm run number-with-unit",
-    "text-suite": "npx rimraf ../@microsoft/recognizers-text-suite/node_modules/@microsoft/recognizers-text-number",
-    "date-time": "npx rimraf ../@microsoft/recognizers-text-date-time/node_modules/@microsoft/recognizers-text-number",
-    "number-with-unit": "npx rimraf ../@microsoft/recognizers-text-number-with-unit/node_modules/@microsoft/recognizers-text-number"
+    "test:compat": "api-extractor run --verbose"
   },
   "files": [
     "_ts3.4",

--- a/libraries/botbuilder-dialogs-adaptive/src/input/confirmInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/confirmInput.ts
@@ -32,7 +32,7 @@ import {
 } from 'botbuilder-dialogs';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import * as Recognizers from '@microsoft/recognizers-text-choice';
+import * as Recognizers from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-choice';
 import { ChoiceOptionsSet } from './choiceOptionsSet';
 
 export interface ConfirmInputConfiguration extends InputDialogConfiguration {

--- a/libraries/botbuilder-dialogs-adaptive/src/input/dateTimeInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/dateTimeInput.ts
@@ -12,7 +12,7 @@ import { InputDialog, InputDialogConfiguration, InputState } from './inputDialog
 import { StringProperty } from '../properties';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import * as Recognizers from '@microsoft/recognizers-text-date-time';
+import * as Recognizers from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-date-time';
 
 export interface DateTimeInputConfiguration extends InputDialogConfiguration {
     defaultLocale?: StringProperty;

--- a/libraries/botbuilder-dialogs-adaptive/src/input/numberInput.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/input/numberInput.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import * as Recognizers from '@microsoft/recognizers-text-number';
+import * as Recognizers from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-number';
 import { Converter, ConverterFactory, DialogContext } from 'botbuilder-dialogs';
 import { InputDialog, InputDialogConfiguration, InputState } from './inputDialog';
 import { NumberProperty, StringProperty } from '../properties';

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/ageEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/ageEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizeAge } from '@microsoft/recognizers-text-number-with-unit';
+import { recognizeAge } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-number-with-unit';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/confirmationEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/confirmationEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizeBoolean } from '@microsoft/recognizers-text-choice';
+import { recognizeBoolean } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-choice';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/currencyEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/currencyEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizeCurrency } from '@microsoft/recognizers-text-number-with-unit';
+import { recognizeCurrency } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-number-with-unit';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/dateTimeEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/dateTimeEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizeDateTime } from '@microsoft/recognizers-text-date-time';
+import { recognizeDateTime } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-date-time';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/dimensionEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/dimensionEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizeDimension } from '@microsoft/recognizers-text-number-with-unit';
+import { recognizeDimension } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-number-with-unit';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/emailEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/emailEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizeEmail } from '@microsoft/recognizers-text-sequence';
+import { recognizeEmail } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-sequence';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/guidEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/guidEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizeGUID } from '@microsoft/recognizers-text-sequence';
+import { recognizeGUID } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-sequence';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/hashtagEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/hashtagEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizeHashtag } from '@microsoft/recognizers-text-sequence';
+import { recognizeHashtag } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-sequence';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/index.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-// NumberRangeEntityRecognizer not implemented due to lack of supoort in @microsoft/recognizers-text-suite
+// NumberRangeEntityRecognizer not implemented due to lack of supoort in botbuilder-stdlib/vendors/@microsoft/recognizers-text-suite
 
 export * from './ageEntityRecognizer';
 export * from './channelMentionEntityRecognizer';

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/ipEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/ipEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizeIpAddress } from '@microsoft/recognizers-text-sequence';
+import { recognizeIpAddress } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-sequence';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/mentionEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/mentionEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizeMention } from '@microsoft/recognizers-text-sequence';
+import { recognizeMention } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-sequence';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/numberEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/numberEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizeNumber } from '@microsoft/recognizers-text-number';
+import { recognizeNumber } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-number';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/ordinalEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/ordinalEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizeOrdinal } from '@microsoft/recognizers-text-number';
+import { recognizeOrdinal } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-number';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/percentageEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/percentageEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizePercentage } from '@microsoft/recognizers-text-number';
+import { recognizePercentage } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-number';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/phoneNumberEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/phoneNumberEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizePhoneNumber } from '@microsoft/recognizers-text-sequence';
+import { recognizePhoneNumber } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-sequence';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/temperatureEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/temperatureEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizeTemperature } from '@microsoft/recognizers-text-number-with-unit';
+import { recognizeTemperature } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-number-with-unit';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/textEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/textEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { Culture } from '@microsoft/recognizers-text';
+import { Culture } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text';
 import { Entity } from 'botbuilder';
 import { DialogContext, ModelResult } from 'botbuilder-dialogs';
 import { EntityRecognizer } from './entityRecognizer';

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/urlEntityRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/entityRecognizers/urlEntityRecognizer.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { recognizeURL } from '@microsoft/recognizers-text-sequence';
+import { recognizeURL } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-sequence';
 import { ModelResult } from 'botbuilder-dialogs';
 import { TextEntityRecognizer } from './textEntityRecognizer';
 

--- a/libraries/botbuilder-dialogs-adaptive/src/recognizers/regexRecognizer.ts
+++ b/libraries/botbuilder-dialogs-adaptive/src/recognizers/regexRecognizer.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { Culture } from '@microsoft/recognizers-text-suite';
+import { Culture } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-suite';
 import { Activity, Entity, RecognizerResult } from 'botbuilder';
 import { Converter, ConverterFactory, DialogContext } from 'botbuilder-dialogs';
 import { IntentPattern } from './intentPattern';

--- a/libraries/botbuilder-dialogs-adaptive/tests/activityUtils.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/activityUtils.js
@@ -1,4 +1,4 @@
-const { Culture } = require('@microsoft/recognizers-text-suite');
+const { Culture } = require('botbuilder-stdlib/vendors/@microsoft/recognizers-text-suite');
 const { ActivityTypes, TestAdapter, TurnContext } = require('botbuilder');
 const { DialogContext, DialogSet } = require('botbuilder-dialogs');
 const user = {

--- a/libraries/botbuilder-dialogs-adaptive/tests/regexRecognizer.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/regexRecognizer.test.js
@@ -32,7 +32,7 @@ const {
 } = require('./recognizerTelemetryUtils');
 const { createContext, createMessageActivity } = require('./activityUtils');
 const { validateCodeIntent, validateColorIntent } = require('./intentValidations');
-const { Culture } = require('@microsoft/recognizers-text-suite');
+const { Culture } = require('botbuilder-stdlib/vendors/@microsoft/recognizers-text-suite');
 
 describe('RegexRecognizer Tests', function () {
     const recognizer = new RegexRecognizer().configure({

--- a/libraries/botbuilder-dialogs/package.json
+++ b/libraries/botbuilder-dialogs/package.json
@@ -27,10 +27,7 @@
     }
   },
   "dependencies": {
-    "@microsoft/recognizers-text-choice": "1.1.4",
-    "@microsoft/recognizers-text-date-time": "1.1.4",
-    "@microsoft/recognizers-text-number": "1.3.1",
-    "@microsoft/recognizers-text-suite": "1.1.4",
+    "botbuilder-stdlib": "4.1.6",
     "botbuilder-core": "4.1.6",
     "botbuilder-dialogs-adaptive-runtime-core": "4.1.6",
     "botframework-connector": "4.1.6",
@@ -53,11 +50,7 @@
     "postbuild": "downlevel-dts lib _ts3.4/lib --checksum",
     "test": "npm-run-all build test:mocha",
     "test:mocha": "nyc mocha --recursive --require source-map-support/register tests",
-    "test:compat": "api-extractor run --verbose",
-    "postinstall": "npm run text-suite && npm run date-time && npm run number-with-unit",
-    "text-suite": "npx rimraf ../@microsoft/recognizers-text-suite/node_modules/@microsoft/recognizers-text-number",
-    "date-time": "npx rimraf ../@microsoft/recognizers-text-date-time/node_modules/@microsoft/recognizers-text-number",
-    "number-with-unit": "npx rimraf ../@microsoft/recognizers-text-number-with-unit/node_modules/@microsoft/recognizers-text-number"
+    "test:compat": "api-extractor run --verbose"
   },
   "files": [
     "_ts3.4",

--- a/libraries/botbuilder-dialogs/src/choices/recognizeChoices.ts
+++ b/libraries/botbuilder-dialogs/src/choices/recognizeChoices.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import * as Recognizers from '@microsoft/recognizers-text-number';
+import * as Recognizers from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-number';
 import { Choice, findChoices, FindChoicesOptions, FoundChoice } from './findChoices';
 import { ModelResult } from './modelResult';
 

--- a/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/confirmPrompt.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import * as Recognizers from '@microsoft/recognizers-text-choice';
+import * as Recognizers from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-choice';
 import { Activity, TurnContext } from 'botbuilder-core';
 import { Choice, ChoiceFactoryOptions, recognizeChoices } from '../choices';
 import { ListStyle, Prompt, PromptOptions, PromptRecognizerResult, PromptValidator } from './prompt';

--- a/libraries/botbuilder-dialogs/src/prompts/datetimePrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/datetimePrompt.ts
@@ -5,7 +5,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import * as Recognizers from '@microsoft/recognizers-text-date-time';
+import * as Recognizers from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-date-time';
 import { Activity, InputHints, TurnContext } from 'botbuilder-core';
 import { Prompt, PromptOptions, PromptRecognizerResult, PromptValidator } from './prompt';
 

--- a/libraries/botbuilder-dialogs/src/prompts/numberPrompt.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/numberPrompt.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 import * as Globalize from 'globalize';
-import * as Recognizers from '@microsoft/recognizers-text-number';
+import * as Recognizers from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-number';
 import * as locales from '../i18n';
 import { InputHints, TurnContext } from 'botbuilder-core';
 import { Prompt, PromptOptions, PromptRecognizerResult, PromptValidator } from './prompt';

--- a/libraries/botbuilder-dialogs/src/prompts/promptCultureModels.ts
+++ b/libraries/botbuilder-dialogs/src/prompts/promptCultureModels.ts
@@ -1,4 +1,4 @@
-import { Culture } from '@microsoft/recognizers-text-suite';
+import { Culture } from 'botbuilder-stdlib/vendors/@microsoft/recognizers-text-suite';
 
 export interface PromptCultureModel {
     /**

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "json-schema": "0.4.0",
     "jsonwebtoken": "9.0.0",
     "@types/jsonwebtoken": "8.3.5",
-    "@microsoft/recognizers-text-number": "~1.3.1",
     "@xmldom/xmldom": "0.8.6",
     "**/botbuilder-azure/@azure/core-auth/@azure/core-tracing": "1.0.0-preview.9",
     "**/request/tough-cookie": "^4.1.3",

--- a/testing/testbot/dialogs/bookingDialog.js
+++ b/testing/testbot/dialogs/bookingDialog.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const { TimexProperty } = require('@microsoft/recognizers-text-data-types-timex-expression');
+const { TimexProperty } = require('botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression');
 const { InputHints, MessageFactory} = require('botbuilder');
 const { ConfirmPrompt, TextPrompt, WaterfallDialog } = require('botbuilder-dialogs');
 const { CancelAndHelpDialog } = require('./cancelAndHelpDialog');

--- a/testing/testbot/dialogs/dateResolverDialog.js
+++ b/testing/testbot/dialogs/dateResolverDialog.js
@@ -4,7 +4,7 @@
 const { InputHints, MessageFactory } = require('botbuilder');
 const { DateTimePrompt, WaterfallDialog } = require('botbuilder-dialogs');
 const { CancelAndHelpDialog } = require('./cancelAndHelpDialog');
-const { TimexProperty } = require('@microsoft/recognizers-text-data-types-timex-expression');
+const { TimexProperty } = require('botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression');
 
 const DATETIME_PROMPT = 'datetimePrompt';
 const WATERFALL_DIALOG = 'waterfallDialog';

--- a/testing/testbot/dialogs/mainDialog.js
+++ b/testing/testbot/dialogs/mainDialog.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const { TimexProperty } = require('@microsoft/recognizers-text-data-types-timex-expression');
+const { TimexProperty } = require('botbuilder-stdlib/vendors/@microsoft/recognizers-text-data-types-timex-expression');
 const { MessageFactory, InputHints } = require('botbuilder');
 const { LuisRecognizer } = require('botbuilder-ai');
 const { ComponentDialog, DialogSet, DialogTurnStatus, TextPrompt, WaterfallDialog } = require('botbuilder-dialogs');

--- a/testing/testbot/package.json
+++ b/testing/testbot/package.json
@@ -11,7 +11,7 @@
   "author": "Microsoft Corp.",
   "license": "MIT",
   "dependencies": {
-    "@microsoft/recognizers-text-data-types-timex-expression": "1.1.4",
+    "botbuilder-stdlib": "4.1.6",
     "botbuilder": "4.1.6",
     "botbuilder-ai": "4.1.6",
     "botbuilder-dialogs": "4.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1552,85 +1552,6 @@
     node-addon-api "^3.1.0"
     node-gyp "^8.0.0"
 
-"@microsoft/recognizers-text-choice@1.1.4", "@microsoft/recognizers-text-choice@~1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/recognizers-text-choice/-/recognizers-text-choice-1.1.4.tgz#8e9ae8f804ae49bd57dd6bbf227a2ab0e14a9041"
-  integrity sha512-4CddwFe4RVhZeJgW65ocBrEdeukBMghK8pgI0K0Qy2eA5ysPZQpeZ7BGSDz5QMQei5LPY+QaAQ3CHU+ORHoO7A==
-  dependencies:
-    "@microsoft/recognizers-text" "~1.1.4"
-    grapheme-splitter "^1.0.2"
-
-"@microsoft/recognizers-text-data-types-timex-expression@1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/recognizers-text-data-types-timex-expression/-/recognizers-text-data-types-timex-expression-1.1.4.tgz#623453ae65e8df212d8156f6a314675c30696c1d"
-  integrity sha512-2vICaEJfV9EpaDKs5P1PLAEs+WpNqrtpkl7CLsmc5gKmxgpQtsojG4tk6km5JRKg1mYuLV5ZzJ/65oOEeyTMvQ==
-
-"@microsoft/recognizers-text-data-types-timex-expression@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/recognizers-text-data-types-timex-expression/-/recognizers-text-data-types-timex-expression-1.3.0.tgz#fc5d586c826e478e8477b7fcb21e9e2830e81c67"
-  integrity sha512-REHUXmMUI1jL3b9v+aSdzKxLxRdejsfg9McYRxY3LW0Gu4UbwD7Q+K6mtSo40cwg8uh6fiV9GY8hDuKXHH6dVA==
-
-"@microsoft/recognizers-text-date-time@1.1.4", "@microsoft/recognizers-text-date-time@~1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/recognizers-text-date-time/-/recognizers-text-date-time-1.1.4.tgz#d3ccddbc9b9f81bfa564df5b957dbdd740036425"
-  integrity sha512-leMnjN+KYNwNvRD5T4G0ORUzkjlek/BBZDvQIjAujtyrd/pkViUnuouWIPkFT/dbSOxXML8et54CSk2KfHiWIA==
-  dependencies:
-    "@microsoft/recognizers-text" "~1.1.4"
-    "@microsoft/recognizers-text-number" "~1.1.4"
-    "@microsoft/recognizers-text-number-with-unit" "~1.1.4"
-    lodash.isequal "^4.5.0"
-    lodash.tonumber "^4.0.3"
-
-"@microsoft/recognizers-text-number-with-unit@~1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/recognizers-text-number-with-unit/-/recognizers-text-number-with-unit-1.1.4.tgz#a7f2614d419adb2fea99e5c324151ea455262aa8"
-  integrity sha512-zl+CfmfWK0x/x+iSgaBAevKTYO0F4+z7SYHAHztaaaGuX8FERw2jmUjSgVetm5KA3EveyCx0XYGU1mRNY8p7Eg==
-  dependencies:
-    "@microsoft/recognizers-text" "~1.1.4"
-    "@microsoft/recognizers-text-number" "~1.1.4"
-    lodash.escaperegexp "^4.1.2"
-    lodash.last "^3.0.0"
-    lodash.max "^4.0.1"
-
-"@microsoft/recognizers-text-number@1.3.1", "@microsoft/recognizers-text-number@~1.1.4", "@microsoft/recognizers-text-number@~1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/recognizers-text-number/-/recognizers-text-number-1.3.1.tgz#b2bffbb0b5c44eec77121f0c510c5bb40f77c668"
-  integrity sha512-JBxhSdihdQLQilCtqISEBw5kM+CNGTXzy5j5hNoZECNUEvBUPkAGNEJAeQPMP5abrYks29aSklnSvSyLObXaNQ==
-  dependencies:
-    "@microsoft/recognizers-text" "~1.3.1"
-    bignumber.js "^7.2.1"
-    lodash "^4.17.21"
-
-"@microsoft/recognizers-text-sequence@~1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/recognizers-text-sequence/-/recognizers-text-sequence-1.1.4.tgz#339f38292ba207cd78ee27defeea1ab79206fa5d"
-  integrity sha512-rb5j8/aE7HSOdIxaVfCGFrj0wWPpSq0CuykFg/A/iJNPP+FnAU71bgP5HexrwQcpCsDinauisX7u0DKIChrHRA==
-  dependencies:
-    "@microsoft/recognizers-text" "~1.1.4"
-    grapheme-splitter "^1.0.2"
-
-"@microsoft/recognizers-text-suite@1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/recognizers-text-suite/-/recognizers-text-suite-1.1.4.tgz#8adb2128ed3aa60a042be008d4e3449d7128f1df"
-  integrity sha512-hNIaR4M2G0nNeI9WZxt9C0KYh/1vhjeKzX5Ds8XDdT0pxF7zwCSo19WNcPjrVK6aCOeZTw/ULofsAjdu9gSkcA==
-  dependencies:
-    "@microsoft/recognizers-text" "~1.1.4"
-    "@microsoft/recognizers-text-choice" "~1.1.4"
-    "@microsoft/recognizers-text-date-time" "~1.1.4"
-    "@microsoft/recognizers-text-number" "~1.1.4"
-    "@microsoft/recognizers-text-number-with-unit" "~1.1.4"
-    "@microsoft/recognizers-text-sequence" "~1.1.4"
-
-"@microsoft/recognizers-text@~1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/recognizers-text/-/recognizers-text-1.1.4.tgz#264530f748b2cad3fac54d53538f88ad2bf99b7e"
-  integrity sha512-hlSVXcaX5i8JcjuUJpVxmy2Z/GxvFXarF0KVySCFop57wNEnrLWMHe4I4DjP866G19VyIKRw+vPA32pkGhZgTg==
-
-"@microsoft/recognizers-text@~1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/recognizers-text/-/recognizers-text-1.3.1.tgz#eda98a9148101ecdb04ed1424082d472b04aabd9"
-  integrity sha512-HikLoRUgSzM4OKP3JVBzUUp3Q7L4wgI17p/3rERF01HVmopcujY3i6wgx8PenCwbenyTNxjr1AwSDSVuFlYedQ==
-
 "@microsoft/tsdoc-config@~0.16.1":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc-config/-/tsdoc-config-0.16.2.tgz#b786bb4ead00d54f53839a458ce626c8548d3adf"
@@ -2505,10 +2426,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/jsonwebtoken@7.2.8", "@types/jsonwebtoken@8.3.5":
-  version "7.2.8"
-  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz#8d199dab4ddb5bba3234f8311b804d2027af2b3a"
-  integrity sha512-XENN3YzEB8D6TiUww0O8SRznzy1v+77lH7UmuN54xq/IHIsyWjWOzZuFFTtoiRuaE782uAoRwBe/wwow+vQXZw==
+"@types/jsonwebtoken@8.3.5":
+  version "8.3.5"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.3.5.tgz#ff9be1151a844095df1ff5f723651298c2c07659"
+  integrity sha512-VGM1gb+LwsQ5EPevvbvdnKncajBdYqNcrvixBif1BsiDQiSF1q+j4bBTvKC6Bt9n2kqNSx+yNTY2TVJ360E7EQ==
   dependencies:
     "@types/node" "*"
 
@@ -4333,12 +4254,32 @@ cardinal@^2.1.1:
     ansicolors "~0.3.2"
     redeyed "~2.1.0"
 
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
+  dependencies:
+    check-error "^1.0.2"
+
 chai-nightwatch@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/chai-nightwatch/-/chai-nightwatch-0.5.3.tgz#980ecf63dde5a04e7f3524370682c7ff01178ffb"
   integrity sha512-38ixH/mqpY6IwnZkz6xPqx8aB5/KVR+j6VPugcir3EGOsphnWXrPH/mUt8Jp+ninL6ghY0AaJDQ10hSfCPGy/g==
   dependencies:
     assertion-error "1.1.0"
+
+chai@^4.1.2:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.4.1.tgz#3603fa6eba35425b0f2ac91a009fe924106e50d1"
+  integrity sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.3"
+    deep-eql "^4.1.3"
+    get-func-name "^2.0.2"
+    loupe "^2.3.6"
+    pathval "^1.1.1"
+    type-detect "^4.0.8"
 
 chai@^4.2.0:
   version "4.2.0"
@@ -4413,6 +4354,13 @@ check-error@1.0.2, check-error@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
+
+check-error@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.3.tgz#a6502e4312a7ee969f646e83bb3ddd56281bd694"
+  integrity sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==
+  dependencies:
+    get-func-name "^2.0.2"
 
 chokidar@3.5.3:
   version "3.5.3"
@@ -5218,6 +5166,13 @@ deep-eql@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
   integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
+
+deep-eql@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.3.tgz#7c7775513092f7df98d8df9996dd085eb668cc6d"
+  integrity sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==
   dependencies:
     type-detect "^4.0.0"
 
@@ -7014,7 +6969,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-func-name@^2.0.0:
+get-func-name@^2.0.0, get-func-name@^2.0.1, get-func-name@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
   integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==
@@ -9020,7 +8975,7 @@ lodash.escape@^3.0.0:
 lodash.escaperegexp@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
-  integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
+  integrity sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
@@ -9059,12 +9014,12 @@ lodash.keys@^3.0.0:
 lodash.last@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash.last/-/lodash.last-3.0.0.tgz#242f663112dd4c6e63728c60a3c909d1bdadbd4c"
-  integrity sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw=
+  integrity sha512-14mq7rSkCxG4XMy9lF2FbIOqqgF0aH0NfPuQ3LPR3vIh0kHnUvIYP70dqa1Hf47zyXfQ8FzAg0MYOQeSuE1R7A==
 
 lodash.max@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.max/-/lodash.max-4.0.1.tgz#8735566c618b35a9f760520b487ae79658af136a"
-  integrity sha1-hzVWbGGLNan3YFILSHrnllivE2o=
+  integrity sha512-iykTDTb7PK33HSQmKy34zv+hh4WEu7WonJPXQcgODzUbbtradtNs8RsD/GI7XV++60KaKR1xhW56N4ISqHesfQ==
 
 lodash.memoize@~3.0.3:
   version "3.0.4"
@@ -9141,7 +9096,7 @@ lodash.toarray@^3.0.0:
 lodash.tonumber@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz#0b96b31b35672793eb7f5a63ee791f1b9e9025d9"
-  integrity sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk=
+  integrity sha512-SY0SwuPOHRwKcCNTdsntPYb+Zddz5mDUIVFABzRMqmAiL41pMeyoQFGxYAw5zdc9NnH4pbJqiqqp5ckfxa+zSA==
 
 lodash@^4.1.2, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@~4.17.15, lodash@~4.17.19:
   version "4.17.21"
@@ -9179,6 +9134,13 @@ loupe@2.3.4:
   integrity sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==
   dependencies:
     get-func-name "^2.0.0"
+
+loupe@^2.3.6:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.7.tgz#6e69b7d4db7d3ab436328013d37d1c8c3540c697"
+  integrity sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==
+  dependencies:
+    get-func-name "^2.0.1"
 
 lowercase-keys@1.0.0:
   version "1.0.0"
@@ -10879,7 +10841,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pathval@1.1.1, pathval@^1.1.0:
+pathval@1.1.1, pathval@^1.1.0, pathval@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==


### PR DESCRIPTION
#minor

> [!IMPORTANT]
> These changes depend on PR https://github.com/microsoft/botbuilder-js/pull/4660.

## Description
This PR updates all npm Recognizers-Text dependencies' references with `botbuilder-stdlib` Recognizers-Text packages.

## Specific Changes
  - Updated all Recognizers-Text dependencies in package.json files with the one located in `botbuilder-stdlib`.
  - Updated all Recognizers-Text imports path to point to  `botbuilder-stdlib` vendors folder.

## Testing
The following image shows the bot working with the new Recognizers-Text packages inside BotBuilder.
![imagen](https://github.com/southworks/botbuilder-js/assets/62260472/9a6d6a9e-4d85-45ce-8083-bf961564cf33)