### PR TITLE
fix: [#4746] Fix INodeBuffer in TypeScript 5.6 and ESNext target

### DIFF
--- a/libraries/botframework-streaming/etc/botframework-streaming.api.md
+++ b/libraries/botframework-streaming/etc/botframework-streaming.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { Duplex } from 'stream';
 import { DuplexOptions } from 'stream';
 import { default as WebSocket_2 } from 'ws';

--- a/libraries/botframework-streaming/etc/botframework-streaming.api.md
+++ b/libraries/botframework-streaming/etc/botframework-streaming.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="node" />
-
 import { Duplex } from 'stream';
 import { DuplexOptions } from 'stream';
 import { default as WebSocket_2 } from 'ws';
@@ -44,8 +42,6 @@ export interface INodeBuffer extends Uint8Array {
     // (undocumented)
     copy(targetBuffer: Uint8Array, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
     // (undocumented)
-    entries(): IterableIterator<[number, number]>;
-    // (undocumented)
     equals(otherBuffer: Uint8Array): boolean;
     // (undocumented)
     fill(value: any, offset?: number, end?: number): this;
@@ -53,8 +49,6 @@ export interface INodeBuffer extends Uint8Array {
     includes(value: string | number | this, byteOffset?: number, encoding?: string): boolean;
     // (undocumented)
     indexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: string): number;
-    // (undocumented)
-    keys(): IterableIterator<number>;
     // (undocumented)
     lastIndexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: string): number;
     // (undocumented)
@@ -108,8 +102,6 @@ export interface INodeBuffer extends Uint8Array {
     };
     // (undocumented)
     toString(encoding?: string, start?: number, end?: number): string;
-    // (undocumented)
-    values(): IterableIterator<number>;
     // (undocumented)
     write(string: string, offset?: number, length?: number, encoding?: string): number;
     // (undocumented)

--- a/libraries/botframework-streaming/src/interfaces/INodeBuffer.ts
+++ b/libraries/botframework-streaming/src/interfaces/INodeBuffer.ts
@@ -96,8 +96,5 @@ export interface INodeBuffer extends Uint8Array {
     fill(value: any, offset?: number, end?: number): this;
     indexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: string): number;
     lastIndexOf(value: string | number | Uint8Array, byteOffset?: number, encoding?: string): number;
-    entries(): IterableIterator<[number, number]>;
     includes(value: string | number | this, byteOffset?: number, encoding?: string): boolean;
-    keys(): IterableIterator<number>;
-    values(): IterableIterator<number>;
 }


### PR DESCRIPTION
Fixes #4746

## Description
This PR fixes an issue with `INodeBuffer` incorrectly implementing the `Uint8Array`.

> [!NOTE]
> We are working on adding support for TS 5.6 and ESNext target in BotBuilder in a separate PR, which are impacting some of other libraries.

## Specific Changes
  - Removed entries, keys, and values methods from the `INodeBuffer`, so they are inherited correctly across different TS versions.

## Testing
The following image shows the `botframework-streaming` library building correctly with TS 5.6 and ESNext target.
![image](https://github.com/user-attachments/assets/4c03e63f-87de-42c4-8128-9ec5dc0c03c3)
