### PR TITLE
fix: [#4684] Update INodeSocket type

### DIFF
--- a/libraries/botbuilder-dialogs-adaptive-runtime-integration-express/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime-integration-express/src/index.ts
@@ -10,6 +10,7 @@ import type { ServiceCollection } from 'botbuilder-dialogs-adaptive-runtime-core
 import { Configuration, getRuntimeServices } from 'botbuilder-dialogs-adaptive-runtime';
 import type { ConnectorClientOptions } from 'botframework-connector';
 import { json, urlencoded } from 'body-parser';
+import { INodeSocket } from 'botframework-streaming';
 
 // Explicitly fails checks for `""`
 const NonEmptyString = z.string().refine((str) => str.length > 0, { message: 'must be non-empty string' });
@@ -207,8 +208,7 @@ export async function makeApp(
                 const adapter = services.mustMakeInstance<BotFrameworkHttpAdapter>('adapter');
 
                 try {
-                    // TODO: Fix INodeSocket type. Related issue https://github.com/microsoft/botbuilder-js/issues/4684.
-                    await adapter.process(req, socket as any, head, async (context) => {
+                    await adapter.process(req, socket as INodeSocket, head, async (context) => {
                         await bot.run(context);
                     });
                 } catch (err: any) {

--- a/libraries/botbuilder-dialogs-adaptive-runtime-integration-express/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime-integration-express/src/index.ts
@@ -208,7 +208,7 @@ export async function makeApp(
                 const adapter = services.mustMakeInstance<BotFrameworkHttpAdapter>('adapter');
 
                 try {
-                    await adapter.process(req, socket as INodeSocket, head, async (context) => {
+                    await adapter.process(req, socket, head, async (context) => {
                         await bot.run(context);
                     });
                 } catch (err: any) {

--- a/libraries/botbuilder-dialogs-adaptive-runtime-integration-express/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime-integration-express/src/index.ts
@@ -10,7 +10,6 @@ import type { ServiceCollection } from 'botbuilder-dialogs-adaptive-runtime-core
 import { Configuration, getRuntimeServices } from 'botbuilder-dialogs-adaptive-runtime';
 import type { ConnectorClientOptions } from 'botframework-connector';
 import { json, urlencoded } from 'body-parser';
-import { INodeSocket } from 'botframework-streaming';
 
 // Explicitly fails checks for `""`
 const NonEmptyString = z.string().refine((str) => str.length > 0, { message: 'must be non-empty string' });

--- a/libraries/botbuilder-dialogs-adaptive-runtime-integration-restify/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime-integration-restify/src/index.ts
@@ -195,7 +195,7 @@ export async function makeServer(
         const adapter = services.mustMakeInstance<BotFrameworkHttpAdapter>('adapter');
 
         try {
-            await adapter.process(req, socket as INodeSocket, head, async (context) => {
+            await adapter.process(req, socket, head, async (context) => {
                 await bot.run(context);
             });
         } catch (err: any) {

--- a/libraries/botbuilder-dialogs-adaptive-runtime-integration-restify/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime-integration-restify/src/index.ts
@@ -7,7 +7,6 @@ import restify from 'restify';
 import type { ActivityHandlerBase, BotFrameworkHttpAdapter, ChannelServiceRoutes } from 'botbuilder';
 import type { ServiceCollection } from 'botbuilder-dialogs-adaptive-runtime-core';
 import { Configuration, getRuntimeServices } from 'botbuilder-dialogs-adaptive-runtime';
-import { INodeSocket } from 'botframework-streaming';
 
 // Explicitly fails checks for `""`
 const NonEmptyString = z.string().refine((str) => str.length > 0, { message: 'must be non-empty string' });

--- a/libraries/botbuilder-dialogs-adaptive-runtime-integration-restify/src/index.ts
+++ b/libraries/botbuilder-dialogs-adaptive-runtime-integration-restify/src/index.ts
@@ -7,6 +7,7 @@ import restify from 'restify';
 import type { ActivityHandlerBase, BotFrameworkHttpAdapter, ChannelServiceRoutes } from 'botbuilder';
 import type { ServiceCollection } from 'botbuilder-dialogs-adaptive-runtime-core';
 import { Configuration, getRuntimeServices } from 'botbuilder-dialogs-adaptive-runtime';
+import { INodeSocket } from 'botframework-streaming';
 
 // Explicitly fails checks for `""`
 const NonEmptyString = z.string().refine((str) => str.length > 0, { message: 'must be non-empty string' });
@@ -194,8 +195,7 @@ export async function makeServer(
         const adapter = services.mustMakeInstance<BotFrameworkHttpAdapter>('adapter');
 
         try {
-            // TODO: Fix INodeSocket type. Related issue https://github.com/microsoft/botbuilder-js/issues/4684.
-            await adapter.process(req, socket as any, head, async (context) => {
+            await adapter.process(req, socket as INodeSocket, head, async (context) => {
                 await bot.run(context);
             });
         } catch (err: any) {

--- a/libraries/botbuilder/etc/botbuilder.api.md
+++ b/libraries/botbuilder/etc/botbuilder.api.md
@@ -45,6 +45,7 @@ import { HttpClient } from '@azure/core-http';
 import { HttpOperationResponse } from '@azure/core-http';
 import { ICredentialProvider } from 'botframework-connector';
 import { INodeBuffer } from 'botframework-streaming';
+import { INodeDuplex } from 'botframework-streaming';
 import { INodeSocket } from 'botframework-streaming';
 import { InvokeResponse } from 'botbuilder-core';
 import { IReceiveRequest } from 'botframework-streaming';
@@ -187,6 +188,7 @@ export interface BotFrameworkAdapterSettings {
 export interface BotFrameworkHttpAdapter {
     process(req: Request_2, res: Response_2, logic: (context: TurnContext) => Promise<void>): Promise<void>;
     process(req: Request_2, socket: INodeSocket, head: INodeBuffer, logic: (context: TurnContext) => Promise<void>): Promise<void>;
+    process(req: Request_2, socket: INodeDuplex, head: INodeBuffer, logic: (context: TurnContext) => Promise<void>): Promise<void>;
 }
 
 // @public @deprecated (undocumented)
@@ -250,6 +252,7 @@ export class CloudAdapter extends CloudAdapterBase implements BotFrameworkHttpAd
     connectNamedPipe(pipeName: string, logic: (context: TurnContext) => Promise<void>, appId: string, audience: string, callerId?: string, retryCount?: number): Promise<void>;
     process(req: Request_2, res: Response_2, logic: (context: TurnContext) => Promise<void>): Promise<void>;
     process(req: Request_2, socket: INodeSocket, head: INodeBuffer, logic: (context: TurnContext) => Promise<void>): Promise<void>;
+    process(req: Request_2, socket: INodeDuplex, head: INodeBuffer, logic: (context: TurnContext) => Promise<void>): Promise<void>;
     processActivityDirect(authorization: string | AuthenticateRequestResult, activity: Activity, logic: (context: TurnContext) => Promise<void>): Promise<void>;
 }
 

--- a/libraries/botbuilder/src/botFrameworkHttpAdapter.ts
+++ b/libraries/botbuilder/src/botFrameworkHttpAdapter.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import type { INodeBuffer, INodeSocket } from 'botframework-streaming';
+import type { INodeBuffer, INodeDuplex, INodeSocket } from 'botframework-streaming';
 import type { Request, Response } from './interfaces';
 import type { TurnContext } from 'botbuilder-core';
 
@@ -23,6 +23,17 @@ export interface BotFrameworkHttpAdapter {
     process(
         req: Request,
         socket: INodeSocket,
+        head: INodeBuffer,
+        logic: (context: TurnContext) => Promise<void>
+    ): Promise<void>;
+
+    /**
+     * Handle a web socket connection by applying a logic callback function to
+     * each streaming request.
+     */
+    process(
+        req: Request,
+        socket: INodeDuplex,
         head: INodeBuffer,
         logic: (context: TurnContext) => Promise<void>
     ): Promise<void>;

--- a/libraries/botbuilder/src/cloudAdapter.ts
+++ b/libraries/botbuilder/src/cloudAdapter.ts
@@ -26,6 +26,7 @@ import {
 import {
     INodeBuffer,
     INodeSocket,
+    INodeDuplex,
     IReceiveRequest,
     IReceiveResponse,
     IStreamingTransportServer,
@@ -81,11 +82,28 @@ export class CloudAdapter extends CloudAdapterBase implements BotFrameworkHttpAd
     ): Promise<void>;
 
     /**
+     * Handle a web socket connection by applying a logic function to
+     * each streaming request.
+     *
+     * @param req An incoming HTTP [Request](xref:botbuilder.Request)
+     * @param socket The corresponding [INodeDuplex](xref:botframework-streaming.INodeDuplex)
+     * @param head The corresponding [INodeBuffer](xref:botframework-streaming.INodeBuffer)
+     * @param logic The logic function to apply
+     * @returns a promise representing the asynchronous operation.
+     */
+    async process(
+        req: Request,
+        socket: INodeDuplex,
+        head: INodeBuffer,
+        logic: (context: TurnContext) => Promise<void>
+    ): Promise<void>;
+
+    /**
      * @internal
      */
     async process(
         req: Request,
-        resOrSocket: Response | INodeSocket,
+        resOrSocket: Response | INodeSocket | INodeDuplex,
         logicOrHead: ((context: TurnContext) => Promise<void>) | INodeBuffer,
         maybeLogic?: (context: TurnContext) => Promise<void>
     ): Promise<void> {

--- a/libraries/botframework-streaming/etc/botframework-streaming.api.md
+++ b/libraries/botframework-streaming/etc/botframework-streaming.api.md
@@ -8,6 +8,7 @@
 
 import { Duplex } from 'stream';
 import { DuplexOptions } from 'stream';
+import { Socket } from 'net';
 import { default as WebSocket_2 } from 'ws';
 
 // @public
@@ -145,224 +146,25 @@ export interface INodeBuffer extends Uint8Array {
 }
 
 // @public
+export interface INodeDuplex extends Duplex {
+    // (undocumented)
+    on(event: string | symbol, listener: (...args: any[]) => void): this;
+    // (undocumented)
+    on(event: 'data', listener: (chunk: INodeBuffer) => void): this;
+}
+
+// @public
 export interface INodeIncomingMessage {
     headers?: any;
     method?: any;
 }
 
 // @public
-export interface INodeSocket {
-    // (undocumented)
-    [Symbol.asyncIterator](): AsyncIterableIterator<any>;
-    // (undocumented)
-    addListener(event: 'close', listener: () => void): this;
-    // (undocumented)
-    addListener(event: 'data', listener: (chunk: any) => void): this;
-    // (undocumented)
-    addListener(event: 'end', listener: () => void): this;
-    // (undocumented)
-    addListener(event: 'readable', listener: () => void): this;
-    // (undocumented)
-    addListener(event: 'error', listener: (err: Error) => void): this;
-    // (undocumented)
-    addListener(event: string | symbol, listener: (...args: any[]) => void): this;
-    // Warning: (ae-forgotten-export) The symbol "AddressInfo" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    address(): AddressInfo | string;
-    // (undocumented)
-    readonly bufferSize: number;
-    // (undocumented)
-    readonly bytesRead: number;
-    // (undocumented)
-    readonly bytesWritten: number;
-    // (undocumented)
-    connect(options: any, connectionListener?: () => void): any;
-    // (undocumented)
-    connect(port: number, host: string, connectionListener?: () => void): any;
-    // (undocumented)
-    connect(port: number, connectionListener?: () => void): any;
-    // (undocumented)
-    connect(path: string, connectionListener?: () => void): any;
-    // (undocumented)
-    connecting: boolean;
-    // (undocumented)
-    cork(): void;
-    // (undocumented)
-    destroy(error?: Error): void;
-    // (undocumented)
-    _destroy(error: Error | null, callback: (error: Error | null) => void): void;
-    // (undocumented)
-    destroyed: boolean;
-    // (undocumented)
-    emit(event: 'close'): boolean;
-    // (undocumented)
-    emit(event: 'data', chunk: any): boolean;
-    // (undocumented)
-    emit(event: 'end'): boolean;
-    // (undocumented)
-    emit(event: 'readable'): boolean;
-    // (undocumented)
-    emit(event: 'error', err: Error): boolean;
-    // (undocumented)
-    emit(event: string | symbol, ...args: any[]): boolean;
-    // (undocumented)
-    end(cb?: () => void): void;
-    // (undocumented)
-    end(chunk: any, cb?: () => void): void;
-    // (undocumented)
-    end(chunk: any, encoding?: string, cb?: () => void): void;
-    // (undocumented)
-    eventNames(): Array<string | symbol>;
-    // (undocumented)
-    _final(callback: (error?: Error | null) => void): void;
-    // (undocumented)
-    getMaxListeners(): number;
-    // (undocumented)
-    isPaused(): boolean;
-    // (undocumented)
-    listenerCount(type: string | symbol): number;
-    // (undocumented)
-    listeners(event: string | symbol): Function[];
-    // (undocumented)
-    readonly localAddress: string;
-    // (undocumented)
-    readonly localPort: number;
-    // (undocumented)
-    off(event: string | symbol, listener: (...args: any[]) => void): this;
+export interface INodeSocket extends Socket {
     // (undocumented)
     on(event: string, listener: (...args: any[]) => void): this;
     // (undocumented)
-    on(event: 'close', listener: (had_error: boolean) => void): this;
-    // (undocumented)
-    on(event: 'connect', listener: () => void): this;
-    // (undocumented)
     on(event: 'data', listener: (data: INodeBuffer) => void): this;
-    // (undocumented)
-    on(event: 'end', listener: () => void): this;
-    // (undocumented)
-    on(event: 'error', listener: (err: Error) => void): this;
-    // (undocumented)
-    once(event: 'close', listener: () => void): this;
-    // (undocumented)
-    once(event: 'data', listener: (chunk: any) => void): this;
-    // (undocumented)
-    once(event: 'end', listener: () => void): this;
-    // (undocumented)
-    once(event: 'readable', listener: () => void): this;
-    // (undocumented)
-    once(event: 'error', listener: (err: Error) => void): this;
-    // (undocumented)
-    once(event: string | symbol, listener: (...args: any[]) => void): this;
-    // (undocumented)
-    pause(): this;
-    // Warning: (ae-forgotten-export) The symbol "WritableStream_2" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    pipe<T extends WritableStream_2>(destination: T, options?: {
-        end?: boolean;
-    }): T;
-    // (undocumented)
-    prependListener(event: 'close', listener: () => void): this;
-    // (undocumented)
-    prependListener(event: 'data', listener: (chunk: any) => void): this;
-    // (undocumented)
-    prependListener(event: 'end', listener: () => void): this;
-    // (undocumented)
-    prependListener(event: 'readable', listener: () => void): this;
-    // (undocumented)
-    prependListener(event: 'error', listener: (err: Error) => void): this;
-    // (undocumented)
-    prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
-    // (undocumented)
-    prependOnceListener(event: 'close', listener: () => void): this;
-    // (undocumented)
-    prependOnceListener(event: 'data', listener: (chunk: any) => void): this;
-    // (undocumented)
-    prependOnceListener(event: 'end', listener: () => void): this;
-    // (undocumented)
-    prependOnceListener(event: 'readable', listener: () => void): this;
-    // (undocumented)
-    prependOnceListener(event: 'error', listener: (err: Error) => void): this;
-    // (undocumented)
-    prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
-    // (undocumented)
-    push(chunk: any, encoding?: string): boolean;
-    // (undocumented)
-    rawListeners(event: string | symbol): Function[];
-    // (undocumented)
-    read(size?: number): any;
-    // (undocumented)
-    _read(size: number): void;
-    // (undocumented)
-    readable: boolean;
-    // (undocumented)
-    readonly readableFlowing: boolean | null;
-    // (undocumented)
-    readonly readableHighWaterMark: number;
-    // (undocumented)
-    readonly readableLength: number;
-    // (undocumented)
-    ref(): any;
-    // (undocumented)
-    removeAllListeners(event?: string | symbol): this;
-    // (undocumented)
-    removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
-    // (undocumented)
-    resume(): this;
-    // (undocumented)
-    setDefaultEncoding(encoding: string): this;
-    // (undocumented)
-    setEncoding(encoding: string): this;
-    // (undocumented)
-    setKeepAlive(enable?: boolean, initialDelay?: number): this;
-    // (undocumented)
-    setMaxListeners(n: number): this;
-    // (undocumented)
-    setNoDelay(noDelay?: boolean): this;
-    // (undocumented)
-    setTimeout(timeout: number, callback?: () => void): this;
-    // (undocumented)
-    uncork(): void;
-    // (undocumented)
-    unpipe(destination?: any): this;
-    // (undocumented)
-    unref(): any;
-    // (undocumented)
-    unshift(chunk: any): void;
-    // (undocumented)
-    wrap(oldStream: any): this;
-    // (undocumented)
-    writable: boolean;
-    // (undocumented)
-    readonly writableHighWaterMark: number;
-    // (undocumented)
-    readonly writableLength: number;
-    // Warning: (ae-forgotten-export) The symbol "ValidBuffer" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    write(buffer: ValidBuffer, cb?: (err?: Error) => void): boolean;
-    // (undocumented)
-    write(str: string, encoding?: string, cb?: Function): boolean;
-    // (undocumented)
-    write(buffer: ValidBuffer): boolean;
-    // (undocumented)
-    write(str: string, cb?: Function): boolean;
-    // (undocumented)
-    write(str: string, encoding?: string, fd?: string): boolean;
-    // (undocumented)
-    write(data: any, encoding?: string, callback?: Function): void;
-    // (undocumented)
-    write(chunk: any, cb?: (error: Error | null | undefined) => void): boolean;
-    // (undocumented)
-    write(chunk: any, encoding?: string, cb?: (error: Error | null | undefined) => void): boolean;
-    // (undocumented)
-    _write(chunk: any, encoding: string, callback: (error?: Error | null) => void): void;
-    // (undocumented)
-    _writev?(chunks: Array<{
-        chunk: any;
-        encoding: string;
-    }>, callback: (error?: Error | null) => void): void;
 }
 
 // @public

--- a/libraries/botframework-streaming/src/index.ts
+++ b/libraries/botframework-streaming/src/index.ts
@@ -12,6 +12,7 @@ export {
     INodeBuffer,
     INodeIncomingMessage,
     INodeSocket,
+    INodeDuplex,
     IReceiveRequest,
     IReceiveResponse,
     ISocket,

--- a/libraries/botframework-streaming/src/interfaces/INodeDuplex.ts
+++ b/libraries/botframework-streaming/src/interfaces/INodeDuplex.ts
@@ -7,15 +7,15 @@
  * Licensed under the MIT License.
  */
 
-import { Socket } from 'net';
+import { Duplex } from 'stream';
 import { INodeBuffer } from './INodeBuffer';
 
 /**
- * Represents a Socket from the `net` module in Node.js.
+ * Represents a Duplex from the `stream` module in Node.js.
  *
  * This interface supports the framework and is not intended to be called directly for your code.
  */
-export interface INodeSocket extends Socket {
-    on(event: string, listener: (...args: any[]) => void): this;
-    on(event: 'data', listener: (data: INodeBuffer) => void): this;
+export interface INodeDuplex extends Duplex {
+    on(event: string | symbol, listener: (...args: any[]) => void): this;
+    on(event: 'data', listener: (chunk: INodeBuffer) => void): this;
 }

--- a/libraries/botframework-streaming/src/interfaces/index.ts
+++ b/libraries/botframework-streaming/src/interfaces/index.ts
@@ -9,6 +9,7 @@
 export * from './INodeBuffer';
 export * from './INodeIncomingMessage';
 export * from './INodeSocket';
+export * from './INodeDuplex';
 export * from './IReceiveRequest';
 export * from './IReceiveResponse';
 export * from './ISocket';

--- a/libraries/botframework-streaming/src/namedPipe/namedPipeClient.ts
+++ b/libraries/botframework-streaming/src/namedPipe/namedPipeClient.ts
@@ -61,9 +61,8 @@ export class NamedPipeClient implements IStreamingTransportClient {
         const incomingPipeName: string =
             NamedPipeTransport.PipePath + this._baseName + NamedPipeTransport.ServerOutgoingPath;
         const incoming = connect(incomingPipeName);
-        // TODO: Fix INodeSocket type. Related issue https://github.com/microsoft/botbuilder-js/issues/4684.
-        this._sender.connect(new NamedPipeTransport(outgoing as any));
-        this._receiver.connect(new NamedPipeTransport(incoming as any));
+        this._sender.connect(new NamedPipeTransport(outgoing));
+        this._receiver.connect(new NamedPipeTransport(incoming));
     }
 
     /**

--- a/libraries/botframework-streaming/src/webSocket/nodeWebSocket.ts
+++ b/libraries/botframework-streaming/src/webSocket/nodeWebSocket.ts
@@ -10,6 +10,7 @@ import { IncomingMessage, request } from 'http';
 import { URL } from 'url';
 import crypto from 'crypto';
 import WebSocket from 'ws';
+import { Socket } from 'net';
 
 import { INodeIncomingMessage, INodeBuffer, INodeSocket, ISocket } from '../interfaces';
 
@@ -36,12 +37,16 @@ export class NodeWebSocket implements ISocket {
      * @param head A Buffer [INodeBuffer](xref:botframework-streaming.INodeBuffer) interface.
      * @returns A Promise that resolves after the WebSocket upgrade has been handled, otherwise rejects with a thrown error.
      */
-    async create(req: INodeIncomingMessage, socket: INodeSocket, head: INodeBuffer): Promise<void> {
+    async create(req: INodeIncomingMessage, socket: INodeSocket, head: INodeBuffer): Promise<void>;
+
+    /**
+     * @internal
+     */
+    async create(req: IncomingMessage, socket: Socket, head: Buffer): Promise<void> {
         this.wsServer = new WebSocket.Server({ noServer: true });
         return new Promise<void>((resolve, reject) => {
             try {
-                // TODO: Fix INodeSocket type. Related issue https://github.com/microsoft/botbuilder-js/issues/4684.
-                this.wsServer.handleUpgrade(req as IncomingMessage, socket as any, head as any, (websocket) => {
+                this.wsServer.handleUpgrade(req, socket, head, (websocket) => {
                     this.wsSocket = websocket;
                     resolve();
                 });


### PR DESCRIPTION
Addresses #4684
#minor

## Description
This PR updates the INodeSocket type to support the latest Node types. Additionally, it adds a new INodeDuplex interface, to address an issue where either express or restify provided a Duplex socket.

## Specific Changes
  - Remove INodeSocket properties, and inherit them from net.Socket directly.
  - Added INodeDuplex that inherits from stream.Duplex.
  - Updated express and restify adaptive integrations to support INodeDuplex.
  - Updated BotFrameworkHttpAdapter, CloudAdapter to support INodeDuplex, and avoid casting from Duplex to Socket.
  - Updated WebSockets and NamedPipes to better support INodeSocket type.

## Testing
The following image shows how the sample now supports the Duplex type.
![imagen](https://github.com/user-attachments/assets/78116df6-db90-4c0d-96c5-44f62ecf2c9c)
