### PR TITLE
fix: Sort Activity Types and add Delay activity

### DIFF
--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -2089,32 +2089,35 @@ export enum ActivityEventNames {
 
 /**
  * Defines values for ActivityTypes.
- * Possible values include: 'message', 'contactRelationUpdate', 'conversationUpdate', 'typing',
- * 'endOfConversation', 'event', 'invoke', 'deleteUserData', 'messageUpdate', 'messageDelete',
- * 'installationUpdate', 'messageReaction', 'suggestion', 'trace', 'handoff'
+ * Possible values include: 'command', 'commandResult', 'contactRelationUpdate',
+ * 'conversationUpdate', 'delay', 'deleteUserData','endOfConversation', 'event', 
+ * 'handoff', 'installationUpdate', 'invoke', 'invokeResponse', 'message',
+ * 'messageDelete', 'messageReaction', 'messageUpdate', 'suggestion',
+ * 'trace', 'typing'
  *
  * @readonly
  * @enum {string}
  */
 export enum ActivityTypes {
-    Message = 'message',
-    ContactRelationUpdate = 'contactRelationUpdate',
-    ConversationUpdate = 'conversationUpdate',
-    Typing = 'typing',
-    EndOfConversation = 'endOfConversation',
-    Event = 'event',
-    Invoke = 'invoke',
-    InvokeResponse = 'invokeResponse',
-    DeleteUserData = 'deleteUserData',
-    MessageUpdate = 'messageUpdate',
-    MessageDelete = 'messageDelete',
-    InstallationUpdate = 'installationUpdate',
-    MessageReaction = 'messageReaction',
-    Suggestion = 'suggestion',
-    Trace = 'trace',
-    Handoff = 'handoff',
     Command = 'command',
     CommandResult = 'commandResult',
+    ContactRelationUpdate = 'contactRelationUpdate',
+    ConversationUpdate = 'conversationUpdate',
+    Delay = 'delay',
+    DeleteUserData = 'deleteUserData',
+    EndOfConversation = 'endOfConversation',
+    Event = 'event',
+    Handoff = 'handoff',
+    InstallationUpdate = 'installationUpdate',
+    Invoke = 'invoke',
+    InvokeResponse = 'invokeResponse',
+    Message = 'message',
+    MessageDelete = 'messageDelete',
+    MessageReaction = 'messageReaction',
+    MessageUpdate = 'messageUpdate',
+    Suggestion = 'suggestion',
+    Trace = 'trace',
+    Typing = 'typing',
 }
 
 /**


### PR DESCRIPTION
## Description

- Activity Types enum are not sorted. Harder to look what exists or not. Also documentation was not sorted either.

- Delay activity was not set into the Activity Types enum. I had to hardcode the string in my code or set as a constant at project level

## Specific Changes

- Activity Types enum is now sorted. And is clearer to look what exists or not. Documentation for the struct is also sorted trying to keep ~ 80 cols per line.

- Delay activity was added. We will not need to write string or set a constant at project level

