### PR TITLE
bump: [#4684] Upgrade chai using import-sync for esm-only package

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,2 +1,2 @@
-ignores: ["filenamify", "mocha", "rimraf", "sinon", "uuid"]
+ignores: ["chai", "filenamify", "mocha", "rimraf", "sinon", "uuid"]
 ignorePatterns: [".eslintrc.json", "lib"]

--- a/libraries/botbuilder/package.json
+++ b/libraries/botbuilder/package.json
@@ -45,7 +45,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "chai": "^4.5.0",
+    "chai": "^5.1.2",
     "lodash": "^4.17.20",
     "nock": "^13.5.5",
     "node-mocks-http": "^1.16.0"

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -4,7 +4,8 @@
 const assert = require('assert');
 const httpMocks = require('node-mocks-http');
 const net = require('net');
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 const sinon = require('sinon');
 const {
     AuthenticationConfiguration,

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const httpMocks = require('node-mocks-http');
 const net = require('net');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 const sinon = require('sinon');
 const {
     AuthenticationConfiguration,

--- a/libraries/botbuilder/tests/streaming/botFrameworkAdapterStreaming.test.js
+++ b/libraries/botbuilder/tests/streaming/botFrameworkAdapterStreaming.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const { Socket } = require('net');
-
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 const { spy } = require('sinon');
 const { ActivityHandler, ActivityTypes, StatusCodes, TurnContext } = require('botbuilder-core');
 

--- a/libraries/botbuilder/tests/streaming/botFrameworkAdapterStreaming.test.js
+++ b/libraries/botbuilder/tests/streaming/botFrameworkAdapterStreaming.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const { Socket } = require('net');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 const { spy } = require('sinon');
 const { ActivityHandler, ActivityTypes, StatusCodes, TurnContext } = require('botbuilder-core');
 

--- a/libraries/botframework-streaming/package.json
+++ b/libraries/botframework-streaming/package.json
@@ -33,11 +33,12 @@
     "@types/node": "18.19.47",
     "@types/ws": "^6.0.3",
     "eslint-plugin-only-warn": "^1.1.0",
+    "import-sync": "^2.2.2",
     "uuid": "^10.0.0",
     "ws": "^7.5.10"
   },
   "devDependencies": {
-    "chai": "^4.5.0"
+    "chai": "^5.1.2"
   },
   "scripts": {
     "build": "npm-run-all -p build:lib build:browser",

--- a/libraries/botframework-streaming/tests/Assembler.test.js
+++ b/libraries/botframework-streaming/tests/Assembler.test.js
@@ -1,7 +1,8 @@
 const { SubscribableStream } = require('../lib/subscribableStream');
 const { PayloadAssemblerManager, PayloadTypes, StreamManager } = require('../lib/payloads');
 const { PayloadAssembler } = require('../lib/assemblers');
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 
 const streamManager = new StreamManager();
 

--- a/libraries/botframework-streaming/tests/Assembler.test.js
+++ b/libraries/botframework-streaming/tests/Assembler.test.js
@@ -2,7 +2,7 @@ const { SubscribableStream } = require('../lib/subscribableStream');
 const { PayloadAssemblerManager, PayloadTypes, StreamManager } = require('../lib/payloads');
 const { PayloadAssembler } = require('../lib/assemblers');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 
 const streamManager = new StreamManager();
 

--- a/libraries/botframework-streaming/tests/ContentStream.test.js
+++ b/libraries/botframework-streaming/tests/ContentStream.test.js
@@ -3,7 +3,8 @@ const { PayloadAssembler } = require('../lib/assemblers');
 const { PayloadTypes } = require('../lib/payloads/payloadTypes');
 const { StreamManager } = require('../lib/payloads/streamManager');
 const { SubscribableStream } = require('../lib/subscribableStream');
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 
 class TestPayloadAssembler {
     constructor(content) {

--- a/libraries/botframework-streaming/tests/ContentStream.test.js
+++ b/libraries/botframework-streaming/tests/ContentStream.test.js
@@ -4,7 +4,7 @@ const { PayloadTypes } = require('../lib/payloads/payloadTypes');
 const { StreamManager } = require('../lib/payloads/streamManager');
 const { SubscribableStream } = require('../lib/subscribableStream');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 
 class TestPayloadAssembler {
     constructor(content) {

--- a/libraries/botframework-streaming/tests/Disassembler.test.js
+++ b/libraries/botframework-streaming/tests/Disassembler.test.js
@@ -4,7 +4,7 @@ const { HttpContent, StreamingRequest, SubscribableStream } = require('..');
 const { PayloadSender } = require('../lib/payloadTransport');
 const { PayloadTypes } = require('../lib/payloads');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 
 describe('RequestDisassembler', function () {
     it('resolves calls to get stream.', async function () {

--- a/libraries/botframework-streaming/tests/Disassembler.test.js
+++ b/libraries/botframework-streaming/tests/Disassembler.test.js
@@ -3,7 +3,8 @@ const { HttpContentStream } = require('../lib/httpContentStream');
 const { HttpContent, StreamingRequest, SubscribableStream } = require('..');
 const { PayloadSender } = require('../lib/payloadTransport');
 const { PayloadTypes } = require('../lib/payloads');
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 
 describe('RequestDisassembler', function () {
     it('resolves calls to get stream.', async function () {

--- a/libraries/botframework-streaming/tests/HeaderSerializer.test.js
+++ b/libraries/botframework-streaming/tests/HeaderSerializer.test.js
@@ -1,7 +1,7 @@
 const { HeaderSerializer, PayloadTypes } = require('../lib/payloads');
 const { PayloadConstants } = require('../lib/payloads/payloadConstants');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 
 describe('HeaderSerializer', function () {
     it('serializes and deserializes correctly', function () {

--- a/libraries/botframework-streaming/tests/HeaderSerializer.test.js
+++ b/libraries/botframework-streaming/tests/HeaderSerializer.test.js
@@ -1,6 +1,7 @@
 const { HeaderSerializer, PayloadTypes } = require('../lib/payloads');
 const { PayloadConstants } = require('../lib/payloads/payloadConstants');
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 
 describe('HeaderSerializer', function () {
     it('serializes and deserializes correctly', function () {

--- a/libraries/botframework-streaming/tests/NamedPipe.test.js
+++ b/libraries/botframework-streaming/tests/NamedPipe.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 const { expectEventually } = require('./helpers/expectEventually');
 const { NamedPipeClient, NamedPipeServer, StreamingRequest } = require('../lib');
 const { NamedPipeTransport } = require('../lib/namedPipe');

--- a/libraries/botframework-streaming/tests/NamedPipe.test.js
+++ b/libraries/botframework-streaming/tests/NamedPipe.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 const { expectEventually } = require('./helpers/expectEventually');
 const { NamedPipeClient, NamedPipeServer, StreamingRequest } = require('../lib');
 const { NamedPipeTransport } = require('../lib/namedPipe');

--- a/libraries/botframework-streaming/tests/NodeWebSocket.test.js
+++ b/libraries/botframework-streaming/tests/NodeWebSocket.test.js
@@ -1,4 +1,5 @@
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 const { FauxSock, FauxSocket, TestRequest, waitFor } = require('./helpers');
 const { NodeWebSocket } = require('../');
 const { randomBytes } = require('crypto');

--- a/libraries/botframework-streaming/tests/NodeWebSocket.test.js
+++ b/libraries/botframework-streaming/tests/NodeWebSocket.test.js
@@ -1,5 +1,5 @@
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 const { FauxSock, FauxSocket, TestRequest, waitFor } = require('./helpers');
 const { NodeWebSocket } = require('../');
 const { randomBytes } = require('crypto');

--- a/libraries/botframework-streaming/tests/NodeWebSocketFactory.test.js
+++ b/libraries/botframework-streaming/tests/NodeWebSocketFactory.test.js
@@ -1,5 +1,5 @@
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 const { FauxSocket, TestRequest } = require('./helpers');
 const { NodeWebSocket, NodeWebSocketFactory } = require('..');
 const { randomBytes } = require('crypto');

--- a/libraries/botframework-streaming/tests/NodeWebSocketFactory.test.js
+++ b/libraries/botframework-streaming/tests/NodeWebSocketFactory.test.js
@@ -1,4 +1,5 @@
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 const { FauxSocket, TestRequest } = require('./helpers');
 const { NodeWebSocket, NodeWebSocketFactory } = require('..');
 const { randomBytes } = require('crypto');

--- a/libraries/botframework-streaming/tests/PayloadSender.test.js
+++ b/libraries/botframework-streaming/tests/PayloadSender.test.js
@@ -1,7 +1,8 @@
 const { SubscribableStream } = require('..');
 const { PayloadReceiver, PayloadSender } = require('../lib/payloadTransport');
 const { PayloadAssemblerManager, PayloadTypes, StreamManager } = require('../lib/payloads');
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 const sinon = require('sinon');
 
 class FauxSock {

--- a/libraries/botframework-streaming/tests/PayloadSender.test.js
+++ b/libraries/botframework-streaming/tests/PayloadSender.test.js
@@ -2,7 +2,7 @@ const { SubscribableStream } = require('..');
 const { PayloadReceiver, PayloadSender } = require('../lib/payloadTransport');
 const { PayloadAssemblerManager, PayloadTypes, StreamManager } = require('../lib/payloads');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 const sinon = require('sinon');
 
 class FauxSock {
@@ -89,7 +89,7 @@ describe('PayloadTransport', function () {
 
             expect(
                 ps.sendPayload(header, stream, () => {
-                    // This try-catch is required as chai failures need to be caught and bubbled up via done().
+                    // This try-catch is required as chai/lib/chai failures need to be caught and bubbled up via done().
                     try {
                         expect(psSenderSpy.callCount).to.equal(4);
                         done();

--- a/libraries/botframework-streaming/tests/ProtocolAdapter.test.js
+++ b/libraries/botframework-streaming/tests/ProtocolAdapter.test.js
@@ -9,7 +9,8 @@ const RequestHandler = require('../lib/requestHandler');
 const Response = require('../lib/streamingResponse');
 const Request = require('../lib/streamingRequest');
 const StreamManager = require('../lib/payloads/streamManager');
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 const sinon = require('sinon');
 
 class TestRequestHandler extends RequestHandler.RequestHandler {

--- a/libraries/botframework-streaming/tests/ProtocolAdapter.test.js
+++ b/libraries/botframework-streaming/tests/ProtocolAdapter.test.js
@@ -10,7 +10,7 @@ const Response = require('../lib/streamingResponse');
 const Request = require('../lib/streamingRequest');
 const StreamManager = require('../lib/payloads/streamManager');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 const sinon = require('sinon');
 
 class TestRequestHandler extends RequestHandler.RequestHandler {

--- a/libraries/botframework-streaming/tests/RequestManager.test.js
+++ b/libraries/botframework-streaming/tests/RequestManager.test.js
@@ -1,5 +1,6 @@
 const { RequestManager } = require('../lib/payloads');
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 const { expectEventually } = require('./helpers');
 
 const REQUEST_ID = '123';

--- a/libraries/botframework-streaming/tests/RequestManager.test.js
+++ b/libraries/botframework-streaming/tests/RequestManager.test.js
@@ -1,6 +1,6 @@
 const { RequestManager } = require('../lib/payloads');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 const { expectEventually } = require('./helpers');
 
 const REQUEST_ID = '123';

--- a/libraries/botframework-streaming/tests/SendOperations.test.js
+++ b/libraries/botframework-streaming/tests/SendOperations.test.js
@@ -1,7 +1,8 @@
 const { HttpContent, StreamingRequest, StreamingResponse, SubscribableStream } = require('..');
 const { PayloadSender } = require('../lib/payloadTransport');
 const { SendOperations } = require('../lib/payloads');
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 
 describe('SendOperations', function () {
     it('constructs a new instance', function () {

--- a/libraries/botframework-streaming/tests/SendOperations.test.js
+++ b/libraries/botframework-streaming/tests/SendOperations.test.js
@@ -2,7 +2,7 @@ const { HttpContent, StreamingRequest, StreamingResponse, SubscribableStream } =
 const { PayloadSender } = require('../lib/payloadTransport');
 const { SendOperations } = require('../lib/payloads');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 
 describe('SendOperations', function () {
     it('constructs a new instance', function () {

--- a/libraries/botframework-streaming/tests/StreamManager.test.js
+++ b/libraries/botframework-streaming/tests/StreamManager.test.js
@@ -2,7 +2,7 @@ const { PayloadAssembler } = require('../lib/assemblers');
 const { PayloadTypes, StreamManager } = require('../lib/payloads');
 const { SubscribableStream } = require('..');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 
 describe('StreamManager', function () {
     it('properly constructs a new instance', function () {

--- a/libraries/botframework-streaming/tests/StreamManager.test.js
+++ b/libraries/botframework-streaming/tests/StreamManager.test.js
@@ -1,7 +1,8 @@
 const { PayloadAssembler } = require('../lib/assemblers');
 const { PayloadTypes, StreamManager } = require('../lib/payloads');
 const { SubscribableStream } = require('..');
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 
 describe('StreamManager', function () {
     it('properly constructs a new instance', function () {

--- a/libraries/botframework-streaming/tests/StreamingRequest.test.js
+++ b/libraries/botframework-streaming/tests/StreamingRequest.test.js
@@ -1,8 +1,8 @@
 const StreamingRequest = require('../lib/streamingRequest');
 const HttpContent = require('../lib/httpContentStream');
 const SubscribableStream = require('../lib/subscribableStream');
-const chai = require('chai');
-const expect = chai.expect;
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 
 describe('Streaming Extensions Request tests', function () {
     it('creates a new request with undefined properties', function () {

--- a/libraries/botframework-streaming/tests/StreamingRequest.test.js
+++ b/libraries/botframework-streaming/tests/StreamingRequest.test.js
@@ -2,7 +2,7 @@ const StreamingRequest = require('../lib/streamingRequest');
 const HttpContent = require('../lib/httpContentStream');
 const SubscribableStream = require('../lib/subscribableStream');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 
 describe('Streaming Extensions Request tests', function () {
     it('creates a new request with undefined properties', function () {

--- a/libraries/botframework-streaming/tests/StreamingResponse.test.js
+++ b/libraries/botframework-streaming/tests/StreamingResponse.test.js
@@ -1,6 +1,6 @@
 const { HttpContent, StreamingResponse, SubscribableStream } = require('..');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 
 describe('Streaming Extensions Response Tests', function () {
     it('can set the response body', function () {

--- a/libraries/botframework-streaming/tests/StreamingResponse.test.js
+++ b/libraries/botframework-streaming/tests/StreamingResponse.test.js
@@ -1,5 +1,6 @@
 const { HttpContent, StreamingResponse, SubscribableStream } = require('..');
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 
 describe('Streaming Extensions Response Tests', function () {
     it('can set the response body', function () {

--- a/libraries/botframework-streaming/tests/SubscribableStream.test.js
+++ b/libraries/botframework-streaming/tests/SubscribableStream.test.js
@@ -1,6 +1,6 @@
 const { SubscribableStream } = require('../lib/subscribableStream');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 
 describe('Streaming Extensions Stream Tests', function () {
     it('throws on invalid encoding types', function () {

--- a/libraries/botframework-streaming/tests/SubscribableStream.test.js
+++ b/libraries/botframework-streaming/tests/SubscribableStream.test.js
@@ -1,5 +1,6 @@
 const { SubscribableStream } = require('../lib/subscribableStream');
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 
 describe('Streaming Extensions Stream Tests', function () {
     it('throws on invalid encoding types', function () {

--- a/libraries/botframework-streaming/tests/TransportConstants.test.js
+++ b/libraries/botframework-streaming/tests/TransportConstants.test.js
@@ -1,5 +1,6 @@
 const { PayloadConstants } = require('../lib/payloads/payloadConstants');
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 
 describe('PayloadConstants', function () {
     it('has the proper value for MaxPayloadLength', function () {

--- a/libraries/botframework-streaming/tests/TransportConstants.test.js
+++ b/libraries/botframework-streaming/tests/TransportConstants.test.js
@@ -1,6 +1,6 @@
 const { PayloadConstants } = require('../lib/payloads/payloadConstants');
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 
 describe('PayloadConstants', function () {
     it('has the proper value for MaxPayloadLength', function () {

--- a/libraries/botframework-streaming/tests/WebSocket.test.js
+++ b/libraries/botframework-streaming/tests/WebSocket.test.js
@@ -1,4 +1,5 @@
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 const { spy } = require('sinon');
 
 const { BrowserWebSocket } = require('../lib/index-browser');

--- a/libraries/botframework-streaming/tests/WebSocket.test.js
+++ b/libraries/botframework-streaming/tests/WebSocket.test.js
@@ -1,5 +1,5 @@
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 const { spy } = require('sinon');
 
 const { BrowserWebSocket } = require('../lib/index-browser');

--- a/libraries/botframework-streaming/tests/WebSocketClientServer.test.js
+++ b/libraries/botframework-streaming/tests/WebSocketClientServer.test.js
@@ -1,4 +1,5 @@
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 const { Server } = require('ws');
 const { spy, stub } = require('sinon');
 

--- a/libraries/botframework-streaming/tests/WebSocketClientServer.test.js
+++ b/libraries/botframework-streaming/tests/WebSocketClientServer.test.js
@@ -1,5 +1,5 @@
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 const { Server } = require('ws');
 const { spy, stub } = require('sinon');
 

--- a/libraries/botframework-streaming/tests/helpers/expectEventually.js
+++ b/libraries/botframework-streaming/tests/helpers/expectEventually.js
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 
-const { expect } = require('chai');
+const importSync= require('import-sync');
+const { expect } = importSync('chai');
 
 // chai-as-promised is not actively maintained, we need to build something simple.
 

--- a/libraries/botframework-streaming/tests/helpers/expectEventually.js
+++ b/libraries/botframework-streaming/tests/helpers/expectEventually.js
@@ -4,9 +4,9 @@
  */
 
 const importSync= require('import-sync');
-const { expect } = importSync('chai');
+const { expect } = importSync('chai/lib/chai');
 
-// chai-as-promised is not actively maintained, we need to build something simple.
+// chai/lib/chai-as-promised is not actively maintained, we need to build something simple.
 
 module.exports.expectEventually = async function (promise) {
     let error, result;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5416,10 +5416,15 @@ assert@^2.1.0:
     object.assign "^4.1.4"
     util "^0.12.5"
 
-assertion-error@1.1.0, assertion-error@^1.1.0:
+assertion-error@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 assign-symbols@^1.0.0:
   version "1.0.0"
@@ -6193,18 +6198,16 @@ chai-nightwatch@^0.5.3:
   dependencies:
     assertion-error "1.1.0"
 
-chai@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.5.0.tgz#707e49923afdd9b13a8b0b47d33d732d13812fd8"
-  integrity sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==
+chai@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.1.2.tgz#3afbc340b994ae3610ca519a6c70ace77ad4378d"
+  integrity sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==
   dependencies:
-    assertion-error "^1.1.0"
-    check-error "^1.0.3"
-    deep-eql "^4.1.3"
-    get-func-name "^2.0.2"
-    loupe "^2.3.6"
-    pathval "^1.1.1"
-    type-detect "^4.1.0"
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
 
 chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -6256,12 +6259,10 @@ check-error@1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
-check-error@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.3.tgz#a6502e4312a7ee969f646e83bb3ddd56281bd694"
-  integrity sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==
-  dependencies:
-    get-func-name "^2.0.2"
+check-error@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
+  integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
 
 chokidar@3.5.3:
   version "3.5.3"
@@ -7021,12 +7022,10 @@ deep-eql@4.0.1:
   dependencies:
     type-detect "^4.0.0"
 
-deep-eql@^4.1.3:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.4.tgz#d0d3912865911bb8fac5afb4e3acfa6a28dc72b7"
-  integrity sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==
-  dependencies:
-    type-detect "^4.0.0"
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
 
 deep-equal@^2.0.5:
   version "2.2.3"
@@ -8817,7 +8816,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-func-name@^2.0.1, get-func-name@^2.0.2:
+get-func-name@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
   integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==
@@ -10773,12 +10772,17 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-loupe@^2.3.6, loupe@^2.3.7:
+loupe@^2.3.7:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.7.tgz#6e69b7d4db7d3ab436328013d37d1c8c3540c697"
   integrity sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==
   dependencies:
     get-func-name "^2.0.1"
+
+loupe@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.2.tgz#c86e0696804a02218f2206124c45d8b15291a240"
+  integrity sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==
 
 lru-cache@^10.2.0:
   version "10.4.3"
@@ -12485,10 +12489,15 @@ path-type@^5.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-5.0.0.tgz#14b01ed7aea7ddf9c7c3f46181d4d04f9c785bb8"
   integrity sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==
 
-pathval@1.1.1, pathval@^1.1.1:
+pathval@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
+pathval@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.0.tgz#7e2550b422601d4f6b8e26f1301bc8f15a741a25"
+  integrity sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==
 
 pbkdf2@^3.0.3:
   version "3.1.1"
@@ -14366,7 +14375,16 @@ string-argv@~0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14481,7 +14499,14 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@6.0.1, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15915,7 +15940,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15937,6 +15962,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Addresses #4684
#minor

## Description
This PR updates the `chai` package to its latest version 5.1.2. Starting on version 5.x, this package is ESM-only, so we used _import-sync_ to be able to use this version.

## Specific Changes
  - Updated `chai` from 4.5.0 and 5.1.2 in _botbuilder_ and _botframework-streaming_ libraries.
  - Added `import-sync` as a dependency in _botbuilder_ and _botframework-streaming_.
  - Added _chai_ to the _depcheck_ ignore list as it threw a false positive on unused dependency.

## Testing
The following images show the installed version.
![image](https://github.com/user-attachments/assets/9405d160-8cee-4691-bc1f-61412e3bf4b8)

