### PR TITLE
fix: Update Generators versions: Add missing directory to workspaces

### DIFF
--- a/generators/generator-botbuilder/package.json
+++ b/generators/generator-botbuilder/package.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-botbuilder",
-    "version": "4.11.0",
+    "version": "4.1.6",
     "description": "A yeoman generator for creating bots built with Bot Framework v4",
     "homepage": "https://github.com/Microsoft/BotBuilder-JS/tree/main/generators/generator-botbuilder",
     "author": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
       "tools"
     ],
     "generators": [
+      "generators/generator-botbuilder",
       "generators/generator-botbuilder/generators/app/templates/*"
     ],
     "nohoist": [


### PR DESCRIPTION
#minor

## Description
This PR includes the `generators/generator-botbuilder` folder to the project's _workspaces_ so the _update-versions_ script can include the _package.json_ file inside this directory.

## Specific Changes
- Added the `generators/generator-botbuilder` folder to the project's _workspaces_.
- Changed version in `generators/generator-botbuilder/package.json` to 4.1.6 to match the rest of the projects.

## Testing
This image shows the generators' .tgz file created with the correct version.
![image](https://github.com/user-attachments/assets/d996bac9-42c1-40ee-86aa-98635e6a4cb0)
