### PR TITLE
fix: fixes bot state not being saved when it should be

### DIFF
--- a/libraries/botbuilder-core/src/botState.ts
+++ b/libraries/botbuilder-core/src/botState.ts
@@ -110,7 +110,7 @@ export class BotState implements PropertyManager {
      */
     saveChanges(context: TurnContext, force = false): Promise<void> {
         let cached: CachedBotState = context.turnState.get(this.stateKey);
-        if (force || (cached && cached.hash !== calculateChangeHash(cached?.state))) {
+        if (!cached || force || (cached && cached.hash !== calculateChangeHash(cached?.state))) {
             return Promise.resolve(this.storageKey(context)).then((key: string) => {
                 if (!cached) {
                     cached = { state: {}, hash: '' };

--- a/libraries/botbuilder-core/tests/botState.test.js
+++ b/libraries/botbuilder-core/tests/botState.test.js
@@ -92,6 +92,12 @@ describe('BotState', function () {
         assert(state.test === 'foo', 'state not loaded.');
     });
 
+    it('should saveChanges() to storage of an empty state object.', async function () {
+        context.turnState.set(botState.stateKey, undefined);
+        await botState.saveChanges(context, false);
+        assert(context.turnState.get(botState.stateKey), 'state not saved.');
+    });
+
     it('should force saveChanges() to storage of an empty state object.', async function () {
         context.turnState.set(botState.stateKey, undefined);
         await botState.saveChanges(context, true);


### PR DESCRIPTION
## Description

`botState.saveChanges` documentation states the following

https://github.com/microsoft/botbuilder-js/blob/3b8fcab21a0a5434706da8eace17117722ffd78b/libraries/botbuilder-core/src/botState.ts#L96-L110

> if no object has been cached, an empty object will be created and then saved

However:
https://github.com/microsoft/botbuilder-js/blob/3b8fcab21a0a5434706da8eace17117722ffd78b/libraries/botbuilder-core/src/botState.ts#L111-L114

If `cached` does not exist, we will never go through the `if` statement.

## Specific Changes
  - Fixes the bug 
  - Adds a unit test

## Testing

- Unit test added.