### PR TITLE
bump: Update d3-format package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -316,3 +316,6 @@ coverage
 # typescript assets
 *.tsbuildinfo
 *.js.map
+
+# tsup vendors folders
+libraries/**/vendors

--- a/libraries/adaptive-expressions/package.json
+++ b/libraries/adaptive-expressions/package.json
@@ -36,7 +36,7 @@
     "big-integer": "^1.6.52",
     "@types/xmldom": "^0.1.34",
     "btoa-lite": "^1.0.0",
-    "d3-format": "^2.0.0",
+    "d3-format": "^3.1.0",
     "dayjs": "^1.11.13",
     "jspath": "^0.4.0",
     "lodash": "^4.17.21",
@@ -58,18 +58,20 @@
     "build:browser": "npm-run-all build:browser:clean build:browser:run",
     "build:browser:clean": "rimraf --glob lib/browser.*",
     "build:browser:run": "tsup --config ../../tsup/browser.config.ts",
-    "clean": "rimraf lib tsconfig.tsbuildinfo",
-    "depcheck": "depcheck --config ../../.depcheckrc --ignores sinon,@types/xmldom",
+    "clean": "rimraf lib vendors tsconfig.tsbuildinfo",
+    "depcheck": "depcheck --config ../../.depcheckrc --ignores @types/xmldom,d3-format,sinon",
     "build-docs": "typedoc --theme markdown --entryPoint adaptive-expressions --excludePrivate --includeDeclarations --ignoreCompilerErrors --module amd --out ..\\..\\doc\\adaptive-expressions .\\lib\\index.d.ts --hideGenerator --name \"Bot Builder SDK - Expression\" --readme none",
     "test": "yarn build && mocha tests --timeout 60000",
     "test:compat": "api-extractor run --verbose",
     "lint": "eslint .",
+    "prebuild": "tsup ./node_modules/d3-format/src/*.js --format cjs --out-dir vendors/d3-format --clean --sourcemap",
     "antlr-build-expression": "antlr4ts src/parser/ExpressionAntlrLexer.g4 -o src/parser/generated && antlr4ts src/parser/ExpressionAntlrParser.g4 -visitor -o src/parser/generated",
     "antlr-build-commonregex": "antlr4ts src/CommonRegex.g4 -o src/generated -visitor"
   },
   "files": [
     "lib",
     "src",
-    "types"
+    "types",
+    "vendors"
   ]
 }

--- a/libraries/adaptive-expressions/src/builtinFunctions/formatNumber.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/formatNumber.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { formatLocale as d3formatLocale, format as d3format } from 'd3-format';
+import { formatLocale as d3formatLocale, format as d3format } from '../../vendors/d3-format';
 import { Expression } from '../expression';
 import { EvaluateExpressionDelegate, ExpressionEvaluator } from '../expressionEvaluator';
 import { ExpressionType } from '../expressionType';

--- a/libraries/adaptive-expressions/src/builtinFunctions/string.ts
+++ b/libraries/adaptive-expressions/src/builtinFunctions/string.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT License.
  */
 
-import { formatLocale as d3formatLocale, format as d3format } from 'd3-format';
+import { formatLocale as d3formatLocale, format as d3format } from '../../vendors/d3-format';
 import { EvaluateExpressionDelegate, ExpressionEvaluator, ValueWithError } from '../expressionEvaluator';
 import { ExpressionType } from '../expressionType';
 import { FunctionUtils } from '../functionUtils';

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     ],
     "nohoist": [
       "**/@types/selenium-webdriver",
-      "botbuilder/filenamify"
+      "botbuilder/filenamify",
+      "adaptive-expressions/d3-format"
     ],
     "nohoistComments": {
       "**/@types/selenium-webdriver": "This package is excluded from the root @types folder as it requires ES2015+, whereas some BotBuilder libraries support ES5+.",
-      "botbuilder/filenamify": "This package is excluded because it's compiled as CJS by tsup as it's ESM-only."
+      "botbuilder/filenamify": "This package is excluded because it's compiled as CJS by tsup as it's ESM-only.",
+      "adaptive-expressions/d3-format": "This package is excluded because it's compiled as CJS by tsup as it's ESM-only."
     }
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6920,10 +6920,10 @@ csv@^6.2.2:
     csv-stringify "^6.5.0"
     stream-transform "^3.3.2"
 
-d3-format@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-2.0.0.tgz#a10bcc0f986c372b729ba447382413aabf5b0767"
-  integrity sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==
+d3-format@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
+  integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
#minor

## Description
This PR updates the _**d3-format**_ package to the latest version and applies the necessary configuration to keep working in _adaptive-expressions_.

## Specific Changes
  - Updated _**d3-format**_  to version ^3.1.0.
  - Added prebuild scripts to _adaptive-expressions_ to use tsup to compile ESM-only package.
  - Updated imports of  _**d3-format**_  in every class.

## Testing
The following image shows the  _adaptive-expressions_ unit tests working after the updates.
![image](https://github.com/user-attachments/assets/c62892d5-4545-43e8-a284-d5ef97c4b0f6)