### PR TITLE
fix: Run the coveralls step only for windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: yarn test:github
 
       - name: coveralls
-        if: matrix.node-version == '22.x'
+        if: matrix.node-version == '22.x' && matrix.os == 'windows'
         uses: coverallsapp/github-action@v1.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#minor

## Description
This PR updates the test GitHub action to run the coveralls step only for Windows due to a change in coveralls.io ([issue](https://github.com/lemurheavy/coveralls-public/issues/1716#issuecomment-1588043075))

## Specific Changes
- Updated tests.yml to run coveralls step only for Windows os.

## Testing
This image shows the tests passing.
![image](https://github.com/user-attachments/assets/fd1a5dfe-b380-4ea9-a38c-d30391a07919)
