### PR TITLE
port:[#6879] Bot is not accepting v2 tokens from Bot Framework Emulator - Single Tenant Bots

### DIFF
--- a/libraries/botframework-connector/package.json
+++ b/libraries/botframework-connector/package.json
@@ -49,7 +49,8 @@
     "botbuilder-test-utils": "0.0.0",
     "dotenv": "^16.4.5",
     "nock": "^13.5.5",
-    "should": "^13.2.3"
+    "should": "^13.2.3",
+    "uuid": "^11.0.5"
   },
   "scripts": {
     "build": "tsc -b",

--- a/libraries/botframework-connector/src/auth/emulatorValidation.ts
+++ b/libraries/botframework-connector/src/auth/emulatorValidation.ts
@@ -75,28 +75,29 @@ export namespace EmulatorValidation {
             return false;
         }
 
+        const validTokenIssuers = ToBotFromBotOrEmulatorTokenValidationParameters.issuer;
+
         //Validation to manage the issuer object as a string.
-        if (Array.isArray(ToBotFromBotOrEmulatorTokenValidationParameters.issuer)) {
+        if (Array.isArray(validTokenIssuers)) {
             const tenantId = token?.payload[AuthenticationConstants.TenantIdClaim] ?? '';
 
             //Validate if there is an existing issuer with the same tid value.
-            if (
-                tenantId != '' &&
-                ToBotFromBotOrEmulatorTokenValidationParameters.issuer.find((issuer) => issuer.includes(tenantId)) ==
-                    null
-            ) {
+            if (tenantId != '' && validTokenIssuers.find((issuer) => issuer.includes(tenantId)) == null) {
                 //If the issuer doesn't exist, this is added using the Emulator token issuer structure.
                 //This allows use of the SingleTenant authentication through Emulator.
-                const newIssuer = AuthenticationConstants.ValidTokenIssuerUrlTemplateV1 + `${tenantId}/`;
-                ToBotFromBotOrEmulatorTokenValidationParameters.issuer.push(newIssuer);
+                validTokenIssuers.push(`${AuthenticationConstants.ValidTokenIssuerUrlTemplateV1}${tenantId}/`);
+                validTokenIssuers.push(`${AuthenticationConstants.ValidTokenIssuerUrlTemplateV2}${tenantId}/v2.0`);
+                validTokenIssuers.push(
+                    `${AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV1}${tenantId}/`,
+                );
+                validTokenIssuers.push(
+                    `${AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV2}${tenantId}/v2.0`,
+                );
             }
         }
 
         // Is the token issues by a source we consider to be the emulator?
-        if (
-            ToBotFromEmulatorTokenValidationParameters.issuer &&
-            ToBotFromEmulatorTokenValidationParameters.issuer.indexOf(issuer) === -1
-        ) {
+        if (validTokenIssuers && validTokenIssuers.indexOf(issuer) === -1) {
             // Not a Valid Issuer. This is NOT a Bot Framework Emulator Token.
             return false;
         }

--- a/libraries/botframework-connector/tests/auth/emulatorValidation.test.js
+++ b/libraries/botframework-connector/tests/auth/emulatorValidation.test.js
@@ -1,0 +1,61 @@
+const jwt = require('jsonwebtoken');
+const { v4: uuidv4 } = require('uuid');
+const { EmulatorValidation, AuthenticationConstants } = require('../..');
+const { strictEqual } = require('assert');
+
+function generateMockBearerToken(issuer) {
+    const secretKey = 'ThisIsASuperMockSecretKey123456789';
+    const tenantId = uuidv4();
+    const completeIssuer = issuer ? issuer.replace('{0}', tenantId) : null;
+
+    const payload = {
+        name: 'John Doe',
+        role: 'Admin',
+        tid: tenantId,
+        iss: completeIssuer,
+        aud: 'https://api.example.com',
+    };
+
+    const options = {
+        expiresIn: '1h',
+    };
+
+    return `Bearer ${jwt.sign(payload, secretKey, options)}`;
+}
+
+describe('EmulatorValidation', function () {
+    it('should return false on token BadFormat', function () {
+        // Token with bad format is not processed
+        let authHeader = '';
+        strictEqual(EmulatorValidation.isTokenFromEmulator(authHeader), false);
+
+        // If the token doesn't contain an issuer value, it returns false
+        authHeader = generateMockBearerToken(null);
+        strictEqual(EmulatorValidation.isTokenFromEmulator(authHeader), false);
+    });
+
+    it('should return false on invalid token issuer', function () {
+        const authHeader = generateMockBearerToken('https://mockIssuer.com');
+        strictEqual(EmulatorValidation.isTokenFromEmulator(authHeader), false);
+    });
+
+    it('should return true on valid token issuer', function () {
+        // Validate issuer with V1 Token
+        let authHeader = generateMockBearerToken(`${AuthenticationConstants.ValidTokenIssuerUrlTemplateV1}{0}/`);
+        strictEqual(EmulatorValidation.isTokenFromEmulator(authHeader), true);
+
+        // Validate issuer with V2 Token
+        authHeader = generateMockBearerToken(`${AuthenticationConstants.ValidTokenIssuerUrlTemplateV2}{0}/v2.0`);
+        strictEqual(EmulatorValidation.isTokenFromEmulator(authHeader), true);
+
+        // Validate Government issuer with V1 Token
+        authHeader = generateMockBearerToken(`${AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV1}{0}/`);
+        strictEqual(EmulatorValidation.isTokenFromEmulator(authHeader), true);
+
+        // Validate Government issuer with V2 Token
+        authHeader = generateMockBearerToken(
+            `${AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV2}{0}/v2.0`,
+        );
+        strictEqual(EmulatorValidation.isTokenFromEmulator(authHeader), true);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -15502,6 +15502,11 @@ uuid@^10.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
   integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
+uuid@^11.0.5:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.5.tgz#07b46bdfa6310c92c3fb3953a8720f170427fc62"
+  integrity sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==
+
 uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"


### PR DESCRIPTION
#minor

## Description
This PR adds support for every possible token issuer version in Emulator validation.

## Specific Changes
  - Added 3 new valid token issuers in token emulator validation.
  - Added unit tests to check IsTokenFromEmulator expected results.

## Testing
The following image shows the new unit tests working.
![image](https://github.com/user-attachments/assets/726f494a-3711-4045-a64a-1c5a3a133a57)