### PR TITLE
fix: [#4786] Clarify createBotFrameworkAuthenticationFromConfiguration usage in yo templates

### DIFF
--- a/libraries/botbuilder-core/etc/botbuilder-core.api.md
+++ b/libraries/botbuilder-core/etc/botbuilder-core.api.md
@@ -391,7 +391,7 @@ export interface CoreAppCredentials {
 }
 
 // @public
-export function createBotFrameworkAuthenticationFromConfiguration(configuration: Configuration, credentialsFactory?: ServiceClientCredentialsFactory, authConfiguration?: AuthenticationConfiguration, botFrameworkClientFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>, connectorClientOptions?: ConnectorClientOptions): BotFrameworkAuthentication;
+export function createBotFrameworkAuthenticationFromConfiguration(configuration: Configuration | null, credentialsFactory?: ServiceClientCredentialsFactory, authConfiguration?: AuthenticationConfiguration, botFrameworkClientFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>, connectorClientOptions?: ConnectorClientOptions): BotFrameworkAuthentication;
 
 // @public
 export function createServiceClientCredentialFactoryFromConfiguration(configuration: Configuration): ConfigurationServiceClientCredentialFactory;

--- a/libraries/botbuilder-core/src/configurationBotFrameworkAuthentication.ts
+++ b/libraries/botbuilder-core/src/configurationBotFrameworkAuthentication.ts
@@ -268,7 +268,7 @@ export class ConfigurationBotFrameworkAuthentication extends BotFrameworkAuthent
  * @returns A [ConfigurationBotFrameworkAuthentication](xref:botbuilder-core.ConfigurationBotFrameworkAuthentication) instance.
  */
 export function createBotFrameworkAuthenticationFromConfiguration(
-    configuration: Configuration,
+    configuration: Configuration | null,
     credentialsFactory?: ServiceClientCredentialsFactory,
     authConfiguration?: AuthenticationConfiguration,
     botFrameworkClientFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>,


### PR DESCRIPTION
#minor

## Description
This PR updates the signature of the `createBotFrameworkAuthenticationFromConfiguration` function to allow _null_ values for the _Configuration_ parameter, avoiding an error when using _@ts-check_ or _strict_ setting in TS bots.

## Specific Changes
- Added the _null_ option for the _Configuration_ parameter in createBotFrameworkAuthenticationFromConfiguration.
- Updated the function signature in _botbuilder-core.api.md_

## Testing
The changes were tested using anonymous and credentials configurations for the bots.
![image](https://github.com/user-attachments/assets/e7a902d7-a69f-4bbf-b3d8-66c3aeb9e4f3)

These images show the error before the changes and no errors after.
![image](https://github.com/user-attachments/assets/f9def2af-031f-4de4-a490-61c85d211b96)
