### PR TITLE
fix: [#4853] ConfigurationBotFrameworkAuthentication errors when initialized with process.env

### DIFF
--- a/libraries/botbuilder-core/etc/botbuilder-core.api.md
+++ b/libraries/botbuilder-core/etc/botbuilder-core.api.md
@@ -343,13 +343,7 @@ export class ComponentRegistration {
 
 // @public
 export class ConfigurationBotFrameworkAuthentication extends BotFrameworkAuthentication {
-    constructor(
-    botFrameworkAuthConfig?: ConfigurationBotFrameworkAuthenticationOptions,
-    credentialsFactory?: ServiceClientCredentialsFactory,
-    authConfiguration?: AuthenticationConfiguration,
-    botFrameworkClientFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>,
-    connectorClientOptions?: ConnectorClientOptions,
-    );
+    constructor(botFrameworkAuthConfig?: ConfigurationBotFrameworkAuthenticationOptions, credentialsFactory?: ServiceClientCredentialsFactory, authConfiguration?: AuthenticationConfiguration, botFrameworkClientFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>, connectorClientOptions?: ConnectorClientOptions);
     authenticateChannelRequest(authHeader: string): Promise<ClaimsIdentity>;
     authenticateRequest(activity: Activity, authHeader: string): Promise<AuthenticateRequestResult>;
     authenticateStreamingRequest(authHeader: string, channelIdHeader: string): Promise<AuthenticateRequestResult>;
@@ -358,10 +352,10 @@ export class ConfigurationBotFrameworkAuthentication extends BotFrameworkAuthent
     createUserTokenClient(claimsIdentity: ClaimsIdentity): Promise<UserTokenClient>;
 }
 
-// Warning: (ae-forgotten-export) The symbol "TypedOptions" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ZodOptions" needs to be exported by the entry point index.d.ts
 //
 // @public
-export interface ConfigurationBotFrameworkAuthenticationOptions extends z.infer<typeof TypedOptions>  {
+export interface ConfigurationBotFrameworkAuthenticationOptions extends ZodOptions {
     // (undocumented)
     [key: string]: string | boolean | undefined;
 }
@@ -400,13 +394,7 @@ export interface CoreAppCredentials {
 }
 
 // @public
-export function createBotFrameworkAuthenticationFromConfiguration(
-configuration: Configuration,
-credentialsFactory?: ServiceClientCredentialsFactory,
-authConfiguration?: AuthenticationConfiguration,
-botFrameworkClientFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>,
-connectorClientOptions?: ConnectorClientOptions,
-): BotFrameworkAuthentication;
+export function createBotFrameworkAuthenticationFromConfiguration(configuration: Configuration, credentialsFactory?: ServiceClientCredentialsFactory, authConfiguration?: AuthenticationConfiguration, botFrameworkClientFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>, connectorClientOptions?: ConnectorClientOptions): BotFrameworkAuthentication;
 
 // @public
 export function createServiceClientCredentialFactoryFromConfiguration(configuration: Configuration): ConfigurationServiceClientCredentialFactory;
@@ -585,6 +573,9 @@ export enum Severity {
     Warning = 2
 }
 
+// @public (undocumented)
+export const sharePointTokenExchange = "cardExtension/token";
+
 // @public
 export class ShowTypingMiddleware implements Middleware {
     constructor(delay?: number, period?: number);
@@ -639,7 +630,6 @@ export class SkypeMentionNormalizeMiddleware implements Middleware {
 export interface StatePropertyAccessor<T = any> {
     delete(context: TurnContext): Promise<void>;
     get(context: TurnContext): Promise<T | undefined>;
-    // (undocumented)
     get(context: TurnContext, defaultValue: T): Promise<T>;
     set(context: TurnContext, value: T): Promise<void>;
 }

--- a/libraries/botbuilder-core/etc/botbuilder-core.api.md
+++ b/libraries/botbuilder-core/etc/botbuilder-core.api.md
@@ -343,7 +343,13 @@ export class ComponentRegistration {
 
 // @public
 export class ConfigurationBotFrameworkAuthentication extends BotFrameworkAuthentication {
-    constructor(botFrameworkAuthConfig?: ConfigurationBotFrameworkAuthenticationOptions, credentialsFactory?: ServiceClientCredentialsFactory, authConfiguration?: AuthenticationConfiguration, botFrameworkClientFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>, connectorClientOptions?: ConnectorClientOptions);
+    constructor(
+    botFrameworkAuthConfig?: ConfigurationBotFrameworkAuthenticationOptions,
+    credentialsFactory?: ServiceClientCredentialsFactory,
+    authConfiguration?: AuthenticationConfiguration,
+    botFrameworkClientFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>,
+    connectorClientOptions?: ConnectorClientOptions,
+    );
     authenticateChannelRequest(authHeader: string): Promise<ClaimsIdentity>;
     authenticateRequest(activity: Activity, authHeader: string): Promise<AuthenticateRequestResult>;
     authenticateStreamingRequest(authHeader: string, channelIdHeader: string): Promise<AuthenticateRequestResult>;
@@ -355,7 +361,10 @@ export class ConfigurationBotFrameworkAuthentication extends BotFrameworkAuthent
 // Warning: (ae-forgotten-export) The symbol "TypedOptions" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type ConfigurationBotFrameworkAuthenticationOptions = z.infer<typeof TypedOptions>;
+export interface ConfigurationBotFrameworkAuthenticationOptions extends z.infer<typeof TypedOptions>  {
+    // (undocumented)
+    [key: string]: string | boolean | undefined;
+}
 
 // @public
 export class ConfigurationServiceClientCredentialFactory extends PasswordServiceClientCredentialFactory {
@@ -391,7 +400,13 @@ export interface CoreAppCredentials {
 }
 
 // @public
-export function createBotFrameworkAuthenticationFromConfiguration(configuration: Configuration, credentialsFactory?: ServiceClientCredentialsFactory, authConfiguration?: AuthenticationConfiguration, botFrameworkClientFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>, connectorClientOptions?: ConnectorClientOptions): BotFrameworkAuthentication;
+export function createBotFrameworkAuthenticationFromConfiguration(
+configuration: Configuration,
+credentialsFactory?: ServiceClientCredentialsFactory,
+authConfiguration?: AuthenticationConfiguration,
+botFrameworkClientFetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>,
+connectorClientOptions?: ConnectorClientOptions,
+): BotFrameworkAuthentication;
 
 // @public
 export function createServiceClientCredentialFactoryFromConfiguration(configuration: Configuration): ConfigurationServiceClientCredentialFactory;
@@ -570,9 +585,6 @@ export enum Severity {
     Warning = 2
 }
 
-// @public (undocumented)
-export const sharePointTokenExchange = "cardExtension/token";
-
 // @public
 export class ShowTypingMiddleware implements Middleware {
     constructor(delay?: number, period?: number);
@@ -627,6 +639,7 @@ export class SkypeMentionNormalizeMiddleware implements Middleware {
 export interface StatePropertyAccessor<T = any> {
     delete(context: TurnContext): Promise<void>;
     get(context: TurnContext): Promise<T | undefined>;
+    // (undocumented)
     get(context: TurnContext, defaultValue: T): Promise<T>;
     set(context: TurnContext, value: T): Promise<void>;
 }

--- a/libraries/botbuilder-core/src/configurationBotFrameworkAuthentication.ts
+++ b/libraries/botbuilder-core/src/configurationBotFrameworkAuthentication.ts
@@ -112,13 +112,14 @@ const TypedOptions = z
     })
     .partial();
 
+type ZodOptions = z.infer<typeof TypedOptions>;
+
 /**
  * Contains settings used to configure a [ConfigurationBotFrameworkAuthentication](xref:botbuilder-core.ConfigurationBotFrameworkAuthentication) instance.
  */
-export interface ConfigurationBotFrameworkAuthenticationOptions extends z.infer<typeof TypedOptions>  {
+export interface ConfigurationBotFrameworkAuthenticationOptions extends ZodOptions {
     [key: string]: string | boolean | undefined;
 }
-
 
 /**
  * Creates a [BotFrameworkAuthentication](xref:botframework-connector.BotFrameworkAuthentication) instance from an object with the authentication values or a [Configuration](xref:botbuilder-dialogs-adaptive-runtime-core.Configuration) instance.

--- a/libraries/botbuilder-core/src/configurationBotFrameworkAuthentication.ts
+++ b/libraries/botbuilder-core/src/configurationBotFrameworkAuthentication.ts
@@ -115,7 +115,10 @@ const TypedOptions = z
 /**
  * Contains settings used to configure a [ConfigurationBotFrameworkAuthentication](xref:botbuilder-core.ConfigurationBotFrameworkAuthentication) instance.
  */
-export type ConfigurationBotFrameworkAuthenticationOptions = z.infer<typeof TypedOptions>;
+export interface ConfigurationBotFrameworkAuthenticationOptions extends z.infer<typeof TypedOptions>  {
+    [key: string]: string | boolean | undefined;
+}
+
 
 /**
  * Creates a [BotFrameworkAuthentication](xref:botframework-connector.BotFrameworkAuthentication) instance from an object with the authentication values or a [Configuration](xref:botbuilder-dialogs-adaptive-runtime-core.Configuration) instance.


### PR DESCRIPTION
Fixes #4853

## Description
This PR adds support for using process.env directly as `ConfigurationBotFrameworkAuthentication` options.

## Specific Changes
  - Allows any optional properties into `ConfigurationBotFrameworkAuthenticationOptions` that are either string or boolean.

## Testing
The following image shows how this implementation works.
![image](https://github.com/user-attachments/assets/2226be81-7bd8-40e5-b05e-09cb581a7468)
