### PR TITLE
fix: Fix actions/cache deprecation

### DIFF
--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -30,7 +30,7 @@ jobs:
         id: yarn-cache-dir
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node22.x-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
         id: yarn-cache-dir
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node22.x-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/test-compat.yml
+++ b/.github/workflows/test-compat.yml
@@ -30,7 +30,7 @@ jobs:
         id: yarn-cache-dir
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node22.x-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/test-consumer.yml
+++ b/.github/workflows/test-consumer.yml
@@ -30,7 +30,7 @@ jobs:
         id: yarn-cache-dir
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node22.x-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/test-repoutils.yml
+++ b/.github/workflows/test-repoutils.yml
@@ -30,7 +30,7 @@ jobs:
         id: yarn-cache-dir
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node22.x-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/test-schemas.yml
+++ b/.github/workflows/test-schemas.yml
@@ -30,7 +30,7 @@ jobs:
         id: yarn-cache-dir
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node22.x-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         id: yarn-cache-dir
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-node${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
#minor

## Description
This PR updates the actions/cache version due to deprecation and causing burnouts preventing workflows to function properly.
More info: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

## Testing
The following image shows the issue.
![image](https://github.com/user-attachments/assets/42c33abf-bdef-4b61-8eb7-9ff9e9183d81)

