### PR TITLE
fix: [#4859] Inconsistent ConversationParameters interface

### DIFF
--- a/libraries/botframework-schema/etc/botframework-schema.api.md
+++ b/libraries/botframework-schema/etc/botframework-schema.api.md
@@ -711,7 +711,7 @@ export interface ConversationMembers {
 
 // @public
 export interface ConversationParameters {
-    activity: Activity;
+    activity?: Activity;
     bot: ChannelAccount;
     channelData: any;
     isGroup: boolean;

--- a/libraries/botframework-schema/src/index.ts
+++ b/libraries/botframework-schema/src/index.ts
@@ -873,7 +873,7 @@ export interface ConversationParameters {
      * (Optional) When creating a new conversation, use this activity as the initial message to the
      * conversation
      */
-    activity: Activity;
+    activity?: Activity;
     /**
      * Channel specific payload for creating the conversation
      */


### PR DESCRIPTION
Fixes #4859

## Description
This PR marks as optional the `Activity` in the `ConversationParameters` interface as its documentation was describing.

## Specific Changes
- Added the ? symbol to the **_activity_** parameter to make it optional.
- The API declaration file was modified accordingly.

## Testing
This image shows the unit tests passing after the change.
![image](https://github.com/user-attachments/assets/b9b14d02-939f-4962-af36-a02452f03bd6)