### PR TITLE
feat: Enable configuration of the OpenIdmetadata's refresh interval

### DIFF
--- a/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
+++ b/libraries/botframework-connector/src/auth/jwtTokenExtractor.ts
@@ -34,22 +34,32 @@ export class JwtTokenExtractor {
      * @param metadataUrl Metadata Url.
      * @param allowedSigningAlgorithms Allowed signing algorithms.
      * @param proxySettings The proxy settings for the request.
+     * @param tokenRefreshInterval The token refresh interval in hours. The default value is 24 hours.
      */
     constructor(
         tokenValidationParameters: VerifyOptions,
         metadataUrl: string,
         allowedSigningAlgorithms: string[] | Algorithm[],
         proxySettings?: ProxySettings,
+        tokenRefreshInterval?: number,
     ) {
         this.tokenValidationParameters = { ...tokenValidationParameters };
         this.tokenValidationParameters.algorithms = allowedSigningAlgorithms as Algorithm[];
-        this.openIdMetadata = JwtTokenExtractor.getOrAddOpenIdMetadata(metadataUrl, proxySettings);
+        this.openIdMetadata = JwtTokenExtractor.getOrAddOpenIdMetadata(
+            metadataUrl,
+            proxySettings,
+            tokenRefreshInterval,
+        );
     }
 
-    private static getOrAddOpenIdMetadata(metadataUrl: string, proxySettings?: ProxySettings): OpenIdMetadata {
+    private static getOrAddOpenIdMetadata(
+        metadataUrl: string,
+        proxySettings?: ProxySettings,
+        tokenRefreshInterval?: number,
+    ): OpenIdMetadata {
         let metadata = this.openIdMetadataCache.get(metadataUrl);
         if (!metadata) {
-            metadata = new OpenIdMetadata(metadataUrl, proxySettings);
+            metadata = new OpenIdMetadata(metadataUrl, proxySettings, tokenRefreshInterval);
             this.openIdMetadataCache.set(metadataUrl, metadata);
         }
 

--- a/libraries/botframework-connector/src/auth/openIdMetadata.ts
+++ b/libraries/botframework-connector/src/auth/openIdMetadata.ts
@@ -26,10 +26,12 @@ export class OpenIdMetadata {
      *
      * @param url Metadata Url.
      * @param proxySettings The proxy settings for the request.
+     * @param tokenRefreshInterval The token refresh interval in hours. The default value is 24 hours.
      */
     constructor(
         private url: string,
         private proxySettings?: ProxySettings,
+        private tokenRefreshInterval: number = 24,
     ) {}
 
     /**
@@ -39,8 +41,8 @@ export class OpenIdMetadata {
      * @returns A `Promise` representation for either a [IOpenIdMetadataKey](botframework-connector:module.IOpenIdMetadataKey) or `null`.
      */
     async getKey(keyId: string): Promise<IOpenIdMetadataKey | null> {
-        // If keys are more than 24 hours old, refresh them
-        if (this.lastUpdated < Date.now() - 1000 * 60 * 60 * 24) {
+        // If keys are older than the refresh interval (default 24 hours), refresh them
+        if (this.lastUpdated < Date.now() - this.tokenRefreshInterval * 1000 * 60 * 60) {
             await this.refreshCache();
 
             // Search the cache even if we failed to refresh

--- a/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
@@ -306,6 +306,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             this.toBotFromEmulatorOpenIdMetadataUrl,
             AuthenticationConstants.AllowedSigningAlgorithms,
             this.connectorClientOptions?.proxySettings,
+            this.connectorClientOptions?.tokenRefreshInterval,
         );
 
         const parts: string[] = authHeader.split(' ');
@@ -393,6 +394,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             this.toBotFromEmulatorOpenIdMetadataUrl,
             AuthenticationConstants.AllowedSigningAlgorithms,
             this.connectorClientOptions?.proxySettings,
+            this.connectorClientOptions?.tokenRefreshInterval,
         );
 
         const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(
@@ -480,6 +482,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
             this.toBotFromChannelOpenIdMetadataUrl,
             AuthenticationConstants.AllowedSigningAlgorithms,
             this.connectorClientOptions?.proxySettings,
+            this.connectorClientOptions?.tokenRefreshInterval,
         );
 
         const identity: ClaimsIdentity = await tokenExtractor.getIdentityFromAuthHeader(

--- a/libraries/botframework-connector/src/connectorApi/models/index.ts
+++ b/libraries/botframework-connector/src/connectorApi/models/index.ts
@@ -17,6 +17,8 @@ export interface ConnectorClientOptions extends ServiceClientOptions {
    * HTTP and HTTPS agents which will be used for every HTTP request (Node.js only).
    */
   agentSettings?: AgentSettings;
+
+  tokenRefreshInterval?: number;
 }
 
 /**

--- a/libraries/botframework-connector/src/connectorApi/models/index.ts
+++ b/libraries/botframework-connector/src/connectorApi/models/index.ts
@@ -18,6 +18,9 @@ export interface ConnectorClientOptions extends ServiceClientOptions {
    */
   agentSettings?: AgentSettings;
 
+  /**
+   * Token refresh interval in hours used to determine when to refresh the token cache. The default value is 24 hours.
+   */
   tokenRefreshInterval?: number;
 }
 


### PR DESCRIPTION
#minor

## Description
This PR adds the **_tokenRefreshInterval_** property to the **_ConnectorClientOptions_** interface to set up the interval in the  bot's configuration. This value is used in _OpenIdMetadata's getKey_ method to retrieve the key from the cache, or to make a new request.

The interval should be configured in the following way:

```JavaScrip
const botFrameworkAuthentication = new ConfigurationBotFrameworkAuthentication(
    process.env,
    undefined,
    undefined,
    undefined,
    { tokenRefreshInterval: 1 } // Set the token refresh interval to 1 hour.
);

const adapter = new CloudAdapter(botFrameworkAuthentication);
```

**Considerations:**
- If tokenRefreshInterval is not set, it defaults to 24 hours (as it was originally).
- If tokenRefreshInterval is set to 0, it refreshes the token for each request.
- If tokenRefreshInterval is set to a value, e.g. 1, it refreshes the token after an hour.

## Specific Changes
  - Updated **_ConnectorClientOptions_** interface to include the _tokenRefreshInterval_ property.
  - Updated **_OpenIdMetadata_** class to receive the interval in the constructor and use it in the _getKey_ method.
  - Updated **_JwtTokenExtractor_** to pass the value of the interval to the _OpenIdMetadata_ class.
  - Updated **_ParameterizedBotFrameworkAuthentication_** to pass the value from the options to the _JwtTokenExtractor_ instances.
  - Added 2 new unit tests in **_openIdMetadata.test_**.
  

## Testing
These images show the configuration tested with a bot and the new tests passing.
![image](https://github.com/user-attachments/assets/9113cb6f-c994-49f9-9dde-383f005b4d0e)
![image](https://github.com/user-attachments/assets/eec625b4-c7ed-47ea-98bb-f4c008171b94)

