### PR TITLE
port: CQA to support TokenCredential instead of key

### DIFF
--- a/libraries/botbuilder-ai/etc/botbuilder-ai.api.md
+++ b/libraries/botbuilder-ai/etc/botbuilder-ai.api.md
@@ -531,6 +531,7 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
     isTest: boolean;
     knowledgeBaseId: StringExpression;
     logPersonalInformation: BoolExpression;
+    managedIdentityClientId: StringExpression;
     noAnswer: TemplateInterface<Partial<Activity>, DialogStateManager>;
     protected onPreBubbleEvent(dc: DialogContext, e: DialogEvent): Promise<boolean>;
     protected options: string;
@@ -543,6 +544,9 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
     threshold: NumberExpression;
     top: IntExpression;
     useTeamsAdaptiveCard: boolean;
+    // Warning: (ae-forgotten-export) The symbol "QnAMakerDialogWithoutOtherAuthorization" needs to be exported by the entry point index.d.ts
+    withEndpointKey(endpointKey: string): QnAMakerDialogWithoutOtherAuthorization;
+    withManagedIdentityClientId(managedIdentityClientId: string): QnAMakerDialogWithoutOtherAuthorization;
 }
 
 // @public
@@ -562,9 +566,10 @@ export interface QnAMakerDialogResponseOptions {
 
 // @public
 export interface QnAMakerEndpoint {
-    endpointKey: string;
+    endpointKey?: string;
     host: string;
     knowledgeBaseId: string;
+    managedIdentityClientId?: string;
     qnaServiceType?: ServiceType;
 }
 

--- a/libraries/botbuilder-ai/package.json
+++ b/libraries/botbuilder-ai/package.json
@@ -27,6 +27,7 @@
     }
   },
   "dependencies": {
+    "@azure/identity": "^4.4.1",
     "adaptive-expressions": "4.1.6",
     "botbuilder-core": "4.1.6",
     "botbuilder-dialogs": "4.1.6",

--- a/libraries/botbuilder-ai/src/qnaMakerDialog.ts
+++ b/libraries/botbuilder-ai/src/qnaMakerDialog.ts
@@ -529,7 +529,7 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
             throw new Error('EndpointKey cannot be null or empty.');
         }
 
-        if (this.managedIdentityClientId) {
+        if (this.managedIdentityClientId.value) {
             throw new Error('Cannot set EndpointKey when ManagedIdentityClientId is already set.');
         }
 
@@ -548,7 +548,7 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
             throw new Error('ManagedIdentityClientId cannot be null or empty.');
         }
 
-        if (this.endpointKey) {
+        if (this.endpointKey.value) {
             throw new Error('Cannot set ManagedIdentityClientId when EndpointKey is already set.');
         }
 

--- a/libraries/botbuilder-ai/src/qnaMakerDialog.ts
+++ b/libraries/botbuilder-ai/src/qnaMakerDialog.ts
@@ -116,6 +116,7 @@ export interface QnAMakerDialogConfiguration extends DialogConfiguration {
     knowledgeBaseId?: string | Expression | StringExpression;
     hostname?: string | Expression | StringExpression;
     endpointKey?: string | Expression | StringExpression;
+    managedIdentityClientId?: string | Expression | StringExpression;
     threshold?: number | string | Expression | NumberExpression;
     top?: number | string | Expression | IntExpression;
     noAnswer?: string | Partial<Activity> | TemplateInterface<Partial<Activity>, DialogStateManager>;
@@ -145,6 +146,8 @@ export type QnASuggestionsActivityFactory = (suggestionsList: string[], noMatche
 const qnaSuggestionsActivityFactory = z.custom<QnASuggestionsActivityFactory>((val) => typeof val === 'function', {
     message: 'QnASuggestionsActivityFactory',
 });
+
+type QnAMakerDialogWithoutOtherAuthorization = Omit<QnAMakerDialog, 'withEndpointKey' | 'withManagedIdentityClientId'>;
 
 /**
  * A dialog that supports multi-step and adaptive-learning QnA Maker services.
@@ -225,6 +228,11 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
      * Gets or sets the QnA Maker endpoint key to use to query the knowledge base.
      */
     endpointKey: StringExpression;
+
+    /**
+     * Gets or sets the Managed Identity ClientId to use to query the knowledge base.
+     */
+    managedIdentityClientId: StringExpression;
 
     /**
      * Gets or sets the threshold for answers returned, based on score.
@@ -335,7 +343,7 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
      * Initializes a new instance of the [QnAMakerDialog](xref:QnAMakerDialog) class.
      *
      * @param {string} knowledgeBaseId The ID of the QnA Maker knowledge base to query.
-     * @param {string} endpointKey The QnA Maker endpoint key to use to query the knowledge base.
+     * @param {string} endpointKey **Deprecated - use withEndpointKey() instead**. The QnA Maker endpoint key to use to query the knowledge base.
      * @param {string} hostname The QnA Maker host URL for the knowledge base, starting with "https://" and ending with "/qnamaker".
      * @param {string} noAnswer (Optional) The activity to send the user when QnA Maker does not find an answer.
      * @param {number} threshold (Optional) The threshold above which to treat answers found from the knowledgebase as a match.
@@ -372,7 +380,7 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
      * Initializes a new instance of the [QnAMakerDialog](xref:QnAMakerDialog) class.
      *
      * @param {string} knowledgeBaseId The ID of the QnA Maker knowledge base to query.
-     * @param {string} endpointKey The QnA Maker endpoint key to use to query the knowledge base.
+     * @param {string} endpointKey **Deprecated - use withEndpointKey() instead**. The QnA Maker endpoint key to use to query the knowledge base.
      * @param {string} hostname The QnA Maker host URL for the knowledge base, starting with "https://" and ending with "/qnamaker".
      * @param {string} noAnswer (Optional) The activity to send the user when QnA Maker does not find an answer.
      * @param {number} threshold (Optional) The threshold above which to treat answers found from the knowledgebase as a match.
@@ -435,6 +443,9 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
         }
 
         if (endpointKey) {
+            console.warn(
+                "Providing an endpointKey in the QnAMakerDialog constructor is deprecated, use withEndpointKey() method instead and provide 'null' or 'empty' value in the constructor.",
+            );
             this.endpointKey = new StringExpression(endpointKey);
         }
 
@@ -508,6 +519,36 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
     }
 
     /**
+     * Uses the provided QnA Maker EndpointKey to authenticate against the resource to query the knowledge base.
+     *
+     * @param endpointKey The QnA Maker endpoint key to use to query the knowledge base.
+     * @returns The QnAMakerDialog instance.
+     */
+    withEndpointKey(endpointKey: string): QnAMakerDialogWithoutOtherAuthorization {
+        if (!endpointKey?.trim()) {
+            throw new Error('EndpointKey cannot be null or empty.');
+        }
+
+        this.endpointKey = new StringExpression(endpointKey);
+        return this;
+    }
+
+    /**
+     * Uses the provided QnA Maker ManagedIdentityClientId to authenticate against the resource to query the knowledge base.
+     *
+     * @param managedIdentityClientId The QnA Maker managed identity client id to use to query the knowledge base.
+     * @returns The QnAMakerDialog instance.
+     */
+    withManagedIdentityClientId(managedIdentityClientId: string): QnAMakerDialogWithoutOtherAuthorization {
+        if (!managedIdentityClientId?.trim()) {
+            throw new Error('ManagedIdentityClientId cannot be null or empty.');
+        }
+
+        this.managedIdentityClientId = new StringExpression(managedIdentityClientId);
+        return this;
+    }
+
+    /**
      * @param property Properties that extend QnAMakerDialogConfiguration.
      * @returns The expression converter.
      */
@@ -518,6 +559,8 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
             case 'hostname':
                 return new StringExpressionConverter();
             case 'endpointKey':
+                return new StringExpressionConverter();
+            case 'managedIdentityClientId':
                 return new StringExpressionConverter();
             case 'threshold':
                 return new NumberExpressionConverter();
@@ -655,9 +698,16 @@ export class QnAMakerDialog extends WaterfallDialog implements QnAMakerDialogCon
             return qnaClient;
         }
 
+        if (!this.endpointKey && !this.managedIdentityClientId) {
+            throw new Error(
+                'An authorization method is required. Either EndpointKey or ManagedIdentityClientId must be set, use withEndpointKey() or withManagedIdentityClientId() respectively.',
+            );
+        }
+
         const endpoint = {
             knowledgeBaseId: this.knowledgeBaseId.getValue(dc.state),
-            endpointKey: this.endpointKey.getValue(dc.state),
+            endpointKey: this.endpointKey?.getValue(dc.state),
+            managedIdentityClientId: this.managedIdentityClientId?.getValue(dc.state),
             host: this.qnaServiceType === ServiceType.language ? this.hostname.getValue(dc.state) : this.getHost(dc),
             qnaServiceType: this.qnaServiceType,
         };

--- a/libraries/botbuilder-ai/src/qnamaker-interfaces/qnamakerEndpoint.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-interfaces/qnamakerEndpoint.ts
@@ -21,7 +21,7 @@ export interface QnAMakerEndpoint {
      * Your endpoint key. For `v2` or `v3` knowledge bases this is your subscription key.
      * For example: `4cb65a02697745eca369XXXXXXXXXXXX`
      */
-    endpointKey: string;
+    endpointKey?: string;
 
     /**
      * The host path. For example: `https://testqnamaker.azurewebsites.net/qnamaker`
@@ -32,4 +32,9 @@ export interface QnAMakerEndpoint {
      * QnA service type '' - qnamaker, language
      */
     qnaServiceType?: ServiceType;
+
+    /**
+     * The ClientId of the Managed Identity resource. Access control (IAM) role `Cognitive Services User` must be assigned in the Language resource to the Managed Identity resource.
+     */
+    managedIdentityClientId?: string;
 }

--- a/libraries/botbuilder-ai/src/qnamaker-utils/httpRequestUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/httpRequestUtils.ts
@@ -49,7 +49,7 @@ export class HttpRequestUtils {
         }
 
         if (!endpoint) {
-            throw new TypeError('Payload body cannot be null.');
+            throw new TypeError('Endpoint body cannot be null.');
         }
 
         const headers = await this.getHeaders(endpoint);

--- a/libraries/botbuilder-ai/src/qnamaker-utils/httpRequestUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/httpRequestUtils.ts
@@ -7,6 +7,7 @@
  */
 
 import * as os from 'os';
+import { ManagedIdentityCredential } from '@azure/identity';
 
 import { KnowledgeBaseAnswers } from '../qnamaker-interfaces/knowledgeBaseAnswers';
 import { QnAMakerEndpoint } from '../qnamaker-interfaces/qnamakerEndpoint';
@@ -51,7 +52,7 @@ export class HttpRequestUtils {
             throw new TypeError('Payload body cannot be null.');
         }
 
-        const headers = this.getHeaders(endpoint);
+        const headers = await this.getHeaders(endpoint);
 
         const qnaResult = await fetch(requestUrl, {
             method: 'POST',
@@ -75,11 +76,17 @@ export class HttpRequestUtils {
      *
      * @private
      */
-    private getHeaders(endpoint: QnAMakerEndpoint): Record<string, string> {
+    private async getHeaders(endpoint: QnAMakerEndpoint): Promise<Record<string, string>> {
         const headers = {};
 
-        headers['Ocp-Apim-Subscription-Key'] = endpoint.endpointKey;
-        headers['Authorization'] = `EndpointKey ${endpoint.endpointKey}`;
+        if (endpoint.endpointKey) {
+            headers['Ocp-Apim-Subscription-Key'] = endpoint.endpointKey;
+            headers['Authorization'] = `EndpointKey ${endpoint.endpointKey}`;
+        } else if (endpoint.managedIdentityClientId) {
+            const client = new ManagedIdentityCredential({ clientId: endpoint.managedIdentityClientId });
+            const tokenResponse = await client.getToken(endpoint.host);
+            headers['Authorization'] = `Bearer ${tokenResponse.token}`;
+        }
         headers['User-Agent'] = this.getUserAgent();
         headers['Content-Type'] = 'application/json';
 

--- a/libraries/botbuilder-ai/src/qnamaker-utils/httpRequestUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/httpRequestUtils.ts
@@ -84,7 +84,7 @@ export class HttpRequestUtils {
             headers['Authorization'] = `EndpointKey ${endpoint.endpointKey}`;
         } else if (endpoint.managedIdentityClientId) {
             const client = new ManagedIdentityCredential({ clientId: endpoint.managedIdentityClientId });
-            const tokenResponse = await client.getToken(endpoint.host);
+            const tokenResponse = await client.getToken('https://cognitiveservices.azure.com/.default');
             headers['Authorization'] = `Bearer ${tokenResponse.token}`;
         }
         headers['User-Agent'] = this.getUserAgent();

--- a/libraries/botbuilder-ai/src/qnamaker-utils/languageServiceUtils.ts
+++ b/libraries/botbuilder-ai/src/qnamaker-utils/languageServiceUtils.ts
@@ -116,7 +116,7 @@ export class LanguageServiceUtils {
             return this.formatQnaResult(qnaResults as KnowledgeBaseAnswers);
         }
 
-        throw new Error(`Failed to query knowledgebase: ${qnaResults}`);
+        throw new Error(`Failed to query knowledgebase: ${JSON.stringify(qnaResults)}`);
     }
 
     /**


### PR DESCRIPTION
Related DotNet issue https://github.com/microsoft/botbuilder-dotnet/issues/6889
#minor

## Description
This PR adds the ability to use a Managed Identity ClientId to authenticate to the Language service.

## Specific Changes
  - Added managedIdentityClientId property to the QnAMakerDialog config.
  - Added withEndpointKey and withManagedIdentityClientId methods to the QnAMakerDialog class to configure which authentication the request will use.
  - Added the ability to detect and get the MSI token in the httpRequestUtils file.

## Testing
The following image shows the bot working with both authorization types.
![image](https://github.com/user-attachments/assets/7f826c9f-1f33-4482-a47f-2c76666eb1d9)
