### PR TITLE
fix: CodeQL issues with severity High

### DIFF
--- a/libraries/botbuilder-core/tests/transcriptUtilities.js
+++ b/libraries/botbuilder-core/tests/transcriptUtilities.js
@@ -172,9 +172,13 @@ const decompressZip = (inputPath, outputPath, callback) => {
         .pipe(unzip.Parse())
         .on('entry', (entry) => {
             if (entry.type === 'File' && entry.path.includes(zipTranscriptsRelativePath)) {
-                const fileExtractPath = path.join(outputPath, entry.path);
-                ensureDirectoryExists(fileExtractPath);
-                entry.pipe(fs.createWriteStream(fileExtractPath)).on('error', console.log);
+                if (entry.path.indexOf('..') == -1) {
+                    const fileExtractPath = path.join(outputPath, entry.path);
+                    ensureDirectoryExists(fileExtractPath);
+                    entry.pipe(fs.createWriteStream(fileExtractPath)).on('error', console.log);
+                } else {
+                    console.warn(`Skipping file ${entry.path} as it contains '..' in its path.`);
+                }
             } else {
                 entry.autodrain();
             }

--- a/libraries/botbuilder/src/channelServiceHandler.ts
+++ b/libraries/botbuilder/src/channelServiceHandler.ts
@@ -43,26 +43,27 @@ export class ChannelServiceHandler extends ChannelServiceHandlerBase {
     }
 
     protected async authenticate(authHeader: string): Promise<ClaimsIdentity> {
-        if (!authHeader) {
-            const isAuthDisabled = await this.credentialProvider.isAuthenticationDisabled();
-            if (!isAuthDisabled) {
-                throw new StatusCodeError(StatusCodes.UNAUTHORIZED);
-            }
+        const isAuthDisabled = await this.credentialProvider.isAuthenticationDisabled();
 
+        if (isAuthDisabled) {
             // In the scenario where Auth is disabled, we still want to have the
             // IsAuthenticated flag set in the ClaimsIdentity. To do this requires
             // adding in an empty claim.
             // Since ChannelServiceHandler calls are always a skill callback call, we set the skill claim too.
             return SkillValidation.createAnonymousSkillClaim();
-        }
+        } else {
+            if (!authHeader) {
+                throw new StatusCodeError(StatusCodes.UNAUTHORIZED);
+            }
 
-        return JwtTokenValidation.validateAuthHeader(
-            authHeader,
-            this.credentialProvider,
-            this.channelService,
-            'unknown',
-            undefined,
-            this.authConfig,
-        );
+            return JwtTokenValidation.validateAuthHeader(
+                authHeader,
+                this.credentialProvider,
+                this.channelService,
+                'unknown',
+                undefined,
+                this.authConfig,
+            );
+        }
     }
 }

--- a/libraries/botbuilder/tests/channelServiceHandler.test.js
+++ b/libraries/botbuilder/tests/channelServiceHandler.test.js
@@ -14,7 +14,7 @@ const {
 
 const AUTH_HEADER = 'Bearer HelloWorld';
 const AUTH_CONFIG = new AuthenticationConfiguration();
-const CREDENTIALS = new SimpleCredentialProvider('', '');
+const CREDENTIALS = new SimpleCredentialProvider('appId', 'appSecret');
 const ACTIVITY = { id: 'testId', type: ActivityTypes.Message };
 
 class NoAuthHandler extends ChannelServiceHandler {

--- a/libraries/botbuilder/tests/cloudAdapter.test.js
+++ b/libraries/botbuilder/tests/cloudAdapter.test.js
@@ -213,8 +213,8 @@ describe('CloudAdapter', function () {
             const claimsValidators = allowedCallersClaimsValidator(['*']);
             const authConfig = new AuthenticationConfiguration([], claimsValidators, validTokenIssuers);
             const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
-                MicrosoftAppId: '',
-                MicrosoftAppPassword: '',
+                MicrosoftAppId: 'app-id',
+                MicrosoftAppPassword: 'app-password',
                 MicrosoftAppType: '',
                 MicrosoftAppTenantId: '',
             });

--- a/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
@@ -85,22 +85,17 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
      * @returns The identity validation result.
      */
     async authenticateChannelRequest(authHeader: string): Promise<ClaimsIdentity> {
-        if (!authHeader.trim()) {
-            const isAuthDisabled = await this.credentialsFactory.isAuthenticationDisabled();
-            if (!isAuthDisabled) {
+        if (!(await this.credentialsFactory.isAuthenticationDisabled())) {
+            return SkillValidation.createAnonymousSkillClaim();
+        } else {
+            if (!authHeader.trim()) {
                 throw new AuthenticationError(
                     'Unauthorized Access. Request is not authorized',
                     StatusCodes.UNAUTHORIZED,
                 );
             }
-
-            // In the scenario where auth is disabled, we still want to have the isAuthenticated flag set in the
-            // ClaimsIdentity. To do this requires adding in an empty claim. Since ChannelServiceHandler calls are
-            // always a skill callback call, we set the skill claim too.
-            return SkillValidation.createAnonymousSkillClaim();
+            return this.JwtTokenValidation_validateAuthHeader(authHeader, 'unknown', null);
         }
-
-        return this.JwtTokenValidation_validateAuthHeader(authHeader, 'unknown', null);
     }
 
     /**

--- a/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
+++ b/libraries/botframework-connector/src/auth/parameterizedBotFrameworkAuthentication.ts
@@ -85,7 +85,7 @@ export class ParameterizedBotFrameworkAuthentication extends BotFrameworkAuthent
      * @returns The identity validation result.
      */
     async authenticateChannelRequest(authHeader: string): Promise<ClaimsIdentity> {
-        if (!(await this.credentialsFactory.isAuthenticationDisabled())) {
+        if (await this.credentialsFactory.isAuthenticationDisabled()) {
             return SkillValidation.createAnonymousSkillClaim();
         } else {
             if (!authHeader.trim()) {


### PR DESCRIPTION
#minor

## Description
This PR solves the following CodeQL issues of `high` severity:
- [CWE-22](https://cwe.mitre.org/data/definitions/22.html)
- [CWE-295](https://cwe.mitre.org/data/definitions/295.html)
- [CWE-807](https://cwe.mitre.org/data/definitions/807.html)

## Specific Changes
- Added a validation to the path of the zip file before moving to the directory in **_transcriptUtilities_**.
- Reordered validations to avoid relaying on user input to make authentication decisions in: 
   - channelServiceHandler
   - jwtTokenValidation
   - parameterizedBotFrameworkAuthentication
-  Added a private function _isValidServiceURL_ in **_jwtTokenValidation_** to validate the URL before using it in the condition.
- Fixed failing tests in **_channelServiceHandler.test_**

## Testing
These images show a bot working with anonymous and credential authentication after the changes.
<img width="1686" height="812" alt="image" src="https://github.com/user-attachments/assets/ebdb4458-f776-45a9-9acc-59a1d0183931" />
