### PR TITLE
fix: CodeQL issues with Medium and Error severity

### DIFF
--- a/libraries/botbuilder-core/tests/chatdown.js
+++ b/libraries/botbuilder-core/tests/chatdown.js
@@ -638,7 +638,7 @@ function* fileLineIterator(fileContents) {
 }
 
 function getHashCode(contents) {
-    return crypto.createHash('sha1').update(contents).digest('base64');
+    return crypto.createHash('sha512').update(contents).digest('base64');
 }
 
 class Activity {

--- a/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
+++ b/libraries/botbuilder-dialogs-adaptive-testing/tests/action.test.js
@@ -36,7 +36,7 @@ class MockSkillConversationIdFactory extends SkillConversationIdFactoryBase {
         if (this.useCreateSkillConversationId) {
             return super.createSkillConversationIdWithOptions();
         }
-        const key = createHash('md5')
+        const key = createHash('sha512')
             .update(opts.activity.conversation.id + opts.activity.serviceUrl)
             .digest('hex');
 
@@ -51,7 +51,7 @@ class MockSkillConversationIdFactory extends SkillConversationIdFactoryBase {
     }
 
     async createSkillConversationId(convRef) {
-        const key = createHash('md5')
+        const key = createHash('sha512')
             .update(convRef.conversation.id + convRef.serviceUrl)
             .digest('hex');
 

--- a/libraries/botbuilder-dialogs-adaptive/tests/beginSkill.test.js
+++ b/libraries/botbuilder-dialogs-adaptive/tests/beginSkill.test.js
@@ -27,7 +27,7 @@ class SimpleConversationIdFactory extends SkillConversationIdFactoryBase {
         if (this.useCreateSkillConversationId) {
             return super.createSkillConversationIdWithOptions();
         }
-        const key = createHash('md5')
+        const key = createHash('sha512')
             .update(opts.activity.conversation.id + opts.activity.serviceUrl)
             .digest('hex');
 
@@ -42,7 +42,7 @@ class SimpleConversationIdFactory extends SkillConversationIdFactoryBase {
     }
 
     async createSkillConversationId(convRef) {
-        const key = createHash('md5')
+        const key = createHash('sha512')
             .update(convRef.conversation.id + convRef.serviceUrl)
             .digest('hex');
 

--- a/libraries/botbuilder-dialogs-declarative/tests/jsonLoad.test.js
+++ b/libraries/botbuilder-dialogs-declarative/tests/jsonLoad.test.js
@@ -474,7 +474,7 @@ describe('Json load tests', function () {
             .assertReply('Done! You have added a pet named "TestPetName" with id "12121"')
             .assertReply('Now try to specify the id of your pet, and I will help your find it out from the store.')
             .send('12121')
-            .assertReply('Great! I found your pet named "TestPetName"')
+            .assertReply('Great! I found your pet named "TestPetName"', null, 5000)
             .startTest();
     });
 

--- a/libraries/botbuilder-dialogs/tests/skillDialog.test.js
+++ b/libraries/botbuilder-dialogs/tests/skillDialog.test.js
@@ -677,7 +677,7 @@ class SimpleConversationIdFactory extends SkillConversationIdFactoryBase {
         if (this.useCreateSkillConversationId) {
             return super.createSkillConversationIdWithOptions();
         }
-        const key = createHash('md5')
+        const key = createHash('sha512')
             .update(options.activity.conversation.id + options.activity.serviceUrl)
             .digest('hex');
 
@@ -694,7 +694,7 @@ class SimpleConversationIdFactory extends SkillConversationIdFactoryBase {
     async createSkillConversationId(convRef) {
         this.createCount++;
 
-        const key = createHash('md5')
+        const key = createHash('sha512')
             .update(convRef.conversation.id + convRef.serviceUrl)
             .digest('hex');
 

--- a/libraries/botbuilder/src/channelServiceRoutes.ts
+++ b/libraries/botbuilder/src/channelServiceRoutes.ts
@@ -436,7 +436,12 @@ export class ChannelServiceRoutes {
      */
     private static handleError(err: any, res: WebResponse): void {
         res.status(typeof err?.statusCode === 'number' ? err.statusCode : 500);
-        res.send(err instanceof Error ? err.message : err);
+        if (err instanceof Error) {
+            res.send(err.message);
+        } else {
+            res.send('An error occurred while processing the request.');
+            console.log(err);
+        }
         res.end();
     }
 }

--- a/libraries/botbuilder/src/channelServiceRoutes.ts
+++ b/libraries/botbuilder/src/channelServiceRoutes.ts
@@ -440,7 +440,7 @@ export class ChannelServiceRoutes {
             res.send(err.message);
         } else {
             res.send('An error occurred while processing the request.');
-            console.log(err);
+            console.error(err);
         }
         res.end();
     }


### PR DESCRIPTION
#minor

## Description
This PR solves the following CodeQL issues:
- [CWE-209](https://cwe.mitre.org/data/definitions/209.html) - Medium
- [CWE-327](https://cwe.mitre.org/data/definitions/327.html) - Error

Additionally, it extends the timeout for the _jsonLoad_ unit test that frequently fails in the pipelines.

## Specific Changes
- Updated the _handleError_ function in **_channelServiceRoutes_** to log the error trace instead of sending it to the user in the HTTP Response.
- Changed the hash algorithm to a more secure one in: 
   - chatdown.js
   - action.test.js
   - beginSkill.test.js
   - skillDialog.test.js
- Added a 5 seconds timeout to fix transient errors in **_jsonLoad.test.js_** unit test.

## Testing
These images show the involved tests passing after the changes.
<img width="2187" height="1269" alt="image" src="https://github.com/user-attachments/assets/8e75e03e-e670-483a-8a0e-a3d63b88d10a" />