### PR TITLE
fix: [#4902][onTurnError] unhandled error for informative streaming

### DIFF
--- a/libraries/botframework-connector/src/connectorApi/models/mappers.ts
+++ b/libraries/botframework-connector/src/connectorApi/models/mappers.ts
@@ -399,6 +399,11 @@ export const Entity: CompositeMapper = {
           className: "ChannelAccount"
         }
       }
+    },
+    additionalProperties: {
+      type: {
+        name: "Object"
+      }
     }
   }
 };
@@ -711,12 +716,7 @@ export const Activity: CompositeMapper = {
           element: {
             type: {
               name: "Composite",
-              className: "Entity",
-              additionalProperties: {
-                type: {
-                  name: "Object"
-                }
-              }
+              className: "Entity"
             }
           }
         }


### PR DESCRIPTION
Fixes #4902

## Description
After migrating from _azure/core-http_ to _azure/core-client_ package, the _CompositeMapper_ changed its behavior regarding additional properties. Now, they must be defined in the model.
This PR fixes the issue of unmapped additional properties in the **Entity** by explicitly incorporating the object into the _Entity_ model.

## Specific Changes
- Updated `connectorApi/models/mappers` including the `additionalProperties` object in the _Entity_ model. Additionally, we removed it from the _entities_ array as it was redundant.

## Testing
This image shows the informative streamInfo message being displayed after applying the fix.
<img width="1770" height="631" alt="image" src="https://github.com/user-attachments/assets/8e5f7204-ba24-4e98-9230-ea85077f999f" />